### PR TITLE
fix(vscode): show provider hints in model selector

### DIFF
--- a/.changeset/show-model-provider-hints.md
+++ b/.changeset/show-model-provider-hints.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show the model provider next to every model in the model selector.

--- a/packages/kilo-vscode/tests/model-selector-accessibility.spec.ts
+++ b/packages/kilo-vscode/tests/model-selector-accessibility.spec.ts
@@ -26,6 +26,8 @@ test("model selector exposes combobox relationships and active option movement",
   await expect(combobox).toHaveAttribute("aria-controls", await tree.getAttribute("id"))
   await expect(combobox).toHaveAttribute("aria-activedescendant", await alpha.getAttribute("id"))
   await expect(combobox).toHaveAccessibleDescription("Choose the model used for code review tasks.")
+  await expect(alpha.locator(".model-selector-item-provider-tag")).toHaveText("Kilo")
+  await expect(bravo.locator(".model-selector-item-provider-tag")).toHaveText("Kilo")
   await expect(alpha.locator("button")).toHaveCount(0)
   await expect(page.getByRole("button", { name: "Add to favorites: Alpha" })).toBeVisible()
   await expect(page.locator(".model-selector-group-label").nth(0)).toContainText("Auto Models")
@@ -114,7 +116,7 @@ test("provider groups collapse, expand, and skip their model rows", async ({ pag
   await page.getByRole("button", { name: "Review model: Alpha" }).click()
   const combobox = page.getByRole("combobox", { name: "Review model: Alpha. Search models" })
   const kilo = page.getByRole("treeitem", { name: "Kilo", exact: true })
-  const nvidia = page.getByRole("treeitem", { name: "NVIDIA" })
+  const nvidia = page.getByRole("treeitem", { name: "NVIDIA", exact: true })
 
   await combobox.press("ArrowDown")
   await combobox.press("ArrowLeft")

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -1011,7 +1011,6 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
                           const hovered = () => isSelected(row.key)
                           const preActive = () => isPreActive(row.key)
                           const starred = () => favoriteKeys().has(modelKey(model.providerID, model.id))
-                          const showProvider = () => row.kind === "favorite" || hasSearch()
                           const showSelect = () => expanded() && preActive() && !isActive(model)
                           const starLabel = () =>
                             `${starred() ? language.t("model.favorite.remove") : language.t("model.favorite.add")}: ${sanitizeName(model.name)}`
@@ -1082,9 +1081,7 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
                                       </Show>
                                     </span>
                                   </Show>
-                                  <Show when={showProvider()}>
-                                    <span class="model-selector-item-provider-tag">{model.providerName}</span>
-                                  </Show>
+                                  <span class="model-selector-item-provider-tag">{model.providerName}</span>
                                 </div>
                               </div>
                               <Show when={session && props.favorites !== false}>


### PR DESCRIPTION
The normal model selector currently hides provider names unless the list is searched or the model is favorited. This makes duplicate model names ambiguous when browsing the default grouped list, even though the search view already exposes the needed context.

Render the existing provider hint beside every model row, including recommended, recent, grouped, and favorite entries. The hint keeps the compact styling already used by search results, while the focused selector coverage verifies the normal-list behavior and keeps provider-group keyboard targeting deterministic.

<img width="420" alt="Model selector showing provider hints beside every model" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260817-model-selector-provider-hints.png?raw=true" />