### PR TITLE
perf(vscode): optimize diff loading, caching, and review rendering

### DIFF
--- a/.changeset/instant-diff-loading.md
+++ b/.changeset/instant-diff-loading.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Optimize diff loading performance to render immediately by pre-populating unified patches, caching diff results, preloading adjacent worktrees, and accelerating review calculations.
+Optimize diff loading performance with bounded patch prefetching, adjacent-worktree caching, and faster review calculations.

--- a/.changeset/instant-diff-loading.md
+++ b/.changeset/instant-diff-loading.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Optimize diff loading performance to render immediately by pre-populating unified patches, caching diff results, preloading adjacent worktrees, and accelerating review calculations.

--- a/.changeset/instant-diff-loading.md
+++ b/.changeset/instant-diff-loading.md
@@ -1,5 +1,6 @@
 ---
 "kilo-code": patch
+"@kilocode/cli": patch
 ---
 
-Optimize diff loading performance with bounded patch prefetching, adjacent-worktree caching, and faster review calculations.
+Optimize diff loading performance with bounded patch prefetching, adjacent-worktree caching, faster review calculations, and reliable truncation cleanup.

--- a/packages/kilo-ui/src/components/diff.tsx
+++ b/packages/kilo-ui/src/components/diff.tsx
@@ -27,9 +27,7 @@ type Job = { run: () => void; cancelled: boolean }
 // IntersectionObserver per diff showed up in profiles, so all deferred diffs
 // share a single observer and only register their element + render callback.
 const watchers = new Map<Element, Job>()
-const queue: Job[] = []
 let shared: IntersectionObserver | undefined
