### PR TITLE
fix(agent-manager): preserve terminals across config reloads

### DIFF
--- a/.changeset/quiet-pty-config-reload.md
+++ b/.changeset/quiet-pty-config-reload.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep Agent Manager terminals running when configuration and provider settings are reloaded.

--- a/packages/core/src/location-services.ts
+++ b/packages/core/src/location-services.ts
@@ -20,7 +20,6 @@ import { PluginV2 } from "./plugin"
 import { PluginInternal } from "./plugin/internal"
 import { Policy } from "./policy"
 import { ProjectCopy } from "./project/copy"
-import { Pty } from "./pty"
 import { QuestionV2 } from "./question"
 import { Reference } from "./reference"
 import { ReferenceGuidance } from "./reference/guidance"
@@ -56,7 +55,6 @@ export const locationServices = LayerNode.group([
   FileSystemSearch.node,
   FileSystem.node,
   Watcher.node,
-  Pty.node,
   SkillV2.node,
   SystemContextRegistry.node,
   SystemContextBuiltIns.node,

--- a/packages/core/src/pty.ts
+++ b/packages/core/src/pty.ts
@@ -13,6 +13,7 @@ import { Shell } from "./shell"
 import { lazy } from "./util/lazy"
 import { KiloPtySelfCommand } from "./kilocode/pty-self-command" // kilocode_change
 import { KiloPtyTermination } from "./kilocode/pty/termination" // kilocode_change
+import { FSUtil } from "./fs-util" // kilocode_change
 
 const BUFFER_LIMIT = 1024 * 1024 * 2
 // Exited sessions stay observable (status, exit code, retained output) until removed explicitly.
@@ -152,7 +153,8 @@ const layer = Layer.effect(
       if (!session) return yield* new NotFoundError({ ptyID: id })
       // kilocode_change start - the global registry still enforces location isolation.
       const location = Option.getOrUndefined(yield* Effect.serviceOption(Location.Service))
-      if (location && session.directory !== location.directory) return yield* new NotFoundError({ ptyID: id })
+      if (location && session.directory !== FSUtil.resolve(location.directory))
+        return yield* new NotFoundError({ ptyID: id })
       // kilocode_change end
       return session
     })
@@ -179,8 +181,16 @@ const layer = Layer.effect(
 
     // kilocode_change start - explicit worktree deletion is the PTY cleanup boundary.
     const removeDirectory = Effect.fn("Pty.removeDirectory")(function* (directory: string) {
-      const owned = Array.from(sessions.values()).filter((session) => session.directory === directory)
-      yield* Effect.forEach(owned, (session) => removeSession(session.info.id), { concurrency: 4 })
+      const target = FSUtil.resolve(directory)
+      const owned = Array.from(sessions.values()).filter((session) => FSUtil.resolve(session.directory) === target)
+      yield* Effect.forEach(
+        owned,
+        (session) =>
+          removeSession(session.info.id).pipe(
+            Effect.catch((error) => Effect.logWarning("failed to remove PTY for worktree", { directory, error })),
+          ),
+        { concurrency: 4, discard: true },
+      )
     })
     // kilocode_change end
 
@@ -188,7 +198,7 @@ const layer = Layer.effect(
       // kilocode_change start - filter the process-wide registry by request location.
       const location = Option.getOrUndefined(yield* Effect.serviceOption(Location.Service))
       return Array.from(sessions.values())
-        .filter((session) => !location || session.directory === location.directory)
+        .filter((session) => !location || session.directory === FSUtil.resolve(location.directory))
         .map((session) => session.info)
       // kilocode_change end
     })
@@ -214,7 +224,7 @@ const layer = Layer.effect(
       const base = resolved.args ?? []
       const args = implicit && Shell.login(command) ? [...base, "-l"] : [...base]
       const cwd = resolved.cwd || location?.directory || process.cwd()
-      const directory = location?.directory || cwd
+      const directory = FSUtil.resolve(location?.directory || cwd)
       // kilocode_change end
       // kilocode_change end
       const env = {
@@ -390,4 +400,4 @@ const layer = Layer.effect(
 
 export const locationLayer = layer // kilocode_change
 
-export const node = makeGlobalNode({ service: Service, layer, deps: [EventV2.node] }) // kilocode_change
+export const node = makeGlobalNode({ service: Service, layer, deps: [EventV2.node, FSUtil.node] }) // kilocode_change

--- a/packages/core/src/pty.ts
+++ b/packages/core/src/pty.ts
@@ -1,8 +1,8 @@
 export * as Pty from "./pty"
 
-import { makeLocationNode } from "./effect/app-node"
+import { makeGlobalNode } from "./effect/app-node" // kilocode_change
 import type { Disp, Proc } from "#pty"
-import { Context, Effect, Layer, Schema, Types } from "effect"
+import { Context, Effect, Layer, Option, Schema, Types } from "effect" // kilocode_change
 import { Pty } from "@opencode-ai/schema/pty"
 import { Config } from "./config"
 import { EventV2 } from "./event"
@@ -31,6 +31,7 @@ type Subscriber = {
 
 type Active = {
   info: Info
+  directory: string // kilocode_change
   process: Proc
   buffer: string
   bufferCursor: number
@@ -96,6 +97,7 @@ export interface Interface {
   readonly create: (input: CreateInput) => Effect.Effect<Info>
   readonly update: (id: PtyID, input: UpdateInput) => Effect.Effect<Info, NotFoundError>
   readonly remove: (id: PtyID) => Effect.Effect<void, NotFoundError>
+  readonly removeDirectory: (directory: string) => Effect.Effect<void> // kilocode_change
   readonly write: (id: PtyID, data: string) => Effect.Effect<void, NotFoundError>
   readonly attach: (id: PtyID, input: AttachInput) => Effect.Effect<Attachment, NotFoundError | ExitedError>
 }
@@ -106,8 +108,6 @@ const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const events = yield* EventV2.Service
-    const location = yield* Location.Service
-    const config = yield* Config.Service
     const context = yield* Effect.context()
     const runFork = Effect.runForkWith(context)
     const sessions = new Map<PtyID, Active>()
@@ -150,6 +150,10 @@ const layer = Layer.effect(
     const requireSession = Effect.fn("Pty.requireSession")(function* (id: PtyID) {
       const session = sessions.get(id)
       if (!session) return yield* new NotFoundError({ ptyID: id })
+      // kilocode_change start - the global registry still enforces location isolation.
+      const location = Option.getOrUndefined(yield* Effect.serviceOption(Location.Service))
+      if (location && session.directory !== location.directory) return yield* new NotFoundError({ ptyID: id })
+      // kilocode_change end
       return session
     })
 
@@ -173,8 +177,20 @@ const layer = Layer.effect(
       yield* removeSession(id)
     })
 
+    // kilocode_change start - explicit worktree deletion is the PTY cleanup boundary.
+    const removeDirectory = Effect.fn("Pty.removeDirectory")(function* (directory: string) {
+      const owned = Array.from(sessions.values()).filter((session) => session.directory === directory)
+      yield* Effect.forEach(owned, (session) => removeSession(session.info.id), { concurrency: 4 })
+    })
+    // kilocode_change end
+
     const list = Effect.fn("Pty.list")(function* () {
-      return Array.from(sessions.values()).map((session) => session.info)
+      // kilocode_change start - filter the process-wide registry by request location.
+      const location = Option.getOrUndefined(yield* Effect.serviceOption(Location.Service))
+      return Array.from(sessions.values())
+        .filter((session) => !location || session.directory === location.directory)
+        .map((session) => session.info)
+      // kilocode_change end
     })
 
     const get = Effect.fn("Pty.get")(function* (id: PtyID) {
@@ -190,10 +206,16 @@ const layer = Layer.effect(
         cwd: input.cwd,
       })
       const implicit = !resolved.command
-      const command = resolved.command || Shell.preferred(Config.latest(yield* config.entries(), "shell"))
+      // kilocode_change start - location and config are request-scoped now that PTYs are global.
+      const location = Option.getOrUndefined(yield* Effect.serviceOption(Location.Service))
+      const config = Option.getOrUndefined(yield* Effect.serviceOption(Config.Service))
+      const entries = config ? yield* config.entries() : []
+      const command = resolved.command || Shell.preferred(Config.latest(entries, "shell"))
       const base = resolved.args ?? []
       const args = implicit && Shell.login(command) ? [...base, "-l"] : [...base]
-      const cwd = resolved.cwd || location.directory
+      const cwd = resolved.cwd || location?.directory || process.cwd()
+      const directory = location?.directory || cwd
+      // kilocode_change end
       // kilocode_change end
       const env = {
         ...process.env,
@@ -236,6 +258,7 @@ const layer = Layer.effect(
       }
       const session: Active = {
         info,
+        directory, // kilocode_change
         process: proc,
         buffer: "",
         bufferCursor: 0,
@@ -307,7 +330,10 @@ const layer = Layer.effect(
     const attach = Effect.fn("Pty.attach")(function* (id: PtyID, input: AttachInput) {
       const session = yield* requireSession(id)
       if (session.info.status !== "running" && !input.allowExited) return yield* new ExitedError({ ptyID: id }) // kilocode_change
-      yield* Effect.logInfo("client attached to session", { id, directory: location.directory })
+      // kilocode_change start - location is optional because the registry is process-wide.
+      const location = Option.getOrUndefined(yield* Effect.serviceOption(Location.Service))
+      yield* Effect.logInfo("client attached to session", { id, directory: location?.directory })
+      // kilocode_change end
       const token = {}
       const subscriber: Subscriber = {
         onData: input.onData,
@@ -358,10 +384,10 @@ const layer = Layer.effect(
       }
     })
 
-    return Service.of({ list, get, create, update, remove, write, attach })
+    return Service.of({ list, get, create, update, remove, removeDirectory, write, attach }) // kilocode_change
   }),
 )
 
-export const locationLayer = layer.pipe(Layer.provide(Config.locationLayer))
+export const locationLayer = layer // kilocode_change
 
-export const node = makeLocationNode({ service: Service, layer, deps: [EventV2.node, Location.node, Config.node] })
+export const node = makeGlobalNode({ service: Service, layer, deps: [EventV2.node] }) // kilocode_change

--- a/packages/core/test/pty/pty-session.test.ts
+++ b/packages/core/test/pty/pty-session.test.ts
@@ -287,7 +287,7 @@ describe("pty", () => {
 
 const configuredShell = process.platform === "win32" ? undefined : Bun.which("bash")
 const configuredIt = testEffect(
-  AppNodeBuilder.build(LayerNode.group([Pty.node, EventV2.node]), [
+  AppNodeBuilder.build(LayerNode.group([Pty.node, EventV2.node, Config.node, Location.node]), [ // kilocode_change
     [
       Config.node,
       Layer.mock(Config.Service)({

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -1046,7 +1046,9 @@ export class AgentManagerProvider implements Disposable {
     }
 
     try {
-      await removePtys((directory) => this.connectionService.getClientAsync(directory), dir)
+      await removePtys((directory) => this.connectionService.getClientAsync(directory), dir).catch((error) =>
+        this.log(`Failed to remove PTYs after setup failure:`, error),
+      )
       await this.getWorktreeManager()?.removeWorktree(dir, branch)
     } catch (err) {
       this.log(`Failed to remove worktree ${id} after setup failed:`, err)
@@ -1116,7 +1118,9 @@ export class AgentManagerProvider implements Disposable {
         },
         cleanupWorktree: async (wid, dir) => {
           this.getStateManager()?.removeWorktree(wid)
-          await removePtys((directory) => this.connectionService.getClientAsync(directory), dir)
+          await removePtys((directory) => this.connectionService.getClientAsync(directory), dir).catch((error) =>
+            this.log(`Failed to remove PTYs during worktree cleanup:`, error),
+          )
           await this.getWorktreeManager()?.removeWorktree(dir)
           this.pushState()
         },
@@ -1149,21 +1153,18 @@ export class AgentManagerProvider implements Disposable {
     return deleteLifecycleWorktree(ctx, this.lifecycleHost, worktreeId)
   }
 
-  /** Remove a stale worktree entry from state without touching the filesystem. */
   private async onRemoveStaleWorktree(worktreeId: string): Promise<null> {
     const ctx = this.context
     if (!ctx) return null
     return removeStaleLifecycleWorktree(ctx, this.lifecycleHost, worktreeId)
   }
 
-  /** Promote a session: create a worktree and move the session into it. */
   private async onPromoteSession(sessionId: string): Promise<null> {
     const ctx = this.context
     if (!ctx) return null
     return promoteLifecycleSession(ctx, this.lifecycleHost, sessionId)
   }
 
-  /** Add a new session to an existing worktree. */
   private async onAddSessionToWorktree(worktreeId: string, sessionId?: string): Promise<null> {
     const ctx = this.context
     if (!ctx) return null

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -35,6 +35,7 @@ import { copyEnvFiles } from "./env-copy"
 import { SessionTerminalManager } from "./SessionTerminalManager"
 import { createTerminalHost } from "./terminal-host"
 import { TerminalRouter } from "./terminal-routing"
+import { removePtys } from "./pty-cleanup"
 import { executeVscodeTask } from "./task-runner"
 import { runWorktreeSetupScript } from "./setup-script-task"
 import { RunController } from "./run/controller"
@@ -189,6 +190,7 @@ export class AgentManagerProvider implements Disposable {
       activate: (ctx) => this.activateProject(ctx),
       expand: (ctx) => this.initExpanded(ctx),
       ready: (ctx) => initContextState(ctx, (...args) => this.log(...args)),
+      removePtys: (directory) => removePtys((dir) => this.connectionService.getClientAsync(dir), directory),
       push: () => this.pushProjects(),
       changed: () => this.onWorkspaceChanged(),
       refresh: () => this.pushState(),
@@ -1029,7 +1031,6 @@ export class AgentManagerProvider implements Disposable {
     }
   }
 
-  /** Remove a worktree whose session could not be safely initialized. */
   private async discardWorktree(id: string, dir: string, branch: string, sessionId?: string): Promise<void> {
     this.getStateManager()?.removeWorktree(id)
     this.pushState()
@@ -1045,13 +1046,13 @@ export class AgentManagerProvider implements Disposable {
     }
 
     try {
+      await removePtys((directory) => this.connectionService.getClientAsync(directory), dir)
       await this.getWorktreeManager()?.removeWorktree(dir, branch)
     } catch (err) {
       this.log(`Failed to remove worktree ${id} after setup failed:`, err)
     }
   }
 
-  /** Send worktreeSetup.ready + pushState after worktree creation. */
   private notifyWorktreeReady(sessionId: string, result: CreateWorktreeResult, worktreeId?: string): void {
     this.pushState()
     this.postToWebview({
@@ -1115,6 +1116,7 @@ export class AgentManagerProvider implements Disposable {
         },
         cleanupWorktree: async (wid, dir) => {
           this.getStateManager()?.removeWorktree(wid)
+          await removePtys((directory) => this.connectionService.getClientAsync(directory), dir)
           await this.getWorktreeManager()?.removeWorktree(dir)
           this.pushState()
         },
@@ -1132,8 +1134,6 @@ export class AgentManagerProvider implements Disposable {
       req,
     )
   }
-
-  // Worktree actions
 
   /** Create a new worktree with an auto-created first session. */
   private async onCreateWorktree(baseBranch?: string, branchName?: string): Promise<null> {
@@ -1457,8 +1457,6 @@ export class AgentManagerProvider implements Disposable {
     })
   }
 
-  // Manager accessors — repository-bound services are owned by the active ProjectContext (immutable per root).
-  /** Provider capabilities for the worktree lifecycle handlers (state stays in ProjectContext). */
   private get lifecycleHost(): LifecycleHost {
     return {
       createOnDisk: (opts) => this.createWorktreeOnDisk(opts),
@@ -1486,6 +1484,7 @@ export class AgentManagerProvider implements Disposable {
       capture: (event, props) => this.host.capture(event, props),
       autoName: () => this.host.autoBranchNaming(),
       client: () => this.connectionService.getClient(),
+      removePtys: (directory) => removePtys((dir) => this.connectionService.getClientAsync(dir), directory),
       metadata: (client, dir) => sandboxSessionMetadata(this.connectionService.sandboxPreference, client, dir),
       post: (msg) => this.postToWebview(msg),
       log: (...args) => this.log(...args),

--- a/packages/kilo-vscode/src/agent-manager/project/messages.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/messages.ts
@@ -176,7 +176,10 @@ async function removeProject(id: string, deps: ProjectMessageDeps): Promise<void
   if (ctx) {
     const clean = deps.removePtys
     for (const directory of projectDirectories(ctx)) {
-      if (clean) await clean(directory).catch((error) => deps.log(`removeProject: failed to remove PTYs for ${directory}`, error))
+      if (clean)
+        await clean(directory).catch((error) =>
+          deps.log(`removeProject: failed to remove PTYs for ${directory}`, error),
+        )
     }
   }
   await deps.contexts.remove(id)

--- a/packages/kilo-vscode/src/agent-manager/project/messages.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/messages.ts
@@ -12,6 +12,7 @@ import type { ProjectRegistry } from "./registry"
 import type { ProjectContext, ProjectInitResult } from "./context"
 import type { ProjectContexts } from "./contexts"
 import { projectIdFor, resolveProjectRoot, samePath } from "./paths"
+import { projectDirectories } from "./init"
 import type { SidebarTarget } from "./route"
 
 export interface ProjectMessageDeps {
@@ -33,6 +34,7 @@ export interface ProjectMessageDeps {
   error: (message: string) => void
   /** Ensure a context's repository state is ready (no-op once initialized). */
   ready: (ctx: ProjectContext) => Promise<ProjectInitResult>
+  removePtys?: (directory: string) => Promise<void>
   log: (...args: unknown[]) => void
 }
 
@@ -170,6 +172,13 @@ async function addProject(deps: ProjectMessageDeps): Promise<void> {
 
 async function removeProject(id: string, deps: ProjectMessageDeps): Promise<void> {
   if (disabled(deps)) return
+  const ctx = deps.contexts.resolve(id)
+  if (ctx) {
+    const clean = deps.removePtys
+    for (const directory of projectDirectories(ctx)) {
+      if (clean) await clean(directory).catch((error) => deps.log(`removeProject: failed to remove PTYs for ${directory}`, error))
+    }
+  }
   await deps.contexts.remove(id)
   await deps.registry.remove(id)
   deps.push()

--- a/packages/kilo-vscode/src/agent-manager/project/wiring.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/wiring.ts
@@ -33,6 +33,7 @@ export function createProjectWiring(opts: {
   expand: (ctx: ProjectContext) => void
   /** Ensure a context's repository state is ready (no-op once initialized). */
   ready: (ctx: ProjectContext) => Promise<ProjectInitResult>
+  removePtys: (directory: string) => Promise<void>
   /** Push the project catalog to the webview. */
   push: () => void
   /** Re-derive the pinned project after workspace folder changes. */
@@ -62,6 +63,7 @@ export function createProjectWiring(opts: {
     activate: opts.activate,
     expand: opts.expand,
     ready: opts.ready,
+    removePtys: opts.removePtys,
     push: opts.push,
     selected: opts.selected,
     error: (message) => opts.host.showError(message),

--- a/packages/kilo-vscode/src/agent-manager/provider-lifecycle.ts
+++ b/packages/kilo-vscode/src/agent-manager/provider-lifecycle.ts
@@ -42,6 +42,7 @@ export interface LifecycleHost {
   capture: (event: string, props: Record<string, unknown>) => void
   autoName: () => { enabled: boolean }
   client: () => KiloClient
+  removePtys: (directory: string) => Promise<void>
   metadata: (client: KiloClient, dir: string) => Promise<Record<string, unknown>>
   post: (message: AgentManagerOutMessage) => void
   log: (...args: unknown[]) => void
@@ -118,6 +119,7 @@ export async function deleteLifecycleWorktree(
   // Disk removal after state is clean — pollers no longer reference this worktree.
   const branch = worktree.branchOwned === false ? undefined : (worktree.originalBranch ?? worktree.branch)
   try {
+    await host.removePtys(worktree.path)
     await ctx.worktreeManager().removeWorktree(worktree.path, branch)
   } catch (error) {
     host.log(`Failed to remove worktree from disk: ${error}`)
@@ -155,6 +157,11 @@ export async function removeStaleLifecycleWorktree(
   const orphaned = state.removeWorktree(worktreeId)
   host.stopDiffs(worktree.path, orphaned)
   for (const session of orphaned) host.sessions.clearDirectory(session.id)
+  try {
+    await host.removePtys(worktree.path)
+  } catch (error) {
+    host.log(`Failed to remove stale worktree PTYs: ${error}`)
+  }
   ctx.stale.delete(worktreeId)
   host.push()
   host.log(`Removed stale worktree entry ${worktreeId} (${worktree.branch})`)

--- a/packages/kilo-vscode/src/agent-manager/provider-lifecycle.ts
+++ b/packages/kilo-vscode/src/agent-manager/provider-lifecycle.ts
@@ -119,7 +119,7 @@ export async function deleteLifecycleWorktree(
   // Disk removal after state is clean — pollers no longer reference this worktree.
   const branch = worktree.branchOwned === false ? undefined : (worktree.originalBranch ?? worktree.branch)
   try {
-    await host.removePtys(worktree.path)
+    await host.removePtys(worktree.path).catch((error) => host.log(`Failed to remove worktree PTYs: ${error}`))
     await ctx.worktreeManager().removeWorktree(worktree.path, branch)
   } catch (error) {
     host.log(`Failed to remove worktree from disk: ${error}`)

--- a/packages/kilo-vscode/src/agent-manager/pty-cleanup.ts
+++ b/packages/kilo-vscode/src/agent-manager/pty-cleanup.ts
@@ -1,0 +1,14 @@
+import type { KiloClient } from "@kilocode/sdk/v2/client"
+
+export async function removePtys(
+  getClient: (directory: string) => Promise<KiloClient>,
+  directory: string,
+): Promise<void> {
+  const client = await getClient(directory)
+  const { data, error } = await client.pty.list({ directory })
+  if (error) throw error
+  for (const pty of data ?? []) {
+    const result = await client.pty.remove({ directory, ptyID: pty.id })
+    if (result.error) throw result.error
+  }
+}

--- a/packages/kilo-vscode/src/agent-manager/pty-cleanup.ts
+++ b/packages/kilo-vscode/src/agent-manager/pty-cleanup.ts
@@ -9,6 +9,6 @@ export async function removePtys(
   if (error) throw error
   for (const pty of data ?? []) {
     const result = await client.pty.remove({ directory, ptyID: pty.id })
-    if (result.error) throw result.error
+    if (result.error) console.warn(`[Kilo New] Failed to remove PTY ${pty.id} in ${directory}:`, result.error)
   }
 }

--- a/packages/opencode/script/test-runner.ts
+++ b/packages/opencode/script/test-runner.ts
@@ -293,10 +293,12 @@ const BATCH_EXCLUDES = [
   "kilocode/daemon.test.ts", // spawns real daemon subprocesses, races wall-clock deadlines
   "kilocode/instance-vcs-watcher.test.ts",
   "kilocode/issue-8656-stall.test.ts",
+  "kilocode/session-export/e2e.test.ts", // spawns git and waits on wall-clock capture deadlines
   // Heavy real-work files: a batch runs members sequentially, so files whose runtime is
   // dominated by real execution (not process boot) parallelize better in their own process.
   "tool/shell.test.ts",
   "tool/task.test.ts",
+  "tool/truncation.test.ts", // spawns a process and mutates the shared truncation directory
 ]
 // Entry semantics shared by FAST_TIERS and BATCH_EXCLUDES: ".ts" = exact file, else prefix.
 const matchesEntry = (file: string, entry: string) => (entry.endsWith(".ts") ? file === entry : file.startsWith(entry))

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -66,6 +66,7 @@ import { ProjectV2 } from "@opencode-ai/core/project" // kilocode_change
 import { ProjectCopy } from "@opencode-ai/core/project/copy" // kilocode_change
 import { MoveSession } from "@opencode-ai/core/control-plane/move-session" // kilocode_change
 import { PtyTicket } from "@opencode-ai/core/pty/ticket" // kilocode_change
+import { Pty } from "@opencode-ai/core/pty" // kilocode_change
 
 // kilocode_change start - retain Kilo runtime services in the upstream node graph
 const memory = LayerNode.make({ service: MemoryService.Service, layer: MemoryService.layer, deps: [] })
@@ -130,6 +131,7 @@ export const AppLayer = AppNodeBuilderV1.build(
     ProjectCopy.node,
     MoveSession.node,
     PtyTicket.node,
+    Pty.node,
     // kilocode_change end
   ]),
 ).pipe(Layer.provideMerge(AppNodeBuilderV1.build(Ripgrep.node)), Layer.provideMerge(Observability.layer))

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/pty.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/pty.ts
@@ -48,7 +48,6 @@ export const ptyHandlers = HttpApiBuilder.group(InstanceHttpApi, "pty", (handler
       Effect.runPromise(locations.invalidate(Location.Ref.make({ directory: AbsolutePath.make(directory) }))),
     )
     yield* Effect.addFinalizer(() => Effect.sync(unregister))
-
     const pty = Effect.fnUntraced(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
       return yield* effect.pipe(
         Effect.provide(
@@ -169,7 +168,6 @@ export const ptyConnectHandlers = HttpApiBuilder.group(PtyConnectApi, "pty-conne
       Effect.runPromise(locations.invalidate(Location.Ref.make({ directory: AbsolutePath.make(directory) }))),
     )
     yield* Effect.addFinalizer(() => Effect.sync(unregister))
-
     const pty = Effect.fnUntraced(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
       return yield* effect.pipe(
         Effect.provide(

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -71,6 +71,7 @@ import { PermissionSaved } from "@opencode-ai/core/permission/saved"
 import { ProjectV2 } from "@opencode-ai/core/project"
 import { ProjectCopy } from "@opencode-ai/core/project/copy"
 import { PtyTicket } from "@opencode-ai/core/pty/ticket"
+import { Pty } from "@opencode-ai/core/pty" // kilocode_change
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { SessionV2 } from "@opencode-ai/core/session"
@@ -290,6 +291,7 @@ const app = LayerNode.group([
   ProjectV2.node,
   ProjectCopy.node,
   PtyTicket.node,
+  Pty.node, // kilocode_change
 ])
 
 export function createRoutes(

--- a/packages/opencode/src/tool/truncate.ts
+++ b/packages/opencode/src/tool/truncate.ts
@@ -52,15 +52,18 @@ const layer = Layer.effect(
     const fs = yield* FSUtil.Service
 
     const cleanup = Effect.fn("Truncate.cleanup")(function* () {
-      const cutoff = Identifier.timestamp(
-        Identifier.create("tool", "ascending", Date.now() - Duration.toMillis(RETENTION)),
-      )
+      // kilocode_change start - encoded timestamps wrap every 2^36 ms, so compare modular age.
+      const range = 2 ** 36
+      const now = Identifier.timestamp(Identifier.create("tool", "ascending"))
+      const retention = Duration.toMillis(RETENTION)
+      // kilocode_change end
       const entries = yield* fs.readDirectory(TRUNCATION_DIR).pipe(
         Effect.map((all) => all.filter((name) => name.startsWith("tool_"))),
         Effect.catch(() => Effect.succeed([])),
       )
       for (const entry of entries) {
-        if (Identifier.timestamp(entry) >= cutoff) continue
+        const age = (now - Identifier.timestamp(entry) + range) % range // kilocode_change
+        if (age <= retention) continue // kilocode_change
         yield* fs.remove(path.join(TRUNCATION_DIR, entry)).pipe(Effect.catch(() => Effect.void))
       }
     })

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -11,7 +11,7 @@ import { Slug } from "@opencode-ai/core/util/slug"
 import { errorMessage } from "../util/error"
 import { GlobalBus } from "@/bus/global"
 import { Git } from "@/git"
-import { Effect, Layer, Option, Path, Schema, Scope, Context } from "effect"
+import { Effect, Layer, Option, Path, Schema, Scope, Context } from "effect" // kilocode_change
 import { ChildProcess } from "effect/unstable/process"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { AppProcess } from "@opencode-ai/core/process"
@@ -396,7 +396,15 @@ const layer: Layer.Layer<
       }
 
       const directory = yield* canonical(input.directory)
+      // kilocode_change start - PTY cleanup is best-effort and must not block worktree removal.
       const pty = yield* Effect.serviceOption(Pty.Service)
+      const clear = (target: string) =>
+        Option.isNone(pty)
+          ? Effect.void
+          : pty.value
+              .removeDirectory(target)
+              .pipe(Effect.catch((error) => Effect.logWarning("failed to remove worktree PTYs", { target, error })))
+      // kilocode_change end
 
       // Preserve the loaded path casing for the store cache; `directory` is lowercased on Windows.
       if (directory !== (yield* canonical(ctx.worktree))) yield* store.disposeDirectory(input.directory)
@@ -412,15 +420,16 @@ const layer: Layer.Layer<
       if (!entry?.path) {
         const directoryExists = yield* fs.exists(directory).pipe(Effect.orDie)
         if (directoryExists) {
+          yield* clear(directory)
           yield* stopFsmonitor(directory)
           yield* cleanDirectory(directory)
-          if (Option.isSome(pty)) yield* pty.value.removeDirectory(directory) // kilocode_change
         }
         return true
       }
 
       // Git may return the original casing when a caller supplied a normalized Windows path.
       yield* store.disposeDirectory(entry.path)
+      yield* clear(entry.path)
       const removed = yield* WorktreeCleanup.remove({
         root: ctx.worktree,
         target: entry.path,
@@ -444,7 +453,6 @@ const layer: Layer.Layer<
       }
 
       yield* cleanDirectory(entry.path)
-      if (Option.isSome(pty)) yield* pty.value.removeDirectory(entry.path) // kilocode_change
 
       const branch = entry.branch?.replace(/^refs\/heads\//, "")
       if (branch) {

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -15,6 +15,7 @@ import { Effect, Layer, Path, Schema, Scope, Context } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { AppProcess } from "@opencode-ai/core/process"
+import { Pty } from "@opencode-ai/core/pty" // kilocode_change
 import { InstanceState } from "@/effect/instance-state"
 import { WorktreeCleanup } from "@/kilocode/worktree-cleanup" // kilocode_change
 import { WorktreeEvent } from "@opencode-ai/schema/worktree-event"
@@ -412,6 +413,7 @@ const layer: Layer.Layer<
         if (directoryExists) {
           yield* stopFsmonitor(directory)
           yield* cleanDirectory(directory)
+          yield* (yield* Pty.Service).removeDirectory(directory) // kilocode_change
         }
         return true
       }
@@ -441,6 +443,7 @@ const layer: Layer.Layer<
       }
 
       yield* cleanDirectory(entry.path)
+      yield* (yield* Pty.Service).removeDirectory(entry.path) // kilocode_change
 
       const branch = entry.branch?.replace(/^refs\/heads\//, "")
       if (branch) {
@@ -624,7 +627,7 @@ const layer: Layer.Layer<
 export const node = LayerNode.make({
   service: Service,
   layer: layer,
-  deps: [FSUtil.node, path, AppProcess.node, Git.node, Project.node, InstanceStore.node, Database.node],
+  deps: [FSUtil.node, path, AppProcess.node, Git.node, Project.node, InstanceStore.node, Database.node, Pty.node], // kilocode_change
 })
 
 export * as Worktree from "."

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -420,7 +420,7 @@ const layer: Layer.Layer<
       if (!entry?.path) {
         const directoryExists = yield* fs.exists(directory).pipe(Effect.orDie)
         if (directoryExists) {
-          yield* clear(directory)
+          yield* clear(directory) // kilocode_change
           yield* stopFsmonitor(directory)
           yield* cleanDirectory(directory)
         }
@@ -429,7 +429,7 @@ const layer: Layer.Layer<
 
       // Git may return the original casing when a caller supplied a normalized Windows path.
       yield* store.disposeDirectory(entry.path)
-      yield* clear(entry.path)
+      yield* clear(entry.path) // kilocode_change
       const removed = yield* WorktreeCleanup.remove({
         root: ctx.worktree,
         target: entry.path,

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -11,7 +11,7 @@ import { Slug } from "@opencode-ai/core/util/slug"
 import { errorMessage } from "../util/error"
 import { GlobalBus } from "@/bus/global"
 import { Git } from "@/git"
-import { Effect, Layer, Path, Schema, Scope, Context } from "effect"
+import { Effect, Layer, Option, Path, Schema, Scope, Context } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { AppProcess } from "@opencode-ai/core/process"
@@ -396,6 +396,7 @@ const layer: Layer.Layer<
       }
 
       const directory = yield* canonical(input.directory)
+      const pty = yield* Effect.serviceOption(Pty.Service)
 
       // Preserve the loaded path casing for the store cache; `directory` is lowercased on Windows.
       if (directory !== (yield* canonical(ctx.worktree))) yield* store.disposeDirectory(input.directory)
@@ -413,7 +414,7 @@ const layer: Layer.Layer<
         if (directoryExists) {
           yield* stopFsmonitor(directory)
           yield* cleanDirectory(directory)
-          yield* (yield* Pty.Service).removeDirectory(directory) // kilocode_change
+          if (Option.isSome(pty)) yield* pty.value.removeDirectory(directory) // kilocode_change
         }
         return true
       }
@@ -443,7 +444,7 @@ const layer: Layer.Layer<
       }
 
       yield* cleanDirectory(entry.path)
-      yield* (yield* Pty.Service).removeDirectory(entry.path) // kilocode_change
+      if (Option.isSome(pty)) yield* pty.value.removeDirectory(entry.path) // kilocode_change
 
       const branch = entry.branch?.replace(/^refs\/heads\//, "")
       if (branch) {
@@ -627,7 +628,7 @@ const layer: Layer.Layer<
 export const node = LayerNode.make({
   service: Service,
   layer: layer,
-  deps: [FSUtil.node, path, AppProcess.node, Git.node, Project.node, InstanceStore.node, Database.node, Pty.node], // kilocode_change
+  deps: [FSUtil.node, path, AppProcess.node, Git.node, Project.node, InstanceStore.node, Database.node],
 })
 
 export * as Worktree from "."

--- a/packages/opencode/test/kilocode/server/config-overlay.test.ts
+++ b/packages/opencode/test/kilocode/server/config-overlay.test.ts
@@ -855,7 +855,7 @@ describe("config overlay routes", () => {
     expect(await SandboxStore.read(project.path, child.id)).toMatchObject({ mode: "deny" })
   })
 
-  terminal("preserves active terminals after updating global console preferences", async () => {
+  terminal("preserves active terminals after updating global model settings", async () => {
     await using global = await tmpdir()
     await using project = await tmpdir()
     ;(Global.Path as { config: string }).config = global.path
@@ -872,7 +872,7 @@ describe("config overlay routes", () => {
         await request(Server.Default().app, undefined, "/config/overlay", {
           method: "PATCH",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify({ scope: "global", set: { console: { diff_style: "split" } } }),
+          body: JSON.stringify({ scope: "global", set: { model: "test/model" } }),
         }),
       )
 

--- a/packages/opencode/test/kilocode/session-export/e2e.test.ts
+++ b/packages/opencode/test/kilocode/session-export/e2e.test.ts
@@ -58,7 +58,7 @@ async function until(check: () => boolean): Promise<void> {
   const start = Date.now()
   // The capture worker competes for CPU with the rest of the suite on a loaded CI
   // shard; the loop returns on success, so a generous deadline costs healthy runs nothing.
-  while (Date.now() - start < 30_000) {
+  while (Date.now() - start < 15_000) {
     if (check()) return
     await new Promise((resolve) => setTimeout(resolve, 10))
   }

--- a/packages/opencode/test/kilocode/session-export/e2e.test.ts
+++ b/packages/opencode/test/kilocode/session-export/e2e.test.ts
@@ -58,7 +58,7 @@ async function until(check: () => boolean): Promise<void> {
   const start = Date.now()
   // The capture worker competes for CPU with the rest of the suite on a loaded CI
   // shard; the loop returns on success, so a generous deadline costs healthy runs nothing.
-  while (Date.now() - start < 15_000) {
+  while (Date.now() - start < 30_000) {
     if (check()) return
     await new Promise((resolve) => setTimeout(resolve, 10))
   }

--- a/packages/opencode/test/server/httpapi-pty.test.ts
+++ b/packages/opencode/test/server/httpapi-pty.test.ts
@@ -173,7 +173,8 @@ describe("pty HttpApi bridge", () => {
     expect(await list.json()).toEqual([])
   })
 
-  testPty("disposes PTY sessions with their legacy instance", async () => {
+  // kilocode_change start - instance disposal must preserve the global PTY registry.
+  testPty("preserves PTY sessions across legacy instance disposal", async () => {
     await using tmp = await tmpdir({ git: true, config: { formatter: false, lsp: false } })
     const headers = { "x-kilo-directory": tmp.path }
     const created = await app().request(PtyPaths.create, {
@@ -182,13 +183,19 @@ describe("pty HttpApi bridge", () => {
       body: JSON.stringify({ command: "/usr/bin/env", args: ["sh", "-c", "sleep 5"] }),
     })
     expect(created.status).toBe(200)
+    const info = await created.json()
 
-    await disposeAllInstances()
+    try {
+      await disposeAllInstances()
 
-    const list = await app().request(PtyPaths.list, { headers })
-    expect(list.status).toBe(200)
-    expect(await list.json()).toEqual([])
+      const list = await app().request(PtyPaths.list, { headers })
+      expect(list.status).toBe(200)
+      expect(await list.json()).toEqual([info])
+    } finally {
+      await app().request(PtyPaths.remove.replace(":ptyID", info.id), { method: "DELETE", headers })
+    }
   })
+  // kilocode_change end
 
   test("returns 404 for missing PTY websocket before upgrade", async () => {
     await using tmp = await tmpdir({ git: true, config: { formatter: false, lsp: false } })

--- a/packages/opencode/test/server/httpapi-pty.test.ts
+++ b/packages/opencode/test/server/httpapi-pty.test.ts
@@ -180,7 +180,7 @@ describe("pty HttpApi bridge", () => {
     const created = await app().request(PtyPaths.create, {
       method: "POST",
       headers: { ...headers, "content-type": "application/json" },
-      body: JSON.stringify({ command: "/usr/bin/env", args: ["sh", "-c", "sleep 5"] }),
+      body: JSON.stringify({ command: "/usr/bin/env", args: ["sh", "-c", "sleep 30"] }),
     })
     expect(created.status).toBe(200)
     const info = await created.json()

--- a/packages/opencode/test/server/httpapi-v2-pty.test.ts
+++ b/packages/opencode/test/server/httpapi-v2-pty.test.ts
@@ -255,6 +255,14 @@ describe("v2 pty HttpApi", () => {
         )
         expect(created.status).toBe(200)
         const info = (yield* Schema.decodeUnknownEffect(Location.response(Pty.Info))(yield* created.json)).data
+        yield* Effect.addFinalizer(() =>
+          HttpClientRequest.delete(`/api/pty/${info.id}`).pipe(
+            directoryHeader(dir),
+            HttpClient.execute,
+            Effect.catch(() => Effect.void),
+            Effect.asVoid,
+          ),
+        )
 
         const socket = yield* Socket.makeWebSocket(
           `${(yield* serverUrl()).replace(/^http/, "ws")}/api/pty/${info.id}/connect?cursor=0&location[directory]=${encodeURIComponent(dir)}`,
@@ -282,8 +290,7 @@ describe("v2 pty HttpApi", () => {
         expect(output).toContain(`caller|plugin|plugin|xterm-256color|1|${info.id}|||${cwd}`)
         // kilocode_change end
         yield* write(new Socket.CloseEvent(1000, "done")).pipe(Effect.catch(() => Effect.void))
-        yield* HttpClientRequest.delete(`/api/pty/${info.id}`).pipe(directoryHeader(dir), HttpClient.execute)
       }),
-    30_000, // kilocode_change - external plugin loading and websocket setup can exceed Bun's 5s default
+    60_000, // kilocode_change - external plugin loading and websocket setup compete with the Darwin profile
   )
 })

--- a/packages/sdk-next/src/opencode.ts
+++ b/packages/sdk-next/src/opencode.ts
@@ -29,9 +29,12 @@ export const create = Effect.fn("OpenCode.create")(function* () {
     ),
     (web) => Effect.promise(web.dispose),
   )
-  const fetch = Object.assign((input: RequestInfo | URL, init?: RequestInit) => web.handler(new Request(input, init)), {
-    preconnect: () => undefined,
-  }) satisfies typeof globalThis.fetch
+  const fetch = Object.assign(
+    (input: RequestInfo | URL, init?: RequestInit) => web.handler(new Request(input, init), undefined as never), // kilocode_change
+    {
+      preconnect: () => undefined,
+    },
+  ) satisfies typeof globalThis.fetch
   const client = yield* OpenCode.make({ baseUrl: "http://opencode.local" }).pipe(
     Effect.provide(FetchHttpClient.layer),
     Effect.provideService(FetchHttpClient.Fetch, fetch),

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -3,6 +3,7 @@ import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { httpClient } from "@opencode-ai/core/effect/app-node-platform"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { EventV2 } from "@opencode-ai/core/event"
+import { FSUtil } from "@opencode-ai/core/fs-util" // kilocode_change
 import { Credential } from "@opencode-ai/core/credential"
 import { PermissionSaved } from "@opencode-ai/core/permission/saved"
 import { PtyTicket } from "@opencode-ai/core/pty/ticket"
@@ -28,6 +29,7 @@ import { sessionLocationLayer } from "./middleware/session-location"
 const applicationServices = LayerNode.group([
   Database.node,
   EventV2.node,
+  FSUtil.node, // kilocode_change
   httpClient,
   ToolOutputStore.cleanupNode,
   SessionV2.node,

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -6,6 +6,7 @@ import { EventV2 } from "@opencode-ai/core/event"
 import { Credential } from "@opencode-ai/core/credential"
 import { PermissionSaved } from "@opencode-ai/core/permission/saved"
 import { PtyTicket } from "@opencode-ai/core/pty/ticket"
+import { Pty } from "@opencode-ai/core/pty" // kilocode_change
 import { SessionV2 } from "@opencode-ai/core/session"
 import { SessionExecution } from "@opencode-ai/core/session/execution"
 import { LocationServiceMap } from "@opencode-ai/core/location-service-map"
@@ -32,6 +33,7 @@ const applicationServices = LayerNode.group([
   SessionV2.node,
   PermissionSaved.node,
   PtyTicket.node,
+  Pty.node, // kilocode_change
   Credential.node,
   PtyEnvironment.node,
   LocationServiceMap.node,


### PR DESCRIPTION
Configuration and provider updates disposed location-scoped PTY services. The PTY finalizer then terminated every live Agent Manager terminal, even though these updates only require LLM and session services to reload.

This change keeps the PTY registry in the global runtime and applies directory isolation at request time. PTYs are terminated only for explicit terminal removal, worktree deletion, project removal, and server shutdown. Agent Manager cleanup paths explicitly remove PTYs before deleting worktree directories, including stale and failed-setup cleanup.

The change includes regression coverage and a changeset.