### PR TITLE
feat(vscode): add subagent inspector tabs

### DIFF
--- a/.changeset/subagent-inspector-tabs.md
+++ b/.changeset/subagent-inspector-tabs.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Open delegated subagent sessions in Agent Manager inspector tabs alongside terminals.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -379,6 +379,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private readonly openSessionIds = new Set<string>()
   private modelUsageSessionIds: Set<string> = new Set()
   private syncedChildSessions: Set<string> = new Set()
+  private readonly inspectorSessionIds = new Set<string>()
   private readonly checkpoints = new Map<string, Promise<void>>()
   private readonly sessionCreations = new Map<string, Promise<{ sid: string; dir: string } | undefined>>()
   private readonly draftSessions = new Map<string, { sid: string; dir: string; expires: number }>()
@@ -1083,6 +1084,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       if (await this.handleModelSelectorExpandedMessage(message)) return
       this.handleWebviewFocusMessage(message)
       this.visibleTaskStreams.handle(message)
+      this.handleStreamVisibilityMessage(message)
+      if (this.handleChildSyncMessage(message)) return
       if (await this.handleMemoryMessage(message)) return
       if (this.handleLegacyMigrationMessage(message)) return
       switch (message.type) {
@@ -1171,14 +1174,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           // isn't blocked by slow responses for earlier sessions.
           void this.handleLoadMessages(message.sessionID, {
             mode: message.mode,
+            focus: message.focus,
             before: message.before,
             limit: message.limit,
           })
-          break
-        case "syncSession":
-          this.handleSyncSession(message.sessionID, message.parentSessionID).catch((e) =>
-            console.error("[Kilo New] handleSyncSession failed:", e),
-          )
           break
         case "loadSessions":
           this.handleLoadSessions().catch((e) => console.error("[Kilo New] handleLoadSessions failed:", e))
@@ -1570,6 +1569,33 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     if (this.opts.focusContext) {
       void vscode.commands.executeCommand("setContext", this.opts.focusContext, message.focused === true)
     }
+  }
+
+  private handleChildSyncMessage(
+    message: TypedWebviewMessage & { sessionID?: unknown; parentSessionID?: unknown; scope?: unknown },
+  ): boolean {
+    if (message.type !== "syncSession" && message.type !== "unsyncSession") return false
+    if (typeof message.sessionID !== "string") return true
+    if (message.type === "syncSession") {
+      if (message.scope === "inspector") this.inspectorSessionIds.add(message.sessionID)
+      const parent = typeof message.parentSessionID === "string" ? message.parentSessionID : undefined
+      this.handleSyncSession(message.sessionID, parent).catch((e) =>
+        console.error("[Kilo New] handleSyncSession failed:", e),
+      )
+      return true
+    }
+    this.inspectorSessionIds.delete(message.sessionID)
+    this.releaseChildSession(message.sessionID)
+    return true
+  }
+
+  private handleStreamVisibilityMessage(
+    message: TypedWebviewMessage & { sessionID?: unknown; visible?: unknown },
+  ): void {
+    if (message.type !== "streamSessionVisible" || message.visible !== false || typeof message.sessionID !== "string") {
+      return
+    }
+    this.releaseChildSession(message.sessionID)
   }
 
   private handleEditorOpenMessage(message: Parameters<typeof handleEditorAction>[0]): boolean {
@@ -1976,14 +2002,22 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
   private async handleLoadMessages(
     sessionID: string,
-    options: { mode?: MessageLoadMode; before?: string; limit?: number; preserveStream?: boolean } = {},
+    options: {
+      mode?: MessageLoadMode
+      focus?: boolean
+      before?: string
+      limit?: number
+      preserveStream?: boolean
+    } = {},
   ): Promise<void> {
     const mode = options.mode ?? "replace"
     if (mode === "replace" || mode === "focus") {
-      this.stopCurrentSessionProcesses(sessionID)
       this.trackedSessionIds.add(sessionID)
-      this.focusSession(sessionID)
-      this.contextSessionID = sessionID
+      if (options.focus !== false) {
+        this.stopCurrentSessionProcesses(sessionID)
+        this.focusSession(sessionID)
+        this.contextSessionID = sessionID
+      }
     }
     if (!this.client) {
       this.postMessage({ type: "error", message: "Not connected to CLI backend", sessionID })
@@ -2119,6 +2153,25 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
   }
 
+  private releaseChildSession(sessionID: string): void {
+    if (
+      this.inspectorSessionIds.has(sessionID) ||
+      this.visibleTaskStreams.has(sessionID) ||
+      this.currentSession?.id === sessionID ||
+      this.openSessionIds.has(sessionID)
+    ) {
+      return
+    }
+    if (!this.syncedChildSessions.delete(sessionID)) return
+    this.trackedSessionIds.delete(sessionID)
+    this.streams.drop(sessionID)
+    this.visibleTaskStreams.delete(sessionID)
+    this.sessionDirectories.delete(sessionID)
+    this.sessionGitDirectories.delete(sessionID)
+    this.sessionGitRecoveries.delete(sessionID)
+    this.connectionService.pruneSession(sessionID)
+  }
+
   /**
    * Build the context object used by the extracted session-refresh helpers.
    */
@@ -2252,6 +2305,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.streams.drop(sessionID)
     this.visibleTaskStreams.delete(sessionID)
     this.syncedChildSessions.delete(sessionID)
+    this.inspectorSessionIds.delete(sessionID)
     this.sessionDirectories.delete(sessionID)
     this.sessionGitDirectories.delete(sessionID)
     this.sessionGitRecoveries.delete(sessionID)
@@ -5091,6 +5145,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.trackedSessionIds.clear()
     this.openSessionIds.clear()
     this.syncedChildSessions.clear()
+    this.inspectorSessionIds.clear()
     this.draftSessions.clear()
     this.sessionDirectories.clear()
     this.anacondaDesktop.dispose()

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1584,7 +1584,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       )
       return true
     }
-    this.inspectorSessionIds.delete(message.sessionID)
+    if (message.scope === "inspector") this.inspectorSessionIds.delete(message.sessionID)
     this.releaseChildSession(message.sessionID)
     return true
   }

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -817,6 +817,7 @@ interface LoadMessagesIn {
   type: "loadMessages"
   sessionID: string
   mode?: "replace" | "prepend" | "focus"
+  focus?: boolean
   before?: string
   limit?: number
 }

--- a/packages/kilo-vscode/src/kilo-provider/visible-task-streams.ts
+++ b/packages/kilo-vscode/src/kilo-provider/visible-task-streams.ts
@@ -25,6 +25,10 @@ export class VisibleTaskStreams {
     this.refs.delete(id)
   }
 
