### PR TITLE
fix(vscode): shorten prompt model label

### DIFF
--- a/.changeset/compact-model-trigger-label.md
+++ b/.changeset/compact-model-trigger-label.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep provider names out of the compact prompt model selector label while retaining them in the expanded picker.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/shared/model-selector-large-catalog-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/shared/model-selector-large-catalog-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b197d749f21df8d3061b93d13281a346b52514bec1b6855b474a03cfaeeb117b
-size 2500
+oid sha256:4b2de227517c16c9aa90af0245da92f8e532ad29e21de2142e50121dbebf55fc
+size 1574

--- a/packages/kilo-vscode/tests/model-selector-accessibility.spec.ts
+++ b/packages/kilo-vscode/tests/model-selector-accessibility.spec.ts
@@ -202,8 +202,8 @@ test("selected favorite remains selected when its duplicate group is collapsed",
 test("large catalogs keep the rendered tree bounded and navigate to distant models", async ({ page }) => {
   await load(page, "shared--model-selector-large-catalog")
 
-  await page.getByRole("button", { name: "Select model: Provider 0 / Model 300" }).click()
-  const combobox = page.getByRole("combobox", { name: "Select model: Provider 0 / Model 300. Search models" })
+  await page.getByRole("button", { name: "Select model: Model 300" }).click()
+  const combobox = page.getByRole("combobox", { name: "Select model: Model 300. Search models" })
   const tree = page.getByRole("tree", { name: "Select model" })
 
   // The window mounts before we measure it, yet stays far smaller than the catalog.

--- a/packages/kilo-vscode/tests/unit/model-selector-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/model-selector-utils.test.ts
@@ -255,69 +255,67 @@ describe("hasByok", () => {
 
 describe("buildTriggerLabel", () => {
   it("returns resolved model name for non-kilo provider unchanged", () => {
-    expect(buildTriggerLabel("GPT-4o", "openai", undefined, null, false, "", true, labels)).toBe("GPT-4o")
+    expect(buildTriggerLabel("GPT-4o", "openai", null, false, "", true, labels)).toBe("GPT-4o")
   })
 
   it("strips sub-provider prefix from resolved name for kilo gateway models", () => {
-    expect(
-      buildTriggerLabel("Anthropic: Claude Sonnet", KILO_GATEWAY_ID, undefined, null, false, "", true, labels),
-    ).toBe("Claude Sonnet")
+    expect(buildTriggerLabel("Anthropic: Claude Sonnet", KILO_GATEWAY_ID, null, false, "", true, labels)).toBe(
+      "Claude Sonnet",
+    )
   })
 
   it("does not strip prefix for non-kilo provider even if name contains ': '", () => {
-    expect(buildTriggerLabel("Anthropic: Claude Sonnet", "anthropic", undefined, null, false, "", true, labels)).toBe(
+    expect(buildTriggerLabel("Anthropic: Claude Sonnet", "anthropic", null, false, "", true, labels)).toBe(
       "Anthropic: Claude Sonnet",
     )
   })
 
   it("returns resolved name as-is when providerID is undefined", () => {
-    expect(buildTriggerLabel("GPT-4o", undefined, undefined, null, false, "", true, labels)).toBe("GPT-4o")
+    expect(buildTriggerLabel("GPT-4o", undefined, null, false, "", true, labels)).toBe("GPT-4o")
   })
 
-  it("returns providerName / resolvedName for non-kilo provider with providerName", () => {
-    expect(buildTriggerLabel("GPT-4o", "openai", "OpenAI", null, false, "", true, labels)).toBe("OpenAI / GPT-4o")
+  it("does not add provider name to the compact label", () => {
+    expect(buildTriggerLabel("GPT-5.6 Luna", "openai", null, false, "", true, labels)).toBe("GPT-5.6 Luna")
   })
 
   it("returns modelID for kilo gateway raw selection", () => {
     const raw = { providerID: "kilo", modelID: "kilo-auto/frontier" }
-    expect(buildTriggerLabel(undefined, undefined, undefined, raw, false, "", true, labels)).toBe("kilo-auto/frontier")
+    expect(buildTriggerLabel(undefined, undefined, raw, false, "", true, labels)).toBe("kilo-auto/frontier")
   })
 
   it("returns providerID / modelID for non-kilo raw selection", () => {
     const raw = { providerID: "anthropic", modelID: "claude-3-5-sonnet" }
-    expect(buildTriggerLabel(undefined, undefined, undefined, raw, false, "", true, labels)).toBe(
-      "anthropic / claude-3-5-sonnet",
-    )
+    expect(buildTriggerLabel(undefined, undefined, raw, false, "", true, labels)).toBe("anthropic / claude-3-5-sonnet")
   })
 
   it("returns clearLabel when allowClear and no selection", () => {
-    expect(buildTriggerLabel(undefined, undefined, undefined, null, true, "None", true, labels)).toBe("None")
+    expect(buildTriggerLabel(undefined, undefined, null, true, "None", true, labels)).toBe("None")
   })
 
   it("falls back to labels.notSet when allowClear and clearLabel is empty", () => {
-    expect(buildTriggerLabel(undefined, undefined, undefined, null, true, "", true, labels)).toBe("Not set")
+    expect(buildTriggerLabel(undefined, undefined, null, true, "", true, labels)).toBe("Not set")
   })
 
   it("returns labels.select when providers exist and no selection", () => {
-    expect(buildTriggerLabel(undefined, undefined, undefined, null, false, "", true, labels)).toBe("Select model")
+    expect(buildTriggerLabel(undefined, undefined, null, false, "", true, labels)).toBe("Select model")
   })
 
   it("returns labels.noProviders when no providers available", () => {
-    expect(buildTriggerLabel(undefined, undefined, undefined, null, false, "", false, labels)).toBe("No providers")
+    expect(buildTriggerLabel(undefined, undefined, null, false, "", false, labels)).toBe("No providers")
   })
 
   it("prefers resolvedName over raw selection", () => {
     const raw = { providerID: "anthropic", modelID: "claude-3-5-sonnet" }
-    expect(buildTriggerLabel("Claude Sonnet", undefined, undefined, raw, false, "", true, labels)).toBe("Claude Sonnet")
+    expect(buildTriggerLabel("Claude Sonnet", undefined, raw, false, "", true, labels)).toBe("Claude Sonnet")
   })
 
   it("ignores partial raw selection (only providerID)", () => {
     const raw = { providerID: "anthropic", modelID: "" }
-    expect(buildTriggerLabel(undefined, undefined, undefined, raw, false, "", true, labels)).toBe("Select model")
+    expect(buildTriggerLabel(undefined, undefined, raw, false, "", true, labels)).toBe("Select model")
   })
 
   it("ignores partial raw selection (only modelID)", () => {
     const raw = { providerID: "", modelID: "claude-3-5-sonnet" }
-    expect(buildTriggerLabel(undefined, undefined, undefined, raw, false, "", true, labels)).toBe("Select model")
+    expect(buildTriggerLabel(undefined, undefined, raw, false, "", true, labels)).toBe("Select model")
   })
 })

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -776,7 +776,6 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
     buildTriggerLabel(
       activeModel()?.name,
       activeModel()?.providerID,
-      activeModel()?.providerName,
       props.value,
       props.allowClear ?? false,
       props.clearLabel ?? "",

--- a/packages/kilo-vscode/webview-ui/src/components/shared/model-selector-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/model-selector-utils.ts
@@ -216,7 +216,6 @@ export function stripSubProviderPrefix(name: string): string {
 export function buildTriggerLabel(
   resolvedName: string | undefined,
   providerID: string | undefined,
-  providerName: string | undefined,
   raw: ModelSelection | null,
   allowClear: boolean,
   clearLabel: string,
@@ -225,7 +224,6 @@ export function buildTriggerLabel(
 ): string {
   if (resolvedName) {
     if (providerID === KILO_GATEWAY_ID) return stripSubProviderPrefix(resolvedName)
-    if (providerName) return `${providerName} / ${resolvedName}`
     return resolvedName
   }
   if (raw?.providerID && raw?.modelID) {


### PR DESCRIPTION
The compact model selector in the prompt input repeats the provider name in the button label, producing strings such as `OpenAI / GPT-5.6 Luna`. The provider is already represented by the surrounding selector context, and the duplicated prefix makes the prompt controls wider than necessary.

This changes the compact trigger to show only the resolved model name, while provider names remain visible in the expanded model picker where they help distinguish models. The change also adds regression coverage and a patch changeset.

Before:
<img width="420" alt="Prompt model selector showing a redundant provider prefix" src="https://marius-kilocode.github.io/pr-assets/20260817-provider-trigger-before.png" />

After:
<img width="420" alt="Prompt model selector showing only the model name" src="https://marius-kilocode.github.io/pr-assets/20260817-provider-trigger-after.png" />
