### PR TITLE
fix(agent-manager): restore live diff statistics

### DIFF
--- a/.changeset/restore-agent-manager-diff-stats.md
+++ b/.changeset/restore-agent-manager-diff-stats.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Restore live Git change statistics on the Agent Manager diff toggle for local and worktree selections.

--- a/packages/kilo-vscode/tests/unit/agent-manager-tab-bar.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-tab-bar.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test"
+import fs from "node:fs"
+import path from "node:path"
+
+const TAB_BAR = path.resolve(import.meta.dir, "../../webview-ui/agent-manager/TabBar.tsx")
+
+describe("Agent Manager diff toggle", () => {
+  it("renders live Git stats rather than pull-request stats", () => {
+    const source = fs.readFileSync(TAB_BAR, "utf-8")
+    const start = source.indexOf('title={props.t("agentManager.diff.toggle")}')
+    const end = source.indexOf("</TooltipKeybind>", start)
+    const button = source.slice(start, end)
+
+    expect(start).toBeGreaterThanOrEqual(0)
+    expect(end).toBeGreaterThan(start)
+    expect(button).toContain("<Show when={hasChanges()}>")
+    expect(button).toContain("stats()!.files")
+    expect(button).toContain("stats()!.additions")
+    expect(button).toContain("stats()!.deletions")
+    expect(button).not.toContain("props.prStatus()")
+    expect(button).not.toContain("pr().additions")
+    expect(button).not.toContain("pr().deletions")
+  })
+})

--- a/packages/kilo-vscode/webview-ui/agent-manager/TabBar.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/TabBar.tsx
@@ -243,19 +243,14 @@ export const TabBar: Component<TabBarProps> = (props) => (
                     title={props.t("agentManager.diff.toggle")}
                   >
                     <Icon name="layers" size="small" />
-                    <Show when={props.prStatus()}>
-                      {(pr) => (
-                        <Show when={pr().additions > 0 || pr().deletions > 0}>
-                          <span class="am-diff-toggle-stats">
-                            <Show when={pr().additions > 0}>
-                              <span class="am-stat-additions">+{pr().additions}</span>
-                            </Show>
-                            <Show when={pr().deletions > 0}>
-                              <span class="am-stat-deletions">−{pr().deletions}</span>
-                            </Show>
-                          </span>
+                    <Show when={hasChanges()}>
+                      <span class="am-diff-toggle-stats">
+                        <Show when={stats()!.files > 0}>
+                          <span class="am-stat-files">{stats()!.files}f</span>
                         </Show>
-                      )}
+                        <span class="am-stat-additions">+{stats()!.additions}</span>
+                        <span class="am-stat-deletions">−{stats()!.deletions}</span>
+                      </span>
                     </Show>
                   </button>
                 </TooltipKeybind>


### PR DESCRIPTION
## Problem

The Agent Manager layers button is the diff toggle for the currently selected local or managed worktree, so its badge must describe the selected checkout's live Git changes. It was instead showing pull-request statistics after PR view support was added.

The regression was introduced by [PR #12961](https://github.com/Kilo-Org/kilocode/pull/12961), commit [`70c37d66d8d11322ba82e7d17d783945d054f0b3`](https://github.com/Kilo-Org/kilocode/commit/70c37d66d8d11322ba82e7d17d783945d054f0b3), titled `feat(pr-view): show code -X/+Y on code diff and remove PR number`. Before that commit, the layers button rendered `hasChanges()` and the selected context's `stats()` values (`files`, `additions`, and `deletions`). The commit added a separate pull-request toggle, but also replaced the layers button's live-stat rendering with `props.prStatus()` additions and deletions. That conflated PR diff totals with the selected checkout's working-tree diff and could show stale or irrelevant values for Agent Manager local and worktree selections.

## Fix

Restore `hasChanges()` and the selected context's live `stats()` values for the layers button. The separate pull-request control remains unchanged. Add a regression test that prevents PR status values from being used for the live Git badge.