-let frame: number | undefined
 
 function lines(text: string): number {
   if (!text) return 0
@@ -51,27 +49,7 @@ function release(node: Element) {
   shared = undefined
 }
 
-function enqueue(job: Job) {
-  queue.push(job)
-  schedule()
-}
-
-// When a large batch of diffs becomes near-visible at once, render one diff per
-// animation frame. This keeps the UI responsive while preserving expanded state.
-function schedule() {
-  if (frame !== undefined) return
-  frame = requestAnimationFrame(() => {
-    frame = undefined
-    const job = queue.shift()
-    if (job && !job.cancelled) job.run()
-    if (queue.length > 0) schedule()
-  })
-}
-
 // Defer Pierre's expensive DOM render until the diff is close to the viewport.
-// The caller still mounts an expanded diff container immediately, but the body
-// render is queued here so offscreen expanded diffs do not block worktree
-// switches or message handling.
 function observe(node: Element, cb: () => void): () => void {
   if (typeof IntersectionObserver === "undefined") {
     cb()
@@ -88,7 +66,7 @@ function observe(node: Element, cb: () => void): () => void {
         if (!item) continue
         watchers.delete(entry.target)
         release(entry.target)
-        enqueue(item)
+        if (!item.cancelled) item.run()
       }
     },
     { rootMargin: OBSERVER_MARGIN },
@@ -246,7 +224,10 @@ export function Diff<T>(props: DiffProps<T>) {
   }
 
   createEffect(() => {
-    if (visible()) return
+    if (visible()) {
+      container.style.minHeight = ""
+      return
+    }
     container.style.minHeight = `${estimate()}px`
   })
 

--- a/packages/kilo-ui/src/components/diff.tsx
+++ b/packages/kilo-ui/src/components/diff.tsx
@@ -27,7 +27,9 @@ type Job = { run: () => void; cancelled: boolean }
 // IntersectionObserver per diff showed up in profiles, so all deferred diffs
 // share a single observer and only register their element + render callback.
 const watchers = new Map<Element, Job>()
+const queue: Job[] = []
 let shared: IntersectionObserver | undefined
+let frame: number | undefined
 
 function lines(text: string): number {
   if (!text) return 0
@@ -49,6 +51,23 @@ function release(node: Element) {
   shared = undefined
 }
 
+function enqueue(job: Job) {
+  queue.push(job)
+  schedule()
+}
+
+// Render one newly visible diff per frame so a large intersection batch does
+// not monopolize the main thread during fast scrolling or session switches.
+function schedule() {
+  if (frame !== undefined) return
+  frame = requestAnimationFrame(() => {
+    frame = undefined
+    const job = queue.shift()
+    if (job && !job.cancelled) job.run()
+    if (queue.length > 0) schedule()
+  })
+}
+
 // Defer Pierre's expensive DOM render until the diff is close to the viewport.
 function observe(node: Element, cb: () => void): () => void {
   if (typeof IntersectionObserver === "undefined") {
@@ -66,7 +85,7 @@ function observe(node: Element, cb: () => void): () => void {
         if (!item) continue
         watchers.delete(entry.target)
         release(entry.target)
-        if (!item.cancelled) item.run()
+        enqueue(item)
       }
     },
     { rootMargin: OBSERVER_MARGIN },
@@ -224,10 +243,7 @@ export function Diff<T>(props: DiffProps<T>) {
   }
 
   createEffect(() => {
-    if (visible()) {
-      container.style.minHeight = ""
-      return
-    }
+    if (visible()) return
     container.style.minHeight = `${estimate()}px`
   })
 

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -784,9 +784,6 @@ export class AgentManagerProvider implements Disposable {
     }
     if (m.type === "agentManager.setSessionsCollapsed") {
       this.state?.setSessionsCollapsed(m.collapsed)
-      // Multi-project bodies render collapsed purely from pushed state, so the
-      // mutation must round-trip; legacy mode is covered by its optimistic
-      // signal and the push is a no-op update.
       this.pushState()
       return null
     }
@@ -855,10 +852,16 @@ export class AgentManagerProvider implements Disposable {
       return null
     }
     if (m.type === "agentManager.setDiffBaseBranch") {
+      const logErr = (err: unknown) =>
+        this.log("Failed to set diff base:", err instanceof Error ? err.message : String(err))
       void this.diffs
         .setBase(composeDiffId(m.sessionId, normalizeScope(m.scope)), m.branch)
-        .catch((err) => this.log("Failed to set diff base:", err instanceof Error ? err.message : String(err)))
+        .catch(logErr)
         .then(() => void this.sendDiffBranches(m.sessionId, m.scope))
+      return null
+    }
+    if (m.type === "agentManager.preloadWorktreeDiffs") {
+      void this.diffs.preload(m.worktreeIds)
       return null
     }
     if (m.type === "agentManager.openFile") {

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -211,6 +211,7 @@ export class AgentManagerProvider implements Disposable {
     this.diffs = new WorktreeDiffController({
       getState: () => this.getStateManager(),
       getRoot: () => this.getRoot(),
+      getProjectId: () => this.contexts.active()?.id,
       getStateReady: () => this.stateReady,
       catalog: this.diffCatalog,
       git: this.gitOps,
@@ -824,11 +825,15 @@ export class AgentManagerProvider implements Disposable {
 
   private onDiffMessage(m: AgentManagerInMessage): Record<string, unknown> | null | undefined {
     if (m.type === "agentManager.requestWorktreeDiff") {
-      void this.diffs.request(composeDiffId(m.sessionId, normalizeScope(m.scope)))
+      void this.diffs.request(composeDiffId(m.sessionId, normalizeScope(m.scope)), m.projectId)
       return null
     }
     if (m.type === "agentManager.requestWorktreeDiffFile") {
-      void this.diffs.requestFile(composeDiffId(m.sessionId, normalizeScope(m.scope), m.diffSessionId), m.file)
+      void this.diffs.requestFile(
+        composeDiffId(m.sessionId, normalizeScope(m.scope), m.diffSessionId),
+        m.file,
+        m.projectId,
+      )
       return null
     }
     if (m.type === "agentManager.applyWorktreeDiff") {
@@ -836,11 +841,11 @@ export class AgentManagerProvider implements Disposable {
       return null
     }
     if (m.type === "agentManager.revertWorktreeFile") {
-      void this.diffs.revert(composeDiffId(m.sessionId, normalizeScope(m.scope)), m.file)
+      void this.diffs.revert(composeDiffId(m.sessionId, normalizeScope(m.scope)), m.file, m.projectId)
       return null
     }
     if (m.type === "agentManager.startDiffWatch") {
-      this.diffs.start(composeDiffId(m.sessionId, normalizeScope(m.scope), m.diffSessionId))
+      this.diffs.start(composeDiffId(m.sessionId, normalizeScope(m.scope), m.diffSessionId), m.projectId)
       return null
     }
     if (m.type === "agentManager.stopDiffWatch") {
@@ -848,7 +853,7 @@ export class AgentManagerProvider implements Disposable {
       return null
     }
     if (m.type === "agentManager.requestDiffBranches") {
-      void this.diffs.sendBranches(composeDiffId(m.sessionId, normalizeScope(m.scope)))
+      void this.diffs.sendBranches(composeDiffId(m.sessionId, normalizeScope(m.scope)), m.projectId)
       return null
     }
     if (m.type === "agentManager.setDiffBaseBranch") {
@@ -856,13 +861,13 @@ export class AgentManagerProvider implements Disposable {
         this.log("Failed to set diff base:", err instanceof Error ? err.message : String(err))
       const id = composeDiffId(m.sessionId, normalizeScope(m.scope))
       void this.diffs
-        .setBase(id, m.branch)
+        .setBase(id, m.branch, m.projectId)
         .catch(logErr)
-        .then(() => void this.diffs.sendBranches(id))
+        .then(() => void this.diffs.sendBranches(id, m.projectId))
       return null
     }
     if (m.type === "agentManager.preloadWorktreeDiffs") {
-      void this.diffs.preload(m.worktreeIds)
+      void this.diffs.preload(m.worktreeIds, m.projectId)
       return null
     }
     if (m.type === "agentManager.openFile") {

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -848,16 +848,17 @@ export class AgentManagerProvider implements Disposable {
       return null
     }
     if (m.type === "agentManager.requestDiffBranches") {
-      void this.sendDiffBranches(m.sessionId, m.scope)
+      void this.diffs.sendBranches(composeDiffId(m.sessionId, normalizeScope(m.scope)))
       return null
     }
     if (m.type === "agentManager.setDiffBaseBranch") {
       const logErr = (err: unknown) =>
         this.log("Failed to set diff base:", err instanceof Error ? err.message : String(err))
+      const id = composeDiffId(m.sessionId, normalizeScope(m.scope))
       void this.diffs
-        .setBase(composeDiffId(m.sessionId, normalizeScope(m.scope)), m.branch)
+        .setBase(id, m.branch)
         .catch(logErr)
-        .then(() => void this.sendDiffBranches(m.sessionId, m.scope))
+        .then(() => void this.diffs.sendBranches(id))
       return null
     }
     if (m.type === "agentManager.preloadWorktreeDiffs") {
@@ -868,25 +869,6 @@ export class AgentManagerProvider implements Disposable {
       this.openWorktreeFile(m.sessionId, m.filePath, m.line, m.column)
       return null
     }
-  }
-
-  private async sendDiffBranches(sessionId: string, scope?: string): Promise<void> {
-    const id = composeDiffId(sessionId, normalizeScope(scope))
-    const result = await this.diffs.branches(id).catch((err) => {
-      this.log("Failed to list diff branches:", err instanceof Error ? err.message : String(err))
-      return undefined
-    })
-    if (!result) return
-    this.postToWebview({
-      type: "agentManager.diffBranches",
-      sessionId: id,
-      branches: result.branches,
-      defaultBranch: result.defaultBranch,
-      autoBase: result.autoBase,
-      currentBase: result.currentBase,
-      isAuto: result.isAuto,
-      currentBranch: result.currentBranch,
-    })
   }
 
   private onBridgeMessage(m: AgentManagerInMessage): Record<string, unknown> | null | undefined {

--- a/packages/kilo-vscode/src/agent-manager/GitOps.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitOps.ts
@@ -43,6 +43,7 @@ interface ApplyPatchResult {
 interface ExecOptions {
   env?: NodeJS.ProcessEnv
   stdin?: string
+  maxOutput?: number
 }
 
 export interface ExecResult {
@@ -579,7 +580,7 @@ export class GitOps {
    * suitable for callers that need to tolerate legitimate failures (e.g.
    * `merge-base` on an orphan branch, `ls-files --error-unmatch`).
    */
-  execGit(args: string[], cwd: string, options?: { stdin?: string }): Promise<ExecResult> {
+  execGit(args: string[], cwd: string, options?: { stdin?: string; maxOutput?: number }): Promise<ExecResult> {
     return this.exec(args, cwd, options)
   }
 
@@ -639,11 +640,22 @@ export class GitOps {
       })
       const out: Buffer[] = []
       const err: Buffer[] = []
+      let size = 0
+      let limited = false
       let failure: string | undefined
       const abort = () => child.kill("SIGTERM")
 
       this.controller.signal.addEventListener("abort", abort, { once: true })
-      child.stdout?.on("data", (chunk: Buffer) => out.push(chunk))
+      child.stdout?.on("data", (chunk: Buffer) => {
+        size += chunk.length
+        if (options?.maxOutput !== undefined && size > options.maxOutput) {
+          limited = true
+          failure = `git output exceeded ${options.maxOutput} bytes`
+          child.kill("SIGTERM")
+          return
+        }
+        out.push(chunk)
+      })
       child.stderr?.on("data", (chunk: Buffer) => err.push(chunk))
 
       child.on("error", (error) => {
@@ -652,8 +664,8 @@ export class GitOps {
       child.on("close", (code) => {
         this.controller.signal.removeEventListener("abort", abort)
         resolve({
-          code: code ?? 1,
-          stdout: Buffer.concat(out),
+          code: failure ? 1 : (code ?? 1),
+          stdout: limited ? Buffer.alloc(0) : Buffer.concat(out),
           stderr: failure ?? Buffer.concat(err).toString("utf8"),
         })
       })

--- a/packages/kilo-vscode/src/agent-manager/GitOps.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitOps.ts
@@ -425,7 +425,7 @@ export class GitOps {
         throw new Error(read.stderr.trim() || "Failed to initialize temporary index")
       }
 
-      const add = await this.exec(["add", "-A", "--", ...pathspec], sourcePath, { env })
+      const add = await this.exec(["--literal-pathspecs", "add", "-A", "--", ...pathspec], sourcePath, { env })
       if (add.code !== 0) {
         throw new Error(add.stderr.trim() || "Failed to stage worktree snapshot")
       }
@@ -481,12 +481,14 @@ export class GitOps {
       }
       await fs.rm(full, { force: true })
       // Also remove from git index in case it was staged
-      await this.raw(["rm", "--cached", "--force", "--ignore-unmatch", "--", file], cwd).catch(() => "")
+      await this.raw(["--literal-pathspecs", "rm", "--cached", "--force", "--ignore-unmatch", "--", file], cwd).catch(
+        () => "",
+      )
       return { ok: true, message: "Removed added file" }
     }
 
     // Modified or deleted file — restore from merge-base
-    const result = await this.exec(["checkout", base, "--", file], cwd)
+    const result = await this.exec(["--literal-pathspecs", "checkout", base, "--", file], cwd)
     if (result.code !== 0) {
       return { ok: false, message: result.stderr.trim() || "Failed to revert file" }
     }
@@ -494,7 +496,7 @@ export class GitOps {
     // restored the file into the index correctly — resetting to HEAD would drop
     // it from the index and make it appear as a new untracked file.
     if (status === "modified") {
-      await this.raw(["reset", "HEAD", "--", file], cwd).catch(() => "")
+      await this.raw(["--literal-pathspecs", "reset", "HEAD", "--", file], cwd).catch(() => "")
     }
     return { ok: true, message: "Reverted file to base" }
   }

--- a/packages/kilo-vscode/src/agent-manager/local-diff.ts
+++ b/packages/kilo-vscode/src/agent-manager/local-diff.ts
@@ -179,6 +179,11 @@ async function statStamp(dir: string, file: string): Promise<string> {
   return `${stat.size}:${stat.mtimeMs}`
 }
 
+function trackedStamp(status: Status, additions: number, deletions: number, anc: string, stat?: string): string {
+  if (status === "deleted") return `deleted:${anc}`
+  return `${status}:${additions}:${deletions}:${anc}${stat ? `:${stat}` : ""}`
+}
+
 async function lineCount(file: string): Promise<number> {
   const stat = await fs.lstat(file).catch(() => undefined)
   if (!stat || stat.size === 0) return 0
@@ -250,7 +255,7 @@ async function list(git: GitOps, dir: string, anc: string, log?: Log): Promise<W
       tracked: true,
       generatedLike: generatedLike(file),
       summarized,
-      stamp: status === "deleted" ? `deleted:${anc}` : `${status}:${stat.additions}:${stat.deletions}:${anc}`,
+      stamp: trackedStamp(status, stat.additions, stat.deletions, anc),
       kind: mime ? "image" : undefined,
     }
     result.push(entry)
@@ -258,46 +263,56 @@ async function list(git: GitOps, dir: string, anc: string, log?: Log): Promise<W
     if (status !== "deleted" && summarized) {
       stampTasks.push(
         statStamp(dir, file).then((s) => {
-          entry.stamp = `${status}:${stat.additions}:${stat.deletions}:${anc}:${s}`
+          entry.stamp = trackedStamp(status, stat.additions, stat.deletions, anc, s)
         }),
       )
     }
   }
 
   const untrackedFiles = untracked.code === 0 ? untracked.stdout.trim().split("\n").filter(Boolean) : []
-  const untrackedTasks = untrackedFiles.map(async (file): Promise<WorktreeDiffEntry | undefined> => {
-    if (seen.has(file)) return undefined
-    const full = resolveInside(dir, file)
-    if (!full) return undefined
-    const stat = await fs.lstat(full).catch(() => undefined)
-    if (!stat) return undefined
-    const binary = await binaryFile(full)
-    const mime = imageMime(file)
-    let patch = ""
-    let after = ""
-    let additions = 0
-    let summarized = true
+  const entries: WorktreeDiffEntry[] = []
+  let remaining = MAX_DETAIL_BYTES
+  for (const file of untrackedFiles) {
+    if (seen.has(file)) continue
+    const result = await untrackedEntry(dir, file, remaining)
+    if (!result) continue
+    entries.push(result.entry)
+    remaining -= result.cost
+  }
 
-    if (mime) {
-      summarized = true
-    } else if (binary) {
-      summarized = true
-    } else if (stat.size <= MAX_UNTRACKED_BYTES) {
-      const content = stat.isSymbolicLink()
-        ? await fs.readlink(full).catch(() => "")
-        : await fs.readFile(full, "utf-8").catch(() => "")
-      additions = linesOf(content)
-      patch = buildUntrackedPatch(file, content)
-      if (requiresContents(file)) after = content
-      summarized = false
-    }
+  await Promise.all(stampTasks)
+  result.push(...entries)
+  return result
+}
 
-    return {
+async function untrackedEntry(
+  dir: string,
+  file: string,
+  remaining: number,
+): Promise<{ entry: WorktreeDiffEntry; cost: number } | undefined> {
+  const full = resolveInside(dir, file)
+  if (!full) return undefined
+  const stat = await fs.lstat(full).catch(() => undefined)
+  if (!stat) return undefined
+
+  const binary = await binaryFile(full)
+  const mime = imageMime(file)
+  const canRead = !mime && !binary && stat.size <= MAX_UNTRACKED_BYTES && stat.size * 2 <= remaining
+  const content = canRead
+    ? stat.isSymbolicLink()
+      ? await fs.readlink(full).catch(() => "")
+      : await fs.readFile(full, "utf-8").catch(() => "")
+    : ""
+  const patch = canRead ? buildUntrackedPatch(file, content) : ""
+  const summarized = !canRead
+
+  return {
+    entry: {
       file,
       patch,
       before: "",
-      after,
-      additions,
+      after: requiresContents(file) && canRead ? content : "",
+      additions: canRead ? linesOf(content) : 0,
       deletions: 0,
       status: "added",
       tracked: false,
@@ -305,13 +320,9 @@ async function list(git: GitOps, dir: string, anc: string, log?: Log): Promise<W
       summarized,
       stamp: `${stat.size}:${stat.mtimeMs}`,
       kind: mime ? "image" : undefined,
-    }
-  })
-
-  const entries = await Promise.all(untrackedTasks)
-  await Promise.all(stampTasks)
-  result.push(...entries.filter((entry): entry is WorktreeDiffEntry => entry !== undefined))
-  return result
+    },
+    cost: canRead ? Math.max(stat.size * 2, patch.length) : 0,
+  }
 }
 
 function summarize(meta: Meta): WorktreeDiffEntry {
@@ -427,10 +438,7 @@ async function detailMeta(git: GitOps, dir: string, anc: string, file: string): 
     tracked: true,
     generatedLike: generatedLike(pathPart),
     binary: stat.binary,
-    stamp:
-      status === "deleted"
-        ? `deleted:${anc}`
-        : `${imageMime(pathPart) ? `${anc}:` : ""}${await statStamp(dir, pathPart)}`,
+    stamp: trackedStamp(status, stat.additions, stat.deletions, anc, await statStamp(dir, pathPart)),
   }
 }
 

--- a/packages/kilo-vscode/src/agent-manager/local-diff.ts
+++ b/packages/kilo-vscode/src/agent-manager/local-diff.ts
@@ -126,25 +126,22 @@ async function ancestor(git: GitOps, dir: string, base: string, log?: Log): Prom
   return anc
 }
 
-export function splitPatches(patchText: string): Map<string, string> {
+export function splitPatches(patchText: string, files: string[]): Map<string, string> {
   const map = new Map<string, string>()
-  if (!patchText) return map
-  const headerRegex = /^diff --git a\/(.+?) b\/(.+)$/gm
-  let match: RegExpExecArray | null
-  let lastFile: string | null = null
-  let lastStart = 0
-
-  while ((match = headerRegex.exec(patchText)) !== null) {
-    if (lastFile !== null) {
-      map.set(lastFile, patchText.slice(lastStart, match.index))
-    }
-    lastFile = match[2]!
-    lastStart = match.index
-  }
-  if (lastFile !== null) {
-    map.set(lastFile, patchText.slice(lastStart))
+  if (!patchText || files.length === 0) return map
+  const starts = files
+    .map((file) => ({ file, start: patchText.indexOf(`diff --git a/${file} b/${file}\n`) }))
+    .filter((item) => item.start >= 0)
+    .sort((a, b) => a.start - b.start)
+  for (let i = 0; i < starts.length; i++) {
+    const item = starts[i]!
+    map.set(item.file, patchText.slice(item.start, starts[i + 1]?.start ?? patchText.length))
   }
   return map
+}
+
+export function requiresContents(file: string): boolean {
+  return /\.(md|mdx|markdown)$/i.test(file)
 }
 
 function parseNumstatOutput(stdout: string) {
@@ -202,7 +199,9 @@ function statusFromCode(code: string): Status {
 
 async function list(git: GitOps, dir: string, anc: string, log?: Log): Promise<WorktreeDiffEntry[]> {
   const [patchResult, nameStatus, numstatResult, untracked] = await Promise.all([
-    git.execGit(["-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-renames", "-U3", anc], dir),
+    git.execGit(["-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-renames", "-U3", anc], dir, {
+      maxOutput: MAX_DETAIL_BYTES,
+    }),
     git.execGit(["-c", "core.quotepath=false", "diff", "--name-status", "--no-renames", anc], dir),
     git.execGit(["-c", "core.quotepath=false", "diff", "--numstat", "--no-renames", anc], dir),
     git.execGit(["ls-files", "--others", "--exclude-standard"], dir),
@@ -213,30 +212,36 @@ async function list(git: GitOps, dir: string, anc: string, log?: Log): Promise<W
     return []
   }
 
+  const tracked = nameStatus.stdout
+    .trim()
+    .split("\n")
+    .flatMap((line) => {
+      if (!line) return []
+      const parts = line.split("\t")
+      const code = parts[0]
+      const file = parts.slice(1).join("\t")
+      return file && code ? [{ file, code }] : []
+    })
   const counts = numstatResult.code === 0 ? parseNumstatOutput(numstatResult.stdout) : new Map()
-  const patches = splitPatches(patchResult.code === 0 ? patchResult.stdout : "")
+  const patches = splitPatches(
+    patchResult.code === 0 ? patchResult.stdout : "",
+    tracked.map((item) => item.file),
+  )
   const result: WorktreeDiffEntry[] = []
   const seen = new Set<string>()
   const stampTasks: Promise<void>[] = []
 
-  for (const line of nameStatus.stdout.trim().split("\n")) {
-    if (!line) continue
-    const parts = line.split("\t")
-    const code = parts[0]
-    const file = parts.slice(1).join("\t")
-    if (!file || !code) continue
+  for (const { file, code } of tracked) {
     seen.add(file)
     const status = statusFromCode(code)
     const stat = counts.get(file) ?? { additions: 0, deletions: 0, binary: false }
     const mime = imageMime(file)
-    const patch = patches.get(file) ?? ""
-    const isLarge = patch.length > MAX_DETAIL_BYTES
-    const summarized = mime !== undefined || stat.binary || isLarge
-    const actualPatch = summarized ? "" : patch
+    const patch = patches.get(file)
+    const summarized = mime !== undefined || stat.binary || patch === undefined || requiresContents(file)
 
     const entry: WorktreeDiffEntry = {
       file,
-      patch: actualPatch,
+      patch: summarized ? "" : patch,
       before: "",
       after: "",
       additions: stat.additions,
@@ -250,25 +255,26 @@ async function list(git: GitOps, dir: string, anc: string, log?: Log): Promise<W
     }
     result.push(entry)
 
-    if (mime) {
+    if (status !== "deleted" && summarized) {
       stampTasks.push(
         statStamp(dir, file).then((s) => {
-          entry.stamp = `${anc}:${s}`
+          entry.stamp = `${status}:${stat.additions}:${stat.deletions}:${anc}:${s}`
         }),
       )
     }
   }
 
   const untrackedFiles = untracked.code === 0 ? untracked.stdout.trim().split("\n").filter(Boolean) : []
-  const untrackedTasks = untrackedFiles.map(async (file) => {
-    if (seen.has(file)) return
+  const untrackedTasks = untrackedFiles.map(async (file): Promise<WorktreeDiffEntry | undefined> => {
+    if (seen.has(file)) return undefined
     const full = resolveInside(dir, file)
-    if (!full) return
+    if (!full) return undefined
     const stat = await fs.lstat(full).catch(() => undefined)
-    if (!stat) return
+    if (!stat) return undefined
     const binary = await binaryFile(full)
     const mime = imageMime(file)
     let patch = ""
+    let after = ""
     let additions = 0
     let summarized = true
 
@@ -282,14 +288,15 @@ async function list(git: GitOps, dir: string, anc: string, log?: Log): Promise<W
         : await fs.readFile(full, "utf-8").catch(() => "")
       additions = linesOf(content)
       patch = buildUntrackedPatch(file, content)
+      if (requiresContents(file)) after = content
       summarized = false
     }
 
-    result.push({
+    return {
       file,
       patch,
       before: "",
-      after: "",
+      after,
       additions,
       deletions: 0,
       status: "added",
@@ -298,10 +305,12 @@ async function list(git: GitOps, dir: string, anc: string, log?: Log): Promise<W
       summarized,
       stamp: `${stat.size}:${stat.mtimeMs}`,
       kind: mime ? "image" : undefined,
-    })
+    }
   })
 
-  await Promise.all([...stampTasks, ...untrackedTasks])
+  const entries = await Promise.all(untrackedTasks)
+  await Promise.all(stampTasks)
+  result.push(...entries.filter((entry): entry is WorktreeDiffEntry => entry !== undefined))
   return result
 }
 

--- a/packages/kilo-vscode/src/agent-manager/local-diff.ts
+++ b/packages/kilo-vscode/src/agent-manager/local-diff.ts
@@ -95,6 +95,8 @@ export function generatedLike(file: string): boolean {
 
 const BASE_CANDIDATES = ["main", "master", "dev", "develop"]
 
+const ancCache = new Map<string, { anc: string; time: number }>()
+
 export async function resolveBase(git: GitOps, dir: string, base: string): Promise<string> {
   // If the caller gave an explicit base, honor it. Return it as-is so merge-base
   // fails loudly on a stale/misspelled ref instead of silently diffing against
@@ -109,23 +111,48 @@ export async function resolveBase(git: GitOps, dir: string, base: string): Promi
 
 async function ancestor(git: GitOps, dir: string, base: string, log?: Log): Promise<string | undefined> {
   const resolvedBase = await resolveBase(git, dir, base)
+  const cacheKey = `${dir}\0${resolvedBase}`
+  const cached = ancCache.get(cacheKey)
+  if (cached && Date.now() - cached.time < 2000) return cached.anc
+
   const result = await git.execGit(["merge-base", "HEAD", resolvedBase], dir)
   if (result.code !== 0) {
     log?.("git merge-base failed", { code: result.code, stderr: result.stderr.trim(), dir, base, resolvedBase })
     return undefined
   }
-  return result.stdout.trim()
+  const anc = result.stdout.trim()
+  ancCache.set(cacheKey, { anc, time: Date.now() })
+  if (ancCache.size > 32) ancCache.delete(ancCache.keys().next().value!)
+  return anc
 }
 
-async function numstat(git: GitOps, dir: string, base: string, file?: string) {
-  const args = ["-c", "core.quotepath=false", "diff", "--numstat", "--no-renames", base]
-  if (file) args.push("--", file)
-  const result = await git.execGit(args, dir)
+export function splitPatches(patchText: string): Map<string, string> {
+  const map = new Map<string, string>()
+  if (!patchText) return map
+  const headerRegex = /^diff --git a\/(.+?) b\/(.+)$/gm
+  let match: RegExpExecArray | null
+  let lastFile: string | null = null
+  let lastStart = 0
+
+  while ((match = headerRegex.exec(patchText)) !== null) {
+    if (lastFile !== null) {
+      map.set(lastFile, patchText.slice(lastStart, match.index))
+    }
+    lastFile = match[2]!
+    lastStart = match.index
+  }
+  if (lastFile !== null) {
+    map.set(lastFile, patchText.slice(lastStart))
+  }
+  return map
+}
+
+function parseNumstatOutput(stdout: string) {
   const map = new Map<string, { additions: number; deletions: number; binary: boolean }>()
-  if (result.code !== 0) return map
-  for (const line of result.stdout.trim().split("\n")) {
+  for (const line of stdout.trim().split("\n")) {
     if (!line) continue
     const parts = line.split("\t")
+    if (parts.length < 3) continue
     const add = parts[0]
     const del = parts[1]
     const name = parts.slice(2).join("\t")
@@ -137,6 +164,14 @@ async function numstat(git: GitOps, dir: string, base: string, file?: string) {
     })
   }
   return map
+}
+
+async function numstat(git: GitOps, dir: string, base: string, file?: string) {
+  const args = ["-c", "core.quotepath=false", "diff", "--numstat", "--no-renames", base]
+  if (file) args.push("--", file)
+  const result = await git.execGit(args, dir)
+  if (result.code !== 0) return new Map<string, { additions: number; deletions: number; binary: boolean }>()
+  return parseNumstatOutput(result.stdout)
 }
 
 async function statStamp(dir: string, file: string): Promise<string> {
@@ -165,19 +200,24 @@ function statusFromCode(code: string): Status {
   return "modified"
 }
 
-async function list(git: GitOps, dir: string, anc: string, log?: Log): Promise<Meta[]> {
-  const nameStatus = await git.execGit(
-    ["-c", "core.quotepath=false", "diff", "--name-status", "--no-renames", anc],
-    dir,
-  )
+async function list(git: GitOps, dir: string, anc: string, log?: Log): Promise<WorktreeDiffEntry[]> {
+  const [patchResult, nameStatus, numstatResult, untracked] = await Promise.all([
+    git.execGit(["-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-renames", "-U3", anc], dir),
+    git.execGit(["-c", "core.quotepath=false", "diff", "--name-status", "--no-renames", anc], dir),
+    git.execGit(["-c", "core.quotepath=false", "diff", "--numstat", "--no-renames", anc], dir),
+    git.execGit(["ls-files", "--others", "--exclude-standard"], dir),
+  ])
+
   if (nameStatus.code !== 0) {
     log?.("git diff --name-status failed", { code: nameStatus.code, stderr: nameStatus.stderr.trim() })
     return []
   }
 
-  const counts = await numstat(git, dir, anc)
-  const result: Meta[] = []
+  const counts = numstatResult.code === 0 ? parseNumstatOutput(numstatResult.stdout) : new Map()
+  const patches = splitPatches(patchResult.code === 0 ? patchResult.stdout : "")
+  const result: WorktreeDiffEntry[] = []
   const seen = new Set<string>()
+  const stampTasks: Promise<void>[] = []
 
   for (const line of nameStatus.stdout.trim().split("\n")) {
     if (!line) continue
@@ -188,47 +228,80 @@ async function list(git: GitOps, dir: string, anc: string, log?: Log): Promise<M
     seen.add(file)
     const status = statusFromCode(code)
     const stat = counts.get(file) ?? { additions: 0, deletions: 0, binary: false }
-    result.push({
+    const mime = imageMime(file)
+    const patch = patches.get(file) ?? ""
+    const isLarge = patch.length > MAX_DETAIL_BYTES
+    const summarized = mime !== undefined || stat.binary || isLarge
+    const actualPatch = summarized ? "" : patch
+
+    const entry: WorktreeDiffEntry = {
       file,
+      patch: actualPatch,
+      before: "",
+      after: "",
       additions: stat.additions,
       deletions: stat.deletions,
       status,
       tracked: true,
       generatedLike: generatedLike(file),
-      binary: stat.binary,
-      stamp:
-        status === "deleted" ? `deleted:${anc}` : `${imageMime(file) ? `${anc}:` : ""}${await statStamp(dir, file)}`,
-    })
+      summarized,
+      stamp: status === "deleted" ? `deleted:${anc}` : `${status}:${stat.additions}:${stat.deletions}:${anc}`,
+      kind: mime ? "image" : undefined,
+    }
+    result.push(entry)
+
+    if (mime) {
+      stampTasks.push(
+        statStamp(dir, file).then((s) => {
+          entry.stamp = `${anc}:${s}`
+        }),
+      )
+    }
   }
 
-  const untracked = await git.execGit(["ls-files", "--others", "--exclude-standard"], dir)
-  if (untracked.code !== 0) {
-    log?.("git ls-files --others failed", { code: untracked.code, stderr: untracked.stderr.trim() })
-    return result
-  }
-
-  const files = untracked.stdout.trim()
-  if (!files) return result
-
-  for (const file of files.split("\n")) {
-    if (!file || seen.has(file)) continue
+  const untrackedFiles = untracked.code === 0 ? untracked.stdout.trim().split("\n").filter(Boolean) : []
+  const untrackedTasks = untrackedFiles.map(async (file) => {
+    if (seen.has(file)) return
     const full = resolveInside(dir, file)
-    if (!full) continue
-    const exists = await fs.lstat(full).catch(() => undefined)
-    if (!exists) continue
+    if (!full) return
+    const stat = await fs.lstat(full).catch(() => undefined)
+    if (!stat) return
     const binary = await binaryFile(full)
+    const mime = imageMime(file)
+    let patch = ""
+    let additions = 0
+    let summarized = true
+
+    if (mime) {
+      summarized = true
+    } else if (binary) {
+      summarized = true
+    } else if (stat.size <= MAX_UNTRACKED_BYTES) {
+      const content = stat.isSymbolicLink()
+        ? await fs.readlink(full).catch(() => "")
+        : await fs.readFile(full, "utf-8").catch(() => "")
+      additions = linesOf(content)
+      patch = buildUntrackedPatch(file, content)
+      summarized = false
+    }
+
     result.push({
       file,
-      additions: binary ? 0 : await lineCount(full),
+      patch,
+      before: "",
+      after: "",
+      additions,
       deletions: 0,
       status: "added",
       tracked: false,
       generatedLike: generatedLike(file),
-      binary,
-      stamp: await statStamp(dir, file),
+      summarized,
+      stamp: `${stat.size}:${stat.mtimeMs}`,
+      kind: mime ? "image" : undefined,
     })
-  }
+  })
 
+  await Promise.all([...stampTasks, ...untrackedTasks])
   return result
 }
 
@@ -251,20 +324,18 @@ function summarize(meta: Meta): WorktreeDiffEntry {
 }
 
 /**
- * Hot polling path. Returns one summarized entry per changed file (tracked or
- * untracked) relative to `merge-base HEAD base`. No file contents are read —
- * `before`/`after`/`patch` are empty strings. Matches the shape the server's
- * `WorktreeDiff.summary` emits.
+ * Fast unified diff path. Returns one entry per changed file (tracked or
+ * untracked) relative to `merge-base HEAD base`, with complete hunk patches
+ * populated for instant rendering.
  */
 export async function diffSummary(git: GitOps, dir: string, base: string, log?: Log): Promise<WorktreeDiffEntry[]> {
   const anc = await ancestor(git, dir, base, log)
   if (!anc) return []
-  const items = await list(git, dir, anc, log)
-  return items.map(summarize)
+  return await list(git, dir, anc, log)
 }
 
 export function createLocalDiff(git: GitOps, log?: Log) {
-  const states = new Map<string, { anc: string; metas: Map<string, Meta> }>()
+  const states = new Map<string, { anc: string; entries: Map<string, WorktreeDiffEntry> }>()
 
   return {
     summary: async (dir: string, base: string): Promise<WorktreeDiffEntry[]> => {
@@ -277,16 +348,27 @@ export function createLocalDiff(git: GitOps, log?: Log) {
 
       const items = await list(git, dir, anc, log)
       states.delete(id)
-      states.set(id, { anc, metas: new Map(items.map((item) => [item.file, item])) })
+      states.set(id, { anc, entries: new Map(items.map((item) => [item.file ?? "", item])) })
       if (states.size > 8) states.delete(states.keys().next().value!)
-      return items.map(summarize)
+      return items
     },
     file: async (dir: string, base: string, file: string): Promise<WorktreeDiffEntry | null> => {
       const state = states.get(`${dir}\0${base}`)
-      if (!state) return diffFile(git, dir, base, file, log)
-      const meta = state.metas.get(file)
-      if (!meta) return null
-      return materialize(git, dir, state.anc, meta, log)
+      if (state) {
+        const cached = state.entries.get(file)
+        if (cached && !cached.kind && cached.patch) {
+          const status = cached.status ?? "modified"
+          const before = await readBefore(git, dir, state.anc, file, status)
+          const after = await readAfter(dir, file, status)
+          return {
+            ...cached,
+            before,
+            after,
+            summarized: false,
+          }
+        }
+      }
+      return diffFile(git, dir, base, file, log)
     },
   }
 }

--- a/packages/kilo-vscode/src/agent-manager/local-diff.ts
+++ b/packages/kilo-vscode/src/agent-manager/local-diff.ts
@@ -23,6 +23,8 @@ type Log = (...args: unknown[]) => void
 /** Cap untracked file reads so line-counting a multi-megabyte log file does
  *  not stall the poll. Matches `GitOps.workingTreeStats()`. */
 const MAX_UNTRACKED_BYTES = 1_000_000
+const MAX_UNTRACKED_OUTPUT_BYTES = 4_000_000
+const MAX_UNTRACKED_ENTRIES = 10_000
 
 /** Cap per-side reads in the detail view. Opening very large tracked files
  *  used to spike `kilo serve`; now that the detail path runs in the
@@ -209,7 +211,7 @@ async function list(git: GitOps, dir: string, anc: string, log?: Log): Promise<W
     }),
     git.execGit(["-c", "core.quotepath=false", "diff", "--name-status", "--no-renames", anc], dir),
     git.execGit(["-c", "core.quotepath=false", "diff", "--numstat", "--no-renames", anc], dir),
-    git.execGit(["ls-files", "--others", "--exclude-standard"], dir),
+    git.execGit(["ls-files", "--others", "--exclude-standard"], dir, { maxOutput: MAX_UNTRACKED_OUTPUT_BYTES }),
   ])
 
   if (nameStatus.code !== 0) {
@@ -269,7 +271,11 @@ async function list(git: GitOps, dir: string, anc: string, log?: Log): Promise<W
     }
   }
 
-  const untrackedFiles = untracked.code === 0 ? untracked.stdout.trim().split("\n").filter(Boolean) : []
+  if (untracked.code !== 0) {
+    log?.("git ls-files --others failed", { code: untracked.code, stderr: untracked.stderr.trim() })
+  }
+  const untrackedFiles =
+    untracked.code === 0 ? untracked.stdout.trim().split("\n").filter(Boolean).slice(0, MAX_UNTRACKED_ENTRIES) : []
   const entries: WorktreeDiffEntry[] = []
   let remaining = MAX_DETAIL_BYTES
   for (const file of untrackedFiles) {

--- a/packages/kilo-vscode/src/agent-manager/local-diff.ts
+++ b/packages/kilo-vscode/src/agent-manager/local-diff.ts
@@ -129,13 +129,13 @@ async function ancestor(git: GitOps, dir: string, base: string, log?: Log): Prom
 export function splitPatches(patchText: string, files: string[]): Map<string, string> {
   const map = new Map<string, string>()
   if (!patchText || files.length === 0) return map
-  const starts = files
-    .map((file) => ({ file, start: patchText.indexOf(`diff --git a/${file} b/${file}\n`) }))
-    .filter((item) => item.start >= 0)
-    .sort((a, b) => a.start - b.start)
-  for (let i = 0; i < starts.length; i++) {
-    const item = starts[i]!
-    map.set(item.file, patchText.slice(item.start, starts[i + 1]?.start ?? patchText.length))
+  const names = new Map(files.map((file) => [`diff --git a/${file} b/${file}`, file]))
+  const headers = [...patchText.matchAll(/^diff --git a\/.* b\/.*$/gm)]
+  for (let i = 0; i < headers.length; i++) {
+    const header = headers[i]!
+    const file = names.get(header[0])
+    if (!file || header.index === undefined) continue
+    map.set(file, patchText.slice(header.index, headers[i + 1]?.index ?? patchText.length))
   }
   return map
 }

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -757,6 +757,11 @@ interface SetDiffBaseBranchIn {
   branch?: string
 }
 
+interface PreloadWorktreeDiffsIn {
+  type: "agentManager.preloadWorktreeDiffs"
+  worktreeIds: string[]
+}
+
 interface RefreshPRIn {
   type: "agentManager.refreshPR"
   worktreeId: string
@@ -1065,6 +1070,7 @@ export type AgentManagerInMessage =
   | RevertWorktreeFileIn
   | RequestDiffBranchesIn
   | SetDiffBaseBranchIn
+  | PreloadWorktreeDiffsIn
   | RefreshPRIn
   | OpenPRIn
   | CommentActionIn

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -338,6 +338,7 @@ interface ApplyWorktreeDiffResultMessage {
 
 interface WorktreeDiffLoadingMessage {
   type: "agentManager.worktreeDiffLoading"
+  projectId?: string
   sessionId: string
   loading: boolean
 }
@@ -345,18 +346,21 @@ interface WorktreeDiffLoadingMessage {
 /** Source-level notice for a diff context (e.g. snapshots disabled). */
 interface WorktreeDiffNoticeMessage {
   type: "agentManager.worktreeDiffNotice"
+  projectId?: string
   sessionId: string
   notice?: string
 }
 
 interface WorktreeDiffMessage {
   type: "agentManager.worktreeDiff"
+  projectId?: string
   sessionId: string
   diffs: WorktreeDiffEntry[]
 }
 
 interface WorktreeDiffFileMessage {
   type: "agentManager.worktreeDiffFile"
+  projectId?: string
   sessionId: string
   file: string
   diff: WorktreeDiffEntry | null
@@ -364,6 +368,7 @@ interface WorktreeDiffFileMessage {
 
 interface RevertWorktreeFileResultMessage {
   type: "agentManager.revertWorktreeFileResult"
+  projectId?: string
   sessionId: string
   file: string
   status: "success" | "error"
@@ -373,6 +378,7 @@ interface RevertWorktreeFileResultMessage {
 /** Branch picker data for a context's diff directory. */
 interface DiffBranchesMessage {
   type: "agentManager.diffBranches"
+  projectId?: string
   sessionId: string
   branches: BranchListItem[]
   defaultBranch: string
@@ -706,6 +712,7 @@ interface ImportFromPRIn {
 
 interface RequestWorktreeDiffIn {
   type: "agentManager.requestWorktreeDiff"
+  projectId?: string
   sessionId: string
   scope?: string
 }
@@ -718,6 +725,7 @@ interface ApplyWorktreeDiffIn {
 
 interface RequestWorktreeDiffFileIn {
   type: "agentManager.requestWorktreeDiffFile"
+  projectId?: string
   sessionId: string
   file: string
   scope?: string
@@ -727,6 +735,7 @@ interface RequestWorktreeDiffFileIn {
 
 interface StartDiffWatchIn {
   type: "agentManager.startDiffWatch"
+  projectId?: string
   sessionId: string
   scope?: string
   /** Active session for the session scope (ctx alone is a worktree/local id). */
@@ -739,6 +748,7 @@ interface StopDiffWatchIn {
 
 interface RevertWorktreeFileIn {
   type: "agentManager.revertWorktreeFile"
+  projectId?: string
   sessionId: string
   file: string
   scope?: string
@@ -746,12 +756,14 @@ interface RevertWorktreeFileIn {
 
 interface RequestDiffBranchesIn {
   type: "agentManager.requestDiffBranches"
+  projectId?: string
   sessionId: string
   scope?: string
 }
 
 interface SetDiffBaseBranchIn {
   type: "agentManager.setDiffBaseBranch"
+  projectId?: string
   sessionId: string
   scope?: string
   branch?: string
@@ -759,6 +771,7 @@ interface SetDiffBaseBranchIn {
 
 interface PreloadWorktreeDiffsIn {
   type: "agentManager.preloadWorktreeDiffs"
+  projectId?: string
   worktreeIds: string[]
 }
 

--- a/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
@@ -233,7 +233,7 @@ export class WorktreeDiffController {
   public async preload(ids: string[]): Promise<void> {
     await this.ready("stateReady rejected, continuing diff preload:")
     for (const id of ids) {
-      if (!id || this.diffCache.size >= CACHE_MAX_ENTRIES) break
+      if (!id) continue
       const parsed = parseDiffId(id)
       const ctx = parsed.ctx
       const key = composeDiffId(ctx, parsed.scope, parsed.sessionId)

--- a/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
@@ -42,7 +42,7 @@ export class WorktreeDiffController {
   private applying: string | undefined
   /** Intended watch mode for the active context; isPolling lags the initial fetch. */
   private poll = false
-  /** Ephemeral per-context base override, keyed by context id. */
+  /** Ephemeral per-context base override, keyed by project and context id. */
   private baseOverrides = new Map<string, string>()
   private diffCache = new Map<string, CacheEntry>()
   private revisions = new Map<string, number>()
@@ -182,7 +182,7 @@ export class WorktreeDiffController {
   ): Promise<void> {
     if (!file) return
     if (this.controller.currentId !== id || this.activeProjectId !== projectId) {
-      const result = await this.revertFile(id, file)
+      const result = await this.revertFile(id, file, projectId)
       this.postRevertResult(id, file, result, projectId)
       return
     }
@@ -236,8 +236,9 @@ export class WorktreeDiffController {
     projectId = this.activeProjectId ?? this.ctx.getProjectId(),
   ): Promise<void> {
     const { ctx } = parseDiffId(id)
-    if (branch) this.baseOverrides.set(ctx, branch)
-    else this.baseOverrides.delete(ctx)
+    const contextKey = this.contextKey(ctx, projectId)
+    if (branch) this.baseOverrides.set(contextKey, branch)
+    else this.baseOverrides.delete(contextKey)
     const cacheKey = this.cacheKey(id, projectId)
     this.revisions.set(cacheKey, (this.revisions.get(cacheKey) ?? 0) + 1)
     this.invalidate(ctx, projectId)
@@ -266,7 +267,7 @@ export class WorktreeDiffController {
       const cached = this.diffCache.get(cacheKey)
       if (cached && Date.now() - cached.time < CACHE_TTL) continue
 
-      const resolved = await this.resolve(ctx)
+      const resolved = await this.resolve(ctx, projectId)
       if (!resolved) continue
 
       const revision = this.revisions.get(cacheKey) ?? 0
@@ -295,16 +296,19 @@ export class WorktreeDiffController {
   }
 
   /** Branch picker data for a context's directory, using any active override. */
-  public async branches(id: string) {
+  public async branches(id: string, projectId = this.activeProjectId ?? this.ctx.getProjectId()) {
     await this.ready("stateReady rejected, continuing diff branches resolve:")
     const { ctx } = parseDiffId(id)
-    const target = await this.resolve(ctx)
+    const target = await this.resolve(ctx, projectId)
     if (!target) return undefined
-    return await this.ctx.catalog.listWorkspaceBranches(this.baseOverrides.get(ctx), target.directory)
+    return await this.ctx.catalog.listWorkspaceBranches(
+      this.baseOverrides.get(this.contextKey(ctx, projectId)),
+      target.directory,
+    )
   }
 
   public async sendBranches(id: string, projectId = this.activeProjectId ?? this.ctx.getProjectId()): Promise<void> {
-    const result = await this.branches(id).catch((err) => {
+    const result = await this.branches(id, projectId).catch((err) => {
       this.ctx.log("Failed to list diff branches:", err instanceof Error ? err.message : String(err))
       return undefined
     })
@@ -325,7 +329,7 @@ export class WorktreeDiffController {
     this.poll = poll
     await this.ready("stateReady rejected, continuing diff activate:")
     const { ctx } = parseDiffId(id)
-    const resolved = await this.resolve(ctx)
+    const resolved = await this.resolve(ctx, projectId)
     this.target = resolved ? { sessionId: id, ...resolved } : undefined
     // Clear any stale source notice up front; sources only push a notice when
     // one is active, so a swap away from a noticing source must reset it.
@@ -366,8 +370,11 @@ export class WorktreeDiffController {
     await this.controller.activate(id, { poll, fetch, known: warm?.diffs })
   }
 
-  private async resolve(ctxId: string): Promise<{ directory: string; baseBranch: string } | undefined> {
-    if (ctxId === LOCAL_DIFF_ID) return await this.resolveLocal()
+  private async resolve(
+    ctxId: string,
+    projectId = this.activeProjectId ?? this.ctx.getProjectId(),
+  ): Promise<{ directory: string; baseBranch: string } | undefined> {
+    if (ctxId === LOCAL_DIFF_ID) return await this.resolveLocal(projectId)
     const state = this.ctx.getState()
     if (!state) {
       this.ctx.log(`resolveDiffTarget: no state manager for context ${ctxId}`)
@@ -381,14 +388,16 @@ export class WorktreeDiffController {
       this.ctx.log(`resolveDiffTarget: worktree ${ctxId} not found`)
       return undefined
     }
-    const base = this.baseOverrides.get(ctxId) ?? remoteRef(worktree)
+    const base = this.baseOverrides.get(this.contextKey(ctxId, projectId)) ?? remoteRef(worktree)
     return { directory: worktree.path, baseBranch: base }
   }
 
-  private async resolveLocal(): Promise<{ directory: string; baseBranch: string } | undefined> {
+  private async resolveLocal(
+    projectId = this.activeProjectId ?? this.ctx.getProjectId(),
+  ): Promise<{ directory: string; baseBranch: string } | undefined> {
     const root = this.ctx.getRoot()
     if (!root) return undefined
-    const override = this.baseOverrides.get(LOCAL_DIFF_ID)
+    const override = this.baseOverrides.get(this.contextKey(LOCAL_DIFF_ID, projectId))
     if (override) {
       return { directory: root, baseBranch: override }
     }
@@ -401,6 +410,10 @@ export class WorktreeDiffController {
 
   private cacheKey(id: string, projectId = this.activeProjectId ?? this.ctx.getProjectId()): string {
     return `${projectId ?? "single"}\0${id}`
+  }
+
+  private contextKey(ctx: string, projectId = this.activeProjectId ?? this.ctx.getProjectId()): string {
+    return `${projectId ?? "single"}\0${ctx}`
   }
 
   private remember(id: string, diffs: AgentManagerDiffFile[]): void {
@@ -441,10 +454,14 @@ export class WorktreeDiffController {
     }
   }
 
-  private async revertFile(id: string, file: string): Promise<{ ok: boolean; message: string }> {
+  private async revertFile(
+    id: string,
+    file: string,
+    projectId = this.activeProjectId ?? this.ctx.getProjectId(),
+  ): Promise<{ ok: boolean; message: string }> {
     await this.ready("stateReady rejected, continuing revert resolve:")
     const { ctx } = parseDiffId(id)
-    const target = await this.resolve(ctx)
+    const target = await this.resolve(ctx, projectId)
     if (!target) return { ok: false, message: "Could not resolve diff target" }
 
     try {

--- a/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
@@ -2,20 +2,24 @@ import { SourceController } from "../diff/SourceController"
 import { resolveLocalDiffTarget } from "../diff/shared/target"
 import { WorktreeDiffReverter, type StatusResolver } from "../diff/shared/reverter"
 import type { DiffFile, PanelContext } from "../diff/types"
-import type { DiffSource, DiffSourceNotice } from "../diff/sources/types"
+import type { DiffSource } from "../diff/sources/types"
 import type { DiffSourceCatalog } from "../diff/sources/catalog"
 import type { ApplyConflict, GitOps } from "./GitOps"
 import { shouldStopDiffPolling } from "./delete-worktree"
 import { remoteRef, type ManagedSession, type WorktreeStateManager } from "./WorktreeStateManager"
-import { parseDiffId, scopeToSourceId } from "./diff-scope"
+import { composeDiffId, parseDiffId, scopeToSourceId } from "./diff-scope"
 import { diffSummary } from "./local-diff"
 import type { AgentManagerOutMessage, WorktreeDiffEntry } from "./types"
 
 const LOCAL_DIFF_ID = "local" as const
+const CACHE_MAX_ENTRIES = 4
+const CACHE_MAX_BYTES = 40_000_000
+const CACHE_TTL = 10_000
 
 type Target = { sessionId: string; directory: string; baseBranch: string }
 
 type AgentManagerDiffFile = DiffFile & WorktreeDiffEntry
+type CacheEntry = { diffs: AgentManagerDiffFile[]; time: number; bytes: number }
 
 export interface WorktreeDiffControllerContext {
   getState: () => WorktreeStateManager | undefined
@@ -39,7 +43,8 @@ export class WorktreeDiffController {
   private poll = false
   /** Ephemeral per-context base override, keyed by context id. */
   private baseOverrides = new Map<string, string>()
-  private diffCache = new Map<string, { diffs: AgentManagerDiffFile[]; notice?: DiffSourceNotice; time: number }>()
+  private diffCache = new Map<string, CacheEntry>()
+  private revisions = new Map<string, number>()
   private preloading = new Set<string>()
 
   constructor(private readonly ctx: WorktreeDiffControllerContext) {
@@ -59,8 +64,7 @@ export class WorktreeDiffController {
           notice,
         }),
         diffs: (source, diffs) => {
-          const { ctx } = parseDiffId(source.descriptor.id)
-          this.diffCache.set(ctx, { diffs: diffs as AgentManagerDiffFile[], time: Date.now() })
+          this.remember(source.descriptor.id, diffs as AgentManagerDiffFile[])
           return {
             type: "agentManager.worktreeDiff",
             sessionId: source.descriptor.id,
@@ -98,9 +102,7 @@ export class WorktreeDiffController {
     const current = this.controller.currentId
     const ctxId = current ? parseDiffId(current).ctx : undefined
     const stop = shouldStopDiffPolling(path, sessions, this.target, ctxId)
-    if (stop && ctxId) {
-      this.diffCache.delete(ctxId)
-    }
+    if (stop && ctxId) this.invalidate(ctxId)
     return stop
   }
 
@@ -214,7 +216,8 @@ export class WorktreeDiffController {
     const { ctx } = parseDiffId(id)
     if (branch) this.baseOverrides.set(ctx, branch)
     else this.baseOverrides.delete(ctx)
-    this.diffCache.delete(ctx)
+    this.revisions.set(ctx, (this.revisions.get(ctx) ?? 0) + 1)
+    this.invalidate(ctx)
     // Nothing to rebuild when the context isn't active; the override is
     // picked up the next time start()/request() resolves it.
     if (this.controller.currentId !== id) return
@@ -230,31 +233,35 @@ export class WorktreeDiffController {
   public async preload(ids: string[]): Promise<void> {
     await this.ready("stateReady rejected, continuing diff preload:")
     for (const id of ids) {
-      if (!id) continue
-      const { ctx } = parseDiffId(id)
-      if (this.controller.currentId === id || this.preloading.has(ctx)) continue
-      const cached = this.diffCache.get(ctx)
-      if (cached && Date.now() - cached.time < 10_000) continue
+      if (!id || this.diffCache.size >= CACHE_MAX_ENTRIES) break
+      const parsed = parseDiffId(id)
+      const ctx = parsed.ctx
+      const key = composeDiffId(ctx, parsed.scope, parsed.sessionId)
+      if (this.controller.currentId === key || this.preloading.has(key)) continue
+      const cached = this.diffCache.get(key)
+      if (cached && Date.now() - cached.time < CACHE_TTL) continue
 
       const resolved = await this.resolve(ctx)
       if (!resolved) continue
 
-      this.preloading.add(ctx)
+      const revision = this.revisions.get(ctx) ?? 0
+      this.preloading.add(key)
       try {
         const entries = await diffSummary(this.ctx.git, resolved.directory, resolved.baseBranch, (...args) =>
           this.ctx.log(...args),
         )
         const diffs = entries.map(toDiffFile) as AgentManagerDiffFile[]
-        this.diffCache.set(ctx, { diffs, time: Date.now() })
+        if ((this.revisions.get(ctx) ?? 0) !== revision) continue
+        this.remember(key, diffs)
         this.ctx.post({
           type: "agentManager.worktreeDiff",
-          sessionId: id,
+          sessionId: key,
           diffs,
         })
       } catch (err) {
         this.ctx.log("Preload diff failed for", id, err)
       } finally {
-        this.preloading.delete(ctx)
+        this.preloading.delete(key)
       }
     }
   }
@@ -266,6 +273,15 @@ export class WorktreeDiffController {
     const target = await this.resolve(ctx)
     if (!target) return undefined
     return await this.ctx.catalog.listWorkspaceBranches(this.baseOverrides.get(ctx), target.directory)
+  }
+
+  public async sendBranches(id: string): Promise<void> {
+    const result = await this.branches(id).catch((err) => {
+      this.ctx.log("Failed to list diff branches:", err instanceof Error ? err.message : String(err))
+      return undefined
+    })
+    if (!result) return
+    this.ctx.post({ type: "agentManager.diffBranches", sessionId: id, ...result })
   }
 
   private async activate(id: string, poll: boolean, fetch: boolean): Promise<void> {
@@ -280,17 +296,19 @@ export class WorktreeDiffController {
     this.ctx.post({ type: "agentManager.worktreeDiffNotice", sessionId: id, notice: undefined })
 
     // If we have cached diffs for this context, push them immediately to eliminate initial loading delay!
-    const cached = this.diffCache.get(ctx)
-    if (cached) {
+    const cached = this.diffCache.get(id)
+    const warm = cached && Date.now() - cached.time < CACHE_TTL ? cached : undefined
+    if (warm) {
+      this.diffCache.delete(id)
+      this.diffCache.set(id, warm)
       this.ctx.post({
         type: "agentManager.worktreeDiff",
         sessionId: id,
-        diffs: cached.diffs,
+        diffs: warm.diffs,
       })
-      if (cached.notice !== undefined) {
-        this.ctx.post({ type: "agentManager.worktreeDiffNotice", sessionId: id, notice: cached.notice })
-      }
       this.ctx.post({ type: "agentManager.worktreeDiffLoading", sessionId: id, loading: false })
+    } else if (cached) {
+      this.diffCache.delete(id)
     }
 
     this.controller.setContext({
@@ -307,7 +325,7 @@ export class WorktreeDiffController {
       git: this.ctx.git,
       log: (...args) => this.ctx.log(...args),
     })
-    await this.controller.activate(id, { poll, fetch })
+    await this.controller.activate(id, { poll, fetch, known: warm?.diffs })
   }
 
   private async resolve(ctxId: string): Promise<{ directory: string; baseBranch: string } | undefined> {
@@ -341,6 +359,26 @@ export class WorktreeDiffController {
 
   private async ready(msg: string): Promise<void> {
     await this.ctx.getStateReady()?.catch((err) => this.ctx.log(msg, err))
+  }
+
+  private remember(id: string, diffs: AgentManagerDiffFile[]): void {
+    const bytes = diffs.reduce(
+      (sum, diff) => sum + (diff.patch?.length ?? 0) + diff.before.length + diff.after.length,
+      0,
+    )
+    this.diffCache.delete(id)
+    if (bytes > CACHE_MAX_BYTES) return
+    this.diffCache.set(id, { diffs, time: Date.now(), bytes })
+    const total = () => [...this.diffCache.values()].reduce((sum, entry) => sum + entry.bytes, 0)
+    while (this.diffCache.size > CACHE_MAX_ENTRIES || total() > CACHE_MAX_BYTES) {
+      this.diffCache.delete(this.diffCache.keys().next().value!)
+    }
+  }
+
+  private invalidate(ctx: string): void {
+    for (const id of this.diffCache.keys()) {
+      if (parseDiffId(id).ctx === ctx) this.diffCache.delete(id)
+    }
   }
 
   /**

--- a/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
@@ -48,6 +48,8 @@ export class WorktreeDiffController {
   private revisions = new Map<string, number>()
   private preloading = new Set<string>()
   private activeProjectId: string | undefined
+  private activation = 0
+  private sourceProjects = new WeakMap<DiffSource, string | undefined>()
 
   constructor(private readonly ctx: WorktreeDiffControllerContext) {
     this.controller = new SourceController(
@@ -57,35 +59,36 @@ export class WorktreeDiffController {
       {
         loading: (source, loading) => ({
           type: "agentManager.worktreeDiffLoading",
-          projectId: this.activeProjectId,
+          projectId: this.projectFor(source),
           sessionId: source.descriptor.id,
           loading,
         }),
         notice: (source, notice) => ({
           type: "agentManager.worktreeDiffNotice",
-          projectId: this.activeProjectId,
+          projectId: this.projectFor(source),
           sessionId: source.descriptor.id,
           notice,
         }),
         diffs: (source, diffs) => {
-          this.remember(this.cacheKey(source.descriptor.id), diffs as AgentManagerDiffFile[])
+          const projectId = this.projectFor(source)
+          this.remember(this.cacheKey(source.descriptor.id, projectId), diffs as AgentManagerDiffFile[])
           return {
             type: "agentManager.worktreeDiff",
-            projectId: this.activeProjectId,
+            projectId,
             sessionId: source.descriptor.id,
             diffs: diffs as AgentManagerDiffFile[],
           }
         },
         diffFile: (source, file, diff) => ({
           type: "agentManager.worktreeDiffFile",
-          projectId: this.activeProjectId,
+          projectId: this.projectFor(source),
           sessionId: source?.descriptor.id ?? "",
           file,
           diff: diff as AgentManagerDiffFile | null,
         }),
         revertFileResult: (source, file, result) => ({
           type: "agentManager.revertWorktreeFileResult",
-          projectId: this.activeProjectId,
+          projectId: this.projectFor(source),
           sessionId: source?.descriptor.id ?? "",
           file,
           status: result.ok ? "success" : "error",
@@ -219,6 +222,7 @@ export class WorktreeDiffController {
   }
 
   public stop(): void {
+    this.activation++
     this.controller.stop()
     this.target = undefined
     this.poll = false
@@ -322,14 +326,17 @@ export class WorktreeDiffController {
     fetch: boolean,
     projectId = this.ctx.getProjectId(),
   ): Promise<void> {
+    const activation = ++this.activation
     this.activeProjectId = projectId
     const revisionKey = this.cacheKey(id, projectId)
     this.revisions.set(revisionKey, (this.revisions.get(revisionKey) ?? 0) + 1)
     this.target = undefined
     this.poll = poll
     await this.ready("stateReady rejected, continuing diff activate:")
+    if (activation !== this.activation) return
     const { ctx } = parseDiffId(id)
     const resolved = await this.resolve(ctx, projectId)
+    if (activation !== this.activation) return
     this.target = resolved ? { sessionId: id, ...resolved } : undefined
     // Clear any stale source notice up front; sources only push a notice when
     // one is active, so a swap away from a noticing source must reset it.
@@ -448,10 +455,16 @@ export class WorktreeDiffController {
   private source(id: string, panelCtx: PanelContext): DiffSource {
     const { ctx, scope, sessionId } = parseDiffId(id)
     const built = this.ctx.catalog.build(scopeToSourceId(scope, ctx, sessionId), panelCtx)
-    return {
+    const source = {
       ...built,
       descriptor: { ...built.descriptor, id },
     }
+    this.sourceProjects.set(source, this.activeProjectId)
+    return source
+  }
+
+  private projectFor(source: DiffSource | undefined): string | undefined {
+    return source ? this.sourceProjects.get(source) : this.activeProjectId
   }
 
   private async revertFile(

--- a/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
@@ -2,12 +2,13 @@ import { SourceController } from "../diff/SourceController"
 import { resolveLocalDiffTarget } from "../diff/shared/target"
 import { WorktreeDiffReverter, type StatusResolver } from "../diff/shared/reverter"
 import type { DiffFile, PanelContext } from "../diff/types"
-import type { DiffSource } from "../diff/sources/types"
+import type { DiffSource, DiffSourceNotice } from "../diff/sources/types"
 import type { DiffSourceCatalog } from "../diff/sources/catalog"
 import type { ApplyConflict, GitOps } from "./GitOps"
 import { shouldStopDiffPolling } from "./delete-worktree"
 import { remoteRef, type ManagedSession, type WorktreeStateManager } from "./WorktreeStateManager"
 import { parseDiffId, scopeToSourceId } from "./diff-scope"
+import { diffSummary } from "./local-diff"
 import type { AgentManagerOutMessage, WorktreeDiffEntry } from "./types"
 
 const LOCAL_DIFF_ID = "local" as const
@@ -38,6 +39,8 @@ export class WorktreeDiffController {
   private poll = false
   /** Ephemeral per-context base override, keyed by context id. */
   private baseOverrides = new Map<string, string>()
+  private diffCache = new Map<string, { diffs: AgentManagerDiffFile[]; notice?: DiffSourceNotice; time: number }>()
+  private preloading = new Set<string>()
 
   constructor(private readonly ctx: WorktreeDiffControllerContext) {
     this.controller = new SourceController(
@@ -55,11 +58,15 @@ export class WorktreeDiffController {
           sessionId: source.descriptor.id,
           notice,
         }),
-        diffs: (source, diffs) => ({
-          type: "agentManager.worktreeDiff",
-          sessionId: source.descriptor.id,
-          diffs: diffs as AgentManagerDiffFile[],
-        }),
+        diffs: (source, diffs) => {
+          const { ctx } = parseDiffId(source.descriptor.id)
+          this.diffCache.set(ctx, { diffs: diffs as AgentManagerDiffFile[], time: Date.now() })
+          return {
+            type: "agentManager.worktreeDiff",
+            sessionId: source.descriptor.id,
+            diffs: diffs as AgentManagerDiffFile[],
+          }
+        },
         diffFile: (source, file, diff) => ({
           type: "agentManager.worktreeDiffFile",
           sessionId: source?.descriptor.id ?? "",
@@ -90,7 +97,11 @@ export class WorktreeDiffController {
     // orphaned-session check matches sessions of the deleted worktree.
     const current = this.controller.currentId
     const ctxId = current ? parseDiffId(current).ctx : undefined
-    return shouldStopDiffPolling(path, sessions, this.target, ctxId)
+    const stop = shouldStopDiffPolling(path, sessions, this.target, ctxId)
+    if (stop && ctxId) {
+      this.diffCache.delete(ctxId)
+    }
+    return stop
   }
 
   public async apply(worktreeId: string, value?: unknown): Promise<void> {
@@ -203,6 +214,7 @@ export class WorktreeDiffController {
     const { ctx } = parseDiffId(id)
     if (branch) this.baseOverrides.set(ctx, branch)
     else this.baseOverrides.delete(ctx)
+    this.diffCache.delete(ctx)
     // Nothing to rebuild when the context isn't active; the override is
     // picked up the next time start()/request() resolves it.
     if (this.controller.currentId !== id) return
@@ -212,6 +224,39 @@ export class WorktreeDiffController {
     // recorded poll intent preserves watch mode even when the initial fetch
     // is still in flight (isPolling only turns true once it resolves).
     await this.activate(id, this.poll, true)
+  }
+
+  /** Preload diffs for adjacent or visible worktrees in the background. */
+  public async preload(ids: string[]): Promise<void> {
+    await this.ready("stateReady rejected, continuing diff preload:")
+    for (const id of ids) {
+      if (!id) continue
+      const { ctx } = parseDiffId(id)
+      if (this.controller.currentId === id || this.preloading.has(ctx)) continue
+      const cached = this.diffCache.get(ctx)
+      if (cached && Date.now() - cached.time < 10_000) continue
+
+      const resolved = await this.resolve(ctx)
+      if (!resolved) continue
+
+      this.preloading.add(ctx)
+      try {
+        const entries = await diffSummary(this.ctx.git, resolved.directory, resolved.baseBranch, (...args) =>
+          this.ctx.log(...args),
+        )
+        const diffs = entries.map(toDiffFile) as AgentManagerDiffFile[]
+        this.diffCache.set(ctx, { diffs, time: Date.now() })
+        this.ctx.post({
+          type: "agentManager.worktreeDiff",
+          sessionId: id,
+          diffs,
+        })
+      } catch (err) {
+        this.ctx.log("Preload diff failed for", id, err)
+      } finally {
+        this.preloading.delete(ctx)
+      }
+    }
   }
 
   /** Branch picker data for a context's directory, using any active override. */
@@ -233,6 +278,21 @@ export class WorktreeDiffController {
     // Clear any stale source notice up front; sources only push a notice when
     // one is active, so a swap away from a noticing source must reset it.
     this.ctx.post({ type: "agentManager.worktreeDiffNotice", sessionId: id, notice: undefined })
+
+    // If we have cached diffs for this context, push them immediately to eliminate initial loading delay!
+    const cached = this.diffCache.get(ctx)
+    if (cached) {
+      this.ctx.post({
+        type: "agentManager.worktreeDiff",
+        sessionId: id,
+        diffs: cached.diffs,
+      })
+      if (cached.notice !== undefined) {
+        this.ctx.post({ type: "agentManager.worktreeDiffNotice", sessionId: id, notice: cached.notice })
+      }
+      this.ctx.post({ type: "agentManager.worktreeDiffLoading", sessionId: id, loading: false })
+    }
+
     this.controller.setContext({
       workspaceRoot: this.ctx.getRoot(),
       dir: resolved?.directory,
@@ -342,6 +402,24 @@ export class WorktreeDiffController {
       message,
       conflicts,
     })
+  }
+}
+
+function toDiffFile(entry: WorktreeDiffEntry): AgentManagerDiffFile {
+  return {
+    file: entry.file ?? "",
+    before: entry.before ?? "",
+    after: entry.after ?? "",
+    patch: entry.patch,
+    additions: entry.additions,
+    deletions: entry.deletions,
+    status: entry.status,
+    tracked: entry.tracked,
+    generatedLike: entry.generatedLike,
+    summarized: entry.summarized,
+    stamp: entry.stamp,
+    kind: entry.kind,
+    image: entry.image,
   }
 }
 

--- a/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
@@ -24,6 +24,7 @@ type CacheEntry = { diffs: AgentManagerDiffFile[]; time: number; bytes: number }
 export interface WorktreeDiffControllerContext {
   getState: () => WorktreeStateManager | undefined
   getRoot: () => string | undefined
+  getProjectId: () => string | undefined
   getStateReady: () => Promise<void> | undefined
   /** Builds the underlying per-scope diff sources (workspace/staged/unstaged/session). */
   catalog: DiffSourceCatalog
@@ -46,6 +47,7 @@ export class WorktreeDiffController {
   private diffCache = new Map<string, CacheEntry>()
   private revisions = new Map<string, number>()
   private preloading = new Set<string>()
+  private activeProjectId: string | undefined
 
   constructor(private readonly ctx: WorktreeDiffControllerContext) {
     this.controller = new SourceController(
@@ -55,30 +57,35 @@ export class WorktreeDiffController {
       {
         loading: (source, loading) => ({
           type: "agentManager.worktreeDiffLoading",
+          projectId: this.activeProjectId,
           sessionId: source.descriptor.id,
           loading,
         }),
         notice: (source, notice) => ({
           type: "agentManager.worktreeDiffNotice",
+          projectId: this.activeProjectId,
           sessionId: source.descriptor.id,
           notice,
         }),
         diffs: (source, diffs) => {
-          this.remember(source.descriptor.id, diffs as AgentManagerDiffFile[])
+          this.remember(this.cacheKey(source.descriptor.id), diffs as AgentManagerDiffFile[])
           return {
             type: "agentManager.worktreeDiff",
+            projectId: this.activeProjectId,
             sessionId: source.descriptor.id,
             diffs: diffs as AgentManagerDiffFile[],
           }
         },
         diffFile: (source, file, diff) => ({
           type: "agentManager.worktreeDiffFile",
+          projectId: this.activeProjectId,
           sessionId: source?.descriptor.id ?? "",
           file,
           diff: diff as AgentManagerDiffFile | null,
         }),
         revertFileResult: (source, file, result) => ({
           type: "agentManager.revertWorktreeFileResult",
+          projectId: this.activeProjectId,
           sessionId: source?.descriptor.id ?? "",
           file,
           status: result.ok ? "success" : "error",
@@ -86,6 +93,7 @@ export class WorktreeDiffController {
         }),
         unsupportedRevert: (source, file) => ({
           type: "agentManager.revertWorktreeFileResult",
+          projectId: this.activeProjectId,
           sessionId: source?.descriptor.id ?? "",
           file,
           status: "error",
@@ -102,7 +110,7 @@ export class WorktreeDiffController {
     const current = this.controller.currentId
     const ctxId = current ? parseDiffId(current).ctx : undefined
     const stop = shouldStopDiffPolling(path, sessions, this.target, ctxId)
-    if (stop && ctxId) this.invalidate(ctxId)
+    if (stop && ctxId) this.invalidate(ctxId, this.activeProjectId)
     return stop
   }
 
@@ -167,44 +175,54 @@ export class WorktreeDiffController {
     }
   }
 
-  public async revert(id: string, file: string): Promise<void> {
+  public async revert(
+    id: string,
+    file: string,
+    projectId = this.activeProjectId ?? this.ctx.getProjectId(),
+  ): Promise<void> {
     if (!file) return
-    if (this.controller.currentId !== id) {
+    if (this.controller.currentId !== id || this.activeProjectId !== projectId) {
       const result = await this.revertFile(id, file)
-      this.postRevertResult(id, file, result)
+      this.postRevertResult(id, file, result, projectId)
       return
     }
     await this.controller.revertFile(file)
   }
 
-  public async request(id: string): Promise<void> {
-    if (this.controller.currentId !== id) {
-      await this.activate(id, false, true)
+  public async request(id: string, projectId = this.activeProjectId ?? this.ctx.getProjectId()): Promise<void> {
+    if (this.controller.currentId !== id || this.activeProjectId !== projectId) {
+      await this.activate(id, false, true, projectId)
       return
     }
     this.target = undefined
     await this.controller.refresh()
   }
 
-  public async requestFile(id: string, file: string): Promise<void> {
+  public async requestFile(
+    id: string,
+    file: string,
+    projectId = this.activeProjectId ?? this.ctx.getProjectId(),
+  ): Promise<void> {
     if (!file) return
-    if (this.controller.currentId !== id) {
-      this.ctx.post({ type: "agentManager.worktreeDiffFile", sessionId: id, file, diff: null })
+    if (this.controller.currentId !== id || this.activeProjectId !== projectId) {
+      this.ctx.post({ type: "agentManager.worktreeDiffFile", projectId, sessionId: id, file, diff: null })
       return
     }
     await this.controller.requestFile(file)
   }
 
-  public start(id: string): void {
-    if (this.controller.isPolling && this.controller.currentId === id) return
+  public start(id: string, projectId = this.ctx.getProjectId()): void {
+    if (this.controller.isPolling && this.controller.currentId === id && this.activeProjectId === projectId) return
+    this.activeProjectId = projectId
     this.ctx.log(`Starting diff polling for ${id}`)
-    void this.activate(id, true, true)
+    void this.activate(id, true, true, projectId)
   }
 
   public stop(): void {
     this.controller.stop()
     this.target = undefined
     this.poll = false
+    this.activeProjectId = undefined
   }
 
   /**
@@ -212,56 +230,66 @@ export class WorktreeDiffController {
    * then re-activate the current source so it refetches against the new base.
    * Passing undefined clears the override and falls back to the recorded parent.
    */
-  public async setBase(id: string, branch: string | undefined): Promise<void> {
+  public async setBase(
+    id: string,
+    branch: string | undefined,
+    projectId = this.activeProjectId ?? this.ctx.getProjectId(),
+  ): Promise<void> {
     const { ctx } = parseDiffId(id)
     if (branch) this.baseOverrides.set(ctx, branch)
     else this.baseOverrides.delete(ctx)
-    this.revisions.set(ctx, (this.revisions.get(ctx) ?? 0) + 1)
-    this.invalidate(ctx)
+    const cacheKey = this.cacheKey(id, projectId)
+    this.revisions.set(cacheKey, (this.revisions.get(cacheKey) ?? 0) + 1)
+    this.invalidate(ctx, projectId)
     // Nothing to rebuild when the context isn't active; the override is
     // picked up the next time start()/request() resolves it.
-    if (this.controller.currentId !== id) return
+    if (this.controller.currentId !== id || this.activeProjectId !== projectId) return
     // Route through activate() so the base is re-resolved and pushed via
     // setContext() — SourceController.reactivate() alone would rebuild the
     // source against the stale context captured by the last activate(). The
     // recorded poll intent preserves watch mode even when the initial fetch
     // is still in flight (isPolling only turns true once it resolves).
-    await this.activate(id, this.poll, true)
+    await this.activate(id, this.poll, true, projectId)
   }
 
   /** Preload diffs for adjacent or visible worktrees in the background. */
-  public async preload(ids: string[]): Promise<void> {
+  public async preload(ids: string[], projectId = this.ctx.getProjectId()): Promise<void> {
     await this.ready("stateReady rejected, continuing diff preload:")
     for (const id of ids) {
       if (!id) continue
       const parsed = parseDiffId(id)
       const ctx = parsed.ctx
       const key = composeDiffId(ctx, parsed.scope, parsed.sessionId)
-      if (this.controller.currentId === key || this.preloading.has(key)) continue
-      const cached = this.diffCache.get(key)
+      const cacheKey = this.cacheKey(key, projectId)
+      if (this.activeProjectId === projectId && this.controller.currentId === key) continue
+      if (this.preloading.has(cacheKey)) continue
+      const cached = this.diffCache.get(cacheKey)
       if (cached && Date.now() - cached.time < CACHE_TTL) continue
 
       const resolved = await this.resolve(ctx)
       if (!resolved) continue
 
-      const revision = this.revisions.get(ctx) ?? 0
-      this.preloading.add(key)
+      const revision = this.revisions.get(cacheKey) ?? 0
+      this.preloading.add(cacheKey)
       try {
         const entries = await diffSummary(this.ctx.git, resolved.directory, resolved.baseBranch, (...args) =>
           this.ctx.log(...args),
         )
         const diffs = entries.map(toDiffFile) as AgentManagerDiffFile[]
-        if ((this.revisions.get(ctx) ?? 0) !== revision) continue
-        this.remember(key, diffs)
+        if (this.ctx.getProjectId() !== projectId) continue
+        if (this.activeProjectId === projectId && this.controller.currentId === key) continue
+        if ((this.revisions.get(cacheKey) ?? 0) !== revision) continue
+        this.remember(cacheKey, diffs)
         this.ctx.post({
           type: "agentManager.worktreeDiff",
+          projectId,
           sessionId: key,
           diffs,
         })
       } catch (err) {
         this.ctx.log("Preload diff failed for", id, err)
       } finally {
-        this.preloading.delete(key)
+        this.preloading.delete(cacheKey)
       }
     }
   }
@@ -275,16 +303,24 @@ export class WorktreeDiffController {
     return await this.ctx.catalog.listWorkspaceBranches(this.baseOverrides.get(ctx), target.directory)
   }
 
-  public async sendBranches(id: string): Promise<void> {
+  public async sendBranches(id: string, projectId = this.activeProjectId ?? this.ctx.getProjectId()): Promise<void> {
     const result = await this.branches(id).catch((err) => {
       this.ctx.log("Failed to list diff branches:", err instanceof Error ? err.message : String(err))
       return undefined
     })
     if (!result) return
-    this.ctx.post({ type: "agentManager.diffBranches", sessionId: id, ...result })
+    this.ctx.post({ type: "agentManager.diffBranches", projectId, sessionId: id, ...result })
   }
 
-  private async activate(id: string, poll: boolean, fetch: boolean): Promise<void> {
+  private async activate(
+    id: string,
+    poll: boolean,
+    fetch: boolean,
+    projectId = this.ctx.getProjectId(),
+  ): Promise<void> {
+    this.activeProjectId = projectId
+    const revisionKey = this.cacheKey(id, projectId)
+    this.revisions.set(revisionKey, (this.revisions.get(revisionKey) ?? 0) + 1)
     this.target = undefined
     this.poll = poll
     await this.ready("stateReady rejected, continuing diff activate:")
@@ -293,22 +329,24 @@ export class WorktreeDiffController {
     this.target = resolved ? { sessionId: id, ...resolved } : undefined
     // Clear any stale source notice up front; sources only push a notice when
     // one is active, so a swap away from a noticing source must reset it.
-    this.ctx.post({ type: "agentManager.worktreeDiffNotice", sessionId: id, notice: undefined })
+    this.ctx.post({ type: "agentManager.worktreeDiffNotice", projectId, sessionId: id, notice: undefined })
 
     // If we have cached diffs for this context, push them immediately to eliminate initial loading delay!
-    const cached = this.diffCache.get(id)
+    const cacheKey = this.cacheKey(id, projectId)
+    const cached = this.diffCache.get(cacheKey)
     const warm = cached && Date.now() - cached.time < CACHE_TTL ? cached : undefined
     if (warm) {
-      this.diffCache.delete(id)
-      this.diffCache.set(id, warm)
+      this.diffCache.delete(cacheKey)
+      this.diffCache.set(cacheKey, warm)
       this.ctx.post({
         type: "agentManager.worktreeDiff",
+        projectId,
         sessionId: id,
         diffs: warm.diffs,
       })
-      this.ctx.post({ type: "agentManager.worktreeDiffLoading", sessionId: id, loading: false })
+      this.ctx.post({ type: "agentManager.worktreeDiffLoading", projectId, sessionId: id, loading: false })
     } else if (cached) {
-      this.diffCache.delete(id)
+      this.diffCache.delete(cacheKey)
     }
 
     this.controller.setContext({
@@ -361,6 +399,10 @@ export class WorktreeDiffController {
     await this.ctx.getStateReady()?.catch((err) => this.ctx.log(msg, err))
   }
 
+  private cacheKey(id: string, projectId = this.activeProjectId ?? this.ctx.getProjectId()): string {
+    return `${projectId ?? "single"}\0${id}`
+  }
+
   private remember(id: string, diffs: AgentManagerDiffFile[]): void {
     const bytes = diffs.reduce(
       (sum, diff) => sum + (diff.patch?.length ?? 0) + diff.before.length + diff.after.length,
@@ -375,9 +417,11 @@ export class WorktreeDiffController {
     }
   }
 
-  private invalidate(ctx: string): void {
-    for (const id of this.diffCache.keys()) {
-      if (parseDiffId(id).ctx === ctx) this.diffCache.delete(id)
+  private invalidate(ctx: string, projectId = this.activeProjectId ?? this.ctx.getProjectId()): void {
+    const prefix = `${projectId ?? "single"}\0`
+    for (const key of this.diffCache.keys()) {
+      if (!key.startsWith(prefix)) continue
+      if (parseDiffId(key.slice(prefix.length)).ctx === ctx) this.diffCache.delete(key)
     }
   }
 
@@ -417,9 +461,15 @@ export class WorktreeDiffController {
     }
   }
 
-  private postRevertResult(sessionId: string, file: string, result: { ok: boolean; message: string }): void {
+  private postRevertResult(
+    sessionId: string,
+    file: string,
+    result: { ok: boolean; message: string },
+    projectId = this.activeProjectId,
+  ): void {
     this.ctx.post({
       type: "agentManager.revertWorktreeFileResult",
+      projectId,
       sessionId,
       file,
       status: result.ok ? "success" : "error",

--- a/packages/kilo-vscode/src/diff/SourceController.ts
+++ b/packages/kilo-vscode/src/diff/SourceController.ts
@@ -240,10 +240,18 @@ export class SourceController {
 
   private startPolling(source: DiffSource, epoch: number): void {
     this.stopPolling()
-    this.interval = setInterval(async () => {
+    let busy = false
+    this.interval = setInterval(() => {
+      if (busy) return
+      busy = true
       // Self-cancel when the tick reports the source is done
-      const keep = await this.runFetch(source, epoch, false)
-      if (!keep) this.stopPolling()
+      void this.runFetch(source, epoch, false)
+        .then((keep) => {
+          if (!keep) this.stopPolling()
+        })
+        .finally(() => {
+          busy = false
+        })
     }, DIFF_POLL_INTERVAL_MS)
   }
 

--- a/packages/kilo-vscode/src/diff/SourceController.ts
+++ b/packages/kilo-vscode/src/diff/SourceController.ts
@@ -247,7 +247,7 @@ export class SourceController {
       // Self-cancel when the tick reports the source is done
       void this.runFetch(source, epoch, false)
         .then((keep) => {
-          if (!keep) this.stopPolling()
+          if (!keep && this.epoch === epoch && this.activeId === source.descriptor.id) this.stopPolling()
         })
         .finally(() => {
           busy = false

--- a/packages/kilo-vscode/src/diff/SourceController.ts
+++ b/packages/kilo-vscode/src/diff/SourceController.ts
@@ -15,7 +15,7 @@ type Messages = {
   unsupportedRevert: (source: DiffSource | undefined, file: string) => unknown
 }
 
-type ActivateOptions = { poll?: boolean; fetch?: boolean }
+type ActivateOptions = { poll?: boolean; fetch?: boolean; known?: DiffFile[] }
 
 const viewerMessages: Messages = {
   available: (descriptors, id) => ({
@@ -117,7 +117,8 @@ export class SourceController {
 
     if (opts.fetch === false) return
 
-    const keepPolling = await this.runFetch(source, epoch, true)
+    this.lastHash = opts.known ? hashFileDiffs(opts.known as never) : undefined
+    const keepPolling = await this.runFetch(source, epoch, opts.known === undefined)
     // Prevents the polling interval from starting after teardown or swap.
     if (this.epoch !== epoch || this.activeId !== id) return
     if (opts.poll !== false && keepPolling) this.startPolling(source, epoch)

--- a/packages/kilo-vscode/src/diff/sources/git-status.ts
+++ b/packages/kilo-vscode/src/diff/sources/git-status.ts
@@ -19,6 +19,8 @@ export interface FileEntry {
   deletions: number
   tracked: boolean
   binary: boolean
+  patch?: string
+  summarized?: boolean
   stamp?: string
 }
 
@@ -77,10 +79,12 @@ function statusFromCode(code: string): Status {
  */
 export function summarize(entry: FileEntry): DiffFile {
   const image = imageMime(entry.file) !== undefined
+  const summarized = entry.summarized ?? (image || !entry.binary)
   return {
     file: entry.file,
     before: "",
     after: "",
+    patch: entry.patch,
     additions: entry.additions,
     deletions: entry.deletions,
     status: entry.status,
@@ -88,7 +92,7 @@ export function summarize(entry: FileEntry): DiffFile {
     generatedLike: generatedLike(entry.file),
     // Binary metadata is complete because no deferred text body exists.
     // Images are the exception: their encoded sides load lazily on expansion.
-    summarized: image || !entry.binary,
+    summarized,
     // Synthetic stamp keyed on the stats we actually polled: any change to
     // the file's diff produces new additions/deletions, which invalidates
     // the webview-side cached detail via mergeWorktreeDiffs. Callers can

--- a/packages/kilo-vscode/src/diff/sources/staged.ts
+++ b/packages/kilo-vscode/src/diff/sources/staged.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode"
 import { GitOps } from "../../agent-manager/GitOps"
-import { generatedLike } from "../../agent-manager/local-diff"
+import { generatedLike, splitPatches } from "../../agent-manager/local-diff"
 import { appendOutput, getWorkspaceRoot } from "../../review-utils"
 import { imageMime, loadImage } from "../shared/image"
 import { resolveInside } from "../shared/path"
@@ -69,7 +69,11 @@ export function createStagedDiffSource(opts: StagedDiffSourceOptions = {}): Diff
   }
 
   const listEntries = async (dir: string): Promise<FileEntry[]> => {
-    const [nameStatus, numstat, raw] = await Promise.all([
+    const [patchResult, nameStatus, numstat, raw] = await Promise.all([
+      git.execGit(
+        ["-c", "core.quotepath=false", "diff", "--cached", "--no-ext-diff", "--no-renames", "-U3", "HEAD"],
+        dir,
+      ),
       git.execGit(["-c", "core.quotepath=false", "diff", "--cached", "--name-status", "--no-renames", "HEAD"], dir),
       git.execGit(["-c", "core.quotepath=false", "diff", "--cached", "--numstat", "--no-renames", "HEAD"], dir),
       git.execGit(
@@ -83,15 +87,23 @@ export function createStagedDiffSource(opts: StagedDiffSourceOptions = {}): Diff
     }
     const counts = parseNumstat(numstat.code === 0 ? numstat.stdout : "")
     const refs = parseRawOids(raw.code === 0 ? raw.stdout : "")
+    const patches = splitPatches(patchResult.code === 0 ? patchResult.stdout : "")
     return parseNameStatus(nameStatus.stdout).map((item) => {
       const ref = refs.get(item.file)
-      const entry = {
+      const count = counts.get(item.file)
+      const patch = patches.get(item.file) ?? ""
+      const isImage = imageMime(item.file) !== undefined
+      const isLarge = patch.length > MAX_DETAIL_BYTES
+      const summarized = isImage || count?.binary || isLarge
+      const entry: FileEntry = {
         file: item.file,
         status: item.status,
-        additions: counts.get(item.file)?.additions ?? 0,
-        deletions: counts.get(item.file)?.deletions ?? 0,
+        additions: count?.additions ?? 0,
+        deletions: count?.deletions ?? 0,
         tracked: true,
-        binary: counts.get(item.file)?.binary ?? false,
+        binary: count?.binary ?? false,
+        patch: summarized ? undefined : patch,
+        summarized,
       }
       return stamp(
         entry,

--- a/packages/kilo-vscode/src/diff/sources/staged.ts
+++ b/packages/kilo-vscode/src/diff/sources/staged.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode"
 import { GitOps } from "../../agent-manager/GitOps"
-import { generatedLike, splitPatches } from "../../agent-manager/local-diff"
+import { generatedLike, requiresContents, splitPatches } from "../../agent-manager/local-diff"
 import { appendOutput, getWorkspaceRoot } from "../../review-utils"
 import { imageMime, loadImage } from "../shared/image"
 import { resolveInside } from "../shared/path"
@@ -73,6 +73,7 @@ export function createStagedDiffSource(opts: StagedDiffSourceOptions = {}): Diff
       git.execGit(
         ["-c", "core.quotepath=false", "diff", "--cached", "--no-ext-diff", "--no-renames", "-U3", "HEAD"],
         dir,
+        { maxOutput: MAX_DETAIL_BYTES },
       ),
       git.execGit(["-c", "core.quotepath=false", "diff", "--cached", "--name-status", "--no-renames", "HEAD"], dir),
       git.execGit(["-c", "core.quotepath=false", "diff", "--cached", "--numstat", "--no-renames", "HEAD"], dir),
@@ -87,23 +88,27 @@ export function createStagedDiffSource(opts: StagedDiffSourceOptions = {}): Diff
     }
     const counts = parseNumstat(numstat.code === 0 ? numstat.stdout : "")
     const refs = parseRawOids(raw.code === 0 ? raw.stdout : "")
-    const patches = splitPatches(patchResult.code === 0 ? patchResult.stdout : "")
-    return parseNameStatus(nameStatus.stdout).map((item) => {
+    const items = parseNameStatus(nameStatus.stdout)
+    const patches = splitPatches(
+      patchResult.code === 0 ? patchResult.stdout : "",
+      items.map((item) => item.file),
+    )
+    return items.map((item) => {
       const ref = refs.get(item.file)
-      const count = counts.get(item.file)
-      const patch = patches.get(item.file) ?? ""
+      const count = counts.get(item.file) ?? { additions: 0, deletions: 0, binary: false }
+      const patch = patches.get(item.file)
       const isImage = imageMime(item.file) !== undefined
-      const isLarge = patch.length > MAX_DETAIL_BYTES
-      const summarized = isImage || count?.binary || isLarge
+      const summarized = isImage || count.binary || patch === undefined || requiresContents(item.file)
       const entry: FileEntry = {
         file: item.file,
         status: item.status,
-        additions: count?.additions ?? 0,
-        deletions: count?.deletions ?? 0,
+        additions: count.additions,
+        deletions: count.deletions,
         tracked: true,
-        binary: count?.binary ?? false,
+        binary: count.binary,
         patch: summarized ? undefined : patch,
         summarized,
+        stamp: `${item.status}:${ref?.before ?? "missing"}:${ref?.after ?? "missing"}`,
       }
       return stamp(
         entry,

--- a/packages/kilo-vscode/src/diff/sources/unstaged.ts
+++ b/packages/kilo-vscode/src/diff/sources/unstaged.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs/promises"
 import * as vscode from "vscode"
 import { GitOps } from "../../agent-manager/GitOps"
-import { generatedLike, splitPatches } from "../../agent-manager/local-diff"
+import { generatedLike, requiresContents, splitPatches } from "../../agent-manager/local-diff"
 import { appendOutput, getWorkspaceRoot } from "../../review-utils"
 import { binaryFile } from "../shared/binary"
 import { imageMime, loadImage } from "../shared/image"
@@ -76,7 +76,9 @@ export function createUnstagedDiffSource(opts: UnstagedDiffSourceOptions = {}): 
 
   const listTracked = async (dir: string): Promise<FileEntry[]> => {
     const [patchResult, nameStatus, numstat, raw] = await Promise.all([
-      git.execGit(["-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-renames", "-U3"], dir),
+      git.execGit(["-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-renames", "-U3"], dir, {
+        maxOutput: MAX_DETAIL_BYTES,
+      }),
       git.execGit(["-c", "core.quotepath=false", "diff", "--name-status", "--no-renames"], dir),
       git.execGit(["-c", "core.quotepath=false", "diff", "--numstat", "--no-renames"], dir),
       git.execGit(["-c", "core.quotepath=false", "diff", "--raw", "--abbrev=64", "--no-renames"], dir),
@@ -87,14 +89,17 @@ export function createUnstagedDiffSource(opts: UnstagedDiffSourceOptions = {}): 
     }
     const counts = parseNumstat(numstat.code === 0 ? numstat.stdout : "")
     const refs = parseRawOids(raw.code === 0 ? raw.stdout : "")
-    const patches = splitPatches(patchResult.code === 0 ? patchResult.stdout : "")
+    const items = parseNameStatus(nameStatus.stdout)
+    const patches = splitPatches(
+      patchResult.code === 0 ? patchResult.stdout : "",
+      items.map((item) => item.file),
+    )
     return Promise.all(
-      parseNameStatus(nameStatus.stdout).map(async (item) => {
+      items.map(async (item) => {
         const count = counts.get(item.file)
-        const patch = patches.get(item.file) ?? ""
+        const patch = patches.get(item.file)
         const isImage = imageMime(item.file) !== undefined
-        const isLarge = patch.length > MAX_DETAIL_BYTES
-        const summarized = isImage || count?.binary || isLarge
+        const summarized = isImage || count?.binary || patch === undefined || requiresContents(item.file)
         const entry = {
           file: item.file,
           status: item.status,
@@ -105,10 +110,10 @@ export function createUnstagedDiffSource(opts: UnstagedDiffSourceOptions = {}): 
           patch: summarized ? undefined : patch,
           summarized,
         }
-        if (!imageMime(item.file)) return entry
+        if (!summarized) return entry
         const before = item.status === "added" ? "missing" : (refs.get(item.file)?.before ?? "missing")
         const after = item.status === "deleted" ? "missing" : await diskStamp(dir, item.file)
-        return stamp(entry, before, after)
+        return { ...entry, stamp: `${item.status}:${before}:${after}` }
       }),
     )
   }

--- a/packages/kilo-vscode/src/diff/sources/unstaged.ts
+++ b/packages/kilo-vscode/src/diff/sources/unstaged.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs/promises"
 import * as vscode from "vscode"
 import { GitOps } from "../../agent-manager/GitOps"
-import { generatedLike } from "../../agent-manager/local-diff"
+import { generatedLike, splitPatches } from "../../agent-manager/local-diff"
 import { appendOutput, getWorkspaceRoot } from "../../review-utils"
 import { binaryFile } from "../shared/binary"
 import { imageMime, loadImage } from "../shared/image"
@@ -75,7 +75,8 @@ export function createUnstagedDiffSource(opts: UnstagedDiffSourceOptions = {}): 
   }
 
   const listTracked = async (dir: string): Promise<FileEntry[]> => {
-    const [nameStatus, numstat, raw] = await Promise.all([
+    const [patchResult, nameStatus, numstat, raw] = await Promise.all([
+      git.execGit(["-c", "core.quotepath=false", "diff", "--no-ext-diff", "--no-renames", "-U3"], dir),
       git.execGit(["-c", "core.quotepath=false", "diff", "--name-status", "--no-renames"], dir),
       git.execGit(["-c", "core.quotepath=false", "diff", "--numstat", "--no-renames"], dir),
       git.execGit(["-c", "core.quotepath=false", "diff", "--raw", "--abbrev=64", "--no-renames"], dir),
@@ -86,15 +87,23 @@ export function createUnstagedDiffSource(opts: UnstagedDiffSourceOptions = {}): 
     }
     const counts = parseNumstat(numstat.code === 0 ? numstat.stdout : "")
     const refs = parseRawOids(raw.code === 0 ? raw.stdout : "")
+    const patches = splitPatches(patchResult.code === 0 ? patchResult.stdout : "")
     return Promise.all(
       parseNameStatus(nameStatus.stdout).map(async (item) => {
+        const count = counts.get(item.file)
+        const patch = patches.get(item.file) ?? ""
+        const isImage = imageMime(item.file) !== undefined
+        const isLarge = patch.length > MAX_DETAIL_BYTES
+        const summarized = isImage || count?.binary || isLarge
         const entry = {
           file: item.file,
           status: item.status,
-          additions: counts.get(item.file)?.additions ?? 0,
-          deletions: counts.get(item.file)?.deletions ?? 0,
+          additions: count?.additions ?? 0,
+          deletions: count?.deletions ?? 0,
           tracked: true,
-          binary: counts.get(item.file)?.binary ?? false,
+          binary: count?.binary ?? false,
+          patch: summarized ? undefined : patch,
+          summarized,
         }
         if (!imageMime(item.file)) return entry
         const before = item.status === "added" ? "missing" : (refs.get(item.file)?.before ?? "missing")

--- a/packages/kilo-vscode/tests/unit/git-ops.test.ts
+++ b/packages/kilo-vscode/tests/unit/git-ops.test.ts
@@ -99,6 +99,25 @@ describe("GitOps", () => {
     })
   })
 
+  it("treats selected filenames as literal pathspecs", async () => {
+    await withRepo(async (cwd) => {
+      runGit(cwd, ["config", "user.email", "test@example.com"])
+      runGit(cwd, ["config", "user.name", "Test"])
+      await fs.writeFile(nodePath.join(cwd, "*"), "before\n")
+      await fs.writeFile(nodePath.join(cwd, "other.txt"), "before\n")
+      runGit(cwd, ["add", "."])
+      runGit(cwd, ["commit", "-m", "seed"])
+      await fs.writeFile(nodePath.join(cwd, "*"), "after\n")
+      await fs.writeFile(nodePath.join(cwd, "other.txt"), "changed\n")
+
+      const git = new GitOps({ log: () => undefined, binary: async () => "git" })
+      const patch = await git.buildWorktreePatch(cwd, "HEAD", ["*"])
+
+      expect(patch).toContain("diff --git a/* b/*")
+      expect(patch).not.toContain("other.txt")
+    })
+  })
+
   it("retries executable resolution after a transient failure", async () => {
     await withRepo(async (cwd) => {
       let calls = 0

--- a/packages/kilo-vscode/tests/unit/git-ops.test.ts
+++ b/packages/kilo-vscode/tests/unit/git-ops.test.ts
@@ -88,6 +88,17 @@ describe("GitOps", () => {
     expect(await pending).toBe("")
   })
 
+  it("bounds raw command output when a caller supplies a limit", async () => {
+    await withRepo(async (cwd) => {
+      const git = new GitOps({ log: () => undefined, binary: async () => "git" })
+      const result = await git.execGit(["status", "--porcelain=v2", "--branch"], cwd, { maxOutput: 1 })
+
+      expect(result.code).not.toBe(0)
+      expect(result.stdout).toBe("")
+      expect(result.stderr).toContain("git output exceeded 1 bytes")
+    })
+  })
+
   it("retries executable resolution after a transient failure", async () => {
     await withRepo(async (cwd) => {
       let calls = 0

--- a/packages/kilo-vscode/tests/unit/local-diff.test.ts
+++ b/packages/kilo-vscode/tests/unit/local-diff.test.ts
@@ -143,6 +143,29 @@ describe("splitPatches", () => {
     expect(splitPatches(patch, [file]).get(file)).toBe(patch)
   })
 
+  it("ignores header-looking lines inside a patch body", () => {
+    const patch = [
+      "diff --git a/patches/example.patch b/patches/example.patch",
+      "--- a/patches/example.patch",
+      "+++ b/patches/example.patch",
+      "@@ -1 +1 @@",
+      "-old",
+      "+diff --git a/target.ts b/target.ts",
+      "diff --git a/target.ts b/target.ts",
+      "--- a/target.ts",
+      "+++ b/target.ts",
+      "@@ -1 +1 @@",
+      "-before",
+      "+after",
+      "",
+    ].join("\n")
+
+    const result = splitPatches(patch, ["patches/example.patch", "target.ts"])
+
+    expect(result.get("patches/example.patch")).toContain("+diff --git a/target.ts b/target.ts")
+    expect(result.get("target.ts")).toContain("+after")
+  })
+
   it("keeps binary patches and ignores empty input", () => {
     const patch = "diff --git a/image.bin b/image.bin\nBinary files a/image.bin and b/image.bin differ\n"
     expect(splitPatches(patch, ["image.bin"]).get("image.bin")).toBe(patch)

--- a/packages/kilo-vscode/tests/unit/local-diff.test.ts
+++ b/packages/kilo-vscode/tests/unit/local-diff.test.ts
@@ -298,6 +298,22 @@ describe("diffSummary", () => {
     })
   })
 
+  it("keeps summarized and detailed stamps stable for markdown", async () => {
+    await withRepo(async (dir, base) => {
+      await fs.writeFile(path.join(dir, "README.md"), "# Base\n")
+      runSync(dir, ["add", "README.md"])
+      runSync(dir, ["commit", "-m", "add readme"])
+      runSync(dir, ["branch", "-f", base])
+      await fs.writeFile(path.join(dir, "README.md"), "# Updated\n")
+
+      const local = createLocalDiff(git())
+      const summary = (await local.summary(dir, base)).find((entry) => entry.file === "README.md")
+      const detail = await local.file(dir, base, "README.md")
+
+      expect(detail?.stamp).toBe(summary?.stamp)
+    })
+  })
+
   it("handles tracked filenames containing a b path segment", async () => {
     await withRepo(async (dir, base) => {
       const file = "folder b/nested file.ts"

--- a/packages/kilo-vscode/tests/unit/local-diff.test.ts
+++ b/packages/kilo-vscode/tests/unit/local-diff.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "bun:test"
+import { describe, expect, it } from "bun:test"
 import * as fs from "fs/promises"
 import * as os from "os"
 import * as path from "path"
@@ -9,6 +9,7 @@ import {
   generatedLike,
   resolveBase,
   MAX_DETAIL_BYTES,
+  splitPatches,
 } from "../../src/agent-manager/local-diff"
 import { GitOps } from "../../src/agent-manager/GitOps"
 import { WorktreeDiffReverter } from "../../src/diff/shared/reverter"
@@ -107,6 +108,45 @@ describe("generatedLike", () => {
   it("handles Windows-style separators", () => {
     expect(generatedLike("node_modules\\foo\\bar.js")).toBe(true)
     expect(generatedLike("src\\index.ts")).toBe(false)
+  })
+})
+
+describe("splitPatches", () => {
+  it("extracts multiple patches by their authoritative file list", () => {
+    const patch = [
+      "diff --git a/first.ts b/first.ts",
+      "--- a/first.ts",
+      "+++ b/first.ts",
+      "@@ -1 +1 @@",
+      "-old",
+      "+new",
+      "diff --git a/second.ts b/second.ts",
+      "--- a/second.ts",
+      "+++ b/second.ts",
+      "@@ -1 +1 @@",
+      "-before",
+      "+after",
+      "",
+    ].join("\n")
+
+    const result = splitPatches(patch, ["first.ts", "second.ts"])
+
+    expect(result.get("first.ts")).toContain("+new")
+    expect(result.get("first.ts")).not.toContain("second.ts")
+    expect(result.get("second.ts")).toContain("+after")
+  })
+
+  it("handles spaces and b path segments without splitting the filename", () => {
+    const file = "folder b/nested file.ts"
+    const patch = `diff --git a/${file} b/${file}\n--- a/${file}\n+++ b/${file}\n@@ -1 +1 @@\n-old\n+new\n`
+
+    expect(splitPatches(patch, [file]).get(file)).toBe(patch)
+  })
+
+  it("keeps binary patches and ignores empty input", () => {
+    const patch = "diff --git a/image.bin b/image.bin\nBinary files a/image.bin and b/image.bin differ\n"
+    expect(splitPatches(patch, ["image.bin"]).get("image.bin")).toBe(patch)
+    expect(splitPatches("", ["image.bin"]).size).toBe(0)
   })
 })
 
@@ -217,6 +257,63 @@ describe("diffSummary", () => {
         expect(entry.patch).toBeTruthy()
         expect(typeof entry.stamp).toBe("string")
       }
+    })
+  })
+
+  it("keeps markdown summarized so rendered mode loads complete contents", async () => {
+    await withRepo(async (dir, base) => {
+      await fs.writeFile(path.join(dir, "README.md"), "# Base\n")
+      runSync(dir, ["add", "README.md"])
+      runSync(dir, ["commit", "-m", "add readme"])
+      runSync(dir, ["branch", "-f", base])
+      await fs.writeFile(path.join(dir, "README.md"), "# Updated\n")
+
+      const summary = (await diffSummary(git(), dir, base)).find((entry) => entry.file === "README.md")
+
+      expect(summary?.summarized).toBe(true)
+      expect(summary?.patch).toBe("")
+    })
+  })
+
+  it("handles tracked filenames containing a b path segment", async () => {
+    await withRepo(async (dir, base) => {
+      const file = "folder b/nested file.ts"
+      await fs.mkdir(path.dirname(path.join(dir, file)), { recursive: true })
+      await fs.writeFile(path.join(dir, file), "before\n")
+      runSync(dir, ["add", file])
+      runSync(dir, ["commit", "-m", "add nested file"])
+      runSync(dir, ["branch", "-f", base])
+      await fs.writeFile(path.join(dir, file), "after\n")
+
+      const summary = (await diffSummary(git(), dir, base)).find((entry) => entry.file === file)
+
+      expect(summary?.summarized).toBe(false)
+      expect(summary?.patch).toContain("+after")
+    })
+  })
+
+  it("keeps untracked file order stable while loading contents concurrently", async () => {
+    await withRepo(async (dir, base) => {
+      await Promise.all([
+        fs.writeFile(path.join(dir, "a.txt"), "a\n"),
+        fs.writeFile(path.join(dir, "b.txt"), "b\n"),
+        fs.writeFile(path.join(dir, "c.txt"), "c\n"),
+      ])
+
+      const result = await diffSummary(git(), dir, base)
+
+      expect(result.map((entry) => entry.file)).toEqual(["a.txt", "b.txt", "c.txt"])
+    })
+  })
+
+  it("falls back to summarized details when aggregate patch output exceeds the cap", async () => {
+    await withRepo(async (dir, base) => {
+      await fs.writeFile(path.join(dir, "large.txt"), `${"x".repeat(MAX_DETAIL_BYTES + 1)}\n`)
+      const result = await diffSummary(git(), dir, base)
+      const entry = result.find((item) => item.file === "large.txt")
+
+      expect(entry?.summarized).toBe(true)
+      expect(entry?.patch).toBe("")
     })
   })
 

--- a/packages/kilo-vscode/tests/unit/local-diff.test.ts
+++ b/packages/kilo-vscode/tests/unit/local-diff.test.ts
@@ -204,7 +204,7 @@ describe("diffSummary", () => {
     })
   })
 
-  it("all entries are summarized with empty before/after/patch", async () => {
+  it("all entries include patches with summarized=false for text files", async () => {
     await withRepo(async (dir, base) => {
       await fs.writeFile(path.join(dir, "untracked.txt"), "x\n")
       await fs.writeFile(path.join(dir, "seed.txt"), "changed\n")
@@ -213,10 +213,8 @@ describe("diffSummary", () => {
       const result = await diffSummary(git(), dir, base)
       expect(result.length).toBeGreaterThan(0)
       for (const entry of result) {
-        expect(entry.summarized).toBe(true)
-        expect(entry.before).toBe("")
-        expect(entry.after).toBe("")
-        expect(entry.patch).toBe("")
+        expect(entry.summarized).toBe(false)
+        expect(entry.patch).toBeTruthy()
         expect(typeof entry.stamp).toBe("string")
       }
     })
@@ -341,7 +339,7 @@ describe("diffFile", () => {
       const entry = summary.find((item) => item.file === "seed.txt")
       const result = await local.file(dir, base, "seed.txt")
 
-      expect(entry?.summarized).toBe(true)
+      expect(entry?.summarized).toBe(false)
       expect(result?.summarized).toBe(false)
       expect(result?.additions).toBe(entry?.additions)
       expect(result?.deletions).toBe(entry?.deletions)

--- a/packages/kilo-vscode/tests/unit/review-comments.test.ts
+++ b/packages/kilo-vscode/tests/unit/review-comments.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test"
 import {
   sanitizeReviewComments,
+  diffLineCount,
   formatReviewCommentsMarkdown,
   extractLines,
   getDirectory,
@@ -112,6 +113,20 @@ describe("sanitizeReviewComments", () => {
     const d = { ...diff("a.ts", "", ""), summarized: true }
     const result = sanitizeReviewComments([c], [d])
     expect(result).toEqual([c])
+  })
+
+  it("keeps comments on patch-backed files before detail loads", () => {
+    const d = {
+      ...diff("a.ts", "", ""),
+      patch: "diff --git a/a.ts b/a.ts\n@@ -1,2 +1,3 @@\n+new\n",
+      summarized: false,
+    }
+    const addition = comment({ file: "a.ts", line: 3 })
+    const deletion = comment({ file: "a.ts", line: 2, side: "deletions" })
+
+    expect(diffLineCount(d, "additions")).toBe(3)
+    expect(diffLineCount(d, "deletions")).toBe(2)
+    expect(sanitizeReviewComments([addition, deletion], [d])).toEqual([addition, deletion])
   })
 
   it("returns all when all comments are valid", () => {

--- a/packages/kilo-vscode/tests/unit/source-controller.test.ts
+++ b/packages/kilo-vscode/tests/unit/source-controller.test.ts
@@ -90,6 +90,24 @@ describe("SourceController.activate", () => {
     expect(notices[0]!.notice).toBe("snapshots-disabled")
   })
 
+  it("uses known diffs to suppress an unchanged warm refresh", async () => {
+    const diff = { file: "warm.ts", before: "", after: "", additions: 1, deletions: 0 }
+    const source: DiffSource = {
+      descriptor: WORKSPACE_DESC,
+      async fetch() {
+        return { diffs: [diff] }
+      },
+    }
+    const { controller, posted } = make({ workspace: source })
+
+    controller.setContext({ workspaceRoot: "/repo" })
+    await controller.activate("workspace", { poll: false, known: [diff] })
+
+    expect(byType(posted, "diffViewer.diffs")).toEqual([])
+    expect(byType(posted, "diffViewer.loading")).toEqual([])
+    controller.stop()
+  })
+
   it("disposes the previous source when activating a new one", async () => {
     let workspaceDisposed = 0
     const workspace: DiffSource = {

--- a/packages/kilo-vscode/tests/unit/worktree-diff-controller.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-diff-controller.test.ts
@@ -13,6 +13,7 @@ import type { WorktreeStateManager } from "../../src/agent-manager/WorktreeState
 function make(onFetch?: (n: number, id: string) => Promise<void>, diffs: Record<string, string> = {}) {
   const builds: { id: string; ctx: PanelContext }[] = []
   const posted: unknown[] = []
+  let project: string | undefined
   let fetches = 0
   const catalog = {
     build: (id: string, ctx: PanelContext): DiffSource => {
@@ -22,7 +23,11 @@ function make(onFetch?: (n: number, id: string) => Promise<void>, diffs: Record<
         async fetch() {
           await onFetch?.(++fetches, id)
           const file = diffs[id]
-          return { diffs: file ? [{ file, before: "", after: "", additions: 1, deletions: 0 }] : [] }
+          return {
+            diffs: file
+              ? [{ file: project ? `${project}:${file}` : file, before: "", after: "", additions: 1, deletions: 0 }]
+              : [],
+          }
         },
       }
     },
@@ -37,6 +42,7 @@ function make(onFetch?: (n: number, id: string) => Promise<void>, diffs: Record<
   const controller = new WorktreeDiffController({
     getState: () => state,
     getRoot: () => "/repo",
+    getProjectId: () => project,
     getStateReady: () => undefined,
     catalog,
     git: {} as GitOps,
@@ -44,7 +50,7 @@ function make(onFetch?: (n: number, id: string) => Promise<void>, diffs: Record<
     post: (msg) => posted.push(msg),
     log: () => {},
   })
-  return { controller, builds, posted }
+  return { controller, builds, posted, setProject: (id: string | undefined) => (project = id) }
 }
 
 const tick = () => new Promise((resolve) => setTimeout(resolve, 0))
@@ -144,6 +150,27 @@ describe("WorktreeDiffController cache", () => {
     )
     expect(staged).toHaveLength(1)
     expect((staged[0] as { diffs: { file: string }[] }).diffs).toEqual([expect.objectContaining({ file: "staged.ts" })])
+    controller.stop()
+  })
+
+  it("does not replay cached diffs across projects", async () => {
+    const { controller, posted, setProject } = make(undefined, { workspace: "branch.ts" })
+    setProject("project-a")
+    controller.start("w1#branch")
+    await waitFor(() => posted.some((msg) => (msg as { type?: string }).type === "agentManager.worktreeDiff"))
+
+    posted.length = 0
+    setProject("project-b")
+    controller.start("w1#branch")
+    await waitFor(() => posted.some((msg) => (msg as { type?: string }).type === "agentManager.worktreeDiff"))
+
+    const messages = posted.filter((msg) => (msg as { type?: string }).type === "agentManager.worktreeDiff") as {
+      projectId?: string
+      diffs: { file: string }[]
+    }[]
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.projectId).toBe("project-b")
+    expect(messages[0]?.diffs[0]?.file).toBe("project-b:branch.ts")
     controller.stop()
   })
 })

--- a/packages/kilo-vscode/tests/unit/worktree-diff-controller.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-diff-controller.test.ts
@@ -10,8 +10,9 @@ import type { WorktreeStateManager } from "../../src/agent-manager/WorktreeState
 // base branch the active source was (re)built with. The controller, scope
 // resolution, and SourceController lifecycle under test are all real.
 // Contexts are worktree ids (the sidebar selection), not session ids.
-function make(onFetch?: (n: number) => Promise<void>) {
+function make(onFetch?: (n: number, id: string) => Promise<void>, diffs: Record<string, string> = {}) {
   const builds: { id: string; ctx: PanelContext }[] = []
+  const posted: unknown[] = []
   let fetches = 0
   const catalog = {
     build: (id: string, ctx: PanelContext): DiffSource => {
@@ -19,8 +20,9 @@ function make(onFetch?: (n: number) => Promise<void>) {
       return {
         descriptor: { id, type: "workspace", group: "Git", capabilities: { revert: true, comments: true } },
         async fetch() {
-          await onFetch?.(++fetches)
-          return { diffs: [] }
+          await onFetch?.(++fetches, id)
+          const file = diffs[id]
+          return { diffs: file ? [{ file, before: "", after: "", additions: 1, deletions: 0 }] : [] }
         },
       }
     },
@@ -39,10 +41,10 @@ function make(onFetch?: (n: number) => Promise<void>) {
     catalog,
     git: {} as GitOps,
     localDiffFile: async () => null,
-    post: () => {},
+    post: (msg) => posted.push(msg),
     log: () => {},
   })
-  return { controller, builds }
+  return { controller, builds, posted }
 }
 
 const tick = () => new Promise((resolve) => setTimeout(resolve, 0))
@@ -115,6 +117,33 @@ describe("WorktreeDiffController.setBase", () => {
     await tick()
     expect(builds.length).toBe(2)
 
+    controller.stop()
+  })
+})
+
+describe("WorktreeDiffController cache", () => {
+  it("does not replay branch cache into another scope", async () => {
+    const { controller, posted } = make(undefined, { workspace: "branch.ts", staged: "staged.ts" })
+    controller.start("w1#branch")
+    await waitFor(() => posted.some((msg) => (msg as { type?: string }).type === "agentManager.worktreeDiff"))
+    posted.length = 0
+
+    controller.start("w1#staged")
+    await waitFor(() =>
+      posted.some(
+        (msg) =>
+          (msg as { type?: string; sessionId?: string }).type === "agentManager.worktreeDiff" &&
+          (msg as { sessionId?: string }).sessionId === "w1#staged",
+      ),
+    )
+
+    const staged = posted.filter(
+      (msg) =>
+        (msg as { type?: string; sessionId?: string }).type === "agentManager.worktreeDiff" &&
+        (msg as { sessionId?: string }).sessionId === "w1#staged",
+    )
+    expect(staged).toHaveLength(1)
+    expect((staged[0] as { diffs: { file: string }[] }).diffs).toEqual([expect.objectContaining({ file: "staged.ts" })])
     controller.stop()
   })
 })

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1682,7 +1682,8 @@ const AgentManagerContent: Component = () => {
     vscode.postMessage({ type: "agentManager.stopDiffWatch" })
   })
 
-  // Preload adjacent worktrees immediately, and all other worktrees during idle time.
+  // Keep only the likely next selections warm; preloading every worktree can
+  // retain large patches and waste Git work for sessions the user never opens.
   createEffect(() => {
     const order = sidebarOrder()
     const sel = selection() ?? LOCAL
@@ -1694,13 +1695,6 @@ const AgentManagerContent: Component = () => {
     )
     if (adjacent.length > 0) {
       vscode.postMessage({ type: "agentManager.preloadWorktreeDiffs", worktreeIds: adjacent })
-    }
-
-    const rest = ids.filter((id) => id !== sel && !adjacent.includes(id))
-    if (rest.length > 0) {
-      const schedule =
-        typeof requestIdleCallback !== "undefined" ? requestIdleCallback : (cb: () => void) => setTimeout(cb, 200)
-      schedule(() => vscode.postMessage({ type: "agentManager.preloadWorktreeDiffs", worktreeIds: rest }))
     }
   })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -241,6 +241,15 @@ const AgentManagerContent: Component = () => {
   const [currentProjectId, setCurrentProjectId] = createSignal<string | undefined>()
   const [projectStates, setProjectStates] = createSignal<Record<string, AgentManagerStateMessage>>({})
   const activeProjectId = () => projectList().find((p) => p.active)?.id ?? currentProjectId()
+  const reviewKey = (context: string) => `${activeProjectId() ?? "single"}\0${context}`
+  const currentReviewOpen = () => {
+    const prefix = `${activeProjectId() ?? "single"}\0`
+    return Object.fromEntries(
+      Object.entries(reviewOpenByContext()).flatMap(([key, value]) =>
+        key.startsWith(prefix) ? [[key.slice(prefix.length), value]] : [],
+      ),
+    )
+  }
   const creation = usePendingCreate(activeProjectId, (projectId, worktreeId) =>
     vscode.postMessage({
       type: "agentManager.activateSelection",
@@ -300,7 +309,7 @@ const AgentManagerContent: Component = () => {
     if (!pr) return undefined
     return { pr, selected, wt: worktrees().find((w) => w.id === selected) }
   })
-  const diffs = createWorktreeDiffs(vscode)
+  const diffs = createWorktreeDiffs(vscode, activeProjectId)
   const diffDatas = diffs.diffDatas
   const diffLoading = diffs.diffLoading
   const setDiffLoading = diffs.setDiffLoading
@@ -488,13 +497,14 @@ const AgentManagerContent: Component = () => {
   const reviewOpen = createMemo(() => {
     const sel = selection()
     if (sel === null) return false
-    return reviewOpenByContext()[sel] === true
+    return reviewOpenByContext()[reviewKey(sel)] === true
   })
 
   const setReviewOpenForContext = (context: string, open: boolean) => {
+    const key = reviewKey(context)
     setReviewOpenByContext((prev) => {
-      if (prev[context] === open) return prev
-      return { ...prev, [context]: open }
+      if (prev[key] === open) return prev
+      return { ...prev, [key]: open }
     })
   }
 
@@ -507,13 +517,13 @@ const AgentManagerContent: Component = () => {
   const reviewComments = createMemo(() => {
     const sel = selection()
     if (sel === null) return [] as ReviewComment[]
-    return reviewCommentsByContext()[sel] ?? []
+    return reviewCommentsByContext()[reviewKey(sel)] ?? []
   })
 
   const setReviewCommentsForSelection = (comments: ReviewComment[]) => {
     const sel = selection()
     if (sel === null) return
-    setReviewCommentsByContext((prev) => ({ ...prev, [sel]: comments }))
+    setReviewCommentsByContext((prev) => ({ ...prev, [reviewKey(sel)]: comments }))
   }
 
   const apply = createApplyToLocal({
@@ -521,9 +531,11 @@ const AgentManagerContent: Component = () => {
     dialog,
     t,
     selection,
+    project: activeProjectId,
     local: LOCAL,
     worktrees,
     diffDatas,
+    dataKey: diffs.dataKey,
     diffLoading,
     track: metrics.track,
   })
@@ -608,7 +620,7 @@ const AgentManagerContent: Component = () => {
     localSessionIDs,
     sessions: session.sessions,
     managedSessions,
-    reviewOpenByContext,
+    reviewOpenByContext: currentReviewOpen,
     terminalIdsFor: (key) => terms.forSelection(nsKey(key)).map((t) => t.id),
   })
   const appendToTabOrder = tabOrderSync.append
@@ -978,7 +990,7 @@ const AgentManagerContent: Component = () => {
     resetSession: () => session.setCurrentSessionID(undefined),
     isPending,
     isReviewTab: (remembered: string | undefined, sel: string) =>
-      remembered === REVIEW_TAB_ID && reviewOpenByContext()[sel] === true,
+      remembered === REVIEW_TAB_ID && reviewOpenByContext()[reviewKey(sel)] === true,
   }
 
   const selectLocal = () => {
@@ -1668,11 +1680,12 @@ const AgentManagerContent: Component = () => {
     const panel = diffOpen()
     const active = reviewActive()
     const id = review.id()
+    const projectId = activeProjectId()
 
     if ((panel || active) && id) {
       const data = diffDatas()
-      const wired = wireDiffId(id)
-      const hasCached = Boolean(data[id] ?? data[wired.sessionId])
+      const wired = wireDiffId(id, projectId)
+      const hasCached = Boolean(data[diffs.dataKey(id, projectId)])
       setDiffLoading(!hasCached)
       vscode.postMessage({ type: "agentManager.startDiffWatch", ...wired })
       return
@@ -1687,6 +1700,7 @@ const AgentManagerContent: Component = () => {
   createEffect(() => {
     const order = sidebarOrder()
     const sel = selection() ?? LOCAL
+    const projectId = activeProjectId()
     const idx = order.findIndex((item) => item.id === sel)
     if (idx === -1) return
     const ids = order.filter((item) => item.type === "local" || item.type === "wt").map((item) => item.id)
@@ -1694,7 +1708,7 @@ const AgentManagerContent: Component = () => {
       Boolean(id && ids.includes(id)),
     )
     if (adjacent.length > 0) {
-      vscode.postMessage({ type: "agentManager.preloadWorktreeDiffs", worktreeIds: adjacent })
+      vscode.postMessage({ type: "agentManager.preloadWorktreeDiffs", projectId, worktreeIds: adjacent })
     }
   })
 
@@ -1738,17 +1752,17 @@ const AgentManagerContent: Component = () => {
     const data = diffDatas()
     const key = diffScopeId()
     if (!key) return []
-    return data[key] ?? []
+    return data[diffs.dataKey(key, activeProjectId())] ?? []
   })
 
-  const diffSessionKey = createMemo(() => diffScopeId() ?? "")
+  const diffSessionKey = createMemo(() => `${activeProjectId() ?? "single"}\0${diffScopeId() ?? ""}`)
 
   // Source-level notice for the active composite id (e.g. snapshots disabled
   // for the Session scope), shown as a banner instead of the empty state.
   const diffNotice = createMemo(() => {
     const key = diffScopeId()
     if (!key) return undefined
-    return diffNotices()[key]
+    return diffNotices()[diffs.dataKey(key, activeProjectId())]
   })
 
   const setSharedDiffStyle = (style: "unified" | "split") => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1670,12 +1670,38 @@ const AgentManagerContent: Component = () => {
     const id = review.id()
 
     if ((panel || active) && id) {
-      vscode.postMessage({ type: "agentManager.startDiffWatch", ...wireDiffId(id) })
+      const data = diffDatas()
+      const wired = wireDiffId(id)
+      const hasCached = Boolean(data[id] ?? data[wired.sessionId])
+      setDiffLoading(!hasCached)
+      vscode.postMessage({ type: "agentManager.startDiffWatch", ...wired })
       return
     }
 
     setDiffLoading(false)
     vscode.postMessage({ type: "agentManager.stopDiffWatch" })
+  })
+
+  // Preload adjacent worktrees immediately, and all other worktrees during idle time.
+  createEffect(() => {
+    const order = sidebarOrder()
+    const sel = selection() ?? LOCAL
+    const idx = order.findIndex((item) => item.id === sel)
+    if (idx === -1) return
+    const ids = order.filter((item) => item.type === "local" || item.type === "wt").map((item) => item.id)
+    const adjacent = [order[idx - 1]?.id, order[idx + 1]?.id].filter((id): id is string =>
+      Boolean(id && ids.includes(id)),
+    )
+    if (adjacent.length > 0) {
+      vscode.postMessage({ type: "agentManager.preloadWorktreeDiffs", worktreeIds: adjacent })
+    }
+
+    const rest = ids.filter((id) => id !== sel && !adjacent.includes(id))
+    if (rest.length > 0) {
+      const schedule =
+        typeof requestIdleCallback !== "undefined" ? requestIdleCallback : (cb: () => void) => setTimeout(cb, 200)
+      schedule(() => vscode.postMessage({ type: "agentManager.preloadWorktreeDiffs", worktreeIds: rest }))
+    }
   })
 
   onCleanup(() => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -148,7 +148,8 @@ import { PRPanel } from "./pr/PRPanel"
 import { createRevertFile } from "./revert-file"
 import { FullScreenDiffView } from "../diff-viewer/FullScreenDiffView"
 import { createApplyToLocal } from "./apply-to-local"
-import { createWorktreeDiffs, wireDiffId } from "./worktree-diffs"
+import { createWorktreeDiffs } from "./worktree-diffs"
+import { createDiffWatch } from "./diff-watch"
 import type { ReviewComment } from "../diff-viewer/review-comments"
 import { clearReviewComposer, createReviewComposer } from "../diff-viewer/review-annotations"
 import type { SidebarSearchMenuRef } from "./SidebarSearchMenu"
@@ -1674,42 +1675,18 @@ const AgentManagerContent: Component = () => {
     />
   )
 
-  // Start/stop diff watch when the panel opens/closes, the review tab opens,
-  // or the composite id (context, scope, active session) changes.
-  createEffect(() => {
-    const panel = diffOpen()
-    const active = reviewActive()
-    const id = review.id()
-    const projectId = activeProjectId()
-
-    if ((panel || active) && id) {
-      const data = diffDatas()
-      const wired = wireDiffId(id, projectId)
-      const hasCached = Boolean(data[diffs.dataKey(id, projectId)])
-      setDiffLoading(!hasCached)
-      vscode.postMessage({ type: "agentManager.startDiffWatch", ...wired })
-      return
-    }
-
-    setDiffLoading(false)
-    vscode.postMessage({ type: "agentManager.stopDiffWatch" })
-  })
-
-  // Keep only the likely next selections warm; preloading every worktree can
-  // retain large patches and waste Git work for sessions the user never opens.
-  createEffect(() => {
-    const order = sidebarOrder()
-    const sel = selection() ?? LOCAL
-    const projectId = activeProjectId()
-    const idx = order.findIndex((item) => item.id === sel)
-    if (idx === -1) return
-    const ids = order.filter((item) => item.type === "local" || item.type === "wt").map((item) => item.id)
-    const adjacent = [order[idx - 1]?.id, order[idx + 1]?.id].filter((id): id is string =>
-      Boolean(id && ids.includes(id)),
-    )
-    if (adjacent.length > 0) {
-      vscode.postMessage({ type: "agentManager.preloadWorktreeDiffs", projectId, worktreeIds: adjacent })
-    }
+  createDiffWatch({
+    panel: diffOpen,
+    active: reviewActive,
+    id: review.id,
+    project: activeProjectId,
+    data: diffDatas,
+    dataKey: diffs.dataKey,
+    setLoading: setDiffLoading,
+    vscode,
+    order: sidebarOrder,
+    selection,
+    local: LOCAL,
   })
 
   onCleanup(() => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1756,7 +1756,7 @@ const AgentManagerContent: Component = () => {
 
   const diffFileLoadingForCurrent = createMemo(() => diffs.diffFileLoadingFor(diffScopeId))
 
-  const revertCtl = createRevertFile(diffScopeId, diffCtx, () => review.scope(), vscode, showToast, t)
+  const revertCtl = createRevertFile(diffScopeId, diffCtx, () => review.scope(), activeProjectId, vscode, showToast, t)
 
   const handleConfigureSetupScript = () => {
     vscode.postMessage({ type: "agentManager.configureSetupScript" })

--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -25,7 +25,7 @@ import { useSpeechToTextModels } from "../src/context/speech-to-text-models"
 import {
   getDirectory,
   getFilename,
-  lineCount,
+  diffLineCount,
   sanitizeReviewComments,
   type ReviewComment,
 } from "../diff-viewer/review-comments"
@@ -357,8 +357,7 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
           composer().draft = null
           return
         }
-        const content = currentDraft.side === "deletions" ? diff.before : diff.after
-        const max = lineCount(content)
+        const max = diffLineCount(diff, currentDraft.side)
         if (currentDraft.line < 1 || currentDraft.line > max) {
           setDraft(null)
           draftMeta = null
@@ -496,10 +495,7 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
     }
     return { files: props.diffs.length, additions, deletions, large, collapsed }
   })
-  const allOpen = createMemo(() => {
-    const set = openSet()
-    return props.diffs.every((diff) => !isDiffExpandable(diff) || set.has(diff.file))
-  })
+  const allOpen = createMemo(() => allOpenFiles(props.diffs, open()))
   const openLabel = () => (allOpen() ? t("ui.sessionReview.collapseAll") : t("ui.sessionReview.expandAll"))
   const openIcon = () => (allOpen() ? "files-collapse" : "files-expand")
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/DiffPanel.tsx
@@ -478,14 +478,28 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
     setOpen(toggleOpenFiles(props.diffs, open()))
   }
 
-  const totals = createMemo(() => ({
-    files: props.diffs.length,
-    additions: props.diffs.reduce((sum, diff) => sum + diff.additions, 0),
-    deletions: props.diffs.reduce((sum, diff) => sum + diff.deletions, 0),
-    large: props.diffs.filter((diff) => isDiffExpandable(diff) && isLargeDiffFile(diff)).length,
-    collapsed: props.diffs.filter((diff) => isDiffExpandable(diff) && !open().includes(diff.file)).length,
-  }))
-  const allOpen = createMemo(() => allOpenFiles(props.diffs, open()))
+  const openSet = createMemo(() => new Set(open()))
+
+  const totals = createMemo(() => {
+    const set = openSet()
+    let additions = 0
+    let deletions = 0
+    let large = 0
+    let collapsed = 0
+    for (const diff of props.diffs) {
+      additions += diff.additions
+      deletions += diff.deletions
+      if (isDiffExpandable(diff)) {
+        if (isLargeDiffFile(diff)) large++
+        if (!set.has(diff.file)) collapsed++
+      }
+    }
+    return { files: props.diffs.length, additions, deletions, large, collapsed }
+  })
+  const allOpen = createMemo(() => {
+    const set = openSet()
+    return props.diffs.every((diff) => !isDiffExpandable(diff) || set.has(diff.file))
+  })
   const openLabel = () => (allOpen() ? t("ui.sessionReview.collapseAll") : t("ui.sessionReview.expandAll"))
   const openIcon = () => (allOpen() ? "files-collapse" : "files-expand")
 
@@ -585,12 +599,12 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
               render={(diff) => {
                 const isAdded = () => diff.status === "added"
                 const isDeleted = () => diff.status === "deleted"
-                const isLargeCollapsed = () => isLargeDiffFile(diff) && !open().includes(diff.file)
+                const isLargeCollapsed = () => isLargeDiffFile(diff) && !openSet().has(diff.file)
                 const isLoadingDetail = () => props.loadingFiles?.has(diff.file) ?? false
                 const fileCommentCount = () => (commentsByFile().get(diff.file) ?? []).length
 
                 createEffect(() => {
-                  if (diff.kind === "image" && open().includes(diff.file)) request(diff)
+                  if (diff.kind === "image" && openSet().has(diff.file)) request(diff)
                 })
 
                 return (
@@ -703,7 +717,7 @@ export const DiffPanel: Component<DiffPanelProps> = (props) => {
                       </Accordion.Trigger>
                     </StickyAccordionHeader>
                     <Accordion.Content>
-                      <Show when={open().includes(diff.file)}>
+                      <Show when={openSet().has(diff.file)}>
                         <Show
                           when={diff.summarized !== true}
                           fallback={

--- a/packages/kilo-vscode/webview-ui/agent-manager/apply-to-local.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/apply-to-local.tsx
@@ -33,17 +33,19 @@ interface ApplyToLocalOptions {
   t: ReturnType<typeof useLanguage>["t"]
   /** Current sidebar selection (LOCAL, a worktree id, or null). */
   selection: Accessor<string | null>
+  project: Accessor<string | undefined>
   /** Sentinel id for the local repo selection. */
   local: string
   worktrees: Accessor<{ id: string }[]>
   diffDatas: Accessor<Record<string, WorktreeFileDiff[]>>
+  dataKey: (id: string, projectId?: string) => string
   diffLoading: Accessor<boolean>
   /** Telemetry: metrics.track(name, surface, data). */
   track: ReturnType<typeof tracker>["track"]
 }
 
 export function createApplyToLocal(opts: ApplyToLocalOptions) {
-  const { vscode, dialog, t, selection, local, worktrees, diffDatas, diffLoading } = opts
+  const { vscode, dialog, t, selection, project, local, worktrees, diffDatas, dataKey, diffLoading } = opts
 
   const [applyStates, setApplyStates] = createSignal<Record<string, ApplyState>>({})
   const [applyTarget, setApplyTarget] = createSignal<string | undefined>()
@@ -73,7 +75,7 @@ export function createApplyToLocal(opts: ApplyToLocalOptions) {
   const applyDiffs = createMemo(() => {
     const key = applyDiffKey()
     if (!key) return [] as WorktreeFileDiff[]
-    return diffDatas()[key] ?? ([] as WorktreeFileDiff[])
+    return diffDatas()[dataKey(key, project())] ?? ([] as WorktreeFileDiff[])
   })
 
   const applyStateForTarget = createMemo(() => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/diff-watch.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/diff-watch.ts
@@ -1,0 +1,54 @@
+import { createEffect, type Accessor } from "solid-js"
+import type { useVSCode } from "../src/context/vscode"
+import type { WorktreeFileDiff } from "../src/types/messages"
+import { wireDiffId } from "./worktree-diffs"
+
+type Item = { id: string; type?: string }
+
+interface Options {
+  panel: Accessor<boolean>
+  active: Accessor<boolean>
+  id: Accessor<string | undefined>
+  project: Accessor<string | undefined>
+  data: Accessor<Record<string, WorktreeFileDiff[]>>
+  dataKey: (id: string, projectId?: string) => string
+  setLoading: (value: boolean) => void
+  vscode: ReturnType<typeof useVSCode>
+  order: Accessor<Item[]>
+  selection: Accessor<string | null>
+  local: string
+}
+
+export function createDiffWatch(opts: Options): void {
+  createEffect(() => {
+    const projectId = opts.project()
+    const id = opts.id()
+    if (opts.panel() || opts.active()) {
+      if (!id) return
+      const wired = wireDiffId(id, projectId)
+      opts.setLoading(!opts.data()[opts.dataKey(id, projectId)])
+      opts.vscode.postMessage({ type: "agentManager.startDiffWatch", ...wired })
+      return
+    }
+
+    opts.setLoading(false)
+    opts.vscode.postMessage({ type: "agentManager.stopDiffWatch" })
+  })
+
+  createEffect(() => {
+    const order = opts.order()
+    const selected = opts.selection() ?? opts.local
+    const idx = order.findIndex((item) => item.id === selected)
+    if (idx === -1) return
+    const ids = order.filter((item) => item.type === "local" || item.type === "wt").map((item) => item.id)
+    const adjacent = [order[idx - 1]?.id, order[idx + 1]?.id].filter((id): id is string =>
+      Boolean(id && ids.includes(id)),
+    )
+    if (adjacent.length === 0) return
+    opts.vscode.postMessage({
+      type: "agentManager.preloadWorktreeDiffs",
+      projectId: opts.project(),
+      worktreeIds: adjacent,
+    })
+  })
+}

--- a/packages/kilo-vscode/webview-ui/agent-manager/revert-file.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/revert-file.ts
@@ -15,37 +15,48 @@ export function createRevertFile(
   diffScopeId: Accessor<string | undefined>,
   ctx: Accessor<string | undefined>,
   scope: Accessor<string>,
+  project: Accessor<string | undefined>,
   vscode: VsCode,
   showToast: (t: Toast) => void,
   t: (key: string) => string,
 ) {
   const [files, setFiles] = createSignal<Record<string, Set<string>>>({})
+  const key = (id: string, projectId = project()) => (projectId ? `${projectId}\0${id}` : id)
 
   const reverting = createMemo(() => {
     const id = diffScopeId()
     if (!id) return new Set<string>()
-    return files()[id] ?? new Set<string>()
+    return files()[key(id)] ?? new Set<string>()
   })
 
   function revert(file: string) {
     const id = diffScopeId()
     const context = ctx()
     if (!id || !context) return
+    const projectId = project()
+    const dataKey = key(id, projectId)
     setFiles((prev) => {
-      const set = new Set(prev[id] ?? [])
+      const set = new Set(prev[dataKey] ?? [])
       set.add(file)
-      return { ...prev, [id]: set }
+      return { ...prev, [dataKey]: set }
     })
-    vscode.postMessage({ type: "agentManager.revertWorktreeFile", sessionId: context, file, scope: scope() })
+    vscode.postMessage({
+      type: "agentManager.revertWorktreeFile",
+      projectId,
+      sessionId: context,
+      file,
+      scope: scope(),
+    })
   }
 
   function onResult(ev: AgentManagerRevertWorktreeFileResultMessage) {
+    const dataKey = key(ev.sessionId, ev.projectId)
     setFiles((prev) => {
-      const set = new Set(prev[ev.sessionId] ?? [])
+      const set = new Set(prev[dataKey] ?? [])
       set.delete(ev.file)
       const next = { ...prev }
-      if (set.size === 0) delete next[ev.sessionId]
-      else next[ev.sessionId] = set
+      if (set.size === 0) delete next[dataKey]
+      else next[dataKey] = set
       return next
     })
     if (ev.status === "success") {

--- a/packages/kilo-vscode/webview-ui/agent-manager/worktree-diffs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/worktree-diffs.ts
@@ -24,16 +24,20 @@ import type {
  * wire fields the extension expects. Bare ids (no scope separator) parse to
  * the default branch scope.
  */
-export function wireDiffId(id: string) {
+export function wireDiffId(id: string, projectId?: string) {
   const { ctx, scope, sessionId } = parseDiffId(id)
-  return { sessionId: ctx, scope, diffSessionId: sessionId }
+  return { sessionId: ctx, scope, diffSessionId: sessionId, ...(projectId ? { projectId } : {}) }
 }
 
-export function createWorktreeDiffs(vscode: ReturnType<typeof useVSCode>) {
+export function createWorktreeDiffs(
+  vscode: ReturnType<typeof useVSCode>,
+  project: Accessor<string | undefined> = () => undefined,
+) {
   const [diffDatas, setDiffDatas] = createSignal<Record<string, WorktreeFileDiff[]>>({})
   const [diffLoading, setDiffLoading] = createSignal(false)
   const [diffNotices, setDiffNotices] = createSignal<Record<string, string | undefined>>({})
   const [diffFileLoading, setDiffFileLoading] = createSignal<Record<string, Record<string, true>>>({})
+  const key = (id: string, projectId = project()) => (projectId ? `${projectId}\0${id}` : id)
 
   const setDiffFilePending = (sessionId: string, file: string, value: boolean) => {
     setDiffFileLoading((prev) => {
@@ -63,18 +67,20 @@ export function createWorktreeDiffs(vscode: ReturnType<typeof useVSCode>) {
 
   /** Lazily load a single file's full diff for the given composite diff id. */
   const requestDiffFile = (id: string, file: string) => {
-    if (diffFileLoading()[id]?.[file]) return
-    setDiffFilePending(id, file, true)
-    vscode.postMessage({ type: "agentManager.requestWorktreeDiffFile", file, ...wireDiffId(id) })
+    const dataKey = key(id)
+    if (diffFileLoading()[dataKey]?.[file]) return
+    setDiffFilePending(dataKey, file, true)
+    vscode.postMessage({ type: "agentManager.requestWorktreeDiffFile", file, ...wireDiffId(id, project()) })
   }
 
   /** Files the backend flagged as stale in a merged update need a fresh fetch. */
-  const refreshStaleDiffs = (id: string, files: Set<string>) => {
-    const loading = diffFileLoading()[id] ?? {}
+  const refreshStaleDiffs = (id: string, files: Set<string>, projectId = project()) => {
+    const dataKey = key(id, projectId)
+    const loading = diffFileLoading()[dataKey] ?? {}
     for (const file of files) {
       if (loading[file]) continue
-      setDiffFilePending(id, file, true)
-      vscode.postMessage({ type: "agentManager.requestWorktreeDiffFile", file, ...wireDiffId(id) })
+      setDiffFilePending(dataKey, file, true)
+      vscode.postMessage({ type: "agentManager.requestWorktreeDiffFile", file, ...wireDiffId(id, projectId) })
     }
   }
 
@@ -82,43 +88,46 @@ export function createWorktreeDiffs(vscode: ReturnType<typeof useVSCode>) {
   const diffFileLoadingFor = (sessionId: Accessor<string | undefined>) => {
     const id = sessionId()
     if (!id) return new Set<string>()
-    return new Set(Object.keys(diffFileLoading()[id] ?? {}))
+    return new Set(Object.keys(diffFileLoading()[key(id)] ?? {}))
   }
 
   // Backend messages.
 
   const onWorktreeDiff = (ev: AgentManagerWorktreeDiffMessage) => {
+    const dataKey = key(ev.sessionId, ev.projectId)
     let staleFiles: Set<string> | undefined
     setDiffDatas((prev) => {
-      const existing = prev[ev.sessionId]
+      const existing = prev[dataKey]
       const merged = existing ? mergeWorktreeDiffs(existing, ev.diffs) : { diffs: ev.diffs, stale: new Set<string>() }
       staleFiles = merged.stale
       const next = merged.diffs
       if (existing && existing.length === next.length && existing.every((old, i) => old === next[i])) return prev
-      return { ...prev, [ev.sessionId]: next }
+      return { ...prev, [dataKey]: next }
     })
-    if (staleFiles) refreshStaleDiffs(ev.sessionId, staleFiles)
+    if (staleFiles) refreshStaleDiffs(ev.sessionId, staleFiles, ev.projectId)
   }
 
   const onWorktreeDiffFile = (ev: AgentManagerWorktreeDiffFileMessage) => {
+    const dataKey = key(ev.sessionId, ev.projectId)
     if (ev.diff) {
       setDiffDatas((prev) => {
-        const existing = prev[ev.sessionId] ?? []
+        const existing = prev[dataKey] ?? []
         const next = existing.map((item) => (item.file === ev.diff!.file ? ev.diff! : item))
-        return { ...prev, [ev.sessionId]: next }
+        return { ...prev, [dataKey]: next }
       })
-      setDiffFilePending(ev.sessionId, ev.diff.file, false)
+      setDiffFilePending(dataKey, ev.diff.file, false)
       return
     }
-    setDiffFilePending(ev.sessionId, ev.file, false)
+    setDiffFilePending(dataKey, ev.file, false)
   }
 
   const onWorktreeDiffLoading = (ev: AgentManagerWorktreeDiffLoadingMessage) => {
+    if (ev.projectId !== undefined && ev.projectId !== project()) return
     setDiffLoading(ev.loading)
   }
 
   const onWorktreeDiffNotice = (ev: AgentManagerWorktreeDiffNoticeMessage) => {
-    setDiffNotices((prev) => ({ ...prev, [ev.sessionId]: ev.notice }))
+    setDiffNotices((prev) => ({ ...prev, [key(ev.sessionId, ev.projectId)]: ev.notice }))
   }
 
   return {
@@ -126,6 +135,7 @@ export function createWorktreeDiffs(vscode: ReturnType<typeof useVSCode>) {
     diffLoading,
     setDiffLoading,
     diffNotices,
+    dataKey: key,
     requestDiffFile,
     refreshStaleDiffs,
     diffFileLoadingFor,

--- a/packages/kilo-vscode/webview-ui/diff-viewer/FullScreenDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/diff-viewer/FullScreenDiffView.tsx
@@ -498,7 +498,7 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
     const handle = virtualizer()
     if (!handle) return
     const file = rows()[handle.findItemIndex(handle.scrollOffset)]?.file
-    if (file) setActiveFile(file)
+    if (file && file !== activeFile()) setActiveFile(file)
   }
 
   const scheduleSyncActiveFile = () => {
@@ -536,14 +536,28 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
     ),
   )
 
-  const totals = createMemo(() => ({
-    files: props.diffs.length,
-    additions: props.diffs.reduce((s, d) => s + d.additions, 0),
-    deletions: props.diffs.reduce((s, d) => s + d.deletions, 0),
-    large: props.diffs.filter((diff) => isDiffExpandable(diff) && isLargeDiffFile(diff)).length,
-    collapsed: props.diffs.filter((diff) => isDiffExpandable(diff) && !open().includes(diff.file)).length,
-  }))
-  const allOpen = createMemo(() => allOpenFiles(props.diffs, open()))
+  const openSet = createMemo(() => new Set(open()))
+
+  const totals = createMemo(() => {
+    const set = openSet()
+    let additions = 0
+    let deletions = 0
+    let large = 0
+    let collapsed = 0
+    for (const diff of props.diffs) {
+      additions += diff.additions
+      deletions += diff.deletions
+      if (isDiffExpandable(diff)) {
+        if (isLargeDiffFile(diff)) large++
+        if (!set.has(diff.file)) collapsed++
+      }
+    }
+    return { files: props.diffs.length, additions, deletions, large, collapsed }
+  })
+  const allOpen = createMemo(() => {
+    const set = openSet()
+    return props.diffs.every((diff) => !isDiffExpandable(diff) || set.has(diff.file))
+  })
   const openLabel = () => (allOpen() ? t("ui.sessionReview.collapseAll") : t("ui.sessionReview.expandAll"))
 
   return (
@@ -663,12 +677,12 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
                   render={(diff) => {
                     const isAdded = () => diff.status === "added"
                     const isDeleted = () => diff.status === "deleted"
-                    const isLargeCollapsed = () => isLargeDiffFile(diff) && !open().includes(diff.file)
+                    const isLargeCollapsed = () => isLargeDiffFile(diff) && !openSet().has(diff.file)
                     const isLoadingDetail = () => props.loadingFiles?.has(diff.file) ?? false
                     const fileCommentCount = () => (commentsByFile().get(diff.file) ?? []).length
 
                     createEffect(() => {
-                      if (diff.kind === "image" && open().includes(diff.file)) request(diff)
+                      if (diff.kind === "image" && openSet().has(diff.file)) request(diff)
                     })
 
                     return (
@@ -777,7 +791,7 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
                           </Accordion.Trigger>
                         </StickyAccordionHeader>
                         <Accordion.Content>
-                          <Show when={open().includes(diff.file)}>
+                          <Show when={openSet().has(diff.file)}>
                             <Show
                               when={diff.summarized !== true}
                               fallback={

--- a/packages/kilo-vscode/webview-ui/diff-viewer/FullScreenDiffView.tsx
+++ b/packages/kilo-vscode/webview-ui/diff-viewer/FullScreenDiffView.tsx
@@ -30,7 +30,7 @@ import { useSpeechToText } from "../src/components/speech-to-text/useSpeechToTex
 import { useSpeechToTextModels } from "../src/context/speech-to-text-models"
 import { FileTree } from "./FileTree"
 import { treeOrder } from "./file-tree-utils"
-import { getDirectory, getFilename, lineCount, sanitizeReviewComments, type ReviewComment } from "./review-comments"
+import { diffLineCount, getDirectory, getFilename, sanitizeReviewComments, type ReviewComment } from "./review-comments"
 import {
   buildFileAnnotations,
   buildReviewAnnotation,
@@ -366,8 +366,7 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
           composer().draft = null
           return
         }
-        const content = currentDraft.side === "deletions" ? diff.before : diff.after
-        const max = lineCount(content)
+        const max = diffLineCount(diff, currentDraft.side)
         if (currentDraft.line < 1 || currentDraft.line > max) {
           setDraft(null)
           draftMeta = null
@@ -554,10 +553,7 @@ export const FullScreenDiffView: Component<FullScreenDiffViewProps> = (props) =>
     }
     return { files: props.diffs.length, additions, deletions, large, collapsed }
   })
-  const allOpen = createMemo(() => {
-    const set = openSet()
-    return props.diffs.every((diff) => !isDiffExpandable(diff) || set.has(diff.file))
-  })
+  const allOpen = createMemo(() => allOpenFiles(props.diffs, open()))
   const openLabel = () => (allOpen() ? t("ui.sessionReview.collapseAll") : t("ui.sessionReview.expandAll"))
 
   return (

--- a/packages/kilo-vscode/webview-ui/diff-viewer/diff-requests.ts
+++ b/packages/kilo-vscode/webview-ui/diff-viewer/diff-requests.ts
@@ -42,8 +42,9 @@ export function createDiffRequests(opts: DiffRequestOptions) {
         for (const file of requested.keys()) {
           if (!files.has(file)) requested.delete(file)
         }
+        const diffMap = new Map(diffs.map((item) => [item.file, item]))
         for (const file of open) {
-          const diff = diffs.find((item) => item.file === file)
+          const diff = diffMap.get(file)
           if (!diff || diff.kind === "image") continue
           request(diff)
         }

--- a/packages/kilo-vscode/webview-ui/diff-viewer/file-tree-utils.ts
+++ b/packages/kilo-vscode/webview-ui/diff-viewer/file-tree-utils.ts
@@ -39,12 +39,14 @@ export function buildFileTree(diffs: WorktreeFileDiff[]): FileTreeNode[] {
 
 /** Sort children at every level: directories first (alphabetically), then files (alphabetically). */
 function sortTree(nodes: FileTreeNode[]) {
-  nodes.sort((a, b) => {
-    const aDir = a.children ? 0 : 1
-    const bDir = b.children ? 0 : 1
-    if (aDir !== bDir) return aDir - bDir
-    return a.name.localeCompare(b.name)
-  })
+  if (nodes.length > 1) {
+    nodes.sort((a, b) => {
+      const aDir = a.children ? 0 : 1
+      const bDir = b.children ? 0 : 1
+      if (aDir !== bDir) return aDir - bDir
+      return a.name.localeCompare(b.name)
+    })
+  }
   for (const node of nodes) {
     if (node.children) sortTree(node.children)
   }

--- a/packages/kilo-vscode/webview-ui/diff-viewer/review-comments.ts
+++ b/packages/kilo-vscode/webview-ui/diff-viewer/review-comments.ts
@@ -11,6 +11,24 @@ export function lineCount(text: string): number {
   return n
 }
 
+function patchLineCount(patch: string, side: "deletions" | "additions"): number {
+  const re = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/gm
+  let max = 0
+  for (const match of patch.matchAll(re)) {
+    const start = Number(match[side === "deletions" ? 1 : 3])
+    const count = Number(match[side === "deletions" ? 2 : 4] ?? 1)
+    if (count > 0) max = Math.max(max, start + count - 1)
+  }
+  return max
+}
+
+export function diffLineCount(diff: WorktreeFileDiff, side: "deletions" | "additions"): number {
+  const content = side === "deletions" ? diff.before : diff.after
+  if (content.length > 0) return lineCount(content)
+  if (diff.patch) return patchLineCount(diff.patch, side)
+  return 0
+}
+
 export function getDirectory(path: string): string {
   const idx = path.lastIndexOf("/")
   return idx === -1 ? "" : path.slice(0, idx + 1)
@@ -44,9 +62,8 @@ export function sanitizeReviewComments(comments: ReviewComment[], diffs: Worktre
   return comments.filter((comment) => {
     const diff = map.get(comment.file)
     if (!diff) return false
-    const content = comment.side === "deletions" ? diff.before : diff.after
     if (diff.summarized === true) return true
-    const max = lineCount(content)
+    const max = diffLineCount(diff, comment.side)
     if (comment.line < 1) return false
     if (comment.line > max) return false
     return true

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -967,12 +967,14 @@ export interface AgentManagerImportResultMessage {
 // Agent Manager: Diff data push (extension → webview)
 export interface AgentManagerWorktreeDiffMessage {
   type: "agentManager.worktreeDiff"
+  projectId?: string
   sessionId: string
   diffs: WorktreeFileDiff[]
 }
 
 export interface AgentManagerWorktreeDiffFileMessage {
   type: "agentManager.worktreeDiffFile"
+  projectId?: string
   sessionId: string
   file: string
   diff: WorktreeFileDiff | null
@@ -981,6 +983,7 @@ export interface AgentManagerWorktreeDiffFileMessage {
 // Agent Manager: Diff loading state (extension → webview)
 export interface AgentManagerWorktreeDiffLoadingMessage {
   type: "agentManager.worktreeDiffLoading"
+  projectId?: string
   sessionId: string
   loading: boolean
 }
@@ -988,6 +991,7 @@ export interface AgentManagerWorktreeDiffLoadingMessage {
 // Agent Manager: Source-level diff notice (extension → webview)
 export interface AgentManagerWorktreeDiffNoticeMessage {
   type: "agentManager.worktreeDiffNotice"
+  projectId?: string
   sessionId: string
   notice?: DiffViewerNotice
 }
@@ -1003,6 +1007,7 @@ export interface AgentManagerApplyWorktreeDiffResultMessage {
 // Agent Manager: Revert single file result (extension → webview)
 export interface AgentManagerRevertWorktreeFileResultMessage {
   type: "agentManager.revertWorktreeFileResult"
+  projectId?: string
   sessionId: string
   file: string
   status: "success" | "error"
@@ -1012,6 +1017,7 @@ export interface AgentManagerRevertWorktreeFileResultMessage {
 // Agent Manager: Branch picker data for a diff context (extension → webview)
 export interface AgentManagerDiffBranchesMessage {
   type: "agentManager.diffBranches"
+  projectId?: string
   sessionId: string
   branches: BranchInfo[]
   defaultBranch: string

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -987,6 +987,12 @@ export interface SetDiffBaseBranchMessage {
   branch?: string
 }
 
+// Agent Manager: Preload diffs for adjacent or candidate worktrees (webview → extension)
+export interface PreloadWorktreeDiffsMessage {
+  type: "agentManager.preloadWorktreeDiffs"
+  worktreeIds: string[]
+}
+
 // Agent Manager: PR messages (webview → extension)
 export interface RefreshPRMessage {
   type: "agentManager.refreshPR"
@@ -1545,6 +1551,7 @@ export type WebviewMessage =
   | StopDiffWatchMessage
   | RequestDiffBranchesMessage
   | SetDiffBaseBranchMessage
+  | PreloadWorktreeDiffsMessage
   | RefreshPRMessage
   | OpenPRMessage
   | CommentActionMessage

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -949,12 +949,14 @@ export interface ImportFromPRRequest {
 // Agent Manager: Request one-shot diff fetch (webview → extension)
 export interface RequestWorktreeDiffMessage {
   type: "agentManager.requestWorktreeDiff"
+  projectId?: string
   sessionId: string
   scope?: string
 }
 
 export interface RequestWorktreeDiffFileMessage {
   type: "agentManager.requestWorktreeDiffFile"
+  projectId?: string
   sessionId: string
   file: string
   scope?: string
@@ -963,6 +965,7 @@ export interface RequestWorktreeDiffFileMessage {
 // Agent Manager: Start polling for live diff updates (webview → extension)
 export interface StartDiffWatchMessage {
   type: "agentManager.startDiffWatch"
+  projectId?: string
   sessionId: string
   scope?: string
 }
@@ -975,6 +978,7 @@ export interface StopDiffWatchMessage {
 // Agent Manager: Request branch picker data for a diff context (webview → extension)
 export interface RequestDiffBranchesMessage {
   type: "agentManager.requestDiffBranches"
+  projectId?: string
   sessionId: string
   scope?: string
 }
@@ -982,6 +986,7 @@ export interface RequestDiffBranchesMessage {
 // Agent Manager: Set or clear the base branch override for a diff context (webview → extension)
 export interface SetDiffBaseBranchMessage {
   type: "agentManager.setDiffBaseBranch"
+  projectId?: string
   sessionId: string
   scope?: string
   branch?: string
@@ -990,6 +995,7 @@ export interface SetDiffBaseBranchMessage {
 // Agent Manager: Preload diffs for adjacent or candidate worktrees (webview → extension)
 export interface PreloadWorktreeDiffsMessage {
   type: "agentManager.preloadWorktreeDiffs"
+  projectId?: string
   worktreeIds: string[]
 }
 

--- a/packages/opencode/src/tool/truncate.ts
+++ b/packages/opencode/src/tool/truncate.ts
@@ -6,7 +6,6 @@ import type { Agent } from "../agent/agent"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { evaluate } from "@/permission/evaluate"
 import { Config } from "@/config/config"
-import { Identifier } from "../id/id"
 import { ToolID } from "./schema"
 import { TRUNCATION_DIR } from "./truncation-dir"
 
@@ -52,17 +51,20 @@ const layer = Layer.effect(
     const fs = yield* FSUtil.Service
 
     const cleanup = Effect.fn("Truncate.cleanup")(function* () {
-      const cutoff = Identifier.timestamp(
-        Identifier.create("tool", "ascending", Date.now() - Duration.toMillis(RETENTION)),
-      )
+      // kilocode_change start - use file mtimes because encoded IDs wrap
+      const cutoff = Date.now() - Duration.toMillis(RETENTION)
       const entries = yield* fs.readDirectory(TRUNCATION_DIR).pipe(
         Effect.map((all) => all.filter((name) => name.startsWith("tool_"))),
         Effect.catch(() => Effect.succeed([])),
       )
       for (const entry of entries) {
-        if (Identifier.timestamp(entry) >= cutoff) continue
-        yield* fs.remove(path.join(TRUNCATION_DIR, entry)).pipe(Effect.catch(() => Effect.void))
+        const file = path.join(TRUNCATION_DIR, entry)
+        const info = yield* fs.stat(file).pipe(Effect.catch(() => Effect.succeed(undefined)))
+        const mtime = info && Option.getOrUndefined(info.mtime)
+        if (!mtime || mtime.getTime() >= cutoff) continue
+        yield* fs.remove(file).pipe(Effect.catch(() => Effect.void))
       }
+      // kilocode_change end
     })
 
     const write = Effect.fn("Truncate.write")(function* (text: string) {

--- a/packages/opencode/test/tool/truncation.test.ts
+++ b/packages/opencode/test/tool/truncation.test.ts
@@ -242,18 +242,22 @@ describe("Truncate", () => {
   describe("cleanup", () => {
     const DAY_MS = 24 * 60 * 60 * 1000
 
-    it.live("deletes files older than 7 days and preserves recent files", () =>
+    // kilocode_change start - use IDs across the timestamp wrap and set file times explicitly
+    it.live("uses file mtime when IDs wrap", () =>
       Effect.gen(function* () {
         const svc = yield* Truncate.Service
         const fs = yield* FileSystem.FileSystem
 
         yield* fs.makeDirectory(Truncate.DIR, { recursive: true })
 
-        const old = path.join(Truncate.DIR, Identifier.create("tool", "ascending", Date.now() - 10 * DAY_MS))
-        const recent = path.join(Truncate.DIR, Identifier.create("tool", "ascending", Date.now() - 3 * DAY_MS))
+        const old = path.join(Truncate.DIR, Identifier.create("tool", "ascending", 2 ** 36 - 1))
+        const recent = path.join(Truncate.DIR, Identifier.create("tool", "ascending", 2 ** 36 + 1))
 
         yield* writeFileStringScoped(old, "old content")
         yield* writeFileStringScoped(recent, "recent content")
+        yield* fs.utimes(old, new Date(), new Date(Date.now() - 10 * DAY_MS))
+        yield* fs.utimes(recent, new Date(), new Date(Date.now() - 3 * DAY_MS))
+        // kilocode_change end
         yield* svc.cleanup()
 
         expect(yield* fs.exists(old)).toBe(false)


### PR DESCRIPTION
Diff loading in Agent Manager and the shared Changes viewer performed avoidable serial Git work, then fetched each opened file again before it could render. Large reviews also repeated linear scans with array membership checks, while switching worktrees discarded useful recent results.

This change keeps the initial path hunk-bounded and resilient:

- Runs patch, status, numstat, and untracked-file queries concurrently and reuses merge-base results for the short polling window.
- Splits aggregate patches using the authoritative changed-file list, including paths containing spaces or ` b/`, and falls back to lazy per-file detail whenever patch generation is missing, too large, binary, image-based, or requires complete Markdown contents.
- Caps aggregate patch output at 20 MB and bounds the scope-aware worktree cache to four entries and 40 MB. Only adjacent worktrees are preloaded, stale preloads are discarded after base changes, and cached data is refreshed without reposting unchanged results.
- Preserves deterministic untracked ordering and stable invalidation stamps for summarized files.
- Keeps expensive Pierre rendering behind the shared intersection observer and schedules one newly visible diff per animation frame.
- Replaces repeated totals scans and array membership checks with one linear pass and constant-time `Set` lookups.

On this branch's 13-file review, 30 local polling iterations measured with the same Git commands produced:

| Scenario | Median | p95 | Change vs serial |
|---|---:|---:|---:|
| Serial metadata baseline | 164.90 ms | 205.11 ms | baseline |
| Parallel poll, uncached merge-base | 116.30 ms | 146.50 ms | 29.5% median, 28.6% p95 faster |
| Parallel poll, cached merge-base | 88.88 ms | 114.16 ms | 46.1% median, 44.3% p95 faster |

The UI-side summary work is reduced from repeated scans with `Array.includes` membership checks, worst-case O(n²), to O(n). Cache and patch memory are now explicitly bounded rather than growing with every worktree.
