### PR TITLE
fix(core): prevent concurrent WAL recovery crashes

### DIFF
--- a/.changeset/calm-sqlite-recovery.md
+++ b/.changeset/calm-sqlite-recovery.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": patch
+---
+
+Prevent concurrent Kilo processes from crashing while recovering the shared SQLite WAL.

--- a/packages/core/src/database/database.ts
+++ b/packages/core/src/database/database.ts
@@ -27,9 +27,11 @@ const layer = Layer.effect(
   Effect.gen(function* () {
     const db = yield* makeDatabase
 
-    yield* db.run("PRAGMA journal_mode = WAL")
-    yield* db.run("PRAGMA synchronous = NORMAL")
+    // kilocode_change start - install SQLite's busy handler before concurrent processes can race to recover the WAL
     yield* db.run("PRAGMA busy_timeout = 5000")
+    yield* db.run("PRAGMA journal_mode = WAL")
+    // kilocode_change end
+    yield* db.run("PRAGMA synchronous = NORMAL")
     yield* db.run("PRAGMA cache_size = -64000")
     yield* db.run("PRAGMA foreign_keys = ON")
     yield* db.run("PRAGMA wal_checkpoint(PASSIVE)")
@@ -42,7 +44,7 @@ const layer = Layer.effect(
 
 export function layerFromPath(filename: string) {
   DbPreflight.assertWritable(filename) // kilocode_change - actionable error (and self-heal for kilo-owned files) instead of an opaque wal_checkpoint crash on read-only db files
-  return layer.pipe(Layer.provide(sqliteLayer({ filename })))
+  return layer.pipe(Layer.provide(sqliteLayer({ filename, disableWAL: true }))) // kilocode_change - Database configures WAL after busy_timeout
 }
 
 export function path() {

--- a/packages/core/test/kilocode/database-recovery.test.ts
+++ b/packages/core/test/kilocode/database-recovery.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Database } from "@opencode-ai/core/database/database"
+import { Effect, Layer } from "effect"
+import { tmpdir } from "../fixture/tmpdir"
+
+const wait = async (dir: string, glob: string, count = 1, end = Date.now() + 5_000): Promise<void> => {
+  const files = await Array.fromAsync(new Bun.Glob(glob).scan({ cwd: dir }))
+  if (files.length >= count) return
+  if (Date.now() >= end) throw new Error(`Timed out waiting for ${glob}`)
+  await Bun.sleep(1)
+  return wait(dir, glob, count, end)
+}
+
+const remove = async (file: string, retry = 30): Promise<void> => {
+  try {
+    await fs.rm(file, { force: true })
+  } catch (err) {
+    if (retry === 0 || !err || typeof err !== "object" || !("code" in err) || err.code !== "EBUSY") throw err
+    await Bun.sleep(100)
+    return remove(file, retry - 1)
+  }
+}
+
+describe("database WAL recovery", () => {
+  test("starts concurrent processes while recovering an abandoned WAL", async () => {
+    await using tmp = await tmpdir()
+    const file = path.join(tmp.path, "kilo.db")
+    await Effect.runPromise(Layer.build(Database.layerFromPath(file).pipe(Layer.fresh)).pipe(Effect.scoped))
+
+    const worker = path.join(import.meta.dir, "fixture/database-recovery-worker.ts")
+    const seed = Bun.spawn([process.execPath, worker, "seed", tmp.path], { stdout: "ignore", stderr: "pipe" })
+    try {
+      await wait(tmp.path, "seed-ready")
+    } finally {
+      if (seed.exitCode === null) seed.kill(9)
+      await seed.exited
+    }
+
+    await remove(`${file}-shm`)
+    const children: (typeof seed)[] = []
+    try {
+      for (const _ of Array.from({ length: 12 }))
+        children.push(Bun.spawn([process.execPath, worker, "open", tmp.path], { stdout: "ignore", stderr: "pipe" }))
+      await wait(tmp.path, "open-ready-*", children.length)
+      await Bun.write(path.join(tmp.path, "start"), "")
+
+      const statuses = await Promise.all(children.map((child) => child.exited))
+      const errors = await Promise.all(children.map((child) => new Response(child.stderr).text()))
+      if (statuses.some((status) => status !== 0)) throw new Error(errors.filter(Boolean).join("\n"))
+      expect(statuses).toEqual(Array.from({ length: children.length }, () => 0))
+    } finally {
+      for (const child of children) if (child.exitCode === null) child.kill(9)
+      await Promise.all(children.map((child) => child.exited))
+    }
+  }, 20_000)
+})

--- a/packages/core/test/kilocode/fixture/database-recovery-worker.ts
+++ b/packages/core/test/kilocode/fixture/database-recovery-worker.ts
@@ -1,0 +1,30 @@
+import { Database as SQLite } from "bun:sqlite"
+import path from "path"
+import { Database } from "@opencode-ai/core/database/database"
+import { Effect, Layer } from "effect"
+
+const mode = process.argv[2]
+const dir = process.argv[3]
+if (!mode || !dir) throw new Error("Expected mode and data directory")
+
+const file = path.join(dir, "kilo.db")
+
+if (mode === "seed") {
+  const sqlite = new SQLite(file)
+  sqlite.run("PRAGMA journal_mode = WAL")
+  sqlite.run("PRAGMA wal_autocheckpoint = 0")
+  sqlite.run("CREATE TABLE recovery_load (value BLOB)")
+  const insert = sqlite.prepare("INSERT INTO recovery_load VALUES (?)")
+  const value = new Uint8Array(4096)
+  sqlite.transaction(() => {
+    for (const _ of Array.from({ length: 1_000 })) insert.run(value)
+  })()
+  await Bun.write(path.join(dir, "seed-ready"), "")
+  await new Promise(() => {})
+}
+
+if (mode === "open") {
+  await Bun.write(path.join(dir, `open-ready-${process.pid}`), "")
+  while (!(await Bun.file(path.join(dir, "start")).exists())) await Bun.sleep(1)
+  await Effect.runPromise(Layer.build(Database.layerFromPath(file).pipe(Layer.fresh)).pipe(Effect.scoped))
+}


### PR DESCRIPTION
## Issue

Fixes #13028

## Context

Concurrent Kilo processes can crash with `SQLITE_BUSY_RECOVERY` when they open a shared database whose abandoned WAL requires recovery. WAL initialization currently runs before SQLite's busy handler is installed, so competing openers fail immediately instead of waiting.

## Implementation

Defer WAL initialization from the SQLite driver to the Kilo database layer, then install `busy_timeout` before enabling WAL. A real multi-process regression creates an abandoned WAL and races 12 Kilo database openers through the full startup path.

## Screenshots / Video

N/A — non-visual database startup fix.

## How to Test

### Manual/local verification

- Agent ran the regression against the pre-fix control and reproduced `errno: 261` / `SQLITE_BUSY_RECOVERY` on the first run.
- Agent ran the fixed regression 10 consecutive times successfully, covering 120 concurrent openers.
- Agent ran the focused recovery and migration compatibility tests: 7 passed.
- Agent ran the core and repository pre-push typechecks successfully.
- Agent ran the OpenCode annotation guard and `git diff --check` successfully.

### Reviewer test steps

1. Run `cd packages/core`.
2. Run `bun test test/kilocode/database-recovery.test.ts test/kilocode/database-migration-compat.test.ts`.

### Blocked checks and substitute verification

- None.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

N/A
