### PR TITLE
fix(vscode): launch isolated host without cmd shell on Windows

### DIFF
--- a/.changeset/windows-isolated-launch.md
+++ b/.changeset/windows-isolated-launch.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix isolated Extension Development Host launch on Windows when VS Code is installed under a path that contains spaces.

--- a/.changeset/windows-isolated-launch.md
+++ b/.changeset/windows-isolated-launch.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Fix isolated Extension Development Host launch on Windows when VS Code is installed under a path that contains spaces.
+Fix isolated Extension Development Host launch on Windows when VS Code is installed under a path that contains spaces. Prefer `Code.exe` over `code.cmd`; keep a cmd shell only for leftover batch shims.

--- a/packages/kilo-vscode/script/launch.ts
+++ b/packages/kilo-vscode/script/launch.ts
@@ -32,7 +32,8 @@ import { createHash } from "node:crypto"
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs"
 import { homedir, tmpdir } from "node:os"
 import { delimiter, join, resolve } from "node:path"
-import { spawn } from "node:child_process"
+import { spawn, spawnSync } from "node:child_process"
+import { preferWindowsGuiExecutable, spawnNeedsWindowsShell, windowsPathExtensions } from "./windows-app"
 
 const win = process.platform === "win32"
 const root = join(import.meta.dir, "..")
