### PR TITLE
fix(cli): use full GPT-5.6 OAuth context

### DIFF
--- a/.changeset/gpt-56-oauth-context.md
+++ b/.changeset/gpt-56-oauth-context.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Use the full Codex context window for GPT-5.6 models authenticated through ChatGPT OAuth.

--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -422,8 +422,8 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
                     }
                   : model.id.includes("gpt-5.6")
                     ? {
-                        context: 500_000,
-                        input: 372_000,
+                        context: 1_050_000, // kilocode_change - use the current Codex limits for GPT-5.6 OAuth models
+                        input: 922_000, // kilocode_change
                         output: 128_000,
                       }
                     : model.limit,

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -253,9 +253,11 @@ describe("plugin.codex", () => {
 
     expect(models["gpt-5.4"]?.limit).toEqual(limit)
     expect(models["gpt-5.5"]?.limit).toEqual({ context: 400_000, input: 272_000, output: 128_000 })
-    expect(models["gpt-5.6-sol"]?.limit).toEqual({ context: 500_000, input: 372_000, output: 128_000 })
-    expect(models["gpt-5.6-terra"]?.limit).toEqual({ context: 500_000, input: 372_000, output: 128_000 })
-    expect(models["gpt-5.6-luna"]?.limit).toEqual({ context: 500_000, input: 372_000, output: 128_000 })
+    // kilocode_change start - GPT-5.6 OAuth models use the current Codex limits
+    expect(models["gpt-5.6-sol"]?.limit).toEqual(limit)
+    expect(models["gpt-5.6-terra"]?.limit).toEqual(limit)
+    expect(models["gpt-5.6-luna"]?.limit).toEqual(limit)
+    // kilocode_change end
     expect(models["gpt-5.4-pro"]).toBeUndefined()
     expect(models["gpt-5.7-pro"]).toBeDefined()
     expect(models["gpt-5.6-sol-high"]).toBeDefined()


### PR DESCRIPTION
Kilo currently reports a 500k context limit for ChatGPT OAuth GPT-5.6 models, even though the current Codex limits support a 1.05M-token context window and 922k input window. This causes Kilo to compact or reject conversations earlier than necessary.

Use the current Codex context and input limits for every GPT-5.6 OAuth model while preserving the existing GPT-5.5 behavior. The release metadata documents the user-facing limit increase.