### PR TITLE
fix(vscode): preserve cached reasoning variants

### DIFF
--- a/.changeset/quiet-variants-cache.md
+++ b/.changeset/quiet-variants-cache.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Preserve cached reasoning variants when starting new VS Code sessions.

--- a/packages/kilo-vscode/tests/unit/session-variants.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-variants.test.ts
@@ -66,15 +66,24 @@ describe("session variants", () => {
 
   it("persists an explicit default selection", () => {
     const state = setup()
+    state.selections["agent/code/anthropic/claude-sonnet-4"] = "high"
     state.variants.select(undefined)
     expect(state.selections).toEqual({ "agent/code/anthropic/claude-sonnet-4": "" })
     expect(state.variants.current()).toBeUndefined()
     expect(state.messages).toEqual([{ type: "persistVariant", key: "agent/code/anthropic/claude-sonnet-4", value: "" }])
   })
 
-  it("carries the model default across model changes", () => {
-    const state = setup()
-    state.variants.carry(model, undefined, "code")
-    expect(state.selections).toEqual({ "agent/code/anthropic/claude-sonnet-4": "" })
+  it("does not shadow a cached variant when carrying the model default", () => {
+    const global = setup()
+    global.selections["agent/code/anthropic/claude-sonnet-4"] = "high"
+    global.variants.carry(model, undefined, "code")
+    expect(global.selections).toEqual({ "agent/code/anthropic/claude-sonnet-4": "high" })
+    expect(global.messages).toEqual([])
+
+    const session = setup("session-a")
+    session.selections["agent/code/anthropic/claude-sonnet-4"] = "high"
+    session.variants.carry(model, undefined, "code", "session-a")
+    expect(session.selections).toEqual({ "agent/code/anthropic/claude-sonnet-4": "high" })
+    expect(session.variants.current()).toBe("high")
   })
 })

--- a/packages/kilo-vscode/webview-ui/src/context/session-variants.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-variants.ts
@@ -53,7 +53,10 @@ export function createSessionVariants(options: Options) {
   const carry = (selection: ModelSelection, value: string | undefined, name: string, sessionID?: string) => {
     const list = Object.keys(options.find(selection)?.variants ?? {})
     if (list.length === 0) return
-    const next = value === undefined ? DEFAULT_VARIANT : preserveVariant(value, list)
+    // An absent value means the model default, not an explicit user choice.
+    // Do not write a default sentinel here because it would shadow a cached
+    // agent-level variant when this selection is resolved for a new session.
+    const next = preserveVariant(value, list)
     if (next === undefined) return
     const key = variantKey(selection, name, sessionID)
     options.set(key, next)


### PR DESCRIPTION
## Summary

Default reasoning support introduced a sentinel value for explicit model-default selections. Model changes also pass through the variant carry path, where an absent current value was persisted as that sentinel. Because session resolution gives the session/model key precedence over the agent/model cache, new sessions could lose the previously selected reasoning effort.

This changes the carry path to leave the cache untouched when there is no concrete variant to carry. Explicit user selection of Default continues to persist the sentinel through the select path. Regression coverage covers both global new-session state and session-scoped state.

The introducing change was PR #13063.