### PR TITLE
docs(kilo-docs): remove maximum review time setting from Code Reviews

### DIFF
--- a/packages/kilo-docs/pages/automate/code-reviews/github.md
+++ b/packages/kilo-docs/pages/automate/code-reviews/github.md
@@ -39,7 +39,6 @@ The GitHub App requests the following permissions:
    - **Review Style** — Strict, Balanced, or Lenient
    - **Repository Selection** — All repositories or select specific ones
    - **Focus Areas** — Security, performance, bugs, style, testing, documentation
-   - **Max Review Time** — 5 to 30 minutes
    - **Use REVIEW.md** — Load repository-specific review guidance, including sub-agent usage, from the base branch
 4. Click **Save Configuration**
 
@@ -93,7 +92,7 @@ The repository list is synced from GitHub and can be refreshed from the configur
 
 - Check the Code Reviews page for error details on specific reviews
 - Ensure you have sufficient Kilo Code credits
-- Very large PRs may time out — try increasing the max review time
+- Very large PRs may time out — consider splitting the change into smaller PRs
 
 ### The GitHub App is missing permissions
 

--- a/packages/kilo-docs/pages/automate/code-reviews/gitlab.md
+++ b/packages/kilo-docs/pages/automate/code-reviews/gitlab.md
@@ -36,7 +36,6 @@ Once connected, return here to configure the Review Agent.
    - **Review Style** — Strict, Balanced, or Lenient
    - **Repository Selection** — All repositories or select specific ones
    - **Focus Areas** — Security, performance, bugs, style, testing, documentation
-   - **Max Review Time** — 5 to 30 minutes
    - **Use REVIEW.md** — Load repository-specific review guidance, including sub-agent usage, from the base branch
 4. Click **Save Configuration**
 
@@ -120,7 +119,7 @@ You need **Maintainer role** on the GitLab project. Both webhook creation and bo
 
 - Check the Code Reviews page for error details
 - Ensure you have sufficient Kilo Code credits
-- Large MRs may time out — increase the max review time setting
+- Large MRs may time out — consider splitting the change into smaller MRs
 
 ### No projects listed after connecting
 

--- a/packages/kilo-docs/pages/automate/code-reviews/overview.md
+++ b/packages/kilo-docs/pages/automate/code-reviews/overview.md
@@ -45,8 +45,7 @@ Before enabling Code Reviews:
 4. Select a **Review Style** — Strict, Balanced, or Lenient.
 5. Choose which **repositories** should receive automatic reviews.
 6. Optionally select **Focus Areas** such as security, performance, bugs, style, testing, or documentation.
-7. Set a **maximum review time** (5–30 minutes).
-8. Optionally enable **Use REVIEW.md** and add a `REVIEW.md` file at the repository root to shape how the agent reviews your code.
+7. Optionally enable **Use REVIEW.md** and add a `REVIEW.md` file at the repository root to shape how the agent reviews your code.
 
 Once configured, the Review Agent runs automatically on PR/MR events. For platform-specific setup, see:
 
@@ -154,8 +153,7 @@ When a pull request or merge request is opened or updated:
    - Summary findings
    - Suggested fixes
    - Risk and severity tagging
-5. Reviews respect the **maximum time limit** you set.
-6. Only repositories you’ve selected will trigger automatic analysis.
+5. Only repositories you’ve selected will trigger automatic analysis.
 
 Reviews are posted directly in your platform (GitHub or GitLab) as if coming from a team reviewer.
 
@@ -235,7 +233,7 @@ The Review Agent is ideal for:
 
 ## Limitations and Guidance
 
-- Reviews can run for **up to 30 minutes** depending on your setting.
+- Reviews are subject to a fixed time limit — consider splitting very large PRs into smaller ones.
 - The agent reviews **only the changed files**, not the entire repository.
 - Some highly dynamic or domain-specific code may require additional context in `REVIEW.md`.
 - The agent will only run on **selected repositories**.


### PR DESCRIPTION
## Issue

Fixes #13147

## Context

The maximum review time setting was removed server-side ([Kilo-Org/cloud#3470](https://github.com/Kilo-Org/cloud/pull/3470), `fix(code-reviews): remove unused time setting`): the slider was removed from the configuration form and `maxReviewTimeMinutes` was dropped from the API schemas and DB config. The Code Reviews docs still described this setting, which is why users can no longer find it in the dashboard.

## Implementation

Removed all references to the maximum review time setting from the Code Reviews docs:

- **overview.md**: dropped the "Set a maximum review time (5–30 minutes)" Getting Started step, the "Reviews respect the maximum time limit you set" item in How Code Reviews Work, and replaced the "up to 30 minutes depending on your setting" limitation with a note about a fixed time limit
- **github.md / gitlab.md**: removed the "Max Review Time — 5 to 30 minutes" configuration bullet and rewrote the troubleshooting tips that suggested increasing the max review time to instead suggest splitting large PRs/MRs

## Screenshots / Video

N/A — docs text-only change.

## How to Test

### Manual/local verification

- Ran `bun run script/check-md-table-padding.ts` — 393 files checked, no padded tables found (agent)
- Verified with grep that no references to "max(imum) review time" remain in `packages/kilo-docs/pages/automate/code-reviews/` (agent)

### Reviewer test steps

1. Read the changed pages and confirm no mention of a configurable maximum review time remains
2. Compare the described Code Reviews settings with the current [app.kilo.ai/code-reviews](https://app.kilo.ai/code-reviews) form

### Blocked checks and substitute verification

- None

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes (docs-only, `kilo-docs` is not a versioned package — no changeset needed)
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.