### PR TITLE
fix(vscode): restore text streaming

### DIFF
--- a/.changeset/fix-text-streaming.md
+++ b/.changeset/fix-text-streaming.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Restore incremental assistant text streaming across Kilo chat surfaces.

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -2715,7 +2715,9 @@ export const SessionProvider: ParentComponent = (props) => {
     return id ? store.messages[id] || [] : []
   }
 
-  const getParts = (messageID: string) => stash.peek(messageID) ?? untrack(() => store.parts[messageID]) ?? []
+  // Keep off-screen history in the non-reactive stash, but track live parts so
+  // newly streamed messages invalidate the transcript.
+  const getParts = (messageID: string) => stash.peek(messageID) ?? store.parts[messageID] ?? []
 
   const getSessionToolParts = (sessionID: string) => store.toolParts[sessionID] ?? []
 


### PR DESCRIPTION
Assistant text updates were still arriving and being stored, but the transcript lookup introduced by #13154 read live parts inside `untrack`. New assistant turns therefore did not invalidate the rendered transcript while their text was streaming.\n\nThe lookup now keeps stashed history non-reactive while reading live parts reactively, restoring incremental updates without bringing back the whole-session reactive cascade. This applies consistently to the sidebar, Agent Manager, and editor-tab chat surfaces.