### PR TITLE
fix(opencode): prompt before sandboxed git writes

### DIFF
--- a/.changeset/sandbox-git-escalation.md
+++ b/.changeset/sandbox-git-escalation.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prompt for explicit, one-shot approval before mutating Git commands run outside the sandbox.

--- a/packages/kilo-vscode/src/commands/toggle-auto-approve.ts
+++ b/packages/kilo-vscode/src/commands/toggle-auto-approve.ts
@@ -73,6 +73,7 @@ export function registerToggleAutoApprove(
         const { data: pending } = await client.permission.list({ directory: dir }, { throwOnError: true })
         for (const req of pending) {
           if (generation !== snapshot) break
+          if (req.metadata?.["sandboxEscalation"] === true) continue
           await client.permission
             .reply({ requestID: req.id, directory: dir, reply: "once" }, { throwOnError: true })
             .catch((err) => {
@@ -91,6 +92,7 @@ export function registerToggleAutoApprove(
     if (!active) return false
     const client = tryGetClient(connectionService)
     if (!client) return false
+    if (event.properties.metadata?.["sandboxEscalation"] === true) return false
     const dir =
       directory ?? connectionService.getPermissionDirectory(event.properties.id) ?? resolve(event.properties.sessionID)
     return client.permission

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -130,7 +130,7 @@ export const PermissionDock: Component<{
   }
 
   const title = () => {
-    if (sandboxEscalation()) return "Allow Git operation outside the sandbox?"
+    if (sandboxEscalation()) return language.t("notification.permission.titleSandboxEscalation")
     const skill = props.request.args?.skill
     if (skillShell() && typeof skill === "string" && skill.length > 0)
       // Escape the untrusted skill name so bidi/control chars can't reorder the header text.

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -62,6 +62,7 @@ export const PermissionDock: Component<{
   }
   const text = (rule: string) => (command() ? label(rule) : describeRule(props.request.toolName, rule, language.t))
   const external = () => props.request.toolName === "external_directory"
+  const sandboxEscalation = () => props.request.toolName === "sandbox_escalation"
   const cmdDescription = () => {
     const val = props.request.args?.description
     return typeof val === "string" && val.length > 0 ? val : undefined
@@ -129,6 +130,7 @@ export const PermissionDock: Component<{
   }
 
   const title = () => {
+    if (sandboxEscalation()) return "Allow Git operation outside the sandbox?"
     const skill = props.request.args?.skill
     if (skillShell() && typeof skill === "string" && skill.length > 0)
       // Escape the untrusted skill name so bidi/control chars can't reorder the header text.

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -265,6 +265,7 @@ export const dict = {
   "notification.permission.title": "مطلوب إذن",
   "notification.permission.titleSubagent": "مطلوب إذن (وكيل فرعي)",
   "notification.permission.titleSkillShell": "هل تريد تشغيل أوامر الصدفة من المهارة «{{skill}}»؟",
+  "notification.permission.titleSandboxEscalation": "السماح بعملية Git خارج البيئة المعزولة؟",
   "ui.permission.manageAutoApprove": "إدارة قواعد الموافقة التلقائية",
   "ui.permission.doomLoop.prompt": "تم اكتشاف حلقة محتملة في أداة {{tool}}. هل تريد متابعة التشغيل؟",
   "ui.permission.doomLoop.rule": "متابعة استدعاءات {{tool}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -275,6 +275,7 @@ export const dict = {
   "notification.permission.title": "Permissão necessária",
   "notification.permission.titleSubagent": "Permissão necessária (subagente)",
   "notification.permission.titleSkillShell": "Executar comandos de shell da skill “{{skill}}”?",
+  "notification.permission.titleSandboxEscalation": "Permitir operação do Git fora da sandbox?",
   "ui.permission.manageAutoApprove": "Gerenciar regras de aprovação automática",
   "ui.permission.doomLoop.prompt": "Possível loop detectado na ferramenta {{tool}}. Continuar executando?",
   "ui.permission.doomLoop.rule": "Continuar chamadas de {{tool}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -273,6 +273,7 @@ export const dict = {
   "notification.permission.title": "Potrebna dozvola",
   "notification.permission.titleSubagent": "Potrebna dozvola (podagent)",
   "notification.permission.titleSkillShell": "Pokrenuti shell komande iz vještine „{{skill}}”?",
+  "notification.permission.titleSandboxEscalation": "Dozvoliti Git operaciju izvan sandboxa?",
   "ui.permission.manageAutoApprove": "Upravljanje pravilima automatskog odobravanja",
   "ui.permission.doomLoop.prompt": "Otkrivena je moguća petlja za alat {{tool}}. Nastaviti izvršavanje?",
   "ui.permission.doomLoop.rule": "Nastavi pozive alata {{tool}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -272,6 +272,7 @@ export const dict = {
   "notification.permission.title": "Tilladelse påkrævet",
   "notification.permission.titleSubagent": "Tilladelse påkrævet (underagent)",
   "notification.permission.titleSkillShell": "Kør shell-kommandoer fra færdigheden „{{skill}}“?",
+  "notification.permission.titleSandboxEscalation": "Tillad Git-handling uden for sandkassen?",
   "ui.permission.manageAutoApprove": "Administrer regler for automatisk godkendelse",
   "ui.permission.doomLoop.prompt": "Der blev registreret en mulig løkke for værktøjet {{tool}}. Fortsæt kørslen?",
   "ui.permission.doomLoop.rule": "Fortsæt {{tool}}-kald",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -281,6 +281,7 @@ export const dict = {
   "notification.permission.title": "Berechtigung erforderlich",
   "notification.permission.titleSubagent": "Berechtigung erforderlich (Subagent)",
   "notification.permission.titleSkillShell": "Shell-Befehle aus dem Skill „{{skill}}“ ausführen?",
+  "notification.permission.titleSandboxEscalation": "Git-Vorgang außerhalb der Sandbox zulassen?",
   "ui.permission.manageAutoApprove": "Regeln für automatische Genehmigung verwalten",
   "ui.permission.doomLoop.prompt": "Potenzielle Schleife beim Tool {{tool}} erkannt. Weiter ausführen?",
   "ui.permission.doomLoop.rule": "{{tool}}-Aufrufe fortsetzen",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -270,6 +270,7 @@ export const dict = {
   "notification.permission.title": "Permission required",
   "notification.permission.titleSubagent": "Permission required (subagent)",
   "notification.permission.titleSkillShell": 'Run shell commands from skill "{{skill}}"?',
+  "notification.permission.titleSandboxEscalation": "Allow Git operation outside the sandbox?",
   "ui.permission.manageAutoApprove": "Manage Auto-Approve Rules",
   "ui.permission.doomLoop.prompt": "Potential loop detected for the {{tool}} tool. Continue running?",
   "ui.permission.doomLoop.rule": "Continue {{tool}} calls",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -276,6 +276,7 @@ export const dict = {
   "notification.permission.title": "Permiso requerido",
   "notification.permission.titleSubagent": "Permiso requerido (subagente)",
   "notification.permission.titleSkillShell": "¿Ejecutar comandos de shell de la habilidad «{{skill}}»?",
+  "notification.permission.titleSandboxEscalation": "¿Permitir la operación de Git fuera del entorno aislado?",
   "ui.permission.manageAutoApprove": "Gestionar reglas de aprobación automática",
   "ui.permission.doomLoop.prompt": "Se detectó un posible bucle en la herramienta {{tool}}. ¿Continuar ejecutando?",
   "ui.permission.doomLoop.rule": "Continuar llamadas a {{tool}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
@@ -270,6 +270,7 @@ export const dict = {
   "notification.permission.title": "مجوز لازم است",
   "notification.permission.titleSubagent": "مجوز مورد نیاز است (زیرعامل)",
   "notification.permission.titleSkillShell": "دستورهای شل از مهارت «{{skill}}» اجرا شود؟",
+  "notification.permission.titleSandboxEscalation": "اجازه انجام عملیات Git خارج از sandbox داده شود؟",
   "ui.permission.manageAutoApprove": "مدیریت قوانین تأیید خودکار",
   "ui.permission.doomLoop.prompt": "حلقه احتمالی برای ابزار {{tool}} شناسایی شد. ادامه می‌دهید؟",
   "ui.permission.doomLoop.rule": "ادامه فراخوانی‌های {{tool}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -275,6 +275,7 @@ export const dict = {
   "notification.permission.title": "Permission requise",
   "notification.permission.titleSubagent": "Permission requise (sous-agent)",
   "notification.permission.titleSkillShell": "Exécuter les commandes shell de la compétence «\u00a0{{skill}}\u00a0» ?",
+  "notification.permission.titleSandboxEscalation": "Autoriser l’opération Git en dehors du bac à sable ?",
   "ui.permission.manageAutoApprove": "Gérer les règles d'approbation automatique",
   "ui.permission.doomLoop.prompt": "Boucle potentielle détectée pour l’outil {{tool}}. Continuer l’exécution ?",
   "ui.permission.doomLoop.rule": "Continuer les appels à {{tool}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -187,6 +187,7 @@ export const dict = {
   "notification.permission.title": "Autorizzazione richiesta",
   "notification.permission.titleSubagent": "Autorizzazione richiesta (sub-agent)",
   "notification.permission.titleSkillShell": "Eseguire i comandi shell della skill “{{skill}}”?",
+  "notification.permission.titleSandboxEscalation": "Consentire l'operazione Git al di fuori della sandbox?",
   "ui.permission.manageAutoApprove": "Gestisci regole approvazione automatica",
   "ui.permission.doomLoop.prompt": "Rilevato un potenziale ciclo nello strumento {{tool}}. Continuare l'esecuzione?",
   "ui.permission.doomLoop.rule": "Continua le chiamate a {{tool}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -272,6 +272,7 @@ export const dict = {
   "notification.permission.title": "権限が必要です",
   "notification.permission.titleSubagent": "権限が必要です（サブエージェント）",
   "notification.permission.titleSkillShell": "スキル「{{skill}}」のシェルコマンドを実行しますか？",
+  "notification.permission.titleSandboxEscalation": "サンドボックス外での Git 操作を許可しますか？",
   "ui.permission.manageAutoApprove": "自動承認ルールを管理",
   "ui.permission.doomLoop.prompt": "{{tool}} ツールでループの可能性が検出されました。実行を続行しますか？",
   "ui.permission.doomLoop.rule": "{{tool}} の呼び出しを続行",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -273,6 +273,7 @@ export const dict = {
   "notification.permission.title": "권한 필요",
   "notification.permission.titleSubagent": "권한 필요 (서브에이전트)",
   "notification.permission.titleSkillShell": '스킬 "{{skill}}"의 셸 명령을 실행할까요?',
+  "notification.permission.titleSandboxEscalation": "샌드박스 외부에서 Git 작업을 허용할까요?",
   "ui.permission.manageAutoApprove": "자동 승인 규칙 관리",
   "ui.permission.doomLoop.prompt": "{{tool}} 도구에서 잠재적인 반복 실행이 감지되었습니다. 계속 실행하시겠습니까?",
   "ui.permission.doomLoop.rule": "{{tool}} 호출 계속",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -276,6 +276,7 @@ export const dict = {
   "notification.permission.title": "Toestemming vereist",
   "notification.permission.titleSubagent": "Toestemming vereist (subagent)",
   "notification.permission.titleSkillShell": "Shell-opdrachten uit vaardigheid “{{skill}}” uitvoeren?",
+  "notification.permission.titleSandboxEscalation": "Git-bewerking buiten de sandbox toestaan?",
   "ui.permission.manageAutoApprove": "Beheer automatisch goedkeuren regels",
   "ui.permission.doomLoop.prompt": "Mogelijke lus gedetecteerd voor het hulpmiddel {{tool}}. Doorgaan met uitvoeren?",
   "ui.permission.doomLoop.rule": "Doorgaan met {{tool}}-aanroepen",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -279,6 +279,7 @@ export const dict = {
   "notification.permission.title": "Tillatelse påkrevd",
   "notification.permission.titleSubagent": "Tillatelse påkrevd (underagent)",
   "notification.permission.titleSkillShell": "Kjøre skallkommandoer fra ferdigheten «{{skill}}»?",
+  "notification.permission.titleSandboxEscalation": "Tillate Git-operasjon utenfor sandkassen?",
   "ui.permission.manageAutoApprove": "Administrer regler for automatisk godkjenning",
   "ui.permission.doomLoop.prompt": "Mulig løkke oppdaget for verktøyet {{tool}}. Fortsette kjøringen?",
   "ui.permission.doomLoop.rule": "Fortsett {{tool}}-kall",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -273,6 +273,7 @@ export const dict = {
   "notification.permission.title": "Wymagane uprawnienie",
   "notification.permission.titleSubagent": "Wymagane uprawnienie (podagent)",
   "notification.permission.titleSkillShell": "Uruchomić polecenia powłoki z umiejętności „{{skill}}”?",
+  "notification.permission.titleSandboxEscalation": "Zezwolić na operację Git poza piaskownicą?",
   "ui.permission.manageAutoApprove": "Zarządzaj regułami automatycznego zatwierdzania",
   "ui.permission.doomLoop.prompt": "Wykryto potencjalną pętlę dla narzędzia {{tool}}. Kontynuować działanie?",
   "ui.permission.doomLoop.rule": "Kontynuuj wywołania {{tool}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -270,6 +270,7 @@ export const dict = {
   "notification.permission.title": "Требуется разрешение",
   "notification.permission.titleSubagent": "Требуется разрешение (субагент)",
   "notification.permission.titleSkillShell": "Выполнить команды оболочки из навыка «{{skill}}»?",
+  "notification.permission.titleSandboxEscalation": "Разрешить операцию Git за пределами песочницы?",
   "ui.permission.manageAutoApprove": "Управление правилами автоодобрения",
   "ui.permission.doomLoop.prompt":
     "Обнаружен потенциальный цикл при работе инструмента {{tool}}. Продолжить выполнение?",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -270,6 +270,7 @@ export const dict = {
   "notification.permission.title": "ต้องการสิทธิ์",
   "notification.permission.titleSubagent": "ต้องการสิทธิ์ (ตัวแทนย่อย)",
   "notification.permission.titleSkillShell": 'เรียกใช้คำสั่งเชลล์จากสกิล "{{skill}}" หรือไม่?',
+  "notification.permission.titleSandboxEscalation": "อนุญาตการดำเนินการ Git นอกแซนด์บ็อกซ์หรือไม่?",
   "ui.permission.manageAutoApprove": "จัดการกฎการอนุมัติอัตโนมัติ",
   "ui.permission.doomLoop.prompt": "ตรวจพบการวนซ้ำที่อาจเกิดขึ้นในเครื่องมือ {{tool}} ต้องการดำเนินการต่อหรือไม่",
   "ui.permission.doomLoop.rule": "เรียกใช้ {{tool}} ต่อไป",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -271,6 +271,8 @@ export const dict = {
   "notification.permission.title": "İzin gerekli",
   "notification.permission.titleSubagent": "İzin gerekli (alt ajan)",
   "notification.permission.titleSkillShell": "“{{skill}}” becerisindeki kabuk komutları çalıştırılsın mı?",
+  "notification.permission.titleSandboxEscalation":
+    "Git işleminin korumalı alan dışında gerçekleştirilmesine izin verilsin mi?",
   "ui.permission.manageAutoApprove": "Otomatik Onay Kurallarını Yönet",
   "ui.permission.doomLoop.prompt": "{{tool}} aracında olası bir döngü algılandı. Çalıştırmaya devam edilsin mi?",
   "ui.permission.doomLoop.rule": "{{tool}} çağrılarına devam et",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -274,6 +274,7 @@ export const dict = {
   "notification.permission.title": "Потрібен дозвіл",
   "notification.permission.titleSubagent": "Потрібен дозвіл (підагент)",
   "notification.permission.titleSkillShell": "Виконати команди оболонки з навички «{{skill}}»?",
+  "notification.permission.titleSandboxEscalation": "Дозволити операцію Git за межами пісочниці?",
   "ui.permission.manageAutoApprove": "Керувати правилами автоматичного схвалення",
   "ui.permission.doomLoop.prompt":
     "Виявлено потенційний цикл під час роботи інструмента {{tool}}. Продовжити виконання?",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -260,6 +260,7 @@ export const dict = {
   "notification.permission.title": "需要权限",
   "notification.permission.titleSubagent": "需要权限（子代理）",
   "notification.permission.titleSkillShell": "要执行技能「{{skill}}」的 shell 命令吗？",
+  "notification.permission.titleSandboxEscalation": "要允许在沙盒外执行 Git 操作吗？",
   "ui.permission.manageAutoApprove": "管理自动审批规则",
   "ui.permission.doomLoop.prompt": "检测到 {{tool}} 工具可能陷入循环。是否继续运行？",
   "ui.permission.doomLoop.rule": "继续调用 {{tool}}",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -258,6 +258,7 @@ export const dict = {
   "notification.permission.title": "需要權限",
   "notification.permission.titleSubagent": "需要權限（子代理）",
   "notification.permission.titleSkillShell": "要執行技能「{{skill}}」的 shell 指令嗎？",
+  "notification.permission.titleSandboxEscalation": "要允許在沙盒外執行 Git 操作嗎？",
   "ui.permission.manageAutoApprove": "管理自動核准規則",
   "ui.permission.doomLoop.prompt": "偵測到 {{tool}} 工具可能陷入迴圈。是否繼續執行？",
   "ui.permission.doomLoop.rule": "繼續呼叫 {{tool}}",

--- a/packages/opencode/src/acp/permission.ts
+++ b/packages/opencode/src/acp/permission.ts
@@ -60,6 +60,12 @@ export class Handler {
     }
 
     const skillShell = SkillShellPrompt.is(permission.metadata) // kilocode_change - skill batches list commands and never persist
+    const temporary = skillShell || permission.metadata?.["sandboxEscalation"] === true // kilocode_change
+    const title = skillShell
+      ? SkillShellPrompt.title
+      : temporary
+        ? "Allow Git operation outside the sandbox"
+        : undefined // kilocode_change
     const result = await this.input.connection
       .requestPermission({
         sessionId: permission.sessionID,
@@ -67,9 +73,9 @@ export class Handler {
           toolCallId: permission.tool?.callID ?? permission.id,
           toolName: permission.permission,
           input: permission.metadata,
-          title: skillShell ? SkillShellPrompt.title : undefined, // kilocode_change
+          title, // kilocode_change
         }),
-        options: skillShell ? SkillShellPrompt.options : permissionOptions, // kilocode_change
+        options: temporary ? SkillShellPrompt.options : permissionOptions, // kilocode_change
       })
       .catch(async () => {
         await this.reply(permission.id, "reject", session.cwd)
@@ -91,7 +97,8 @@ export class Handler {
     await this.reply(permission.id, reply, session.cwd, true) // kilocode_change - human selected via requestPermission
   }
 
-  private async reply(requestID: string, reply: Reply, directory: string, interactive = false) { // kilocode_change - interactive param
+  private async reply(requestID: string, reply: Reply, directory: string, interactive = false) {
+    // kilocode_change - interactive param
     await this.input.sdk.permission.reply({
       requestID,
       reply,

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -281,7 +281,9 @@ export const RunCommand = effectCmd({
     // kilocode_change start - lazy Kilo implementations (see top-of-file note)
     const { createKiloClient } = yield* Effect.promise(() => import("@kilocode/sdk/v2"))
     const { buildRunMessage } = yield* Effect.promise(() => import("@/kilocode/cli/cmd/run-message"))
-    const { importCloudSession, validateCloudFork, reportCloudImportError } = yield* Effect.promise(() => import("@/kilocode/cloud-session"))
+    const { importCloudSession, validateCloudFork, reportCloudImportError } = yield* Effect.promise(
+      () => import("@/kilocode/cloud-session"),
+    )
     const { KiloRunAuto } = yield* Effect.promise(() => import("@/kilocode/cli/run-auto"))
     const { KiloHeadless } = yield* Effect.promise(() => import("@/kilocode/permission/headless"))
     const { KiloRun, KiloRunDaemon } = yield* Effect.promise(() => import("@/kilocode/cli/cmd/run"))
@@ -923,7 +925,7 @@ export const RunCommand = effectCmd({
               const permission = event.properties
               // kilocode_change start - skill shell batches need an interactive human decision. The server ignores
               // non-interactive approvals, so headless runs must reject explicitly rather than leave them pending.
-              if (permission.metadata?.["skillShell"] === true) {
+              if (permission.metadata?.["skillShell"] === true || permission.metadata?.["sandboxEscalation"] === true) {
                 await client.permission.reply({ requestID: permission.id, reply: "reject" })
                 continue
               }

--- a/packages/opencode/src/cli/cmd/run/footer.permission.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.permission.tsx
@@ -27,6 +27,7 @@ import {
   permissionReject,
   permissionRun,
   permissionShift,
+  temporaryPermission,
   type PermissionOption,
 } from "./permission.shared"
 import { footerWidthPolicy } from "./footer.width"
@@ -141,8 +142,8 @@ export function RunPermissionBody(props: {
   const info = createMemo(() => permissionInfo(props.request))
   const ft = createMemo(() => toolFiletype(info().file))
   const narrow = createMemo(() => footerWidthPolicy(dims().width).dialog.narrow)
-  const skillShell = createMemo(() => props.request.metadata?.["skillShell"] === true) // kilocode_change
-  const opts = createMemo(() => permissionOptions(state().stage, skillShell())) // kilocode_change - skillShell-aware options
+  const temporary = createMemo(() => temporaryPermission(props.request)) // kilocode_change
+  const opts = createMemo(() => permissionOptions(state().stage, temporary())) // kilocode_change
   const busy = createMemo(() => state().submitting)
   const title = createMemo(() => {
     if (state().stage === "always") {
@@ -166,7 +167,7 @@ export function RunPermissionBody(props: {
   })
 
   const shift = (dir: -1 | 1) => {
-    setState((prev) => permissionShift(prev, dir, skillShell())) // kilocode_change - skillShell-aware options
+    setState((prev) => permissionShift(prev, dir, temporary())) // kilocode_change
   }
 
   const submit = async (next: PermissionReply) => {

--- a/packages/opencode/src/cli/cmd/run/permission.shared.ts
+++ b/packages/opencode/src/cli/cmd/run/permission.shared.ts
@@ -77,11 +77,10 @@ export function createPermissionBodyState(requestID: string): PermissionBodyStat
   }
 }
 
-export function permissionOptions(stage: PermissionStage, skillShell?: boolean): PermissionOption[] { // kilocode_change - skillShell param
+export function permissionOptions(stage: PermissionStage, temporary?: boolean): PermissionOption[] {
+  // kilocode_change
   if (stage === "permission") {
-    // kilocode_change start - skill-shell batches are never persisted, so no "Allow always"
-    return skillShell ? ["once", "reject"] : ["once", "always", "reject"]
-    // kilocode_change end
+    return temporary ? ["once", "reject"] : ["once", "always", "reject"]
   }
 
   if (stage === "always") {
@@ -97,6 +96,17 @@ export function permissionInfo(request: PermissionRequest): PermissionInfo {
   const info = toolPermissionInfo(request.permission, input, dict(request.metadata), pats)
   if (info) {
     return info
+  }
+
+  if (request.permission === "sandbox_escalation") {
+    const command = text(input.command)
+    return {
+      icon: "!",
+      title: "Allow Git operation outside the sandbox",
+      lines: command
+        ? [`$ ${command}`, "This approval applies to this command only."]
+        : ["This approval applies to this command only."],
+    }
   }
 
   if (request.permission === "external_directory") {
@@ -123,6 +133,10 @@ export function permissionInfo(request: PermissionRequest): PermissionInfo {
     title: `Call tool ${request.permission}`,
     lines: [`Tool: ${request.permission}`],
   }
+}
+
+export function temporaryPermission(request: PermissionRequest) {
+  return request.metadata?.["skillShell"] === true || request.metadata?.["sandboxEscalation"] === true
 }
 
 export function permissionAlwaysLines(request: PermissionRequest): string[] {
@@ -153,8 +167,9 @@ export function permissionReply(requestID: string, reply: PermissionReply["reply
   }
 }
 
-export function permissionShift(state: PermissionBodyState, dir: -1 | 1, skillShell?: boolean): PermissionBodyState { // kilocode_change - skillShell param
-  const list = permissionOptions(state.stage, skillShell) // kilocode_change - skillShell-aware options
+export function permissionShift(state: PermissionBodyState, dir: -1 | 1, temporary?: boolean): PermissionBodyState {
+  // kilocode_change
+  const list = permissionOptions(state.stage, temporary) // kilocode_change
   if (list.length === 0) {
     return state
   }

--- a/packages/opencode/src/cli/cmd/run/permission.shared.ts
+++ b/packages/opencode/src/cli/cmd/run/permission.shared.ts
@@ -102,7 +102,7 @@ export function permissionInfo(request: PermissionRequest): PermissionInfo {
     const command = text(input.command)
     return {
       icon: "!",
-      title: "Allow Git operation outside the sandbox",
+      title: "Allow Git operation outside the sandbox", // kilocode_change
       lines: command
         ? [`$ ${command}`, "This approval applies to this command only."]
         : ["This approval applies to this command only."],

--- a/packages/opencode/src/kilocode/permission/drain.ts
+++ b/packages/opencode/src/kilocode/permission/drain.ts
@@ -35,6 +35,7 @@ export function drainCovered(
       if (ConfigProtection.isRequest(entry.info) && !skill) continue
       // Never auto-resolve a skill shell batch; it must get an explicit reply.
       if (entry.info.metadata?.["skillShell"] === true) continue
+      if (entry.info.metadata?.["sandboxEscalation"] === true) continue
       const actions = entry.info.patterns.map((pattern: string) => {
         const rule = skill
           ? Permission.evaluate(entry.info.permission, skill, approved)

--- a/packages/opencode/src/kilocode/sandbox/git.ts
+++ b/packages/opencode/src/kilocode/sandbox/git.ts
@@ -1,0 +1,113 @@
+const READONLY = new Set([
+  "cat-file",
+  "check-attr",
+  "check-ignore",
+  "check-mailmap",
+  "config",
+  "describe",
+  "diff",
+  "for-each-ref",
+  "grep",
+  "log",
+  "ls-files",
+  "ls-tree",
+  "ls-remote",
+  "merge-base",
+  "name-rev",
+  "rev-list",
+  "rev-parse",
+  "show",
+  "show-ref",
+  "status",
+  "tag",
+  "whatchanged",
+])
+
+const MUTATING = new Set([
+  "add",
+  "am",
+  "apply",
+  "branch",
+  "cherry-pick",
+  "checkout",
+  "clean",
+  "clone",
+  "commit",
+  "fetch",
+  "init",
+  "merge",
+  "mv",
+  "pull",
+  "push",
+  "rebase",
+  "reset",
+  "restore",
+  "rm",
+  "stash",
+  "switch",
+  "update-index",
+])
+
+function args(text: string) {
+  const match = text
+    .trim()
+    .match(
+      /^(?:command\s+|env\s+(?:-[^\s]+\s+|[A-Za-z_][A-Za-z0-9_]*=[^\s]+\s+)*|[A-Za-z_][A-Za-z0-9_]*=[^\s]+\s+)*(?:git|git.exe)(?:\s+|$)(.*)$/i,
+    )
+  if (!match) return
+  return match[1].trim().split(/\s+/).filter(Boolean)
+}
+
+export function mutates(text: string) {
+  if (/[;&|<>`\n\r]/.test(text)) return false
+  const values = args(text)
+  if (!values) return false
+  const options = new Set(["-C", "--git-dir", "--work-tree", "--namespace", "-c"])
+  while (values[0]?.startsWith("-")) {
+    const option = values.shift()!
+    if (options.has(option)) values.shift()
+  }
+  const subcommand = values[0]?.toLowerCase()
+  if (!subcommand) return false
+  if (subcommand === "branch") {
+    return (
+      values.length > 1 &&
+      !values
+        .slice(1)
+        .some((value) =>
+          ["-a", "-r", "-l", "--all", "--list", "--show-current", "--contains", "--merged", "--no-merged"].includes(
+            value,
+          ),
+        )
+    )
+  }
+  if (subcommand === "tag") {
+    return (
+      values.length > 1 &&
+      !values
+        .slice(1)
+        .some((value) => ["-l", "--list", "--contains", "--points-at", "--merged", "--no-merged"].includes(value))
+    )
+  }
+  if (subcommand === "config") {
+    if (values.length === 1) return false
+    return !values
+      .slice(1)
+      .some((value) =>
+        [
+          "--get",
+          "--get-all",
+          "--get-regexp",
+          "--get-urlmatch",
+          "--list",
+          "-l",
+          "--name-only",
+          "--show-origin",
+          "--show-names",
+        ].includes(value),
+      )
+  }
+  if (READONLY.has(subcommand)) return false
+  if (MUTATING.has(subcommand)) return true
+  return true
+}

--- a/packages/opencode/src/kilocode/sandbox/policy.ts
+++ b/packages/opencode/src/kilocode/sandbox/policy.ts
@@ -623,6 +623,10 @@ export function executeTool<A, E, R>(sessionID: SessionID, tool: { id: string },
   return execute(sessionID, Network.tool(tool, effect))
 }
 
+export function executeEscalated<A, E, R>(approved: boolean, effect: Effect.Effect<A, E, R>) {
+  return approved ? unrestricted(effect) : effect
+}
+
 export function executeMcp<A, E, R>(sessionID: SessionID, tool: object, effect: Effect.Effect<A, E, R>) {
   return execute(sessionID, Network.mcp(tool, effect))
 }

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -146,6 +146,7 @@ function subset(permission: string, ruleset: Ruleset) {
 function covered(entry: PendingEntry, approved: Ruleset, local: Ruleset) {
   if (ConfigProtection.isRequest(entry.info)) return false
   if (entry.info.metadata?.["skillShell"] === true) return false // kilocode_change - skill batch needs an explicit reply
+  if (entry.info.metadata?.["sandboxEscalation"] === true) return false // kilocode_change - host access needs an explicit reply
   return entry.info.patterns.every((pattern) => {
     if (veto(entry.info.permission, pattern, entry.hardRuleset)) return false
     return resolve(entry.info.permission, pattern, entry.ruleset, approved, local).action === "allow"
@@ -212,7 +213,7 @@ const layer = Layer.effect(
         : false
       // kilocode_change end
 
-      const forceAsk = request.metadata?.["skillShell"] === true // kilocode_change
+      const forceAsk = request.metadata?.["skillShell"] === true || request.metadata?.["sandboxEscalation"] === true // kilocode_change
       for (const pattern of request.patterns) {
         const rule = resolve(request.permission, pattern, ruleset, approved, local) // kilocode_change — include session-scoped rules
         yield* Effect.logInfo("evaluated", { permission: request.permission, pattern, action: rule })
@@ -291,8 +292,12 @@ const layer = Layer.effect(
       // (auto-approve/YOLO clients omit `interactive`) so the prompt stays pending for a real decision.
       // Log rather than fail silently: a genuine human client sets `interactive`, so a refused reply here
       // means an auto-approver tried to answer — the request intentionally stays pending for a human.
-      if (existing.info.metadata?.["skillShell"] === true && input.reply !== "reject" && input.interactive !== true) {
-        yield* Effect.logWarning("skill shell approval refused: requires an interactive human reply", {
+      if (
+        (existing.info.metadata?.["skillShell"] === true || existing.info.metadata?.["sandboxEscalation"] === true) &&
+        input.reply !== "reject" &&
+        input.interactive !== true
+      ) {
+        yield* Effect.logWarning("sensitive permission approval refused: requires an interactive human reply", {
           id: input.requestID,
         })
         return

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -75,65 +75,79 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
   // kilocode_change end
   const flags = yield* RuntimeFlags.Service
   const restricted = yield* SandboxPolicy.networkRestricted(input.session.id) // kilocode_change
-
-  const context = (args: Record<string, unknown>, options: ToolExecutionOptions): Tool.Context => ({
-    sessionID: input.session.id,
-    abort: options.abortSignal!,
-    messageID: input.processor.message.id,
-    callID: options.toolCallId,
-    extra: { model: input.model, bypassAgentCheck: input.bypassAgentCheck, promptOps: input.promptOps },
-    agent: input.agent.name,
-    messages: input.messages,
-    // kilocode_change start
-    metadata: (val) => input.processor.metadata(options.toolCallId, val),
-    ask: (req) =>
-      KiloSessionPrompt.askPermission({
-        permission,
-        agents,
-        sessions,
-        origins: permissionOrigins,
-        agent: input.agent,
-        session: input.session,
-        request: {
-          ...req,
-          sessionID: input.session.id,
-          tool: { messageID: input.processor.message.id, callID: options.toolCallId },
-        },
-      }).pipe(
-        // record why the call was allowed onto the tool part, then discard the outcome for the tool-facing ask
-        Effect.tap((approval) =>
-          input.processor.metadata(options.toolCallId, {
-            metadata: {
-              approval: PermissionProvenance.tagOutsideWorkspace(
-                approval,
-                req.permission,
-                PermissionProvenance.filepathOf(req.metadata),
-              ),
-            },
-          }),
+  const sandboxed = (yield* SandboxPolicy.status(input.session.id)).enabled // kilocode_change
+  const context = (args: Record<string, unknown>, options: ToolExecutionOptions): Tool.Context => {
+    const extra = {
+      model: input.model,
+      bypassAgentCheck: input.bypassAgentCheck,
+      promptOps: input.promptOps,
+      sandboxed, // kilocode_change
+      sandboxEscalation: false,
+    }
+    return {
+      sessionID: input.session.id,
+      abort: options.abortSignal!,
+      messageID: input.processor.message.id,
+      callID: options.toolCallId,
+      extra,
+      agent: input.agent.name,
+      messages: input.messages,
+      // kilocode_change start
+      metadata: (val) => input.processor.metadata(options.toolCallId, val),
+      ask: (req) =>
+        KiloSessionPrompt.askPermission({
+          permission,
+          agents,
+          sessions,
+          origins: permissionOrigins,
+          agent: input.agent,
+          session: input.session,
+          request: {
+            ...req,
+            sessionID: input.session.id,
+            tool: { messageID: input.processor.message.id, callID: options.toolCallId },
+          },
+        }).pipe(
+          // record why the call was allowed onto the tool part, then discard the outcome for the tool-facing ask
+          Effect.tap((approval) =>
+            Effect.gen(function* () {
+              if (req.metadata?.["sandboxEscalation"] === true && approval.source === "manual") {
+                extra.sandboxEscalation = true
+              }
+              yield* input.processor.metadata(options.toolCallId, {
+                metadata: {
+                  approval: PermissionProvenance.tagOutsideWorkspace(
+                    approval,
+                    req.permission,
+                    PermissionProvenance.filepathOf(req.metadata),
+                  ),
+                },
+              })
+            }),
+          ),
+          // record why the call was denied too, so JSON exports and clients can explain the denial
+          Effect.tapErrorTag("PermissionDeniedError", (err) =>
+            input.processor.metadata(options.toolCallId, {
+              metadata: {
+                approval: PermissionProvenance.tagOutsideWorkspace(
+                  PermissionProvenance.classifyDenial({
+                    ruleset: err.ruleset,
+                    permission: req.permission,
+                    patterns: req.patterns,
+                    agent: input.agent.name,
+                    origins: permissionOrigins,
+                  }),
+                  req.permission,
+                  PermissionProvenance.filepathOf(req.metadata),
+                ),
+              },
+            }),
+          ),
+          Effect.asVoid,
+          Effect.orDie,
         ),
-        // record why the call was denied too, so JSON exports and clients can explain the denial
-        Effect.tapErrorTag("PermissionDeniedError", (err) =>
-          input.processor.metadata(options.toolCallId, {
-            metadata: {
-              approval: PermissionProvenance.tagOutsideWorkspace(
-                PermissionProvenance.classifyDenial({
-                  ruleset: err.ruleset,
-                  permission: req.permission,
-                  patterns: req.patterns,
-                  agent: input.agent.name,
-                  origins: permissionOrigins,
-                }),
-                req.permission,
-                PermissionProvenance.filepathOf(req.metadata),
-              ),
-            },
-          }),
-        ),
-        Effect.asVoid,
-        Effect.orDie,
-      ),
-  })
+    }
+  }
   // kilocode_change end
 
   for (const item of yield* registry.tools({

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -26,6 +26,8 @@ import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
 import { ShellPrompt, type Parameters } from "./shell/prompt"
 import { BashArity } from "@/permission/arity"
+import { mutates as mutatesGit } from "@/kilocode/sandbox/git" // kilocode_change
+import * as SandboxPolicy from "@/kilocode/sandbox/policy" // kilocode_change
 
 export { Parameters } from "./shell/prompt"
 
@@ -327,6 +329,7 @@ type PermissionInput = {
   cwd: string
   shell: string
   description?: string
+  escalate?: boolean // kilocode_change
 }
 
 export const ShellPermission = Effect.gen(function* () {
@@ -430,6 +433,19 @@ export const ShellPermission = Effect.gen(function* () {
           scan.access = "unknown"
         }
         yield* ask(ctx, scan, input.command, metadata, input.description) // kilocode_change
+        const gitMutation = commands(tree.rootNode).some((node) => mutatesGit(node.text))
+        if (input.escalate && gitMutation) {
+          yield* ctx.ask({
+            permission: "sandbox_escalation", // kilocode_change
+            patterns: [input.command],
+            always: [],
+            metadata: {
+              command: normalizeUrls(input.command),
+              ...(input.description ? { description: input.description } : {}),
+              sandboxEscalation: true,
+            },
+          })
+        }
       }),
     )
   })
@@ -729,18 +745,29 @@ export const ShellTool = Tool.define(
                 throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
               }
               const timeout = CommandTimeout.clamp(params.timeout ?? defaultTimeoutMs).timeout // kilocode_change
-              yield* permission.ask(ctx, { command: params.command, cwd, shell, description: params.description }) // kilocode_change
-
-              return yield* run(
-                {
-                  shell,
-                  command: params.command,
-                  cwd,
-                  env: yield* shellEnv(ctx, cwd),
-                  timeout,
-                  description: params.description ?? params.command, // kilocode_change
-                },
-                ctx,
+              const sandboxed = ctx.extra?.["sandboxed"] === true
+              yield* permission.ask(ctx, {
+                command: params.command,
+                cwd,
+                shell,
+                description: params.description,
+                escalate: sandboxed, // kilocode_change
+              }) // kilocode_change
+              const approved = ctx.extra?.["sandboxEscalation"] === true
+              if (ctx.extra) ctx.extra["sandboxEscalation"] = false
+              return yield* SandboxPolicy.executeEscalated(
+                approved,
+                run(
+                  {
+                    shell,
+                    command: params.command,
+                    cwd,
+                    env: yield* shellEnv(ctx, cwd),
+                    timeout,
+                    description: params.description ?? params.command, // kilocode_change
+                  },
+                  ctx,
+                ),
               )
             }),
         }

--- a/packages/opencode/src/tool/shell/shell.txt
+++ b/packages/opencode/src/tool/shell/shell.txt
@@ -11,6 +11,7 @@ IMPORTANT: This tool is for terminal operations like git, npm, docker, etc. DO N
 ${commandSection}
 
 # Git and GitHub
+- When the sandbox is active, read-only Git commands can run normally. Mutating Git commands such as `git add`, `git commit`, `git merge`, `git checkout`, `git reset`, and `git stash` require a separate confirmation and run unsandboxed only for that command. The confirmation is always one-shot and cannot be saved as an always-allow rule.
 - Only commit, amend, push, or create PRs when explicitly requested.
 - Before committing, inspect `git status`, `git diff`, and `git log --oneline -10`; stage only intended files and never commit secrets.
 - Write a concise commit message that matches the repo style.

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -120,10 +120,7 @@ function wrap<Parameters extends Schema.Decoder<unknown>, Result extends Metadat
         }
         return Effect.gen(function* () {
           // kilocode_change start
-          const decoded = yield* decode(
-            args,
-            { errors: "all" },
-          ).pipe(
+          const decoded = yield* decode(args, { errors: "all" }).pipe(
             Effect.mapError(
               (error) =>
                 new InvalidArgumentsError({

--- a/packages/opencode/src/tool/truncate.ts
+++ b/packages/opencode/src/tool/truncate.ts
@@ -6,7 +6,6 @@ import type { Agent } from "../agent/agent"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { evaluate } from "@/permission/evaluate"
 import { Config } from "@/config/config"
-import { Identifier } from "../id/id"
 import { ToolID } from "./schema"
 import { TRUNCATION_DIR } from "./truncation-dir"
 
@@ -52,17 +51,20 @@ const layer = Layer.effect(
     const fs = yield* FSUtil.Service
 
     const cleanup = Effect.fn("Truncate.cleanup")(function* () {
-      const cutoff = Identifier.timestamp(
-        Identifier.create("tool", "ascending", Date.now() - Duration.toMillis(RETENTION)),
-      )
+      // kilocode_change start - use file mtimes because encoded IDs wrap
+      const cutoff = Date.now() - Duration.toMillis(RETENTION)
       const entries = yield* fs.readDirectory(TRUNCATION_DIR).pipe(
         Effect.map((all) => all.filter((name) => name.startsWith("tool_"))),
         Effect.catch(() => Effect.succeed([])),
       )
       for (const entry of entries) {
-        if (Identifier.timestamp(entry) >= cutoff) continue
-        yield* fs.remove(path.join(TRUNCATION_DIR, entry)).pipe(Effect.catch(() => Effect.void))
+        const file = path.join(TRUNCATION_DIR, entry)
+        const info = yield* fs.stat(file).pipe(Effect.catch(() => Effect.succeed(undefined)))
+        const mtime = info && Option.getOrUndefined(info.mtime)
+        if (!mtime || mtime.getTime() >= cutoff) continue
+        yield* fs.remove(file).pipe(Effect.catch(() => Effect.void))
       }
+      // kilocode_change end
     })
 
     const write = Effect.fn("Truncate.write")(function* (text: string) {

--- a/packages/opencode/test/cli/run/permission.shared.test.ts
+++ b/packages/opencode/test/cli/run/permission.shared.test.ts
@@ -139,6 +139,22 @@ describe("run permission shared", () => {
     expect(permissionOptions("permission", true)).toEqual(["once", "reject"])
     expect(permissionOptions("permission")).toEqual(["once", "always", "reject"])
   })
+
+  test("sandbox escalation shows the command and offers only one-shot approval", () => {
+    expect(
+      permissionInfo(
+        req({
+          permission: "sandbox_escalation",
+          metadata: { command: "git add file.txt && git commit -m test", sandboxEscalation: true },
+        }),
+      ),
+    ).toEqual({
+      icon: "!",
+      title: "Allow Git operation outside the sandbox",
+      lines: ["$ git add file.txt && git commit -m test", "This approval applies to this command only."],
+    })
+    expect(permissionOptions("permission", true)).toEqual(["once", "reject"])
+  })
   // kilocode_change end
 
   test("formats always-allow copy for wildcard and explicit patterns", () => {

--- a/packages/opencode/test/kilocode/permission/skill-shell.test.ts
+++ b/packages/opencode/test/kilocode/permission/skill-shell.test.ts
@@ -80,6 +80,27 @@ it.instance(
 )
 
 it.instance(
+  "sandbox escalation - forces a one-shot interactive prompt",
+  () =>
+    Effect.gen(function* () {
+      const fiber = yield* ask({
+        sessionID: SessionID.make("session_sandbox"),
+        permission: "sandbox_escalation",
+        patterns: ["git commit -m message"],
+        metadata: { sandboxEscalation: true },
+        always: [],
+        ruleset: [{ permission: "sandbox_escalation", pattern: "*", action: "allow" }],
+      }).pipe(Effect.forkScoped)
+
+      const pending = yield* waitForPending(1)
+      expect(pending[0]?.metadata?.sandboxEscalation).toBe(true)
+      yield* reply({ requestID: pending[0]!.id, reply: "once", interactive: true })
+      expect((yield* Fiber.join(fiber)).manual).toBe(true)
+    }),
+  { git: true },
+)
+
+it.instance(
   "skillShell - a deny rule stays terminal (build mode, no hard ruleset)",
   () =>
     Effect.gen(function* () {

--- a/packages/opencode/test/kilocode/sandbox/git.test.ts
+++ b/packages/opencode/test/kilocode/sandbox/git.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test"
+import { mutates } from "@/kilocode/sandbox/git"
+
+describe("sandbox Git mutation classification", () => {
+  test("allows read-only Git commands to remain sandboxed", () => {
+    for (const command of [
+      "git status",
+      "git diff --cached",
+      "git log --oneline -5",
+      "git show HEAD:file.ts",
+      "git rev-parse --show-toplevel",
+      "git branch --all",
+      "git tag --list",
+      "git config --get user.name",
+      "GIT_DIR=/repo/.git git status",
+      "GIT_INDEX_FILE=/tmp/index git diff",
+    ]) {
+      expect(mutates(command)).toBe(false)
+    }
+  })
+
+  test("requires escalation for Git state mutations", () => {
+    for (const command of [
+      "git add src/index.ts",
+      "git commit -m message",
+      "git checkout -b feature",
+      "git merge main",
+      "git rebase main",
+      "git stash push",
+      "git -C /repo reset --hard HEAD",
+      "git config user.name Agent",
+      "git unknown-subcommand",
+      "GIT_INDEX_FILE=/tmp/index git commit -m message",
+      "KILO_TEST=1 GIT_INDEX_FILE=/tmp/index git add src/index.ts",
+    ]) {
+      expect(mutates(command)).toBe(true)
+    }
+  })
+
+  test("does not classify unrelated commands as Git mutations", () => {
+    expect(mutates("echo git commit -m unsafe")).toBe(false)
+    expect(mutates("npm run git-status")).toBe(false)
+  })
+
+  test("classifies Git mutations inside compound shell commands", () => {
+    expect(mutates("git add .")).toBe(true)
+    expect(mutates("git add . && git commit -m message")).toBe(false)
+  })
+})

--- a/packages/opencode/test/kilocode/tool/shell-unparsed.test.ts
+++ b/packages/opencode/test/kilocode/tool/shell-unparsed.test.ts
@@ -29,11 +29,15 @@ import { SessionID, MessageID } from "../../../src/session/schema"
 import { disposeAllInstances, provideInstance, testInstanceStoreLayer, tmpdir } from "../../fixture/fixture"
 import { afterEach } from "bun:test"
 
-const layer = Layer.mergeAll(AppNodeBuilder.build(CrossSpawnSpawner.node), AppNodeBuilder.build(FSUtil.node), testInstanceStoreLayer)
+const layer = Layer.mergeAll(
+  AppNodeBuilder.build(CrossSpawnSpawner.node),
+  AppNodeBuilder.build(FSUtil.node),
+  testInstanceStoreLayer,
+)
 
 type ScanRequest = Omit<PermissionV1.Request, "id" | "sessionID" | "tool">
 
-async function scan(dir: string, command: string, shell: string) {
+async function scan(dir: string, command: string, shell: string, sandbox = false) {
   const requests: ScanRequest[] = []
   const ctx = {
     sessionID: SessionID.make("ses_test"),
@@ -52,7 +56,7 @@ async function scan(dir: string, command: string, shell: string) {
     provideInstance(dir)(
       Effect.gen(function* () {
         const permission = yield* ShellPermission
-        yield* permission.ask(ctx, { command, cwd: dir, shell, description: "test" })
+        yield* permission.ask(ctx, { command, cwd: dir, shell, description: "test", escalate: sandbox })
       }),
     ).pipe(Effect.provide(layer)),
   )
@@ -80,6 +84,13 @@ afterEach(async () => {
 })
 
 describe("shell permission scanner fails closed on unparsed commands", () => {
+  test("asks separately before mutating Git when the session sandbox is enabled", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const requests = await scan(tmp.path, "git add . && git commit -m test", "bash", true)
+    expect(requests.map((request) => request.permission)).toEqual(["bash", "sandbox_escalation"])
+    expect(requests[1]?.metadata?.sandboxEscalation).toBe(true)
+  })
+
   test("pwsh: bare '--' git commands now produce a denied pattern", async () => {
     await using tmp = await tmpdir()
     for (const command of ["git checkout -- file", "git restore -- file", "git log -- file", "git checkout -- ."]) {

--- a/packages/opencode/test/tool/truncation.test.ts
+++ b/packages/opencode/test/tool/truncation.test.ts
@@ -242,18 +242,22 @@ describe("Truncate", () => {
   describe("cleanup", () => {
     const DAY_MS = 24 * 60 * 60 * 1000
 
-    it.live("deletes files older than 7 days and preserves recent files", () =>
+    // kilocode_change start - use IDs across the timestamp wrap and set file times explicitly
+    it.live("uses file mtime when IDs wrap", () =>
       Effect.gen(function* () {
         const svc = yield* Truncate.Service
         const fs = yield* FileSystem.FileSystem
 
         yield* fs.makeDirectory(Truncate.DIR, { recursive: true })
 
-        const old = path.join(Truncate.DIR, Identifier.create("tool", "ascending", Date.now() - 10 * DAY_MS))
-        const recent = path.join(Truncate.DIR, Identifier.create("tool", "ascending", Date.now() - 3 * DAY_MS))
+        const old = path.join(Truncate.DIR, Identifier.create("tool", "ascending", 2 ** 36 - 1))
+        const recent = path.join(Truncate.DIR, Identifier.create("tool", "ascending", 2 ** 36 + 1))
 
         yield* writeFileStringScoped(old, "old content")
         yield* writeFileStringScoped(recent, "recent content")
+        yield* fs.utimes(old, new Date(), new Date(Date.now() - 10 * DAY_MS))
+        yield* fs.utimes(recent, new Date(), new Date(Date.now() - 3 * DAY_MS))
+        // kilocode_change end
         yield* svc.cleanup()
 
         expect(yield* fs.exists(old)).toBe(false)

--- a/packages/tui/src/routes/session/permission.tsx
+++ b/packages/tui/src/routes/session/permission.tsx
@@ -334,6 +334,27 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               }
             }
 
+            // kilocode_change start - show sandbox escalation details and keep approval one-shot
+            if (permission === "sandbox_escalation") {
+              const meta = props.request.metadata ?? {}
+              const command = normalizeUrls(
+                typeof data.command === "string" ? data.command : typeof meta.command === "string" ? meta.command : "",
+              )
+              return {
+                icon: "!",
+                title: "Allow Git operation outside the sandbox?",
+                body: (
+                  <box paddingLeft={1} flexDirection="column">
+                    <Show when={command}>
+                      <text fg={theme.text}>{"$ " + command}</text>
+                    </Show>
+                    <text fg={theme.textMuted}>This approval applies to this command only.</text>
+                  </box>
+                ),
+              }
+            }
+            // kilocode_change end
+
             if (permission === "task") {
               const type = typeof data.subagent_type === "string" ? data.subagent_type : "Unknown"
               const desc = typeof data.description === "string" ? data.description : ""
@@ -463,11 +484,12 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
           )
 
           // kilocode_change start - skill shell batches are never persisted: only Allow / Reject
-          const options: Record<string, string> = props.request.metadata?.["skillShell"]
-            ? { once: "Allow", reject: "Reject" }
-            : props.request.metadata?.[ConfigProtection.DISABLE_ALWAYS_KEY]
-              ? { once: "Allow once", reject: "Reject" }
-              : { once: "Allow once", always: "Allow always", reject: "Reject" }
+          const options: Record<string, string> =
+            props.request.metadata?.["skillShell"] || props.request.metadata?.["sandboxEscalation"]
+              ? { once: "Allow", reject: "Reject" }
+              : props.request.metadata?.[ConfigProtection.DISABLE_ALWAYS_KEY]
+                ? { once: "Allow once", reject: "Reject" }
+                : { once: "Allow once", always: "Allow always", reject: "Reject" }
           // kilocode_change end
 
           const body = (


### PR DESCRIPTION
Sandboxed sessions currently cannot complete routine Git state changes because the sandbox denies writes to `.git`, including index lock files. Broadly allowing `.git` would also expose hooks and configuration to untrusted commands.

This change keeps `.git` protected by default and adds a separate, explicit `sandbox_escalation` approval for mutating Git commands. Read-only Git commands remain sandboxed. When a user approves the request, only that shell invocation runs unrestricted, and the approval is one-shot with no `always` option. Automatic approval and headless flows cannot silently approve the escalation.

The flow covers regular shell execution, compound commands, Git environment assignments, CLI/ACP permission presentation, and the VS Code permission dock. Agent Manager worktrees use the same per-command path, so an approved command can update the worktree's own Git metadata without changing the parent checkout.

<img width="700" alt="Git sandbox escalation permission prompt in VS Code" src="https://github.com/marius-kilocode/pr-assets/blob/assets/20260817-sandbox-git-escalation.png?raw=true" />
