### PR TITLE
fix(cli): recover sessions pinned to a retired gateway model

### DIFF
--- a/.changeset/stale-session-gateway-model.md
+++ b/.changeset/stale-session-gateway-model.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Recover sessions pinned to a retired Kilo Gateway model instead of sending the dead ID again.

--- a/packages/opencode/src/kilocode/session/model-recovery.ts
+++ b/packages/opencode/src/kilocode/session/model-recovery.ts
@@ -1,0 +1,29 @@
+import { Effect } from "effect"
+import type { ProviderV2 } from "@opencode-ai/core/provider"
+import type { ModelV2 } from "@opencode-ai/core/model"
+
+export namespace KiloModelRecovery {
+  export type Candidate = {
+    providerID: ProviderV2.ID
+    modelID: ModelV2.ID
+    variant?: string
+  }
+
+  /**
+   * Sessions remember the model they were last prompted with. When the live catalog drops that
+   * ID - a Kilo Gateway slug is retired, an org loses access - the remembered ID is dead and
+   * re-sending it only fails downstream. Return the first candidate the catalog still has so the
+   * caller can fall back to a valid default instead of prompting with a stale ID forever.
+   */
+  export const firstAvailable = <A, E, R>(
+    candidates: readonly Candidate[],
+    lookup: (model: Candidate) => Effect.Effect<A, E, R>,
+  ): Effect.Effect<Candidate | undefined, never, R> =>
+    Effect.gen(function* () {
+      for (const candidate of candidates) {
+        const found = yield* lookup(candidate).pipe(Effect.catch(() => Effect.succeed(undefined)))
+        if (found !== undefined) return candidate
+      }
+      return undefined
+    })
+}

--- a/packages/opencode/src/kilocode/session/tui-sync.ts
+++ b/packages/opencode/src/kilocode/session/tui-sync.ts
@@ -4,4 +4,30 @@ export namespace KiloSessionTuiSync {
     if (!input.parts) return false
     return !input.parts.some((part) => part.type === "compaction")
   }
+
+  export type RestoredModel = {
+    providerID: string
+    modelID: string
+    variant?: string
+  }
+
+  export type Restore =
+    | { type: "skip" }
+    | { type: "stale"; model: RestoredModel }
+    | { type: "apply"; model: RestoredModel }
+
+  /**
+   * Opening an old session restores its last user model into the global picker. If the live
+   * catalog no longer has that ID (a retired Kilo Gateway slug, for example) it must not be
+   * pinned, and its variant must not leak onto whatever model stays selected - the picker keeps
+   * its current valid pick and the caller surfaces the stale ID so the user can re-pick.
+   */
+  export function restore(input: {
+    model?: RestoredModel
+    valid: (model: { providerID: string; modelID: string }) => boolean
+  }): Restore {
+    if (!input.model) return { type: "skip" }
+    if (!input.valid(input.model)) return { type: "stale", model: input.model }
+    return { type: "apply", model: input.model }
+  }
 }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -8,6 +8,7 @@ import os from "os"
 import { KiloSessionPrompt } from "@/kilocode/session/prompt" // kilocode_change
 import { SKILL_SHELL_DISABLED, SKILL_SHELL_UNTRUSTED } from "@/kilocode/skills/display" // kilocode_change
 import { KiloSessionMessageOrder } from "@/kilocode/session/message-order" // kilocode_change
+import { KiloModelRecovery } from "@/kilocode/session/model-recovery" // kilocode_change
 import { KiloSessionPromptQueue } from "@/kilocode/session/prompt-queue" // kilocode_change
 import { KiloSession } from "@/kilocode/session" // kilocode_change
 import { SessionTranscript } from "@/kilocode/session/transcript" // kilocode_change
