### PR TITLE
fix(vscode): default speech to text to Parakeet

### DIFF
--- a/.changeset/dynamic-speech-to-text-models.md
+++ b/.changeset/dynamic-speech-to-text-models.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Use NVIDIA Parakeet TDT 0.6B v3 as the default speech-to-text model while retaining dynamic model discovery and offline fallback support.

--- a/packages/kilo-vscode/src/speech-to-text/models.ts
+++ b/packages/kilo-vscode/src/speech-to-text/models.ts
@@ -7,6 +7,11 @@ export interface SpeechToTextModelDef {
 
 const models: SpeechToTextModelDef[] = [
   {
+    id: "nvidia/parakeet-tdt-0.6b-v3",
+    label: "Parakeet TDT 0.6B v3",
+    provider: "NVIDIA",
+  },
+  {
     id: "openai/whisper-large-v3-turbo",
     label: "Whisper Large V3 Turbo",
     provider: "OpenAI-compatible",
@@ -37,11 +42,6 @@ const models: SpeechToTextModelDef[] = [
     id: "google/chirp-3",
     label: "Chirp 3",
     provider: "Google",
-  },
-  {
-    id: "nvidia/parakeet-tdt-0.6b-v3",
-    label: "Parakeet TDT 0.6B v3",
-    provider: "NVIDIA",
   },
 ]
 

--- a/packages/kilo-vscode/tests/unit/speech-to-text-catalog.test.ts
+++ b/packages/kilo-vscode/tests/unit/speech-to-text-catalog.test.ts
@@ -33,6 +33,6 @@ describe("speech-to-text discovery", () => {
   it("rejects empty or malformed catalogs so callers can use the static fallback", () => {
     expect(parseSpeechToTextCatalog([])).toBeUndefined()
     expect(parseSpeechToTextCatalog({ data: [] })).toBeUndefined()
-    expect(DEFAULT_SPEECH_TO_TEXT_MODEL.id).toBe("openai/whisper-large-v3-turbo")
+    expect(DEFAULT_SPEECH_TO_TEXT_MODEL.id).toBe("nvidia/parakeet-tdt-0.6b-v3")
   })
 })

--- a/packages/kilo-vscode/tests/unit/speech-to-text-models-sync.test.ts
+++ b/packages/kilo-vscode/tests/unit/speech-to-text-models-sync.test.ts
@@ -6,8 +6,8 @@ import {
 } from "../../src/speech-to-text/models"
 
 describe("speech-to-text model catalog", () => {
-  it("uses Whisper Large V3 Turbo as the fallback default", () => {
-    expect(DEFAULT_SPEECH_TO_TEXT_MODEL.id).toBe("openai/whisper-large-v3-turbo")
+  it("uses NVIDIA Parakeet TDT 0.6B v3 as the fallback default", () => {
+    expect(DEFAULT_SPEECH_TO_TEXT_MODEL.id).toBe("nvidia/parakeet-tdt-0.6b-v3")
     expect(DEFAULT_SPEECH_TO_TEXT_MODEL.id).toBe(SPEECH_TO_TEXT_MODELS[0]?.id)
   })
 


### PR DESCRIPTION
Speech-to-text currently falls back to Whisper Large V3 Turbo even though NVIDIA Parakeet TDT 0.6B v3 is available in the model catalog. Make Parakeet the first catalog entry so it is selected by default and used whenever no valid model override is configured. Update the fallback test and release notes to document the new default.