+  has(id: string): boolean {
+    return this.refs.has(id)
+  }
+
   setActive(active: boolean): void {
     if (this.active === active) return
     this.active = active

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -21,6 +21,7 @@ const CSS_FILES = [
 ]
 const TSX_FILES = [
   path.join(ROOT, "webview-ui/agent-manager/AgentManagerApp.tsx"),
+  path.join(ROOT, "webview-ui/agent-manager/SubagentPanel.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/UnassignedSessionsSection.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/NewWorktreeDialog.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/ProjectSelect.tsx"),
@@ -51,6 +52,8 @@ const TSX_FILES = [
   path.join(ROOT, "webview-ui/agent-manager/SidebarBody.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/Skeleton.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/TabBar.tsx"),
+  path.join(ROOT, "webview-ui/agent-manager/ClosableTab.tsx"),
+  path.join(ROOT, "webview-ui/agent-manager/InspectorTabStrip.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/ProjectBranchDialog.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/DefaultBaseBranchDialog.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/tab-rendering.tsx"),

--- a/packages/kilo-vscode/tests/unit/agent-manager-terminal-layout.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-terminal-layout.test.ts
@@ -36,13 +36,16 @@ test("uses one persisted width for every inspector panel", () => {
 })
 
 test("hides keyboard hints only in inspector tabs", () => {
-  const side = readFileSync(resolve(import.meta.dir, "../../webview-ui/agent-manager/terminal/SideTerminalPanel.tsx"), "utf8")
+  const side = readFileSync(
+    resolve(import.meta.dir, "../../webview-ui/agent-manager/terminal/SideTerminalPanel.tsx"),
+    "utf8",
+  )
 
   expect(subagent).toContain("showKeybind={false}")
   expect(side).toContain("showKeybind={false}")
-  expect(readFileSync(resolve(import.meta.dir, "../../webview-ui/agent-manager/terminal/render.tsx"), "utf8")).not.toContain(
-    "showKeybind={false}",
-  )
+  expect(
+    readFileSync(resolve(import.meta.dir, "../../webview-ui/agent-manager/terminal/render.tsx"), "utf8"),
+  ).not.toContain("showKeybind={false}")
 })
 
 test("limits inspector layout updates during resize", () => {

--- a/packages/kilo-vscode/tests/unit/agent-manager-terminal-layout.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-terminal-layout.test.ts
@@ -10,6 +10,7 @@ import {
 
 const css = readFileSync(resolve(import.meta.dir, "../../webview-ui/agent-manager/agent-manager.css"), "utf8")
 const app = readFileSync(resolve(import.meta.dir, "../../webview-ui/agent-manager/AgentManagerApp.tsx"), "utf8")
+const subagent = readFileSync(resolve(import.meta.dir, "../../webview-ui/agent-manager/SubagentPanel.tsx"), "utf8")
 const terminal = readFileSync(
   resolve(import.meta.dir, "../../webview-ui/agent-manager/terminal/TerminalTab.tsx"),
   "utf8",
@@ -25,11 +26,23 @@ test("xterm owns the padding used by FitAddon", () => {
   expect(term).toMatch(/\bpadding\s*:\s*8px\s*;/)
 })
 
-test("uses one persisted width for the diff and terminal inspector", () => {
+test("uses one persisted width for every inspector panel", () => {
   expect(app).toContain("persisted?.sidePanelWidth")
   expect(app).toContain("createPanelResize(setPanelWidth")
+  expect(app).toContain("style={{ width: `${panelWidth()}px` }}")
+  expect(subagent).toContain("InspectorTabStrip")
   expect(app).not.toContain("diffWidth")
   expect(app).not.toContain("terminalWidth")
+})
+
+test("hides keyboard hints only in inspector tabs", () => {
+  const side = readFileSync(resolve(import.meta.dir, "../../webview-ui/agent-manager/terminal/SideTerminalPanel.tsx"), "utf8")
+
+  expect(subagent).toContain("showKeybind={false}")
+  expect(side).toContain("showKeybind={false}")
+  expect(readFileSync(resolve(import.meta.dir, "../../webview-ui/agent-manager/terminal/render.tsx"), "utf8")).not.toContain(
+    "showKeybind={false}",
+  )
 })
 
 test("limits inspector layout updates during resize", () => {

--- a/packages/kilo-vscode/tests/unit/session-select-connection.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-select-connection.test.ts
@@ -50,7 +50,7 @@ describe("selectSession keeps the chat in sync with the selection while offline"
     // Queue a replay unconditionally. The earlier `deferredFetch = ready ? undefined : id`
     // form skipped cached sessions, so a reconnect never re-sent the focus load that
     // re-focuses the backend (focusSession/contextSessionID/SSE tracking/reconcile).
-    expect(body).toContain("deferredFetch = id")
+    expect(body).toContain("deferredFetch = { id, focus }")
     expect(body).not.toMatch(/deferredFetch\s*=\s*ready\s*\?/)
   })
 })
@@ -61,12 +61,15 @@ describe("a deferred fetch is replayed on reconnect", () => {
     const effect = source.slice(source.indexOf("on(server.isConnected"))
     expect(effect).toContain("deferredFetch")
     // Replays with the focus/replace choice so cached sessions still re-focus the backend.
-    expect(effect).toMatch(/loadFocusedMessages\(\s*id,\s*loaded\(\)\.has\(id\)\s*\)/)
+    expect(effect).toMatch(
+      /loadFocusedMessages\(\s*pending\.id,\s*loaded\(\)\.has\(pending\.id\),\s*pending\.focus\s*\)/,
+    )
   })
 
   it("the focused load helper sends focus for cached sessions and replace otherwise", () => {
     const helper = source.slice(source.indexOf("function loadFocusedMessages("))
     expect(helper).toMatch(/mode: "focus"/)
     expect(helper).toMatch(/mode: "replace"/)
+    expect(helper).toContain("focus: false")
   })
 })

--- a/packages/kilo-vscode/tests/unit/subagent-tabs.test.ts
+++ b/packages/kilo-vscode/tests/unit/subagent-tabs.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test"
+import { createRoot, createSignal } from "solid-js"
+import { createSubagentTabs } from "../../webview-ui/agent-manager/subagent-tabs"
+
+function scene() {
+  const [current] = createSignal<string | undefined>("parent")
+  const calls = { synced: [] as Array<[string, string | undefined]>, shown: 0, hidden: 0 }
+  const tabs = createSubagentTabs({
+    current,
+    sync: (id, parent) => calls.synced.push([id, parent]),
+    show: () => calls.shown++,
+    hide: () => calls.hidden++,
+  })
+  return { tabs, calls }
+}
+
+describe("Agent Manager subagent tabs", () => {
+  it("opens multiple child sessions and syncs each to its parent", () => {
+    createRoot((dispose) => {
+      const item = scene()
+      item.tabs.open("child-1", "First", "parent-1")
+      item.tabs.open("child-2", "Second", "parent-2")
+
+      expect(item.tabs.tabs().map((tab) => tab.id)).toEqual(["child-1", "child-2"])
+      expect(item.tabs.active()).toBe("child-2")
+      expect(item.calls.synced).toEqual([
+        ["child-1", "parent-1"],
+        ["child-2", "parent-2"],
+      ])
+      expect(item.calls.shown).toBe(2)
+      dispose()
+    })
+  })
+
+  it("closes the active tab onto its nearest survivor and hides when empty", () => {
+    createRoot((dispose) => {
+      const item = scene()
+      item.tabs.open("one", "One")
+      item.tabs.open("two", "Two")
+      item.tabs.open("three", "Three")
+
+      item.tabs.close("two")
+      expect(item.tabs.tabs().map((tab) => tab.id)).toEqual(["one", "three"])
+      expect(item.tabs.active()).toBe("three")
+
+      item.tabs.close("three")
+      item.tabs.close("one")
+      expect(item.tabs.tabs()).toEqual([])
+      expect(item.tabs.active()).toBeUndefined()
+      expect(item.calls.hidden).toBe(1)
+      dispose()
+    })
+  })
+
+  it("supports Close Others and preserves the selected child", () => {
+    createRoot((dispose) => {
+      const item = scene()
+      item.tabs.open("one")
+      item.tabs.open("two")
+      item.tabs.open("three")
+
+      item.tabs.closeOthers("one")
+      expect(item.tabs.tabs().map((tab) => tab.id)).toEqual(["one"])
+      expect(item.tabs.active()).toBe("one")
+      expect(item.calls.shown).toBe(4)
+      dispose()
+    })
+  })
+
+  it("reorders tabs without changing the active child", () => {
+    createRoot((dispose) => {
+      const item = scene()
+      item.tabs.open("one")
+      item.tabs.open("two")
+      item.tabs.open("three")
+      item.tabs.select("two")
+
+      item.tabs.reorder("three", "one")
+      expect(item.tabs.tabs().map((tab) => tab.id)).toEqual(["three", "one", "two"])
+      expect(item.tabs.active()).toBe("two")
+      dispose()
+    })
+  })
+})

--- a/packages/kilo-vscode/tests/unit/subagent-tabs.test.ts
+++ b/packages/kilo-vscode/tests/unit/subagent-tabs.test.ts
@@ -4,10 +4,16 @@ import { createSubagentTabs } from "../../webview-ui/agent-manager/subagent-tabs
 
 function scene() {
   const [current] = createSignal<string | undefined>("parent")
-  const calls = { synced: [] as Array<[string, string | undefined]>, shown: 0, hidden: 0 }
+  const calls = {
+    synced: [] as Array<[string, string | undefined]>,
+    unsynced: [] as string[],
+    shown: 0,
+    hidden: 0,
+  }
   const tabs = createSubagentTabs({
     current,
     sync: (id, parent) => calls.synced.push([id, parent]),
+    unsync: (id) => calls.unsynced.push(id),
     show: () => calls.shown++,
     hide: () => calls.hidden++,
   })
@@ -47,6 +53,7 @@ describe("Agent Manager subagent tabs", () => {
       item.tabs.close("one")
       expect(item.tabs.tabs()).toEqual([])
       expect(item.tabs.active()).toBeUndefined()
+      expect(item.calls.unsynced).toEqual(["two", "three", "one"])
       expect(item.calls.hidden).toBe(1)
       dispose()
     })
@@ -62,6 +69,7 @@ describe("Agent Manager subagent tabs", () => {
       item.tabs.closeOthers("one")
       expect(item.tabs.tabs().map((tab) => tab.id)).toEqual(["one"])
       expect(item.tabs.active()).toBe("one")
+      expect(item.calls.unsynced).toEqual(["two", "three"])
       expect(item.calls.shown).toBe(4)
       dispose()
     })

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -325,7 +325,8 @@ const AgentManagerContent: Component = () => {
   const [reviewDiffStyle, setReviewDiffStyle] = createSignal<"unified" | "split">("unified")
   const subagents = createSubagentTabs({
     current: session.currentSessionID,
-    sync: session.syncSession,
+    sync: (id, parentID) => session.syncSession(id, parentID, "inspector"),
+    unsync: (id) => session.unsyncSession(id, "inspector"),
     show: () => {
       setHistory(false)
       setReviewActive(false)

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -178,6 +178,8 @@ import { initialMessage, seedInitialVariant } from "./initial-message"
 import { SidebarToggleButton } from "./SidebarToggleButton"
 import { setTabWidths } from "./tab-widths"
 import { clampPanelWidth, createPanelResize, maxPanelWidth, minPanelWidth, SidePanel } from "./side-panel-layout"
+import { SubagentPanel } from "./SubagentPanel"
+import { createSubagentTabs } from "./subagent-tabs"
 import { buildShortcutCategories } from "./shortcuts"
 import { tracker } from "./telemetry"
 import { createChatFocus, createPromptFocus, hasQuestionOption } from "./focus"
@@ -306,8 +308,8 @@ const AgentManagerContent: Component = () => {
   const diffLoading = diffs.diffLoading
   const setDiffLoading = diffs.setDiffLoading
   const diffNotices = diffs.diffNotices
-  // Diff and terminal views share one inspector width, restored from webview
-  // state so the user's divider position survives panel reloads.
+  // Diff, PR, terminal, and subagent views share one inspector width, restored
+  // from webview state so the user's divider position survives panel reloads.
   const [panelWidth, setPanelWidth] = createSignal(clampPanelWidth(persisted?.sidePanelWidth, window.innerWidth))
   const resizeSide = createPanelResize(setPanelWidth, () => window.innerWidth)
   const showSideTerminal = () => {
@@ -321,6 +323,16 @@ const AgentManagerContent: Component = () => {
   const reviewComposer = createReviewComposer()
   const [reviewActive, setReviewActive] = createSignal(false)
   const [reviewDiffStyle, setReviewDiffStyle] = createSignal<"unified" | "split">("unified")
+  const subagents = createSubagentTabs({
+    current: session.currentSessionID,
+    sync: session.syncSession,
+    show: () => {
+      setHistory(false)
+      setReviewActive(false)
+      setSidePanel(SidePanel.Subagents)
+    },
+    hide: () => setSidePanel(null),
+  })
   const markdown = createMarkdownRender(vscode)
   // Per-worktree git stats (diff additions/deletions, commits missing from origin)
   const worktreeStats = () => registry.active().worktreeStats()
@@ -1214,7 +1226,17 @@ const AgentManagerContent: Component = () => {
         if (match) projectNav.jump(parseInt(match[1]!) - 1)
       }
     }
+    const subagent = (event: Event) => {
+      const detail = (event as CustomEvent<{ sessionID?: unknown; title?: unknown; parentSessionID?: unknown }>).detail
+      if (typeof detail?.sessionID !== "string") return
+      subagents.open(
+        detail.sessionID,
+        typeof detail.title === "string" ? detail.title : undefined,
+        typeof detail.parentSessionID === "string" ? detail.parentSessionID : undefined,
+      )
+    }
     window.addEventListener("message", handler)
+    window.addEventListener("agentManager.openSubagent", subagent)
     // Prevent Cmd/Ctrl shortcuts from triggering native browser actions
     const preventDefaults = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey)) return
@@ -1263,6 +1285,7 @@ const AgentManagerContent: Component = () => {
       confirmDeleteWorktree(sel)
     }
     window.addEventListener("keydown", deleteKeyHandler)
+    onCleanup(() => window.removeEventListener("agentManager.openSubagent", subagent))
 
     // Reveal the ⌘/Ctrl+1-9 jump badges on all sidebar items while the modifier is held.
     // Capture phase so the terminal's key handlers can't swallow them; blur resets state
@@ -2157,6 +2180,10 @@ const AgentManagerContent: Component = () => {
   // Close the currently active tab via keyboard shortcut.
   // If no tabs remain, fall through to close the selected worktree.
   const closeActiveTab = () => {
+    if (sidePanel() === SidePanel.Subagents && subagents.active()) {
+      subagents.close(subagents.active()!)
+      return
+    }
     // A focused side terminal owns Cmd+W while its panel is visible.
     // Closing a chat tab out from under the user's cursor would be surprising.
     if (sidePanel() === SidePanel.Terminal && terms.sideFocusedId()) {
@@ -2587,7 +2614,7 @@ const AgentManagerContent: Component = () => {
                   mounted while a side terminal is alive — hidden via
                   .am-side-host-hidden (absolute + opacity), never
                   unmounted, so xterm render loops keep streaming. */}
-              <Show when={sidePanel() !== null || terms.sides().length > 0}>
+              <Show when={sidePanel() !== null || terms.sides().length > 0 || subagents.tabs().length > 0}>
                 <div
                   class={`am-diff-resize ${sidePanel() === null ? "am-side-host-hidden" : ""}`}
                   style={{ width: `${panelWidth()}px` }}
@@ -2652,6 +2679,20 @@ const AgentManagerContent: Component = () => {
                             url: activePR()!.pr.url,
                           })
                         }
+                      />
+                    </Show>
+                    <Show when={subagents.tabs().length > 0}>
+                      <SubagentPanel
+                        tabs={subagents.tabs}
+                        active={subagents.active}
+                        visible={() => sidePanel() === SidePanel.Subagents}
+                        nextKeybind={kb().nextTab ?? ""}
+                        closeKeybind={kb().closeTab ?? ""}
+                        onSelect={subagents.select}
+                        onClose={subagents.close}
+                        onCloseOthers={subagents.closeOthers}
+                        onReorder={subagents.reorder}
+                        onClosePanel={() => setSidePanel(null)}
                       />
                     </Show>
                     <SideTerminalPanel

--- a/packages/kilo-vscode/webview-ui/agent-manager/ClosableTab.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ClosableTab.tsx
@@ -1,0 +1,155 @@
+import type { IconProps } from "@kilocode/kilo-ui/icon"
+import { Icon } from "@kilocode/kilo-ui/icon"
+import { IconButton } from "@kilocode/kilo-ui/icon-button"
+import { Spinner } from "@kilocode/kilo-ui/spinner"
+import { TooltipKeybind } from "@kilocode/kilo-ui/tooltip"
+import { Show, type Component, type JSX } from "solid-js"
+import { SessionTabMenu } from "../src/components/chat/SessionTabMenu"
+import { SortableTabContainer } from "../src/components/chat/TabDnd"
+import { useLanguage } from "../src/context/language"
+import { parseBindingTokens } from "./keybind-tokens"
+
+type TabIcon = IconProps["name"] | "spinner"
+type Value<T> = T | (() => T)
+
+function value<T>(input: Value<T>): T {
+  return typeof input === "function" ? (input as () => T)() : input
+}
+
+export interface ClosableTabProps {
+  id?: string
+  label: Value<string>
+  tooltip: Value<string>
+  icon: Value<TabIcon>
+  iconStatus?: Value<"success" | "failure" | undefined>
+  class?: string
+  focused?: boolean
+  active: boolean
+  closeable?: boolean
+  showKeybind?: boolean
+  keybind?: string
+  closeKeybind?: string
+  role?: "tab"
+  selected?: boolean
+  tabIndex?: number
+  onKeyDown?: JSX.EventHandlerUnion<HTMLDivElement, KeyboardEvent>
+  onSelect: () => void
+  onMiddleClick?: (event: MouseEvent) => void
+  onClose: () => void
+  trailing?: JSX.Element
+}
+
+export const ClosableTabChrome: Component<ClosableTabProps> = (props) => {
+  const { t } = useLanguage()
+  const label = () => value(props.label)
+  const tooltip = () => value(props.tooltip)
+  const icon = () => value(props.icon)
+  const status = () => (props.iconStatus ? value(props.iconStatus) : undefined)
+  const keybind = () => (props.showKeybind === false ? "" : (props.keybind ?? ""))
+  const closeKeybind = () => (props.showKeybind === false ? "" : (props.closeKeybind ?? ""))
+  return (
+    <div
+      class={`am-tab am-tab-closable ${props.active ? "am-tab-active" : ""} ${props.focused ? "am-tab-focused" : ""} ${props.class ?? ""}`}
+    >
+      <div
+        class="am-tab-target"
+        role={props.role}
+        aria-selected={props.selected}
+        aria-label={tooltip()}
+        tabIndex={props.tabIndex}
+        onClick={props.onSelect}
+        onMouseDown={props.onMiddleClick}
+        onKeyDown={props.onKeyDown}
+      >
+        <TooltipKeybind
+          title={tooltip()}
+          keybind={keybind()}
+          placement="bottom"
+          gutter={8}
+          class="am-tab-tooltip"
+          openDelay={0}
+        >
+          <span class="am-tab-title">
+            <span class="am-tab-icon" data-run-status={status()}>
+              <Show when={icon() === "spinner"} fallback={<Icon name={icon() as IconProps["name"]} size="small" />}>
+                <Spinner class="am-tab-spinner" />
+              </Show>
+            </span>
+            <span class="am-tab-label">{label()}</span>
+          </span>
+        </TooltipKeybind>
+      </div>
+      {props.trailing}
+      <Show when={props.closeable !== false}>
+        <TooltipKeybind
+          title={t("agentManager.tab.close")}
+          keybind={closeKeybind()}
+          placement="top"
+          gutter={8}
+          class="am-tab-close-wrap"
+          openDelay={0}
+        >
+          <IconButton
+            icon="close-small"
+            size="small"
+            variant="ghost"
+            aria-label={t("agentManager.tab.closeTab")}
+            tabIndex={props.active ? 0 : -1}
+            class="am-tab-close"
+            data-tab-close="true"
+            onClick={(event) => {
+              event.stopPropagation()
+              props.onClose()
+            }}
+          />
+        </TooltipKeybind>
+      </Show>
+    </div>
+  )
+}
+
+export const SortableClosableTab: Component<
+  ClosableTabProps & {
+    id: string
+    onCloseOthers: () => void
+  }
+> = (props) => (
+  <SortableTabContainer id={props.id}>
+    <SessionTabMenu
+      onClose={props.onClose}
+      onCloseOthers={props.onCloseOthers}
+      closeable={props.closeable}
+      closeShortcut={
+        props.closeKeybind ? (
+          <span class="am-menu-shortcut">
+            {parseBindingTokens(props.closeKeybind).map((token) => (
+              <kbd class="am-menu-key">{token}</kbd>
+            ))}
+          </span>
+        ) : undefined
+      }
+    >
+      <ClosableTabChrome
+        label={props.label}
+        tooltip={props.tooltip}
+        icon={props.icon}
+        iconStatus={props.iconStatus}
+        class={props.class}
+        focused={props.focused}
+        active={props.active}
+        closeable={props.closeable}
+        showKeybind={props.showKeybind}
+        keybind={props.keybind}
+        closeKeybind={props.closeKeybind}
+        role={props.role}
+        selected={props.selected}
+        tabIndex={props.tabIndex}
+        onKeyDown={props.onKeyDown}
+        onSelect={props.onSelect}
+        onMiddleClick={props.onMiddleClick}
+        onClose={props.onClose}
+        trailing={props.trailing}
+      />
+    </SessionTabMenu>
+  </SortableTabContainer>
+)

--- a/packages/kilo-vscode/webview-ui/agent-manager/InspectorTabStrip.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/InspectorTabStrip.tsx
@@ -1,0 +1,108 @@
+import {
+  DragDropProvider,
+  DragDropSensors,
+  DragOverlay,
+  SortableProvider,
+  closestCenter,
+  type DragEvent,
+} from "@thisbeyond/solid-dnd"
+import { For, Show, createSignal, type Accessor, type Component, type JSX } from "solid-js"
+import { ConstrainDragYAxis } from "../src/components/chat/TabDnd"
+import { createTabFocus } from "../src/utils/tab-navigation"
+import { useTabScroll } from "../src/utils/tab-scroll"
+import { setTabWidths } from "../src/utils/tab-widths"
+
+const TABLIST = ".am-inspector-tablist"
+
+type InspectorTabFocus = ReturnType<typeof createTabFocus>
+
+interface InspectorTabStripApi {
+  focus: InspectorTabFocus
+  freeze: () => void
+  release: () => void
+}
+
+interface Props {
+  ids: Accessor<readonly string[]>
+  active: Accessor<string | undefined>
+  label: string
+  renderTab: (id: string, api: InspectorTabStripApi) => JSX.Element
+  overlay: (id: string) => string
+  onSelect: (id: string) => void
+  onReorder: (from: string, to: string) => void
+  action?: (api: InspectorTabStripApi) => JSX.Element
+}
+
+export const InspectorTabStrip: Component<Props> = (props) => {
+  let host!: HTMLDivElement
+  const scroll = useTabScroll(props.ids, props.active)
+  const focus = createTabFocus({ ids: props.ids, select: props.onSelect, root: () => host })
+  const [dragging, setDragging] = createSignal<{ id: string; width: number }>()
+  const freeze = () => setTabWidths(true, host, TABLIST)
+  const release = () => setTabWidths(false, host, TABLIST)
+  const api = { focus, freeze, release }
+  const start = (event: DragEvent) => {
+    const id = event.draggable?.id
+    if (typeof id !== "string") return
+    const width = event.draggable?.layout.width ?? event.draggable?.node.getBoundingClientRect().width
+    freeze()
+    setDragging({ id, width })
+  }
+  const end = () => {
+    setDragging(undefined)
+    release()
+  }
+  const over = (event: DragEvent) => {
+    const from = event.draggable?.id
+    const to = event.droppable?.id
+    if (typeof from !== "string" || typeof to !== "string") return
+    props.onReorder(from, to)
+  }
+
+  return (
+    <div
+      ref={host}
+      class="am-inspector-tabs"
+      onPointerDown={(event) => {
+        if (event.target instanceof Element && event.target.closest(".am-tab-close[data-tab-close]")) freeze()
+      }}
+      onPointerLeave={() => {
+        if (!dragging()) release()
+      }}
+    >
+      <DragDropProvider onDragStart={start} onDragEnd={end} onDragOver={over} collisionDetector={closestCenter}>
+        <DragDropSensors />
+        <ConstrainDragYAxis />
+        <div class="am-tab-scroll-area">
+          <div class={`am-tab-fade am-tab-fade-left ${scroll.showLeft() ? "am-tab-fade-visible" : ""}`} />
+          <div class="am-tab-list-wrap">
+            <div
+              class="am-inspector-tablist"
+              ref={(el) => {
+                scroll.setRef(el)
+              }}
+              role={props.ids().length > 0 ? "tablist" : undefined}
+              aria-label={props.ids().length > 0 ? props.label : undefined}
+              style={{ "--tab-count": `${props.ids().length}` } as JSX.CSSProperties}
+            >
+              <SortableProvider ids={[...props.ids()]}>
+                <For each={props.ids()}>{(id) => props.renderTab(id, api)}</For>
+              </SortableProvider>
+            </div>
+          </div>
+          <div class={`am-tab-fade am-tab-fade-right ${scroll.showRight() ? "am-tab-fade-visible" : ""}`} />
+        </div>
+        <DragOverlay>
+          <Show when={dragging()}>
+            {(tab) => (
+              <div class="am-tab am-tab-overlay" style={{ width: `${tab().width}px` }}>
+                <span class="am-tab-label">{props.overlay(tab().id)}</span>
+              </div>
+            )}
+          </Show>
+        </DragOverlay>
+      </DragDropProvider>
+      {props.action?.(api)}
+    </div>
+  )
+}

--- a/packages/kilo-vscode/webview-ui/agent-manager/SubagentPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/SubagentPanel.tsx
@@ -34,7 +34,7 @@ const SubagentChat: Component<{ active: Accessor<string | undefined> }> = (props
   createEffect(() => {
     const id = props.active()
     if (!id) return
-    session.selectSession(id)
+    session.selectSession(id, { focus: false })
   })
 
   return (
@@ -44,77 +44,88 @@ const SubagentChat: Component<{ active: Accessor<string | undefined> }> = (props
   )
 }
 
-export const SubagentPanel: Component<Props> = (props) => {
+const SubagentContent: Component<Props> = (props) => {
+  const session = useSession()
   const ids = () => props.tabs().map((tab) => tab.id)
   const title = (id: string) => props.tabs().find((tab) => tab.id === id)?.title ?? "Sub-agent"
   const close = (id: string, focus: { restore: () => void }) => {
     props.onClose(id)
+    session.releaseSession(id)
     if (ids().length > 0) focus.restore()
+  }
+  const closeOthers = (id: string) => {
+    const gone = ids().filter((item) => item !== id)
+    props.onCloseOthers(id)
+    for (const item of gone) session.releaseSession(item)
   }
 
   return (
-    <SessionProvider>
-      <section
-        class="am-subagent-panel"
-        classList={{ "am-subagent-panel-visible": props.visible() }}
-        aria-label="Subagents"
-        aria-hidden={!props.visible()}
-        inert={!props.visible()}
-      >
-        <header class="am-subagent-header">
-          <div class="am-subagent-heading">
-            <Icon name="task" size="small" />
-            <span>Subagents</span>
-            <span class="am-subagent-count">{props.tabs().length}</span>
-          </div>
-          <IconButton
-            icon="x"
-            size="small"
-            variant="ghost"
-            aria-label="Close subagents panel"
-            onClick={props.onClosePanel}
-          />
-        </header>
-        <InspectorTabStrip
-          ids={ids}
-          active={props.active}
-          label="Subagent sessions"
-          overlay={title}
-          onSelect={props.onSelect}
-          onReorder={props.onReorder}
-          renderTab={(id, api) => {
-            const label = title(id)
-            return (
-              <SortableClosableTab
-                id={id}
-                label={label}
-                tooltip={label}
-                icon="task"
-                showKeybind={false}
-                keybind={props.active() === id ? "" : props.nextKeybind}
-                closeKeybind={props.closeKeybind}
-                active={props.active() === id}
-                role="tab"
-                selected={props.active() === id}
-                tabIndex={props.active() === id ? 0 : -1}
-                onKeyDown={(event) => api.focus.key(id, event)}
-                onSelect={() => props.onSelect(id)}
-                onMiddleClick={(event) => {
-                  if (event.button !== 1) return
-                  event.preventDefault()
-                  event.stopPropagation()
-                  close(id, api.focus)
-                }}
-                onClose={() => close(id, api.focus)}
-                onCloseOthers={() => props.onCloseOthers(id)}
-              />
-            )
-          }}
-        />
-        <div class="am-subagent-chat">
-          <SubagentChat active={props.active} />
+    <section
+      class="am-subagent-panel"
+      classList={{ "am-subagent-panel-visible": props.visible() }}
+      aria-label="Subagents"
+      aria-hidden={!props.visible()}
+      inert={!props.visible()}
+    >
+      <header class="am-subagent-header">
+        <div class="am-subagent-heading">
+          <Icon name="task" size="small" />
+          <span>Subagents</span>
+          <span class="am-subagent-count">{props.tabs().length}</span>
         </div>
-      </section>
-    </SessionProvider>
+        <IconButton
+          icon="x"
+          size="small"
+          variant="ghost"
+          aria-label="Close subagents panel"
+          onClick={props.onClosePanel}
+        />
+      </header>
+      <InspectorTabStrip
+        ids={ids}
+        active={props.active}
+        label="Subagent sessions"
+        overlay={title}
+        onSelect={props.onSelect}
+        onReorder={props.onReorder}
+        renderTab={(id, api) => {
+          const label = title(id)
+          return (
+            <SortableClosableTab
+              id={id}
+              label={label}
+              tooltip={label}
+              icon="task"
+              showKeybind={false}
+              keybind={props.active() === id ? "" : props.nextKeybind}
+              closeKeybind={props.closeKeybind}
+              active={props.active() === id}
+              role="tab"
+              selected={props.active() === id}
+              tabIndex={props.active() === id ? 0 : -1}
+              onKeyDown={(event) => api.focus.key(id, event)}
+              onSelect={() => props.onSelect(id)}
+              onMiddleClick={(event) => {
+                if (event.button !== 1) return
+                event.preventDefault()
+                event.stopPropagation()
+                close(id, api.focus)
+              }}
+              onClose={() => close(id, api.focus)}
+              onCloseOthers={() => closeOthers(id)}
+            />
+          )
+        }}
+      />
+      <div class="am-subagent-chat">
+        <SubagentChat active={props.active} />
+      </div>
+    </section>
   )
 }
+
+export const SubagentPanel: Component<Props> = (props) => (
+  <SessionProvider>
+    <SubagentContent {...props} />
+  </SessionProvider>
+)

--- a/packages/kilo-vscode/webview-ui/agent-manager/SubagentPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/SubagentPanel.tsx
@@ -88,10 +88,10 @@ export const SubagentPanel: Component<Props> = (props) => {
               <SortableClosableTab
                 id={id}
                 label={label}
-                 tooltip={label}
-                 icon="task"
-                 showKeybind={false}
-                 keybind={props.active() === id ? "" : props.nextKeybind}
+                tooltip={label}
+                icon="task"
+                showKeybind={false}
+                keybind={props.active() === id ? "" : props.nextKeybind}
                 closeKeybind={props.closeKeybind}
                 active={props.active() === id}
                 role="tab"

--- a/packages/kilo-vscode/webview-ui/agent-manager/SubagentPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/SubagentPanel.tsx
@@ -1,0 +1,120 @@
+/**
+ * Read-only subagent chats for the Agent Manager inspector.
+ *
+ * The nested session provider keeps the parent chat selection independent from
+ * the child transcript while still consuming the same webview event stream.
+ */
+
+import { Icon } from "@kilocode/kilo-ui/icon"
+import { IconButton } from "@kilocode/kilo-ui/icon-button"
+import { createEffect, type Accessor, type Component } from "solid-js"
+import { DataBridge } from "../src/App"
+import { ChatView } from "../src/components/chat"
+import { SessionProvider, useSession } from "../src/context/session"
+import { SortableClosableTab } from "./ClosableTab"
+import { InspectorTabStrip } from "./InspectorTabStrip"
+import type { SubagentTab } from "./subagent-tabs"
+
+interface Props {
+  tabs: Accessor<SubagentTab[]>
+  active: Accessor<string | undefined>
+  visible: Accessor<boolean>
+  nextKeybind: string
+  closeKeybind: string
+  onSelect: (id: string) => void
+  onClose: (id: string) => void
+  onCloseOthers: (id: string) => void
+  onReorder: (from: string, to: string) => void
+  onClosePanel: () => void
+}
+
+const SubagentChat: Component<{ active: Accessor<string | undefined> }> = (props) => {
+  const session = useSession()
+
+  createEffect(() => {
+    const id = props.active()
+    if (!id) return
+    session.selectSession(id)
+  })
+
+  return (
+    <DataBridge>
+      <ChatView readonly promptBoxId="agent-manager:subagent" />
+    </DataBridge>
+  )
+}
+
+export const SubagentPanel: Component<Props> = (props) => {
+  const ids = () => props.tabs().map((tab) => tab.id)
+  const title = (id: string) => props.tabs().find((tab) => tab.id === id)?.title ?? "Sub-agent"
+  const close = (id: string, focus: { restore: () => void }) => {
+    props.onClose(id)
+    if (ids().length > 0) focus.restore()
+  }
+
+  return (
+    <SessionProvider>
+      <section
+        class="am-subagent-panel"
+        classList={{ "am-subagent-panel-visible": props.visible() }}
+        aria-label="Subagents"
+        aria-hidden={!props.visible()}
+        inert={!props.visible()}
+      >
+        <header class="am-subagent-header">
+          <div class="am-subagent-heading">
+            <Icon name="task" size="small" />
+            <span>Subagents</span>
+            <span class="am-subagent-count">{props.tabs().length}</span>
+          </div>
+          <IconButton
+            icon="x"
+            size="small"
+            variant="ghost"
+            aria-label="Close subagents panel"
+            onClick={props.onClosePanel}
+          />
+        </header>
+        <InspectorTabStrip
+          ids={ids}
+          active={props.active}
+          label="Subagent sessions"
+          overlay={title}
+          onSelect={props.onSelect}
+          onReorder={props.onReorder}
+          renderTab={(id, api) => {
+            const label = title(id)
+            return (
+              <SortableClosableTab
+                id={id}
+                label={label}
+                 tooltip={label}
+                 icon="task"
+                 showKeybind={false}
+                 keybind={props.active() === id ? "" : props.nextKeybind}
+                closeKeybind={props.closeKeybind}
+                active={props.active() === id}
+                role="tab"
+                selected={props.active() === id}
+                tabIndex={props.active() === id ? 0 : -1}
+                onKeyDown={(event) => api.focus.key(id, event)}
+                onSelect={() => props.onSelect(id)}
+                onMiddleClick={(event) => {
+                  if (event.button !== 1) return
+                  event.preventDefault()
+                  event.stopPropagation()
+                  close(id, api.focus)
+                }}
+                onClose={() => close(id, api.focus)}
+                onCloseOthers={() => props.onCloseOthers(id)}
+              />
+            )
+          }}
+        />
+        <div class="am-subagent-chat">
+          <SubagentChat active={props.active} />
+        </div>
+      </section>
+    </SessionProvider>
+  )
+}

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1514,7 +1514,7 @@ html[data-theme="kilo-vscode"]
   color: var(--vscode-testing-iconFailed, #f87171);
 }
 
-.am-terminal-tab-spinner {
+.am-tab-spinner {
   width: 12px;
   height: 12px;
 }
@@ -4841,8 +4841,9 @@ body.vscode-high-contrast-light {
   }
 }
 
-/* Experimental terminal tabs (feature-flagged) */
+/* Shared sortable inspector tabs. */
 
+.am-tab-closable,
 .am-tab-terminal {
   display: flex;
   align-items: center;
@@ -4850,12 +4851,13 @@ body.vscode-high-contrast-light {
   border-left: 1px solid var(--border-weak-base);
 }
 
+.am-tab-closable [data-component="icon"],
 .am-tab-terminal [data-component="icon"] {
   flex-shrink: 0;
   opacity: 0.7;
 }
 
-.am-tab-terminal-focused {
+.am-tab-focused {
   background: var(--surface-base-hover);
 }
 
@@ -4978,15 +4980,14 @@ body.vscode-high-contrast-light {
   color: var(--text-weak);
 }
 
-/* Side terminal tab strip — one row of tabs reusing the top bar's
-   .am-tab chrome, plus the "+" action. Height matches .am-diff-header
+/* Inspector tab strip — one row of tabs reusing the top bar's
+   .am-tab chrome, plus an optional action. Height matches .am-diff-header
    (32px) so switching inspector modes does not shift the panel chrome.
    No vertical padding: tabs fill the strip like they fill .am-tab-bar,
-   which also keeps the "+" optically centered. The strip itself never
-   scrolls; the tab list does, so a narrow panel never pushes the "+"
-   action out of view (same split as .am-tab-list-wrap /
-   .am-tab-add-wrap). */
-.am-side-terminal-tabs {
+   which also keeps actions optically centered. The strip itself never
+   scrolls; the tab list does, so a narrow panel never pushes an action out
+   of view (same split as .am-tab-list-wrap / .am-tab-add-wrap). */
+.am-inspector-tabs {
   display: flex;
   align-items: stretch;
   height: 32px;
@@ -5001,10 +5002,10 @@ body.vscode-high-contrast-light {
 
 /* Same width model as .am-tab-list: tabs claim an equal share of the
    strip up to a maximum, and the list itself only grows as wide as its
-   tabs, so the "+" action stays glued to the last tab instead of
+   tabs, so an action stays glued to the last tab instead of
    drifting to the far edge of a wide panel. The cap is smaller than the
    top bar's 240px because the panel is narrow. */
-.am-side-terminal-tablist {
+.am-inspector-tablist {
   --am-tab-max-width: 180px;
   --am-tab-width: clamp(72px, calc(100% / var(--tab-count, 1)), var(--am-tab-max-width));
   display: flex;
@@ -5020,17 +5021,16 @@ body.vscode-high-contrast-light {
   scrollbar-width: none;
 }
 
-.am-side-terminal-tablist::-webkit-scrollbar {
+.am-inspector-tablist::-webkit-scrollbar {
   display: none;
 }
 
-.am-side-terminal-tablist[data-tab-widths-frozen] .am-tab-sortable {
+.am-inspector-tablist[data-tab-widths-frozen] .am-tab-sortable {
   transition: none;
 }
 
-/* The left divider marks a terminal among session tabs in the top bar.
-   Every tab here is a terminal, so it would just be noise. */
-.am-side-terminal-tablist .am-tab-terminal {
+/* The left divider belongs to the top-level mixed tab bar. */
+.am-inspector-tablist .am-tab-closable {
   border-left-color: transparent;
 }
 
@@ -5052,6 +5052,69 @@ body.vscode-high-contrast-light {
   bottom: 0;
   opacity: 0;
   pointer-events: none;
+}
+
+/* Subagent inspector panel. It remains mounted while another inspector mode
+   is active so switching back keeps the child transcript and scroll position. */
+.am-subagent-panel {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  opacity: 0;
+  pointer-events: none;
+  z-index: 1;
+  background: var(--surface-base);
+  will-change: opacity;
+}
+
+.am-subagent-panel-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.am-subagent-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  height: 32px;
+  padding: 0 4px 0 8px;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border-weak-base);
+  background: var(--surface-base);
+}
+
+.am-subagent-heading {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 6px;
+  color: var(--text-base);
+  font-size: var(--font-size-small);
+  font-weight: 600;
+}
+
+.am-subagent-count {
+  color: var(--text-weak);
+  font-size: var(--kilo-font-size-10);
+  font-variant-numeric: tabular-nums;
+}
+
+.am-subagent-chat {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
+}
+
+.am-subagent-chat > [data-component="data-provider"],
+.am-subagent-chat [class~="chat-view"] {
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
 }
 
 .am-terminal-host {

--- a/packages/kilo-vscode/webview-ui/agent-manager/index.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/index.tsx
@@ -5,7 +5,12 @@
 import { render } from "solid-js/web"
 import "@kilocode/kilo-ui/styles"
 import "../src/styles/chat.css"
+import { registerExpandedTaskTool } from "../src/components/chat/TaskToolExpanded"
+import { registerVscodeToolOverrides } from "../src/components/chat/VscodeToolOverrides"
 import { AgentManagerApp } from "./AgentManagerApp"
+
+registerExpandedTaskTool()
+registerVscodeToolOverrides()
 
 const root = document.getElementById("root")
 if (root) {

--- a/packages/kilo-vscode/webview-ui/agent-manager/side-panel-layout.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/side-panel-layout.ts
@@ -9,6 +9,7 @@ export enum SidePanel {
   Diff = "diff",
   PR = "pr",
   Terminal = "terminal",
+  Subagents = "subagents",
 }
 
 function viewportWidth(viewport: number): number {

--- a/packages/kilo-vscode/webview-ui/agent-manager/subagent-tabs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/subagent-tabs.ts
@@ -9,6 +9,7 @@ export interface SubagentTab {
 interface Options {
   current: Accessor<string | undefined>
   sync: (id: string, parentID?: string) => void
+  unsync: (id: string) => void
   show: () => void
   hide: () => void
 }
@@ -20,6 +21,7 @@ export function createSubagentTabs(opts: Options) {
   const open = (id: string, title?: string, parentID?: string) => {
     if (!id) return
     const label = title?.trim() || "Sub-agent"
+    const existing = tabs().some((tab) => tab.id === id)
     batch(() => {
       setTabs((prev) => {
         const existing = prev.find((tab) => tab.id === id)
@@ -32,7 +34,7 @@ export function createSubagentTabs(opts: Options) {
       setActive(id)
       opts.show()
     })
-    opts.sync(id, parentID ?? opts.current())
+    if (!existing) opts.sync(id, parentID ?? opts.current())
   }
 
   const select = (id: string) => {
@@ -46,6 +48,7 @@ export function createSubagentTabs(opts: Options) {
     const index = current.findIndex((tab) => tab.id === id)
     if (index < 0) return
     const next = current.filter((tab) => tab.id !== id)
+    opts.unsync(id)
     setTabs(next)
     if (active() !== id) return
     const replacement = next[Math.min(index, next.length - 1)]
@@ -59,6 +62,9 @@ export function createSubagentTabs(opts: Options) {
 
   const closeOthers = (id: string) => {
     if (!tabs().some((tab) => tab.id === id)) return
+    for (const tab of tabs()) {
+      if (tab.id !== id) opts.unsync(tab.id)
+    }
     setTabs((prev) => prev.filter((tab) => tab.id === id))
     setActive(id)
     opts.show()

--- a/packages/kilo-vscode/webview-ui/agent-manager/subagent-tabs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/subagent-tabs.ts
@@ -1,0 +1,84 @@
+import { batch, createSignal, type Accessor } from "solid-js"
+import { reorderTabs } from "../src/utils/tab-order"
+
+export interface SubagentTab {
+  id: string
+  title: string
+}
+
+interface Options {
+  current: Accessor<string | undefined>
+  sync: (id: string, parentID?: string) => void
+  show: () => void
+  hide: () => void
+}
+
+export function createSubagentTabs(opts: Options) {
+  const [tabs, setTabs] = createSignal<SubagentTab[]>([])
+  const [active, setActive] = createSignal<string>()
+
+  const open = (id: string, title?: string, parentID?: string) => {
+    if (!id) return
+    const label = title?.trim() || "Sub-agent"
+    batch(() => {
+      setTabs((prev) => {
+        const existing = prev.find((tab) => tab.id === id)
+        if (!existing) return [...prev, { id, title: label }]
+        if (title?.trim() && existing.title !== label) {
+          return prev.map((tab) => (tab.id === id ? { ...tab, title: label } : tab))
+        }
+        return prev
+      })
+      setActive(id)
+      opts.show()
+    })
+    opts.sync(id, parentID ?? opts.current())
+  }
+
+  const select = (id: string) => {
+    if (!tabs().some((tab) => tab.id === id)) return
+    setActive(id)
+    opts.show()
+  }
+
+  const close = (id: string) => {
+    const current = tabs()
+    const index = current.findIndex((tab) => tab.id === id)
+    if (index < 0) return
+    const next = current.filter((tab) => tab.id !== id)
+    setTabs(next)
+    if (active() !== id) return
+    const replacement = next[Math.min(index, next.length - 1)]
+    if (replacement) {
+      setActive(replacement.id)
+      return
+    }
+    setActive(undefined)
+    opts.hide()
+  }
+
+  const closeOthers = (id: string) => {
+    if (!tabs().some((tab) => tab.id === id)) return
+    setTabs((prev) => prev.filter((tab) => tab.id === id))
+    setActive(id)
+    opts.show()
+  }
+
+  const reorder = (from: string, to: string) => {
+    const order = reorderTabs(
+      tabs().map((tab) => tab.id),
+      from,
+      to,
+    )
+    if (!order) return
+    setTabs((prev) => {
+      const lookup = new Map(prev.map((tab) => [tab.id, tab]))
+      return order.flatMap((id) => {
+        const tab = lookup.get(id)
+        return tab ? [tab] : []
+      })
+    })
+  }
+
+  return { tabs, active, open, select, close, closeOthers, reorder }
+}

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/SideTerminalPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/SideTerminalPanel.tsx
@@ -1,47 +1,25 @@
 /**
  * Right-side terminal panel for the Agent Manager inspector.
  *
- * Lives inside the shared `.am-diff-panel-wrapper` host next to the diff
- * and PR panels, so all three inspector modes share one resize handle
- * and one width.
+ * Lives inside the shared inspector host next to diff, PR, and subagent
+ * panels, so every mode uses the same persisted resize width. The tab row is
+ * the shared inspector strip used by subagents as well.
  *
- * A context can own several side terminals. The header is a tab strip
- * that reuses the top tab bar's whole chrome: `SortableTerminalTab`
- * (icon, title, X close, right-click Close / Close Others), the same
- * `@thisbeyond/solid-dnd` reorder stack, the same overflow scrolling
- * with edge fades, the same width freeze while tabs close, and the same
- * arrow-key tab navigation, so a terminal behaves identically in
- * either surface. Reorder state lives in the terminal state, so it is
- * preserved across sidebar context switches for the webview's lifetime.
- *
- * The `+` action sits directly after the last tab (outside the
- * scrolling region, like the tab bar's `am-tab-add-wrap`), so it never
- * scrolls away and never drifts to the far edge of a wide panel. The
- * strip stays visible even when empty so `+` is always reachable.
- *
- * Visibility is opacity-based, never unmount: the xterm render loop
- * dies when its subtree leaves the paint tree (see `render.tsx`).
+ * Visibility is opacity-based, never unmount: the xterm render loop dies when
+ * its subtree leaves the paint tree (see `render.tsx`).
  */
 
-import type { Accessor, Component, JSX } from "solid-js"
-import { For, Show, createEffect, createSignal } from "solid-js"
-import { DragDropProvider, DragDropSensors, DragOverlay, SortableProvider, closestCenter } from "@thisbeyond/solid-dnd"
-import type { DragEvent } from "@thisbeyond/solid-dnd"
-import { IconButton } from "@kilocode/kilo-ui/icon-button"
+import type { Accessor, Component } from "solid-js"
+import { Show, createEffect } from "solid-js"
 import { Button } from "@kilocode/kilo-ui/button"
+import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
-import { Tooltip, TooltipKeybind } from "@kilocode/kilo-ui/tooltip"
+import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useLanguage } from "../../src/context/language"
-import { ConstrainDragYAxis } from "../../src/components/chat/TabDnd"
-import { useTabScroll } from "../../src/utils/tab-scroll"
-import { setTabWidths } from "../../src/utils/tab-widths"
-import { createTabFocus } from "../../src/utils/tab-navigation"
+import { InspectorTabStrip } from "../InspectorTabStrip"
 import { renderSideTerminalLayer } from "./render"
 import { SortableTerminalTab } from "./SortableTerminalTab"
 import type { TerminalStateControls } from "./state"
-
-/** Only this strip's tabs freeze; the top tab bar keeps its own widths. */
-const TABLIST = ".am-side-terminal-tablist"
 
 interface Props {
   state: TerminalStateControls
@@ -67,65 +45,18 @@ interface Props {
 export const SideTerminalPanel: Component<Props> = (props) => {
   const { t } = useLanguage()
   let panel!: HTMLElement
-  let strip!: HTMLDivElement
   createEffect(() => {
     panel.inert = !props.visible()
   })
-  const [dragging, setDragging] = createSignal<{ id: string; width: number } | undefined>()
   const sides = () => props.state.sidesForContext(props.contextKey())
   const ids = () => sides().map((term) => term.id)
   const active = () => props.state.sideActiveFor(props.contextKey())
   const pending = () => props.state.pendingSide(props.contextKey())
-  const scroll = useTabScroll(ids, active)
-  // Scoped to `strip` so arrow keys and focus restore never jump to a
-  // tab in the top bar, which uses the same role="tab" markup.
-  const focus = createTabFocus({ ids, select: props.onSelect, root: () => strip })
-  // Only freeze while the pointer is over the strip: the widths must
-  // survive until the pointer leaves, so the remaining X buttons stay
-  // put across repeated closes. Releasing on the next frame would undo
-  // the freeze before it is ever painted (rAF runs before paint).
-  // "Close others" needs none of this: its context menu is portaled, so
-  // the pointer is off the strip, and the survivor spans the strip anyway.
-  const freeze = () => {
-    if (strip.closest(".am-side-terminal-tabs")?.matches(":hover")) setTabWidths(true, document, TABLIST)
-  }
-  const release = () => setTabWidths(false, document, TABLIST)
-  const close = (id: string) => {
-    freeze()
+  const close = (id: string, focus: { restore: () => void }) => {
     props.onClose(id)
-    // Restore focus inside the strip only while it still owns a tab.
-    // Falling through to `focusPrompt` would pull focus into the chat
-    // composer while the panel is still open on its empty state.
     if (ids().length > 0) focus.restore()
   }
-  // Adding a tab shrinks every tab's equal share, so any freeze left
-  // over from a close in the same hover has to go first. `+` lives
-  // inside the strip, so no pointerleave happens between the two
-  // clicks and the surviving tabs would keep their wider pixel widths.
-  const start = () => {
-    release()
-    props.onStart()
-  }
-  const onDragStart = (event: DragEvent) => {
-    const id = event.draggable?.id
-    if (typeof id !== "string") return
-    // Pin the overlay to the tab's width: the overlay container uses
-    // min-width, so a long OSC title would otherwise overflow it and
-    // shift the visual center off the cursor (the "drag offset" bug).
-    const width = event.draggable?.layout.width ?? event.draggable?.node.getBoundingClientRect().width
-    setTabWidths(true, document, TABLIST)
-    setDragging({ id, width })
-  }
-  const onDragEnd = () => {
-    setDragging(undefined)
-    release()
-  }
-  const onDragOver = (event: DragEvent) => {
-    const from = event.draggable?.id
-    const to = event.droppable?.id
-    if (typeof from !== "string" || typeof to !== "string") return
-    props.state.reorderSideDrag(props.contextKey(), from, to)
-  }
+
   return (
     <section
       ref={panel}
@@ -133,105 +64,64 @@ export const SideTerminalPanel: Component<Props> = (props) => {
       aria-label={t("agentManager.tab.terminal")}
       aria-hidden={!props.visible()}
     >
-      <div
-        class="am-side-terminal-tabs"
-        onPointerLeave={() => {
-          if (!dragging()) release()
-        }}
-      >
-        <DragDropProvider
-          onDragStart={onDragStart}
-          onDragEnd={onDragEnd}
-          onDragOver={onDragOver}
-          collisionDetector={closestCenter}
-        >
-          <DragDropSensors />
-          <ConstrainDragYAxis />
-          {/* Overflow chrome copied from the top tab bar: the list is the
-              only scrolling element, wrapped by a fade host, so the "+"
-              action stays pinned next to the last tab. */}
-          <div class="am-tab-scroll-area">
-            <div class={`am-tab-fade am-tab-fade-left ${scroll.showLeft() ? "am-tab-fade-visible" : ""}`} />
-            <div class="am-tab-list-wrap">
-              {/* role="tablist" only when tabs exist: axe
-                  aria-required-children rejects an empty tablist. */}
-              <div
-                class="am-side-terminal-tablist"
-                ref={(el) => {
-                  strip = el
-                  scroll.setRef(el)
-                }}
-                role={sides().length > 0 ? "tablist" : undefined}
-                aria-label={sides().length > 0 ? t("agentManager.tab.terminal") : undefined}
-                style={{ "--tab-count": `${sides().length}` } as JSX.CSSProperties}
-              >
-                <SortableProvider ids={ids()}>
-                  <For each={sides()}>
-                    {(term) => (
-                      <SortableTerminalTab
-                        id={term.id}
-                        label={props.state.title(term.id) ?? term.title}
-                        tooltip={props.state.title(term.id) ?? term.title}
-                        status={props.state.scriptStatus(term.id)}
-                        keybind={active() === term.id ? "" : props.nextKeybind}
-                        closeKeybind={props.closeKeybind}
-                        active={active() === term.id}
-                        focused={props.state.sideFocusedId() === term.id}
-                        role="tab"
-                        selected={active() === term.id}
-                        tabIndex={active() === term.id ? 0 : -1}
-                        onKeyDown={(event) => focus.key(term.id, event)}
-                        onSelect={() => props.onSelect(term.id)}
-                        onMiddleClick={(e: MouseEvent) => {
-                          if (e.button !== 1) return
-                          e.preventDefault()
-                          e.stopPropagation()
-                          close(term.id)
-                        }}
-                        onClose={(e: MouseEvent) => {
-                          e.stopPropagation()
-                          close(term.id)
-                        }}
-                        onCloseOthers={() => props.onCloseOthers(term.id)}
-                        onStop={(e: MouseEvent) => {
-                          e.stopPropagation()
-                          props.onStop(term.id)
-                        }}
-                      />
-                    )}
-                  </For>
-                </SortableProvider>
-              </div>
-            </div>
-            <div class={`am-tab-fade am-tab-fade-right ${scroll.showRight() ? "am-tab-fade-visible" : ""}`} />
-          </div>
-          {/* Cursor-following clone of the dragged tab (same pattern as
-              the top tab bar). The overlay is what makes the in-list
-              original use solid-dnd's slot-compensated transform, so the
-              dragged tab tracks the cursor without a jump/offset. The
-              original stays dimmed in its slot via .am-tab-dragging. */}
-          <DragOverlay>
-            <Show when={dragging()}>
-              {(tab) => (
-                <div class="am-tab am-tab-overlay" style={{ width: `${tab().width}px` }}>
-                  <span class="am-tab-label">{props.state.title(tab().id) ?? t("agentManager.tab.terminal")}</span>
-                </div>
-              )}
-            </Show>
-          </DragOverlay>
-        </DragDropProvider>
-        <div class="am-side-terminal-add">
-          <Tooltip value={t("agentManager.terminal.add")} placement="bottom">
-            <IconButton
-              icon="plus"
-              size="small"
-              variant="ghost"
-              aria-label={t("agentManager.terminal.add")}
-              onClick={start}
+      <InspectorTabStrip
+        ids={ids}
+        active={active}
+        label={t("agentManager.tab.terminal")}
+        overlay={(id) => props.state.title(id) ?? t("agentManager.tab.terminal")}
+        onSelect={props.onSelect}
+        onReorder={(from, to) => props.state.reorderSideDrag(props.contextKey(), from, to)}
+        renderTab={(id, api) => {
+          const term = sides().find((item) => item.id === id)
+          if (!term) return null
+          return (
+            <SortableTerminalTab
+              id={term.id}
+              label={props.state.title(term.id) ?? term.title}
+               tooltip={props.state.title(term.id) ?? term.title}
+               status={props.state.scriptStatus(term.id)}
+               showKeybind={false}
+               keybind={active() === term.id ? "" : props.nextKeybind}
+              closeKeybind={props.closeKeybind}
+              active={active() === term.id}
+              focused={props.state.sideFocusedId() === term.id}
+              role="tab"
+              selected={active() === term.id}
+              tabIndex={active() === term.id ? 0 : -1}
+              onKeyDown={(event) => api.focus.key(term.id, event)}
+              onSelect={() => props.onSelect(term.id)}
+              onMiddleClick={(event) => {
+                if (event.button !== 1) return
+                event.preventDefault()
+                event.stopPropagation()
+                close(term.id, api.focus)
+              }}
+              onClose={() => close(term.id, api.focus)}
+              onCloseOthers={() => props.onCloseOthers(term.id)}
+              onStop={(event) => {
+                event.stopPropagation()
+                props.onStop(term.id)
+              }}
             />
-          </Tooltip>
-        </div>
-      </div>
+          )
+        }}
+        action={(api) => (
+          <div class="am-side-terminal-add">
+            <Tooltip value={t("agentManager.terminal.add")} placement="bottom">
+              <IconButton
+                icon="plus"
+                size="small"
+                variant="ghost"
+                aria-label={t("agentManager.terminal.add")}
+                onClick={() => {
+                  api.release()
+                  props.onStart()
+                }}
+              />
+            </Tooltip>
+          </div>
+        )}
+      />
       {renderSideTerminalLayer({
         state: props.state,
         contextKey: props.contextKey,

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/SideTerminalPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/SideTerminalPanel.tsx
@@ -78,10 +78,10 @@ export const SideTerminalPanel: Component<Props> = (props) => {
             <SortableTerminalTab
               id={term.id}
               label={props.state.title(term.id) ?? term.title}
-               tooltip={props.state.title(term.id) ?? term.title}
-               status={props.state.scriptStatus(term.id)}
-               showKeybind={false}
-               keybind={active() === term.id ? "" : props.nextKeybind}
+              tooltip={props.state.title(term.id) ?? term.title}
+              status={props.state.scriptStatus(term.id)}
+              showKeybind={false}
+              keybind={active() === term.id ? "" : props.nextKeybind}
               closeKeybind={props.closeKeybind}
               active={active() === term.id}
               focused={props.state.sideFocusedId() === term.id}

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/SortableTerminalTab.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/SortableTerminalTab.tsx
@@ -1,191 +1,99 @@
 /**
- * Tab chrome for xterm terminals.
+ * Terminal-specific adapter for the shared sortable inspector tab.
  *
- * `TerminalTabChrome` is the shared visual tab: console icon, title,
- * tooltip/keybinding hints, and the X close button — the same
- * `am-tab*` structure the session tabs use. `SortableTerminalTab`
- * wraps it with drag-and-drop and a right-click context menu; both the
- * top tab bar and the side terminal panel render that wrapper, so a
- * terminal tab behaves identically in either surface.
+ * PTY status determines the icon and whether a Setup tab can be closed. The
+ * tab chrome, drag wrapper, context menu, and close behavior are shared with
+ * subagent tabs.
  */
 
-import { Component, Show, type JSX } from "solid-js"
+import { Show, type Component } from "solid-js"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
-import { Icon } from "@kilocode/kilo-ui/icon"
-import { Spinner } from "@kilocode/kilo-ui/spinner"
 import { TooltipKeybind } from "@kilocode/kilo-ui/tooltip"
-import { ContextMenu } from "@kilocode/kilo-ui/context-menu"
 import { useLanguage } from "../../src/context/language"
-import { SortableTabContainer } from "../../src/components/chat/TabDnd"
-import { parseBindingTokens } from "../keybind-tokens"
+import { SortableClosableTab, type ClosableTabProps } from "../ClosableTab"
 import { terminalChrome, terminalClosable, terminalStoppable } from "./chrome"
 import type { ScriptTerminalStatus } from "./state"
 
-export const TerminalTabChrome: Component<{
+interface Props extends Omit<ClosableTabProps, "icon" | "onClose" | "trailing"> {
   label: string
   tooltip: string
   status?: ScriptTerminalStatus
-  keybind?: string
-  closeKeybind?: string
-  focused?: boolean
-  active: boolean
-  role?: "tab"
-  selected?: boolean
-  tabIndex?: number
-  onKeyDown?: JSX.EventHandlerUnion<HTMLDivElement, KeyboardEvent>
-  onSelect: () => void
-  onMiddleClick?: (e: MouseEvent) => void
-  onClose: (e: MouseEvent) => void
-  onStop?: (e: MouseEvent) => void
-}> = (props) => {
+  onClose: () => void
+  onStop?: (event: MouseEvent) => void
+}
+
+const StopButton: Component<{ active: boolean; tabIndex: number; onStop?: (event: MouseEvent) => void }> = (props) => {
   const { t } = useLanguage()
-  const chrome = () => terminalChrome(props.tooltip, props.status)
-  const icon = () => {
-    const kind = chrome().icon
-    if (kind === "success") return "check-small"
-    if (kind === "failure") return "warning"
-    return "console"
-  }
   return (
-    <div
-      class={`am-tab am-tab-terminal ${props.active ? "am-tab-active" : ""} ${props.focused ? "am-tab-terminal-focused" : ""}`}
-    >
-      <div
-        class="am-tab-target"
-        role={props.role}
-        aria-selected={props.selected}
-        aria-label={chrome().tooltip}
-        tabIndex={props.tabIndex}
-        onClick={props.onSelect}
-        onMouseDown={props.onMiddleClick}
-        onKeyDown={props.onKeyDown}
+    <Show when={props.active && props.onStop}>
+      <TooltipKeybind
+        title={t("agentManager.terminal.stopSetup")}
+        keybind=""
+        placement="top"
+        gutter={8}
+        class="am-tab-close-wrap"
+        openDelay={0}
       >
-        <TooltipKeybind
-          title={chrome().tooltip}
-          keybind={props.keybind ?? ""}
-          placement="bottom"
-          gutter={8}
-          class="am-tab-tooltip"
-          openDelay={0}
-        >
-          <span class="am-tab-title">
-            <span class="am-tab-icon" data-run-status={chrome().icon}>
-              <Show when={chrome().icon === "spinner"} fallback={<Icon name={icon()} size="small" />}>
-                <Spinner class="am-terminal-tab-spinner" />
-              </Show>
-            </span>
-            <span class="am-tab-label">{props.label}</span>
-          </span>
-        </TooltipKeybind>
-      </div>
-      <Show when={terminalStoppable(props.status) && props.onStop}>
-        <TooltipKeybind
-          title={t("agentManager.terminal.stopSetup")}
-          keybind=""
-          placement="top"
-          gutter={8}
-          class="am-tab-close-wrap"
-          openDelay={0}
-        >
-          <IconButton
-            icon="stop"
-            size="small"
-            variant="ghost"
-            aria-label={t("agentManager.terminal.stopSetup")}
-            tabIndex={props.active ? 0 : -1}
-            class="am-tab-close"
-            onClick={props.onStop}
-          />
-        </TooltipKeybind>
-      </Show>
-      <Show when={terminalClosable(props.status)}>
-        <TooltipKeybind
-          title={t("agentManager.tab.close")}
-          keybind={props.closeKeybind ?? ""}
-          placement="top"
-          gutter={8}
-          class="am-tab-close-wrap"
-          openDelay={0}
-        >
-          <IconButton
-            icon="close-small"
-            size="small"
-            variant="ghost"
-            aria-label={t("agentManager.tab.closeTab")}
-            tabIndex={props.active ? 0 : -1}
-            class="am-tab-close"
-            onClick={props.onClose}
-          />
-        </TooltipKeybind>
-      </Show>
-    </div>
+        <IconButton
+          icon="stop"
+          size="small"
+          variant="ghost"
+          aria-label={t("agentManager.terminal.stopSetup")}
+          tabIndex={props.tabIndex}
+          class="am-tab-close"
+          onClick={(event) => {
+            event.stopPropagation()
+            props.onStop?.(event)
+          }}
+        />
+      </TooltipKeybind>
+    </Show>
   )
 }
 
-export const SortableTerminalTab: Component<{
-  id: string
-  label: string
-  tooltip: string
-  status?: ScriptTerminalStatus
-  keybind?: string
-  closeKeybind?: string
-  focused?: boolean
-  active: boolean
-  role?: "tab"
-  selected?: boolean
-  tabIndex?: number
-  onKeyDown?: JSX.EventHandlerUnion<HTMLDivElement, KeyboardEvent>
-  onSelect: () => void
-  onMiddleClick: (e: MouseEvent) => void
-  onClose: (e: MouseEvent) => void
-  onCloseOthers: () => void
-  onStop?: (e: MouseEvent) => void
-}> = (props) => {
-  const { t } = useLanguage()
-  return (
-    <SortableTabContainer id={props.id}>
-      <ContextMenu>
-        <ContextMenu.Trigger as="div" style={{ display: "contents" }}>
-          <TerminalTabChrome
-            label={props.label}
-            tooltip={props.tooltip}
-            status={props.status}
-            keybind={props.keybind}
-            closeKeybind={props.closeKeybind}
-            focused={props.focused}
-            active={props.active}
-            role={props.role}
-            selected={props.selected}
-            tabIndex={props.tabIndex}
-            onKeyDown={props.onKeyDown}
-            onSelect={props.onSelect}
-            onMiddleClick={props.onMiddleClick}
-            onClose={props.onClose}
-            onStop={props.onStop}
-          />
-        </ContextMenu.Trigger>
-        <ContextMenu.Portal>
-          <ContextMenu.Content class="am-ctx-menu">
-            <ContextMenu.Item
-              onSelect={() => props.onClose(new MouseEvent("click", { bubbles: true, cancelable: true }) as MouseEvent)}
-            >
-              <Icon name="close" size="small" />
-              <ContextMenu.ItemLabel>{t("agentManager.tab.close")}</ContextMenu.ItemLabel>
-              <Show when={props.closeKeybind}>
-                <span class="am-menu-shortcut">
-                  {parseBindingTokens(props.closeKeybind ?? "").map((token) => (
-                    <kbd class="am-menu-key">{token}</kbd>
-                  ))}
-                </span>
-              </Show>
-            </ContextMenu.Item>
-            <ContextMenu.Item onSelect={props.onCloseOthers}>
-              <Icon name="close" size="small" />
-              <ContextMenu.ItemLabel>{t("agentManager.tab.closeOthers")}</ContextMenu.ItemLabel>
-            </ContextMenu.Item>
-          </ContextMenu.Content>
-        </ContextMenu.Portal>
-      </ContextMenu>
-    </SortableTabContainer>
-  )
+function icon(status: ScriptTerminalStatus | undefined) {
+  const value = terminalChrome("", status).icon
+  if (value === "success") return "check-small" as const
+  if (value === "failure") return "warning" as const
+  if (value === "spinner") return "spinner" as const
+  return "console" as const
 }
+
+function iconStatus(status: ScriptTerminalStatus | undefined) {
+  const value = terminalChrome("", status).icon
+  if (value === "success") return "success" as const
+  if (value === "failure") return "failure" as const
+  return undefined
+}
+
+export const SortableTerminalTab: Component<
+  Props & {
+    id: string
+    onCloseOthers: () => void
+  }
+> = (props) => (
+  <SortableClosableTab
+    id={props.id}
+    label={props.label}
+    tooltip={terminalChrome(props.tooltip, props.status).tooltip}
+    icon={() => icon(props.status)}
+    iconStatus={() => iconStatus(props.status)}
+    class="am-tab-terminal"
+    focused={props.focused}
+    active={props.active}
+    closeable={terminalClosable(props.status)}
+    keybind={props.keybind}
+    closeKeybind={props.closeKeybind}
+    role={props.role}
+    selected={props.selected}
+    tabIndex={props.tabIndex}
+    onKeyDown={props.onKeyDown}
+    onSelect={props.onSelect}
+    onMiddleClick={props.onMiddleClick}
+    onClose={props.onClose}
+    onCloseOthers={props.onCloseOthers}
+    trailing={
+      <StopButton active={terminalStoppable(props.status)} tabIndex={props.active ? 0 : -1} onStop={props.onStop} />
+    }
+  />
+)

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/render.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/render.tsx
@@ -59,10 +59,7 @@ export function renderTerminalTab(deps: TerminalTabRenderDeps): JSX.Element {
       onKeyDown={deps.onKeyDown}
       onSelect={() => deps.onSelect(deps.id)}
       onMiddleClick={(e: MouseEvent) => deps.onMiddleClick(deps.id, e)}
-      onClose={(e: MouseEvent) => {
-        e.stopPropagation()
-        deps.onClose(deps.id)
-      }}
+      onClose={() => deps.onClose(deps.id)}
       onCloseOthers={() => deps.onCloseOthers(deps.id)}
     />
   )

--- a/packages/kilo-vscode/webview-ui/src/components/chat/SessionTabMenu.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/SessionTabMenu.tsx
@@ -8,6 +8,7 @@ export const SessionTabMenu: ParentComponent<{
   onFork?: () => void
   onClose: () => void
   onCloseOthers?: () => void
+  closeable?: boolean
   closeShortcut?: JSX.Element
 }> = (props) => {
   const { t } = useLanguage()
@@ -23,18 +24,22 @@ export const SessionTabMenu: ParentComponent<{
               <Icon name="fork" size="small" />
               <ContextMenu.ItemLabel>{t("agentManager.tab.forkSession")}</ContextMenu.ItemLabel>
             </ContextMenu.Item>
-            <ContextMenu.Separator />
+            <Show when={props.closeable !== false}>
+              <ContextMenu.Separator />
+            </Show>
           </Show>
-          <ContextMenu.Item onSelect={props.onClose}>
-            <Icon name="close" size="small" />
-            <ContextMenu.ItemLabel>{t("agentManager.tab.close")}</ContextMenu.ItemLabel>
-            {props.closeShortcut}
-          </ContextMenu.Item>
-          <Show when={props.onCloseOthers}>
-            <ContextMenu.Item onSelect={() => props.onCloseOthers?.()}>
+          <Show when={props.closeable !== false}>
+            <ContextMenu.Item onSelect={props.onClose}>
               <Icon name="close" size="small" />
-              <ContextMenu.ItemLabel>{t("agentManager.tab.closeOthers")}</ContextMenu.ItemLabel>
+              <ContextMenu.ItemLabel>{t("agentManager.tab.close")}</ContextMenu.ItemLabel>
+              {props.closeShortcut}
             </ContextMenu.Item>
+            <Show when={props.onCloseOthers}>
+              <ContextMenu.Item onSelect={() => props.onCloseOthers?.()}>
+                <Icon name="close" size="small" />
+                <ContextMenu.ItemLabel>{t("agentManager.tab.closeOthers")}</ContextMenu.ItemLabel>
+              </ContextMenu.Item>
+            </Show>
           </Show>
         </ContextMenu.Content>
       </ContextMenu.Portal>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/SessionTabMenu.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/SessionTabMenu.tsx
@@ -24,7 +24,7 @@ export const SessionTabMenu: ParentComponent<{
               <Icon name="fork" size="small" />
               <ContextMenu.ItemLabel>{t("agentManager.tab.forkSession")}</ContextMenu.ItemLabel>
             </ContextMenu.Item>
-            <Show when={props.closeable !== false}>
+            <Show when={props.closeable !== false || props.onCloseOthers}>
               <ContextMenu.Separator />
             </Show>
           </Show>
@@ -34,12 +34,12 @@ export const SessionTabMenu: ParentComponent<{
               <ContextMenu.ItemLabel>{t("agentManager.tab.close")}</ContextMenu.ItemLabel>
               {props.closeShortcut}
             </ContextMenu.Item>
-            <Show when={props.onCloseOthers}>
-              <ContextMenu.Item onSelect={() => props.onCloseOthers?.()}>
-                <Icon name="close" size="small" />
-                <ContextMenu.ItemLabel>{t("agentManager.tab.closeOthers")}</ContextMenu.ItemLabel>
-              </ContextMenu.Item>
-            </Show>
+          </Show>
+          <Show when={props.onCloseOthers}>
+            <ContextMenu.Item onSelect={() => props.onCloseOthers?.()}>
+              <Icon name="close" size="small" />
+              <ContextMenu.ItemLabel>{t("agentManager.tab.closeOthers")}</ContextMenu.ItemLabel>
+            </ContextMenu.Item>
           </Show>
         </ContextMenu.Content>
       </ContextMenu.Portal>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
@@ -52,10 +52,17 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
     }),
   )
 
+  let synced: string | undefined
   createEffect(() => {
     const id = taskVisible(open(), childSessionId())
+    if (synced === id) return
+    if (synced) session.unsyncSession(synced)
+    synced = id
     if (!id) return
     session.syncSession(id)
+  })
+  onCleanup(() => {
+    if (synced) session.unsyncSession(synced)
   })
 
   const title = createMemo(() => i18n.t("ui.tool.agent", { type: props.input.subagent_type || props.tool }))

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
@@ -18,6 +18,7 @@ import { useI18n } from "@kilocode/kilo-ui/context/i18n"
 import { createAutoScroll } from "@kilocode/kilo-ui/hooks"
 import { useSession } from "../../context/session"
 import { useVSCode } from "../../context/vscode"
+import { useWorktreeMode } from "../../context/worktree-mode"
 import { childID } from "../../context/session-utils"
 import { taskResult, taskRunning, taskVisible } from "./task-tool-state"
 
@@ -26,6 +27,7 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
   const language = useLanguage()
   const session = useSession()
   const vscode = useVSCode()
+  const worktree = useWorktreeMode()
 
   const childSessionId = () =>
     childID({
@@ -115,7 +117,16 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
     e.stopPropagation()
     const id = childSessionId()
     if (!id) return
-    vscode.postMessage({ type: "openSubAgentViewer", sessionID: id, title: description() })
+    const title = description()
+    if (worktree) {
+      window.dispatchEvent(
+        new CustomEvent("agentManager.openSubagent", {
+          detail: { sessionID: id, title, parentSessionID: session.currentSessionID() },
+        }),
+      )
+      return
+    }
+    vscode.postMessage({ type: "openSubAgentViewer", sessionID: id, title })
   }
 
   const trigger = () => (
@@ -138,7 +149,7 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
           icon="square-arrow-top-right"
           size="small"
           variant="ghost"
-          aria-label="Open sub-agent in tab"
+          aria-label={worktree ? "Open sub-agent in panel" : "Open sub-agent in tab"}
           onClick={openInTab}
         />
       </Show>

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -286,11 +286,13 @@ interface SessionContextValue {
   clearCurrentSession: () => void
   loadSessions: () => void
   loadOlderMessages: () => boolean
-  selectSession: (id: string) => void
+  selectSession: (id: string, options?: { focus?: boolean }) => void
+  releaseSession: (id: string) => void
   deleteSession: (id: string) => void
   renameSession: (id: string, title: string) => void
   exportSessionTranscript: (id: string) => void
-  syncSession: (sessionID: string, parentSessionID?: string) => void
+  syncSession: (sessionID: string, parentSessionID?: string, scope?: "task" | "inspector") => void
+  unsyncSession: (sessionID: string, scope?: "task" | "inspector") => void
 
   // Cloud session preview
   cloudPreviewId: Accessor<string | null>
@@ -2585,9 +2587,9 @@ export const SessionProvider: ParentComponent = (props) => {
 
   // Session whose message fetch was deferred because the backend was offline at
   // selection time. Replayed by the reconnect effect below.
-  let deferredFetch: string | undefined
+  let deferredFetch: { id: string; focus: boolean } | undefined
 
-  function selectSession(id: string) {
+  function selectSession(id: string, options: { focus?: boolean } = {}) {
     // Cloud preview sessions use a separate keyed path (selectCloudSession).
     if (id.startsWith("cloud:")) {
       console.warn("[Kilo New] Cannot select cloud preview session via selectSession")
@@ -2608,15 +2610,26 @@ export const SessionProvider: ParentComponent = (props) => {
     // load message is what re-focuses the backend (focusSession, contextSessionID,
     // SSE tracking, active worktree) and runs the reconcile self-heal, so skipping
     // it would leave the extension focused on the previously selected session.
+    const focus = options.focus !== false
     if (!server.isConnected()) {
-      deferredFetch = id
+      deferredFetch = { id, focus }
       return
     }
     deferredFetch = undefined
-    loadFocusedMessages(id, ready)
+    loadFocusedMessages(id, ready, focus)
   }
 
-  function loadFocusedMessages(id: string, ready: boolean) {
+  function loadFocusedMessages(id: string, ready: boolean, focus = true) {
+    if (!focus) {
+      vscode.postMessage({
+        type: "loadMessages",
+        sessionID: id,
+        mode: "replace",
+        focus: false,
+        limit: MESSAGE_PAGE_LIMIT,
+      })
+      return
+    }
     vscode.postMessage(
       ready
         ? { type: "loadMessages", sessionID: id, mode: "focus" }
@@ -2631,10 +2644,10 @@ export const SessionProvider: ParentComponent = (props) => {
   createEffect(
     on(server.isConnected, (connected) => {
       if (!connected) return
-      const id = deferredFetch
+      const pending = deferredFetch
       deferredFetch = undefined
-      if (!id || id !== currentSessionID()) return
-      loadFocusedMessages(id, loaded().has(id))
+      if (!pending || pending.id !== currentSessionID()) return
+      loadFocusedMessages(pending.id, loaded().has(pending.id), pending.focus)
     }),
   )
 
@@ -2822,8 +2835,12 @@ export const SessionProvider: ParentComponent = (props) => {
     vscode.postMessage({ type: "deleteMessage", sessionID, messageID })
   }
 
-  function syncSession(sessionID: string, parentSessionID = currentSessionID()) {
-    vscode.postMessage({ type: "syncSession", sessionID, parentSessionID })
+  function syncSession(sessionID: string, parentSessionID = currentSessionID(), scope: "task" | "inspector" = "task") {
+    vscode.postMessage({ type: "syncSession", sessionID, parentSessionID, scope })
+  }
+
+  function unsyncSession(sessionID: string, scope: "task" | "inspector" = "task") {
+    vscode.postMessage({ type: "unsyncSession", sessionID, scope })
   }
 
   const todos = () => {
@@ -3018,10 +3035,12 @@ export const SessionProvider: ParentComponent = (props) => {
     loadSessions,
     loadOlderMessages,
     selectSession,
+    releaseSession: handleSessionDeleted,
     deleteSession,
     renameSession,
     exportSessionTranscript,
     syncSession,
+    unsyncSession,
     cloudPreviewId,
     selectCloudSession,
     draftSessionID,

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -290,7 +290,7 @@ interface SessionContextValue {
   deleteSession: (id: string) => void
   renameSession: (id: string, title: string) => void
   exportSessionTranscript: (id: string) => void
-  syncSession: (sessionID: string) => void
+  syncSession: (sessionID: string, parentSessionID?: string) => void
 
   // Cloud session preview
   cloudPreviewId: Accessor<string | null>
@@ -2822,8 +2822,8 @@ export const SessionProvider: ParentComponent = (props) => {
     vscode.postMessage({ type: "deleteMessage", sessionID, messageID })
   }
 
-  function syncSession(sessionID: string) {
-    vscode.postMessage({ type: "syncSession", sessionID, parentSessionID: currentSessionID() })
+  function syncSession(sessionID: string, parentSessionID = currentSessionID()) {
+    vscode.postMessage({ type: "syncSession", sessionID, parentSessionID })
   }
 
   const todos = () => {

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -82,6 +82,7 @@ export interface LoadMessagesRequest {
   type: "loadMessages"
   sessionID: string
   mode?: MessageLoadMode
+  focus?: boolean
   before?: string
   limit?: number
 }
@@ -591,6 +592,13 @@ export interface SyncSessionRequest {
   type: "syncSession"
   sessionID: string
   parentSessionID?: string
+  scope?: "task" | "inspector"
+}
+
+export interface UnsyncSessionRequest {
+  type: "unsyncSession"
+  sessionID: string
+  scope?: "task" | "inspector"
 }
 
 // Agent Manager worktree messages
@@ -1488,6 +1496,7 @@ export type WebviewMessage =
   | ResetReadNotificationsRequest
   | SettingsTabChangedMessage
   | SyncSessionRequest
+  | UnsyncSessionRequest
   | CreateWorktreeSessionRequest
   | RequestNotificationsMessage
   | DismissNotificationMessage


### PR DESCRIPTION
Agent Manager previously treated delegated subagents as separate viewer flows, making parent and child sessions harder to inspect together and limiting the inspector to one child view at a time.

This adds a persistent Subagents inspector panel for worktree sessions. Each opened child gets an independent sortable and closable tab backed by its own session provider, so parent and child streams remain isolated while multiple children run in parallel. The panel shares inspector resize and tab behavior with side terminals, while inspector hover tabs omit shortcut hints without changing the main session tab bar.

<img width="700" alt="Subagent inspector panel" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260817-agent-manager-subagent-tooltip.png?raw=true" />

<img width="700" alt="Parallel subagent sessions" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260817-agent-manager-subagent-tabs.png?raw=true" />