@@ -801,18 +802,38 @@ export const layer = Layer.effect(
         .where(eq(SessionTable.id, sessionID))
         .get()
         .pipe(Effect.orDie)
-      if (current?.model) {
-        return {
-          providerID: ProviderV2.ID.make(current.model.providerID),
-          modelID: ModelV2.ID.make(current.model.id),
-          ...(current.model.variant && current.model.variant !== "default" ? { variant: current.model.variant } : {}),
-        }
+      // kilocode_change start - never keep prompting with a model the live catalog no longer has
+      const inCatalog = (candidate: KiloModelRecovery.Candidate) =>
+        KiloModelRecovery.firstAvailable([candidate], (model) => provider.getModel(model.providerID, model.modelID))
+
+      const stored: KiloModelRecovery.Candidate | undefined = current?.model
+        ? {
+            providerID: ProviderV2.ID.make(current.model.providerID),
+            modelID: ModelV2.ID.make(current.model.id),
+            ...(current.model.variant && current.model.variant !== "default" ? { variant: current.model.variant } : {}),
+          }
+        : undefined
+      if (stored) {
+        const usable = yield* inCatalog(stored)
+        if (usable) return usable
       }
+
       const match = yield* sessions
         .findMessage(sessionID, (m) => m.info.role === "user" && !!m.info.model)
         .pipe(Effect.orDie)
-      if (Option.isSome(match) && match.value.info.role === "user") return match.value.info.model
+      const last = Option.isSome(match) && match.value.info.role === "user" ? match.value.info.model : undefined
+      if (last) {
+        const usable = yield* inCatalog(last)
+        if (usable) return usable
+      }
+
+      const dead = stored ?? last
+      if (dead)
+        yield* Effect.logWarning(
+          `Session ${sessionID} model ${dead.providerID}/${dead.modelID} is missing from the model catalog, falling back to the default model`,
+        )
       return yield* provider.defaultModel().pipe(Effect.orDie)
+      // kilocode_change end
     })
 
     const createUserMessage = Effect.fn("SessionPrompt.createUserMessage")(function* (input: PromptInput) {

--- a/packages/opencode/test/kilocode/session-model-recovery.test.ts
+++ b/packages/opencode/test/kilocode/session-model-recovery.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { KiloModelRecovery } from "../../src/kilocode/session/model-recovery"
+import { KiloSessionTuiSync } from "../../src/kilocode/session/tui-sync"
+
+const candidate = (providerID: string, modelID: string, variant?: string): KiloModelRecovery.Candidate => ({
+  providerID: ProviderV2.ID.make(providerID),
+  modelID: ModelV2.ID.make(modelID),
+  ...(variant ? { variant } : {}),
+})
+
+class MissingModel extends Error {}
+
+/** Stands in for Provider.getModel: exact key lookup, typed failure when the catalog lacks the ID. */
+function catalog(ids: string[]) {
+  const seen: string[] = []
+  const lookup = (model: KiloModelRecovery.Candidate) =>
+    Effect.suspend(() => {
+      const id = `${model.providerID}/${model.modelID}`
+      seen.push(id)
+      if (!ids.includes(id)) return Effect.fail(new MissingModel(id))
+      return Effect.succeed({ id: model.modelID })
+    })
+  return { lookup, seen }
+}
+
+describe("KiloModelRecovery.firstAvailable", () => {
+  test("drops a retired gateway model the live catalog no longer has", async () => {
+    const live = catalog(["kilo/~anthropic/claude-sonnet-latest"])
+    const result = await Effect.runPromise(
+      KiloModelRecovery.firstAvailable([candidate("kilo", "anthropic/claude-sonnet-4.5")], live.lookup),
+    )
+
+    expect(result).toBeUndefined()
+    expect(live.seen).toEqual(["kilo/anthropic/claude-sonnet-4.5"])
+  })
+
+  test("does not treat a near-miss slug as an alias", async () => {
+    const live = catalog(["kilo/anthropic/claude-sonnet-4-5"])
+    const result = await Effect.runPromise(
+      KiloModelRecovery.firstAvailable([candidate("kilo", "anthropic/claude-sonnet-4.5")], live.lookup),
+    )
+
+    expect(result).toBeUndefined()
+  })
+
+  test("keeps a stored model that is still in the catalog, variant included", async () => {
+    const live = catalog(["kilo/~anthropic/claude-sonnet-latest"])
+    const result = await Effect.runPromise(
+      KiloModelRecovery.firstAvailable([candidate("kilo", "~anthropic/claude-sonnet-latest", "max")], live.lookup),
+    )
+
+    expect(result).toEqual(candidate("kilo", "~anthropic/claude-sonnet-latest", "max"))
+  })
+
+  test("falls through a dead stored model to a live last-message model", async () => {
+    const live = catalog(["kilo/~anthropic/claude-sonnet-latest"])
+    const result = await Effect.runPromise(
+      KiloModelRecovery.firstAvailable(
+        [candidate("kilo", "anthropic/claude-sonnet-4.5"), candidate("kilo", "~anthropic/claude-sonnet-latest")],
+        live.lookup,
+      ),
+    )
+
+    expect(result).toEqual(candidate("kilo", "~anthropic/claude-sonnet-latest"))
+    expect(live.seen).toEqual(["kilo/anthropic/claude-sonnet-4.5", "kilo/~anthropic/claude-sonnet-latest"])
+  })
+
+  test("stops probing once a candidate resolves", async () => {
+    const live = catalog(["kilo/~anthropic/claude-sonnet-latest", "kilo/anthropic/claude-sonnet-4.5"])
+    await Effect.runPromise(
+      KiloModelRecovery.firstAvailable(
+        [candidate("kilo", "~anthropic/claude-sonnet-latest"), candidate("kilo", "anthropic/claude-sonnet-4.5")],
+        live.lookup,
+      ),
+    )
+
+    expect(live.seen).toEqual(["kilo/~anthropic/claude-sonnet-latest"])
+  })
+
+  test("reports nothing usable when the session has no remembered model", async () => {
+    const live = catalog(["kilo/~anthropic/claude-sonnet-latest"])
+    const result = await Effect.runPromise(KiloModelRecovery.firstAvailable([], live.lookup))
+
+    expect(result).toBeUndefined()
+    expect(live.seen).toEqual([])
+  })
+})
+
+describe("KiloSessionTuiSync.restore", () => {
+  const valid = (ids: string[]) => (model: { providerID: string; modelID: string }) =>
+    ids.includes(`${model.providerID}/${model.modelID}`)
+
+  test("does not pin a restored model the catalog dropped", () => {
+    const restored = KiloSessionTuiSync.restore({
+      model: { providerID: "kilo", modelID: "anthropic/claude-sonnet-4.5", variant: "max" },
+      valid: valid(["kilo/~anthropic/claude-sonnet-latest"]),
+    })
+
+    expect(restored.type).toBe("stale")
+    expect(restored.type === "stale" && restored.model.modelID).toBe("anthropic/claude-sonnet-4.5")
+  })
+
+  test("applies a restored model that is still in the catalog", () => {
+    const restored = KiloSessionTuiSync.restore({
+      model: { providerID: "kilo", modelID: "~anthropic/claude-sonnet-latest", variant: "max" },
+      valid: valid(["kilo/~anthropic/claude-sonnet-latest"]),
+    })
+
+    expect(restored).toEqual({
+      type: "apply",
+      model: { providerID: "kilo", modelID: "~anthropic/claude-sonnet-latest", variant: "max" },
+    })
+  })
+
+  test("skips messages without a model", () => {
+    expect(KiloSessionTuiSync.restore({ valid: valid([]) })).toEqual({ type: "skip" })
+  })
+})

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -353,8 +353,21 @@ export function Prompt(props: PromptProps) {
       // Keep command line --agent if specified.
       if (!args.agent) local.agent.set(msg.agent)
       if (msg.model && !primary.model && !args.agent) {
-        local.model.set(msg.model)
-        local.model.variant.set(msg.model.variant)
+        // kilocode_change start - a model the catalog dropped must not be pinned, and its variant
+        // must not leak onto the model that stays selected
+        const restored = KiloSessionTuiSync.restore({ model: msg.model, valid: local.model.isValid })
+        if (restored.type === "apply") {
+          local.model.set(restored.model)
+          local.model.variant.set(restored.model.variant)
+        }
+        if (restored.type === "stale") {
+          toast.show({
+            variant: "warning",
+            message: `${restored.model.providerID}/${restored.model.modelID} is no longer available - pick a model to continue`,
+            duration: 5000,
+          })
+        }
+        // kilocode_change end
       }
     }
   })