@@ -124,7 +125,7 @@ const accessible = opts["accessible"] === true
 
 function which(name: string): string | null {
   const paths = (process.env.PATH ?? "").split(delimiter).filter(Boolean)
-  const exts = win ? [".cmd", ".exe", ".bat", ""] : [""]
+  const exts = win ? windowsPathExtensions() : [""]
 
   for (const dir of paths) {
     for (const ext of exts) {
@@ -138,7 +139,7 @@ function which(name: string): string | null {
 
 function detect(): string {
   const env = explicit ?? process.env["VSCODE_EXEC_PATH"]
-  if (env && existsSync(env)) return env
+  if (env && existsSync(env)) return win ? preferWindowsGuiExecutable(env) : env
 
   const candidates: string[] = []
   const prefer = insiders ? "insiders" : "stable"
@@ -193,7 +194,7 @@ function detect(): string {
 
   // Last resort: PATH lookup
   const path = insiders ? (which("code-insiders") ?? which("code")) : (which("code") ?? which("code-insiders"))
-  if (path) return path
+  if (path) return win ? preferWindowsGuiExecutable(path) : path
 
   console.error(
     `Could not find VS Code. Set VSCODE_EXEC_PATH or pass --app-path.\n` +
@@ -384,6 +385,16 @@ async function launch() {
   console.log(`[launch] Accessibility support: ${accessible ? "on" : "off"}`)
 
   if (blocking) {
+    if (spawnNeedsWindowsShell(app)) {
+      const result = spawnSync(app, args, {
+        cwd: workspace,
+        env,
+        stdio: ["ignore", "inherit", "inherit"],
+        shell: true,
+      })
+      console.log(`[launch] VS Code exited (code ${result.status})`)
+      return
+    }
     const result = Bun.spawnSync([app, ...args], {
       cwd: workspace,
       env,
@@ -393,13 +404,14 @@ async function launch() {
     return
   }
 
-  // Do not set `shell: true` on Windows. cmd.exe splits Code.exe paths that
-  // contain spaces (for example `Microsoft VS Code`), so the isolated host never starts.
+  // Do not wrap Code.exe in cmd.exe: paths with spaces (Microsoft VS Code) get split.
+  // Keep a shell only for leftover .cmd/.bat shims that CreateProcess cannot run.
   const child = spawn(app, args, {
     cwd: workspace,
     detached: !win,
     env,
     stdio: "ignore",
+    ...(spawnNeedsWindowsShell(app) ? { shell: true } : {}),
   })
   child.unref()
 

--- a/packages/kilo-vscode/script/launch.ts
+++ b/packages/kilo-vscode/script/launch.ts
@@ -393,12 +393,13 @@ async function launch() {
     return
   }
 
+  // Do not set `shell: true` on Windows. cmd.exe splits Code.exe paths that
+  // contain spaces (for example `Microsoft VS Code`), so the isolated host never starts.
   const child = spawn(app, args, {
     cwd: workspace,
     detached: !win,
     env,
     stdio: "ignore",
-    ...(win ? { shell: true } : {}),
   })
   child.unref()
 

--- a/packages/kilo-vscode/script/windows-app.ts
+++ b/packages/kilo-vscode/script/windows-app.ts
@@ -1,0 +1,32 @@
+import { existsSync } from "node:fs"
+import { basename, dirname, join, resolve } from "node:path"
+
+export function isWindowsBatchFile(app: string): boolean {
+  return /\.(cmd|bat)$/i.test(app)
+}
+
+/** PATH lookup order on Windows: GUI exe first so `bin\code.cmd` is not preferred. */
+export function windowsPathExtensions(): string[] {
+  return [".exe", ".cmd", ".bat", ""]
+}
+
+/**
+ * VS Code's PATH entry is often `...\Microsoft VS Code\bin\code.cmd`.
+ * The GUI host is the sibling `Code.exe`. Prefer that so spawn() does not need cmd.exe.
+ */
+export function preferWindowsGuiExecutable(app: string): string {
+  if (!isWindowsBatchFile(app)) return app
+  const dir = dirname(app)
+  const insiders = basename(app).toLowerCase().includes("insiders")
+  const exeName = insiders ? "Code - Insiders.exe" : "Code.exe"
+  const nextToBin = resolve(dir, "..", exeName)
+  if (existsSync(nextToBin)) return nextToBin
+  const sameDir = join(dir, exeName)
+  if (existsSync(sameDir)) return sameDir
+  return app
+}
+
+/** cmd.exe is required to run leftover .cmd/.bat; it must not wrap Code.exe paths with spaces. */
+export function spawnNeedsWindowsShell(app: string): boolean {
+  return isWindowsBatchFile(app)
+}

--- a/packages/kilo-vscode/tests/unit/windows-app.test.ts
+++ b/packages/kilo-vscode/tests/unit/windows-app.test.ts
@@ -1,0 +1,40 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import { describe, expect, test } from "bun:test"
+import {
+  isWindowsBatchFile,
+  preferWindowsGuiExecutable,
+  spawnNeedsWindowsShell,
+  windowsPathExtensions,
+} from "../../script/windows-app"
+
+describe("windows launch app", () => {
+  test("PATH lookup prefers .exe before .cmd", () => {
+    expect(windowsPathExtensions()[0]).toBe(".exe")
+    expect(windowsPathExtensions()).toContain(".cmd")
+  })
+
+  test("shell is required only for leftover batch files", () => {
+    expect(isWindowsBatchFile("C:\\Tools\\code.cmd")).toBe(true)
+    expect(isWindowsBatchFile("C:\\Tools\\code.bat")).toBe(true)
+    expect(isWindowsBatchFile("C:\\Program Files\\Microsoft VS Code\\Code.exe")).toBe(false)
+    expect(spawnNeedsWindowsShell("C:\\Program Files\\Microsoft VS Code\\Code.exe")).toBe(false)
+    expect(spawnNeedsWindowsShell("C:\\Scoop\\shims\\code.cmd")).toBe(true)
+  })
+
+  test("resolves bin\\code.cmd to sibling Code.exe when it exists", () => {
+    const root = join(tmpdir(), `kilo-code-layout-${Date.now()}`)
+    const bin = join(root, "bin")
+    mkdirSync(bin, { recursive: true })
+    writeFileSync(join(bin, "code.cmd"), "@echo off\n")
+    writeFileSync(join(root, "Code.exe"), "")
+    expect(preferWindowsGuiExecutable(join(bin, "code.cmd"))).toBe(join(root, "Code.exe"))
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  test("keeps a batch shim when no Code.exe is next to it", () => {
+    const cmd = join(tmpdir(), "scoop-shims", "code.cmd")
+    expect(preferWindowsGuiExecutable(cmd)).toBe(cmd)
+  })
+})


### PR DESCRIPTION
## Summary
- Stop using `spawn(..., { shell: true })` when launching the isolated VS Code host on Windows.
- `cmd.exe` splits `Code.exe` paths that contain spaces (for example `Microsoft VS Code`), so the Extension Development Host never starts.

## Test plan
- [ ] On Windows, with VS Code installed under `...\Microsoft VS Code\Code.exe`, run `bun run extension:isolated`
- [ ] Confirm an `[Extension Development Host]` window stays open
- [ ] macOS/Linux launch still works (`detached: true`, no shell)
