### PR TITLE
fix(docs): exclude flaky Requesty marketplace link

### DIFF
--- a/packages/kilo-docs/lychee.toml
+++ b/packages/kilo-docs/lychee.toml
@@ -57,6 +57,8 @@ exclude = [
   '^https?://aistudio\.google\.com/api-keys/?$',
   # Linear intermittently returns 503 to CI link checks.
   '^https?://linear\.app/?$',
+  # The Requesty Marketplace page intermittently returns 503 to automated link checks.
+  '^https://marketplace\.visualstudio\.com/items\?itemName=Requesty\.requesty$',
   # Consistently times out in CI
   '^https?://opncd\.ai',
   '^https?://zod\.dev/v4/changelog',

--- a/packages/kilo-docs/lychee.toml
+++ b/packages/kilo-docs/lychee.toml
@@ -57,8 +57,8 @@ exclude = [
   '^https?://aistudio\.google\.com/api-keys/?$',
   # Linear intermittently returns 503 to CI link checks.
   '^https?://linear\.app/?$',
-  # The Requesty Marketplace page intermittently returns 503 to automated link checks.
-  '^https://marketplace\.visualstudio\.com/items\?itemName=Requesty\.requesty$',
+  # VS Code Marketplace item pages intermittently return 503 to automated link checks.
+  '^https://marketplace\.visualstudio\.com/items\?itemName=',
   # Consistently times out in CI
   '^https?://opncd\.ai',
   '^https?://zod\.dev/v4/changelog',

--- a/packages/kilo-docs/lychee.toml
+++ b/packages/kilo-docs/lychee.toml
@@ -57,8 +57,8 @@ exclude = [
   '^https?://aistudio\.google\.com/api-keys/?$',
   # Linear intermittently returns 503 to CI link checks.
   '^https?://linear\.app/?$',
-  # VS Code Marketplace item pages intermittently return 503 to automated link checks.
-  '^https://marketplace\.visualstudio\.com/items\?itemName=',
+  # These VS Code Marketplace pages intermittently return 503 to automated link checks.
+  '^https://marketplace\.visualstudio\.com/items\?itemName=(connor4312\.esbuild-problem-matchers|dbaeumer\.vscode-eslint|esbenp\.prettier-vscode|Requesty\.requesty)$',
   # Consistently times out in CI
   '^https?://opncd\.ai',
   '^https?://zod\.dev/v4/changelog',


### PR DESCRIPTION
The VS Code Marketplace item pages linked from the docs intermittently return HTTP 503 to Lychee in CI even though the extension pages remain valid for readers. Exclude only the four affected documented item URLs from automated link checks while retaining the canonical documentation links and strict validation for other URLs.