--- a/packages/tui/src/context/local.tsx
+++ b/packages/tui/src/context/local.tsx
@@ -302,6 +302,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         get ready() {
           return modelStore.ready
         },
+        // kilocode_change start - let callers check the live catalog before restoring a remembered model
+        isValid: isModelValid,
+        // kilocode_change end
         // kilocode_change start - expose persisted per-agent pick separately from overrides
         saved(name: string) {
           return modelStore.model[name]


### PR DESCRIPTION
## Issue

No public issue. Internal report: old TUI sessions kept failing after a Gateway model ID was retired; new sessions worked.

## Context

Prompting reused `session.model` with no catalog check. Opening an old TUI session also wrote that dead ID back into the global picker.

## Implementation

Probe the stored session model (then the last user-message model) against `provider.getModel`. If both are gone, fall back to the current default and log the dead ID. TUI restore applies the model only when it is still in the catalog; otherwise it toasts and does not pin it.

No alias map — `claude-sonnet-4.5` is not treated as `claude-sonnet-4-5`. The dead ID is not rewritten in the DB. Transient provider gaps can now fall back instead of failing loudly.

## Screenshots / Video

N/A

## How to Test

### Manual/local verification

- Agent: `bun test` on `session-model-recovery.test.ts` and `tui-sync.test.ts` — pass
- Agent: `bun run typecheck` in `packages/opencode` and `packages/tui` — clean

### Reviewer test steps

1. `cd packages/opencode && bun test test/kilocode/session-model-recovery.test.ts test/kilocode/tui-sync.test.ts`
2. Open a session whose last model ID is missing from the current catalog. Prompt should use the default instead of sending the dead ID; TUI should toast rather than pin it.

### Blocked checks and substitute verification

- Agent: no live old-session + Gateway run here. Substituted with unit tests of the recovery helper and TUI restore decision.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch