### PR TITLE
fix(agent-manager): default worktree session history

### DIFF
--- a/.changeset/worktree-history-default.md
+++ b/.changeset/worktree-history-default.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Open `/sessions` on a git worktree with the Worktree history filter selected by default.

--- a/packages/kilo-vscode/tests/history-accessibility.spec.ts
+++ b/packages/kilo-vscode/tests/history-accessibility.spec.ts
@@ -105,6 +105,9 @@ test.describe("history session accessibility", () => {
 
     const local = page.getByRole("tab", { name: "Local" })
     const worktree = page.getByRole("tab", { name: "Worktree" })
+    await expect(worktree).toHaveAttribute("aria-selected", "true")
+    await expect(page.getByRole("tabpanel", { name: "Worktree" })).toBeVisible()
+
     await local.focus()
     await page.keyboard.press("End")
     await expect(worktree).toBeFocused()

--- a/packages/kilo-vscode/webview-ui/src/components/history/HistoryView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/history/HistoryView.tsx
@@ -29,15 +29,14 @@ const HistoryView: Component<HistoryViewProps> = (props) => {
   const dialog = useDialog()
   const session = useSession()
   const tabs = useLocalTabs()
-  const [tab, setTab] = createSignal<Source>("local")
+  const worktreeIds = () => props.worktreeSessionIds?.()
+  const [tab, setTab] = createSignal<Source>(worktreeIds() ? "worktree" : "local")
   let local: HTMLButtonElement | undefined
   let cloud: HTMLButtonElement | undefined
   let worktree: HTMLButtonElement | undefined
   let localPanel: HTMLDivElement | undefined
   let cloudPanel: HTMLDivElement | undefined
   let worktreePanel: HTMLDivElement | undefined
-
-  const worktreeIds = () => props.worktreeSessionIds?.()
 
   createEffect(() => {
     if (tab() === "worktree" && !worktreeIds()) setTab("local")


### PR DESCRIPTION
When Agent Manager opens session history from a managed git worktree, the history view starts on Local even though the relevant sessions are scoped to that worktree. This makes the expected sessions appear missing and requires an extra filter click.

The history view now initializes to Worktree only when the worktree-session source is available, while normal sidebar history continues to initialize to Local. Accessibility coverage verifies both the selected tab and visible panel, and a patch changeset records the user-facing fix.