### PR TITLE
fix(ui): preserve streaming chat scroll position

### DIFF
--- a/.changeset/fix-streaming-scroll-follow.md
+++ b/.changeset/fix-streaming-scroll-follow.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-ui": patch
+---
+
+Keep chat pinned to the latest streaming output through layout reflows and downward scrolling.

--- a/packages/kilo-ui/src/hooks/create-auto-scroll.test.tsx
+++ b/packages/kilo-ui/src/hooks/create-auto-scroll.test.tsx
@@ -203,6 +203,39 @@ describe("createAutoScroll non-scrollable layouts", () => {
     ctx.dispose()
   })
 
+  test("continues following streaming growth after a downward wheel at the bottom", () => {
+    const ctx = setup({ working: true })
+    ctx.el.scrollHeight = 1000
+    ctx.el.clientHeight = 200
+    ctx.el.scrollTop = 800
+
+    ctx.el.fire("wheel", new FakeWheelEvent(50, ctx.el) as unknown as Event)
+    ctx.el.scrollHeight = 1048
+    ctx.resize(0)
+
+    expect(ctx.scroll.userScrolled()).toBe(false)
+    expect(ctx.el.scrollTop).toBe(1048)
+    ctx.dispose()
+  })
+
+  test("continues following when streaming reflow emits scroll before resize", () => {
+    const ctx = setup({ working: true })
+    ctx.el.scrollHeight = 1000
+    ctx.el.clientHeight = 200
+    ctx.el.scrollTop = 800
+
+    ctx.el.scrollHeight = 1108
+    ctx.scroll.handleScroll()
+
+    expect(ctx.scroll.userScrolled()).toBe(false)
+
+    ctx.resize(0)
+
+    expect(ctx.scroll.userScrolled()).toBe(false)
+    expect(ctx.el.scrollTop).toBe(1108)
+    ctx.dispose()
+  })
+
   test("follows when initially short content starts overflowing", () => {
     const ctx = setup()
     ctx.resize()

--- a/packages/kilo-ui/src/hooks/create-auto-scroll.test.tsx
+++ b/packages/kilo-ui/src/hooks/create-auto-scroll.test.tsx
@@ -295,4 +295,23 @@ describe("createAutoScroll non-scrollable layouts", () => {
     expect(ctx.el.scrollTop).toBe(600)
     ctx.dispose()
   })
+
+  test("pauses when a native scrollbar drag changes scroll position without input events", () => {
+    const ctx = setup({ working: true })
+    ctx.el.scrollHeight = 1000
+    ctx.el.clientHeight = 200
+    ctx.el.scrollTop = 800
+    ctx.scroll.handleScroll()
+
+    ctx.el.scrollTop = 600
+    ctx.scroll.handleScroll()
+
+    expect(ctx.scroll.userScrolled()).toBe(true)
+
+    ctx.el.scrollHeight = 1050
+    ctx.resize()
+
+    expect(ctx.el.scrollTop).toBe(600)
+    ctx.dispose()
+  })
 })

--- a/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
+++ b/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
@@ -25,6 +25,8 @@ export function createAutoScroll(options: AutoScrollOptions) {
   let settling = false
   let settleTimer: ReturnType<typeof setTimeout> | undefined
   let cleanup: (() => void) | undefined
+  let lastTop = 0
+  let lastHeight = 0
 
   const [store, setStore] = createStore({
     contentRef: undefined as HTMLElement | undefined,
@@ -101,6 +103,9 @@ export function createAutoScroll(options: AutoScrollOptions) {
 
     const input = userActivity.consumeScroll()
     const distance = distanceFromBottom(scroll)
+    const moved = Math.abs(scroll.scrollTop - lastTop) > 1 && Math.abs(scroll.scrollHeight - lastHeight) <= 1
+    lastTop = scroll.scrollTop
+    lastHeight = scroll.scrollHeight
 
     if (!canScroll(scroll)) return
 
@@ -111,7 +116,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
 
     // Virtualizer and layout remeasurement can emit scroll before the
     // ResizeObserver restores bottom-follow. Only user input should pause it.
-    if (!store.userScrolled && !input && !userActivity.isRecent()) return
+    if (!store.userScrolled && !input && !userActivity.isRecent() && !moved) return
 
     stop()
   }
@@ -204,6 +209,8 @@ export function createAutoScroll(options: AutoScrollOptions) {
 
     if (!el) return
 
+    lastTop = el.scrollTop
+    lastHeight = el.scrollHeight
     updateOverflowAnchor(el)
     cleanup = userActivity.listen(el)
   }

--- a/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
+++ b/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
@@ -99,7 +99,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
   const handleScroll = () => {
     if (!scroll) return
 
-    userActivity.consumeScroll()
+    const input = userActivity.consumeScroll()
     const distance = distanceFromBottom(scroll)
 
     if (!canScroll(scroll)) return
@@ -108,6 +108,10 @@ export function createAutoScroll(options: AutoScrollOptions) {
       if (store.userScrolled && (distance < 2 || !userActivity.isRecent())) setStore("userScrolled", false)
       return
     }
+
+    // Virtualizer and layout remeasurement can emit scroll before the
+    // ResizeObserver restores bottom-follow. Only user input should pause it.
+    if (!store.userScrolled && !input && !userActivity.isRecent()) return
 
     stop()
   }

--- a/packages/kilo-ui/src/hooks/scroll-user-activity.ts
+++ b/packages/kilo-ui/src/hooks/scroll-user-activity.ts
@@ -26,8 +26,8 @@ export const createUserActivity = (options: UserActivityOptions) => {
   const handleWheel = (event: WheelEvent) => {
     if (!isPotentialScrollInput(event)) return
     if (!scroll || scroll.scrollHeight - scroll.clientHeight <= 1) return
-    mark(event)
     if (event.deltaY >= 0 || scroll.scrollTop <= 0) return
+    mark(event)
     options.onWheelUp()
   }
 


### PR DESCRIPTION
## Problem

Streaming transcript layout changes can emit scroll events before the resize observer restores bottom-follow. The chat previously treated those browser and virtualizer events as user intent, so chart rendering, Bash output, tables, throughput updates, and other growing content could leave the transcript stuck above the bottom. Downward wheel input at the bottom could trigger the same state, and the initial input-aware fix did not cover native scrollbar drags or long touch gestures after the interaction grace period.

## Fix

Auto-follow now distinguishes user movement from layout remeasurement:

- Scroll events caused by streaming reflow, virtualizer measurement, browser anchoring, or content growth no longer pause follow on their own.
- Downward wheel and trackpad input at the bottom does not mark the transcript as intentionally paused.
- Upward wheel input still pauses immediately.
- Native scrollbar movement and scroll-position changes with stable content height are treated as intentional user scrolling.
- Pointer, keyboard, and touch interaction protections remain in place, including long gestures that outlast the short activity grace period.

This keeps active streaming output pinned while preserving deliberate user scrolling.

## Related Reports

- #13119, chat appears frozen mid-output when smart-scroll pauses.
- #11485, small upward-wheel auto-scroll regression in the same hook.
- #10741, auto-scroll lost on streamed tool calls and permission prompts.
- #7879, original chat auto-scroll regression.