### PR TITLE
feat: queue Agent Manager prompts until idle and add managed-session primitives

### DIFF
--- a/.changeset/managed-session-foundation.md
+++ b/.changeset/managed-session-foundation.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Queue Agent Manager prompts while a session is busy, persist them for safe resume, and add generic managed-session primitives with a clock-based stall watchdog.

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ tsconfig.tsbuildinfo
 
 # Kilo
 .kilo/.gitignore
+.kilo/managed-inbox/
 .kilo/package.json
 .kilo/package-lock.json
 .kilo/pnpm-lock.yaml

--- a/bun.lock
+++ b/bun.lock
@@ -279,6 +279,16 @@
         "vitest": "4.1.0",
       },
     },
+    "packages/kilo-foundation": {
+      "name": "@kilocode/kilo-foundation",
+      "version": "7.4.22",
+      "devDependencies": {
+        "@tsconfig/bun": "catalog:",
+        "@types/bun": "catalog:",
+        "@typescript/native-preview": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "packages/kilo-gateway": {
       "name": "@kilocode/kilo-gateway",
       "version": "7.4.22",
@@ -359,7 +369,7 @@
     },
     "packages/kilo-jetbrains": {
       "name": "@kilocode/kilo-jetbrains",
-      "version": "7.4.21",
+      "version": "7.4.22",
     },
     "packages/kilo-memory": {
       "name": "@kilocode/kilo-memory",
@@ -447,6 +457,7 @@
       "version": "7.4.22",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
+        "@kilocode/kilo-foundation": "workspace:*",
         "@kilocode/kilo-gateway": "workspace:*",
         "@kilocode/kilo-i18n": "workspace:*",
         "@kilocode/kilo-indexing": "workspace:*",
@@ -1693,6 +1704,8 @@
     "@kilocode/kilo-console": ["@kilocode/kilo-console@workspace:packages/kilo-console"],
 
     "@kilocode/kilo-docs": ["@kilocode/kilo-docs@workspace:packages/kilo-docs"],
+
+    "@kilocode/kilo-foundation": ["@kilocode/kilo-foundation@workspace:packages/kilo-foundation"],
 
     "@kilocode/kilo-gateway": ["@kilocode/kilo-gateway@workspace:packages/kilo-gateway"],
 

--- a/packages/kilo-foundation/package.json
+++ b/packages/kilo-foundation/package.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "name": "@kilocode/kilo-foundation",
+  "version": "7.4.22",
+  "type": "module",
+  "license": "MIT",
+  "description": "Generic managed-session primitives: inbox, safe resume, lifecycle, stall watchdog. Upstream-candidate; no product-specific team roles.",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "typecheck": "tsgo --noEmit",
+    "build": "tsc",
+    "test": "bun test",
+    "test:ci": "mkdir -p .artifacts/unit && bun test --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml"
+  },
+  "devDependencies": {
+    "@tsconfig/bun": "catalog:",
+    "@types/bun": "catalog:",
+    "typescript": "catalog:",
+    "@typescript/native-preview": "catalog:"
+  }
+}

--- a/packages/kilo-foundation/src/__tests__/kilo-status.test.ts
+++ b/packages/kilo-foundation/src/__tests__/kilo-status.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test"
+import { mapKiloRuntimeActivity, mapKiloRuntimeStatus } from "../kilo-status"
+import { resumeDecision } from "../resume"
+import { assertSessionIsolation } from "../lifecycle"
+
+describe("kilo runtime status mapping", () => {
+  test("maps idle to a safe deliver/resume boundary", () => {
+    expect(mapKiloRuntimeStatus("idle")).toBe("reachable")
+    expect(resumeDecision(mapKiloRuntimeStatus("idle"))).toBe("resume")
+    expect(mapKiloRuntimeActivity("idle")).toBe("idle")
+  })
+
+  test("does not deliver while busy or retrying", () => {
+    expect(resumeDecision(mapKiloRuntimeStatus("busy"))).toBe("wait")
+    expect(resumeDecision(mapKiloRuntimeStatus("retry"))).toBe("wait")
+  })
+
+  test("treats offline as paused so restore can resume", () => {
+    expect(mapKiloRuntimeStatus("offline")).toBe("paused")
+    expect(resumeDecision(mapKiloRuntimeStatus("offline"))).toBe("resume")
+  })
+})
+
+describe("session isolation", () => {
+  test("rejects an isolated session at the workspace root", () => {
+    expect(() =>
+      assertSessionIsolation({
+        workspaceRoot: "C:\\repo",
+        sessionDirectory: "C:\\repo",
+        isolated: true,
+      }),
+    ).toThrow("workspace root")
+  })
+
+  test("allows a worktree path under the root", () => {
+    expect(() =>
+      assertSessionIsolation({
+        workspaceRoot: "C:\\repo",
+        sessionDirectory: "C:\\repo\\.kilo\\worktrees\\wt-1",
+        isolated: true,
+      }),
+    ).not.toThrow()
+  })
+})

--- a/packages/kilo-foundation/src/__tests__/kilo-status.test.ts
+++ b/packages/kilo-foundation/src/__tests__/kilo-status.test.ts
@@ -41,4 +41,17 @@ describe("session isolation", () => {
       }),
     ).not.toThrow()
   })
+
+  test("rejects an isolated session at the workspace root ignoring Windows path casing", () => {
+    const mixed = {
+      workspaceRoot: "C:\\Repo",
+      sessionDirectory: "C:\\repo",
+      isolated: true,
+    }
+    if (process.platform === "win32") {
+      expect(() => assertSessionIsolation(mixed)).toThrow("workspace root")
+    } else {
+      expect(() => assertSessionIsolation(mixed)).not.toThrow()
+    }
+  })
 })

--- a/packages/kilo-foundation/src/__tests__/layer-boundary.test.ts
+++ b/packages/kilo-foundation/src/__tests__/layer-boundary.test.ts
@@ -1,0 +1,32 @@
+import { readdir, readFile } from "node:fs/promises"
+import path from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const srcRoot = path.join(import.meta.dir, "..")
+
+async function collectTs(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true })
+  const files: string[] = []
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name === "__tests__") continue
+      files.push(...(await collectTs(full)))
+    } else if (entry.name.endsWith(".ts")) {
+      files.push(full)
+    }
+  }
+  return files
+}
+
+describe("kilo-foundation stays generic", () => {
+  test("source does not name AutoAITeam product roles or task statuses", async () => {
+    const files = await collectTs(srcRoot)
+    expect(files.length).toBeGreaterThan(0)
+    const banned = /Engineering Manager|Reviewer|Tester|Discovery|MILESTONE_GATE|REVIEW_APPROVED|TEST_FAILED|DB_AGENT/
+    for (const file of files) {
+      const source = await readFile(file, "utf8")
+      expect(source, file).not.toMatch(banned)
+    }
+  })
+})

--- a/packages/kilo-foundation/src/__tests__/layer-boundary.test.ts
+++ b/packages/kilo-foundation/src/__tests__/layer-boundary.test.ts
@@ -20,7 +20,7 @@ async function collectTs(dir: string): Promise<string[]> {
 }
 
 describe("kilo-foundation stays generic", () => {
-  test("source does not name AutoAITeam product roles or task statuses", async () => {
+  test("source does not name product-specific team roles or task statuses", async () => {
     const files = await collectTs(srcRoot)
     expect(files.length).toBeGreaterThan(0)
     const banned = /Engineering Manager|Reviewer|Tester|Discovery|MILESTONE_GATE|REVIEW_APPROVED|TEST_FAILED|DB_AGENT/

--- a/packages/kilo-foundation/src/__tests__/session-inbox.test.ts
+++ b/packages/kilo-foundation/src/__tests__/session-inbox.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import {
+  consumeManagedBatch,
+  enqueueManaged,
+  shouldWakeCoordinator,
+  unconsumedManaged,
+} from "../session-inbox"
+import { FOUNDATION_EVENT, FOUNDATION_WAKE_TYPES, type ManagedEvent } from "../types"
+
+type GenericType = "CHILD_DONE" | "HEARTBEAT"
+
+function event(type: GenericType, id: string, createdAt: string): ManagedEvent<GenericType> {
+  return {
+    id,
+    type,
+    payload: {},
+    createdAt,
+  }
+}
+
+function key(item: ManagedEvent<GenericType>): string {
+  return `${item.type}:${item.payload["job"] ?? ""}`
+}
+
+describe("foundation session inbox", () => {
+  test("dedupes unconsumed events by caller key without product types", () => {
+    const items: ManagedEvent<GenericType>[] = []
+    const first = event("CHILD_DONE", "a", "2026-08-16T10:00:00.000Z")
+    first.payload = { job: "1" }
+    const duplicate = event("CHILD_DONE", "b", "2026-08-16T10:00:01.000Z")
+    duplicate.payload = { job: "1" }
+
+    enqueueManaged(items, first, key)
+    enqueueManaged(items, duplicate, key)
+
+    expect(unconsumedManaged(items)).toHaveLength(1)
+    expect(unconsumedManaged(items)[0]?.id).toBe("a")
+  })
+
+  test("consumeManagedBatch marks the oldest events consumed", () => {
+    const items: ManagedEvent<GenericType>[] = []
+    const older = event("CHILD_DONE", "old", "2026-08-16T10:00:00.000Z")
+    const newer = event("CHILD_DONE", "new", "2026-08-16T10:00:01.000Z")
+    enqueueManaged(items, newer, (item) => item.id)
+    enqueueManaged(items, older, (item) => item.id)
+
+    const batch = consumeManagedBatch(items, 1, "2026-08-16T11:00:00.000Z")
+    expect(batch[0]?.id).toBe("old")
+    expect(batch[0]?.consumedAt).toBe("2026-08-16T11:00:00.000Z")
+    expect(unconsumedManaged(items)[0]?.id).toBe("new")
+  })
+
+  test("wake policy is a caller-supplied set", () => {
+    const wake = new Set<GenericType>(["CHILD_DONE"])
+    expect(shouldWakeCoordinator("CHILD_DONE", wake)).toBe(true)
+    expect(shouldWakeCoordinator("HEARTBEAT", wake)).toBe(false)
+    expect(shouldWakeCoordinator(FOUNDATION_EVENT.MESSAGE_RECEIVED, FOUNDATION_WAKE_TYPES)).toBe(true)
+    expect(shouldWakeCoordinator(FOUNDATION_EVENT.STALLED, FOUNDATION_WAKE_TYPES)).toBe(true)
+    expect(shouldWakeCoordinator(FOUNDATION_EVENT.STATUS_CHANGED, FOUNDATION_WAKE_TYPES)).toBe(false)
+  })
+})

--- a/packages/kilo-foundation/src/__tests__/session-inbox.test.ts
+++ b/packages/kilo-foundation/src/__tests__/session-inbox.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test"
 import {
+  compactConsumed,
   consumeManagedBatch,
   enqueueManaged,
+  forgetManagedSession,
   shouldWakeCoordinator,
   unconsumedManaged,
 } from "../session-inbox"
@@ -57,5 +59,24 @@ describe("foundation session inbox", () => {
     expect(shouldWakeCoordinator(FOUNDATION_EVENT.MESSAGE_RECEIVED, FOUNDATION_WAKE_TYPES)).toBe(true)
     expect(shouldWakeCoordinator(FOUNDATION_EVENT.STALLED, FOUNDATION_WAKE_TYPES)).toBe(true)
     expect(shouldWakeCoordinator(FOUNDATION_EVENT.STATUS_CHANGED, FOUNDATION_WAKE_TYPES)).toBe(false)
+  })
+
+  test("compactConsumed drops consumed events and forgetManagedSession drops a session", () => {
+    const items: ManagedEvent<GenericType>[] = []
+    const kept = event("CHILD_DONE", "keep", "2026-08-16T10:00:00.000Z")
+    kept.sessionId = "s1"
+    const gone = event("HEARTBEAT", "gone", "2026-08-16T10:00:01.000Z")
+    gone.sessionId = "s1"
+    gone.consumedAt = "2026-08-16T11:00:00.000Z"
+    const other = event("CHILD_DONE", "other", "2026-08-16T10:00:02.000Z")
+    other.sessionId = "s2"
+    enqueueManaged(items, kept, (item) => item.id)
+    enqueueManaged(items, gone, (item) => item.id)
+    enqueueManaged(items, other, (item) => item.id)
+
+    compactConsumed(items)
+    expect(items.map((item) => item.id)).toEqual(["keep", "other"])
+    forgetManagedSession(items, "s1")
+    expect(items.map((item) => item.id)).toEqual(["other"])
   })
 })

--- a/packages/kilo-foundation/src/__tests__/session-messaging.test.ts
+++ b/packages/kilo-foundation/src/__tests__/session-messaging.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from "node:fs"
+import { mkdtempSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import { describe, expect, test } from "bun:test"
@@ -16,9 +16,10 @@ describe("file-backed session messenger", () => {
     expect(await messenger.listSessions()).toEqual([id])
   })
 
-  test("lists and consumes pending envelopes in order", async () => {
+  test("lists and consumes pending envelopes in createdAt order", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "kilo-foundation-pending-"))
-    const messenger = new FileBackedSessionMessenger(root)
+    let now = 1_700_000_000_000
+    const messenger = new FileBackedSessionMessenger(root, { now: () => now++ })
     const id = await messenger.createSession("s1")
     await messenger.sendQueued(id, "first", "/repo")
     await messenger.sendQueued(id, "second", "/repo")
@@ -27,5 +28,28 @@ describe("file-backed session messenger", () => {
     const consumed = await messenger.consumePending(id, 1)
     expect(consumed.map((item) => item.message)).toEqual(["first"])
     expect((await messenger.listPending(id)).map((item) => item.message)).toEqual(["second"])
+  })
+
+  test("does not unlink unreadable envelopes and keeps remaining files after a consume", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "kilo-foundation-corrupt-"))
+    let now = 1_700_000_000_000
+    const messenger = new FileBackedSessionMessenger(root, { now: () => now++ })
+    const id = await messenger.createSession("s1")
+    await messenger.sendQueued(id, "keep", "/repo")
+    writeFileSync(path.join(root, id, "0-corrupt.json"), "{not-json", "utf8")
+    const listed = await messenger.listPending(id)
+    expect(listed.map((item) => item.message)).toEqual(["keep"])
+    const consumed = await messenger.consumePending(id, 1)
+    expect(consumed.map((item) => item.message)).toEqual(["keep"])
+    expect(await messenger.listPending(id)).toEqual([])
+  })
+
+  test("persists extra fields on queued envelopes", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "kilo-foundation-extra-"))
+    const messenger = new FileBackedSessionMessenger(root, { now: () => 1_700_000_000_000 })
+    const id = await messenger.createSession("s1")
+    await messenger.sendQueued(id, "later", "/repo", { messageID: "msg_1", noReply: true })
+    const pending = await messenger.listPending(id)
+    expect(pending[0]?.extra).toEqual({ messageID: "msg_1", noReply: true })
   })
 })

--- a/packages/kilo-foundation/src/__tests__/session-messaging.test.ts
+++ b/packages/kilo-foundation/src/__tests__/session-messaging.test.ts
@@ -15,4 +15,17 @@ describe("file-backed session messenger", () => {
     expect(probe.sessionCount).toBe(1)
     expect(await messenger.listSessions()).toEqual([id])
   })
+
+  test("lists and consumes pending envelopes in order", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "kilo-foundation-pending-"))
+    const messenger = new FileBackedSessionMessenger(root)
+    const id = await messenger.createSession("s1")
+    await messenger.sendQueued(id, "first", "/repo")
+    await messenger.sendQueued(id, "second", "/repo")
+    const listed = await messenger.listPending(id)
+    expect(listed.map((item) => item.message)).toEqual(["first", "second"])
+    const consumed = await messenger.consumePending(id, 1)
+    expect(consumed.map((item) => item.message)).toEqual(["first"])
+    expect((await messenger.listPending(id)).map((item) => item.message)).toEqual(["second"])
+  })
 })

--- a/packages/kilo-foundation/src/__tests__/session-messaging.test.ts
+++ b/packages/kilo-foundation/src/__tests__/session-messaging.test.ts
@@ -1,0 +1,18 @@
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { describe, expect, test } from "bun:test"
+import { FileBackedSessionMessenger } from "../session-messaging"
+
+describe("file-backed session messenger", () => {
+  test("creates a session and persists a message without polling", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "kilo-foundation-inbox-"))
+    const messenger = new FileBackedSessionMessenger(root)
+    const id = await messenger.createSession("child-1")
+    await messenger.sendMessage(id, "hello")
+    const probe = await messenger.probe()
+    expect(probe.reachable).toBe(true)
+    expect(probe.sessionCount).toBe(1)
+    expect(await messenger.listSessions()).toEqual([id])
+  })
+})

--- a/packages/kilo-foundation/src/__tests__/watchdog.test.ts
+++ b/packages/kilo-foundation/src/__tests__/watchdog.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test"
+import { canSafelyResume, resumeDecision } from "../resume"
+import { detectSessionStall, scanSessionStalls, suggestEscalation } from "../watchdog"
+import { GENERIC_RETRY_POLICY } from "../types"
+
+describe("foundation watchdog and resume", () => {
+  test("detects stall only for active sessions past the idle window", () => {
+    expect(
+      detectSessionStall({
+        status: "running",
+        nowIso: "2026-08-16T12:20:00.000Z",
+        lastProgressIso: "2026-08-16T12:00:00.000Z",
+        stallAfterMs: 15 * 60 * 1000,
+      }),
+    ).toBe(true)
+
+    expect(
+      detectSessionStall({
+        status: "idle",
+        nowIso: "2026-08-16T12:20:00.000Z",
+        lastProgressIso: "2026-08-16T12:00:00.000Z",
+      }),
+    ).toBe(false)
+  })
+
+  test("escalates with generic coordinator language", () => {
+    expect(suggestEscalation(GENERIC_RETRY_POLICY.workerAttempts - 1)).toBe("retry")
+    expect(suggestEscalation(GENERIC_RETRY_POLICY.workerAttempts)).toBe("debug")
+    expect(suggestEscalation(GENERIC_RETRY_POLICY.workerAttempts + GENERIC_RETRY_POLICY.debugEscalation)).toBe(
+      "coordinator",
+    )
+  })
+
+  test("resumes only on a safe lifecycle boundary", () => {
+    expect(canSafelyResume("paused")).toBe(true)
+    expect(canSafelyResume("running")).toBe(false)
+    expect(resumeDecision("running")).toBe("wait")
+    expect(resumeDecision("failed")).toBe("fail")
+  })
+
+  test("scanSessionStalls returns only active sessions past the window", () => {
+    const stalled = scanSessionStalls(
+      [
+        {
+          sessionId: "busy-silent",
+          activity: "running",
+          lastProgressIso: "2026-08-16T12:00:00.000Z",
+        },
+        {
+          sessionId: "idle",
+          activity: "idle",
+          lastProgressIso: "2026-08-16T12:00:00.000Z",
+        },
+      ],
+      "2026-08-16T12:20:00.000Z",
+      15 * 60 * 1000,
+    )
+    expect(stalled.map((item) => item.sessionId)).toEqual(["busy-silent"])
+  })
+})

--- a/packages/kilo-foundation/src/index.ts
+++ b/packages/kilo-foundation/src/index.ts
@@ -1,0 +1,33 @@
+export { canSafelyResume, resumeDecision } from "./resume"
+export {
+  consumeManagedBatch,
+  enqueueManaged,
+  shouldWakeCoordinator,
+  unconsumedManaged,
+} from "./session-inbox"
+export { FileBackedSessionMessenger } from "./session-messaging"
+export type { SessionEnvelope } from "./session-messaging"
+export { assertSessionIsolation, isSessionReachable, toLifecycleStatus } from "./lifecycle"
+export { createGenericTelemetry, recordCoordinatorWake, recordResume, recordStall } from "./telemetry"
+export { detectSessionStall, scanSessionStalls, suggestEscalation } from "./watchdog"
+export type { SessionProgress } from "./watchdog"
+export { mapKiloRuntimeActivity, mapKiloRuntimeStatus } from "./kilo-status"
+export {
+  DEFAULT_STALL_AFTER_MS,
+  FOUNDATION_EVENT,
+  FOUNDATION_WAKE_TYPES,
+  GENERIC_RETRY_POLICY,
+} from "./types"
+export type {
+  Escalation,
+  FoundationEventType,
+  GenericTelemetry,
+  KiloRuntimeStatus,
+  ManagedEvent,
+  ManagedSessionClient,
+  RetryPolicy,
+  SessionActivityStatus,
+  SessionId,
+  SessionLifecycleStatus,
+  SessionProbeResult,
+} from "./types"

--- a/packages/kilo-foundation/src/index.ts
+++ b/packages/kilo-foundation/src/index.ts
@@ -1,7 +1,9 @@
 export { canSafelyResume, resumeDecision } from "./resume"
 export {
+  compactConsumed,
   consumeManagedBatch,
   enqueueManaged,
+  forgetManagedSession,
   shouldWakeCoordinator,
   unconsumedManaged,
 } from "./session-inbox"

--- a/packages/kilo-foundation/src/kilo-status.ts
+++ b/packages/kilo-foundation/src/kilo-status.ts
@@ -1,0 +1,39 @@
+import type { KiloRuntimeStatus, SessionActivityStatus, SessionLifecycleStatus } from "./types"
+
+/**
+ * Map Kilo `session.status` runtime values onto generic lifecycle/activity.
+ *
+ * idle     → reachable (safe to deliver or resume)
+ * busy     → running (mid-generation; wait)
+ * retry    → starting (provider backoff; do not pile on)
+ * offline  → paused (network; resume after restore)
+ */
+export function mapKiloRuntimeStatus(status: KiloRuntimeStatus | string | undefined): SessionLifecycleStatus {
+  switch (status) {
+    case "idle":
+      return "reachable"
+    case "busy":
+      return "running"
+    case "retry":
+      return "starting"
+    case "offline":
+      return "paused"
+    default:
+      return "unknown"
+  }
+}
+
+export function mapKiloRuntimeActivity(status: KiloRuntimeStatus | string | undefined): SessionActivityStatus {
+  switch (status) {
+    case "idle":
+      return "idle"
+    case "busy":
+      return "running"
+    case "retry":
+      return "waiting"
+    case "offline":
+      return "blocked"
+    default:
+      return "stopped"
+  }
+}

--- a/packages/kilo-foundation/src/lifecycle.ts
+++ b/packages/kilo-foundation/src/lifecycle.ts
@@ -1,0 +1,28 @@
+import type { SessionLifecycleStatus } from "./types"
+
+export function toLifecycleStatus(status: SessionLifecycleStatus): SessionLifecycleStatus {
+  return status
+}
+
+export function isSessionReachable(status: SessionLifecycleStatus): boolean {
+  return status === "reachable" || status === "running" || status === "paused" || status === "stalled"
+}
+
+/**
+ * Worktree/session isolation: a session directory must not be the parent
+ * workspace root when isolation is required.
+ */
+export function assertSessionIsolation(input: {
+  workspaceRoot: string
+  sessionDirectory: string
+  isolated: boolean
+}): void {
+  if (!input.isolated) {
+    return
+  }
+  const root = input.workspaceRoot.replace(/[\\/]+$/, "")
+  const session = input.sessionDirectory.replace(/[\\/]+$/, "")
+  if (session === root) {
+    throw new Error("Isolated session directory must not be the workspace root.")
+  }
+}

--- a/packages/kilo-foundation/src/lifecycle.ts
+++ b/packages/kilo-foundation/src/lifecycle.ts
@@ -12,6 +12,11 @@ export function isSessionReachable(status: SessionLifecycleStatus): boolean {
  * Worktree/session isolation: a session directory must not be the parent
  * workspace root when isolation is required.
  */
+function normalizeIsolationPath(value: string): string {
+  const trimmed = value.replace(/[\\/]+$/, "").replace(/\\/g, "/")
+  return process.platform === "win32" ? trimmed.toLowerCase() : trimmed
+}
+
 export function assertSessionIsolation(input: {
   workspaceRoot: string
   sessionDirectory: string
@@ -20,8 +25,8 @@ export function assertSessionIsolation(input: {
   if (!input.isolated) {
     return
   }
-  const root = input.workspaceRoot.replace(/[\\/]+$/, "")
-  const session = input.sessionDirectory.replace(/[\\/]+$/, "")
+  const root = normalizeIsolationPath(input.workspaceRoot)
+  const session = normalizeIsolationPath(input.sessionDirectory)
   if (session === root) {
     throw new Error("Isolated session directory must not be the workspace root.")
   }

--- a/packages/kilo-foundation/src/resume.ts
+++ b/packages/kilo-foundation/src/resume.ts
@@ -1,0 +1,26 @@
+import type { SessionLifecycleStatus } from "./types"
+
+const RESUMABLE: ReadonlySet<SessionLifecycleStatus> = new Set(["reachable", "paused", "stalled"])
+
+const UNSAFE: ReadonlySet<SessionLifecycleStatus> = new Set(["starting", "running", "unknown"])
+
+/**
+ * Automatic safe resume: only resume when the session is not mid-generation
+ * and the lifecycle status is a known safe boundary.
+ */
+export function canSafelyResume(status: SessionLifecycleStatus): boolean {
+  return RESUMABLE.has(status)
+}
+
+export function resumeDecision(status: SessionLifecycleStatus): "resume" | "wait" | "fail" {
+  if (canSafelyResume(status)) {
+    return "resume"
+  }
+  if (status === "failed" || status === "stopped") {
+    return "fail"
+  }
+  if (UNSAFE.has(status)) {
+    return "wait"
+  }
+  return "wait"
+}

--- a/packages/kilo-foundation/src/session-inbox.ts
+++ b/packages/kilo-foundation/src/session-inbox.ts
@@ -33,6 +33,18 @@ export function unconsumedManaged<T extends ManagedEvent>(items: T[]): T[] {
   return unconsumedOf(items)
 }
 
+/** Drop consumed events in place so the inbox cannot grow without bound. */
+export function compactConsumed<T extends ManagedEvent>(items: T[]): void {
+  const pending = items.filter((event) => event.consumedAt === undefined)
+  items.splice(0, items.length, ...pending)
+}
+
+/** Drop every event for a session in place (closed/deleted session). */
+export function forgetManagedSession<T extends ManagedEvent>(items: T[], sessionId: string): void {
+  const remaining = items.filter((event) => event.sessionId !== sessionId)
+  items.splice(0, items.length, ...remaining)
+}
+
 export function shouldWakeCoordinator<TType extends string>(eventType: TType, wakeTypes: ReadonlySet<TType>): boolean {
   return wakeTypes.has(eventType)
 }

--- a/packages/kilo-foundation/src/session-inbox.ts
+++ b/packages/kilo-foundation/src/session-inbox.ts
@@ -1,0 +1,38 @@
+import type { ManagedEvent } from "./types"
+
+function unconsumedOf<T extends ManagedEvent>(items: T[]): T[] {
+  return items.filter((event) => event.consumedAt === undefined)
+}
+
+export function enqueueManaged<T extends ManagedEvent>(items: T[], event: T, keyFn: (event: T) => string): void {
+  const key = keyFn(event)
+  const alreadyQueued = unconsumedOf(items).some((candidate) => keyFn(candidate) === key)
+  if (alreadyQueued) {
+    return
+  }
+  items.push(event)
+}
+
+export function consumeManagedBatch<T extends ManagedEvent>(
+  items: T[],
+  limit = 10,
+  nowIso = new Date().toISOString(),
+): T[] {
+  const pending = unconsumedOf(items).sort((left, right) => {
+    const byCreated = left.createdAt.localeCompare(right.createdAt)
+    return byCreated !== 0 ? byCreated : left.id.localeCompare(right.id)
+  })
+  const batch = pending.slice(0, Math.max(0, limit))
+  for (const event of batch) {
+    event.consumedAt = nowIso
+  }
+  return batch
+}
+
+export function unconsumedManaged<T extends ManagedEvent>(items: T[]): T[] {
+  return unconsumedOf(items)
+}
+
+export function shouldWakeCoordinator<TType extends string>(eventType: TType, wakeTypes: ReadonlySet<TType>): boolean {
+  return wakeTypes.has(eventType)
+}

--- a/packages/kilo-foundation/src/session-messaging.ts
+++ b/packages/kilo-foundation/src/session-messaging.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises"
+import { mkdir, readdir, readFile, rm, unlink, writeFile } from "node:fs/promises"
 import path from "node:path"
 import type { ManagedSessionClient, SessionId, SessionProbeResult } from "./types"
 
@@ -8,6 +8,16 @@ export interface SessionEnvelope {
   message?: string
   directory?: string
   createdAt: string
+  extra?: Record<string, unknown>
+}
+
+export type SessionMessengerClock = {
+  now(): number
+}
+
+type ListedEnvelope = {
+  file: string
+  envelope: SessionEnvelope | undefined
 }
 
 function sanitizeSessionId(sessionId: string): string {
@@ -19,11 +29,31 @@ function isNotFound(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && (error as { code: unknown }).code === "ENOENT"
 }
 
+function sameEnvelope(left: SessionEnvelope, right: SessionEnvelope): boolean {
+  return (
+    left.sessionId === right.sessionId &&
+    left.kind === right.kind &&
+    left.message === right.message &&
+    left.directory === right.directory &&
+    left.createdAt === right.createdAt
+  )
+}
+
+function compareListed(left: ListedEnvelope, right: ListedEnvelope): number {
+  const byCreated = (left.envelope?.createdAt ?? "").localeCompare(right.envelope?.createdAt ?? "")
+  return byCreated !== 0 ? byCreated : left.file.localeCompare(right.file)
+}
+
 /**
  * Persist envelopes on disk and deliver at a safe boundary. No LLM polling.
  */
 export class FileBackedSessionMessenger implements ManagedSessionClient {
-  constructor(private readonly inboxRoot: string) {}
+  private seq = 0
+
+  constructor(
+    private readonly inboxRoot: string,
+    private readonly clock: SessionMessengerClock = { now: () => Date.now() },
+  ) {}
 
   private sessionDir(sessionId: string): string {
     return path.join(this.inboxRoot, sanitizeSessionId(sessionId))
@@ -54,44 +84,71 @@ export class FileBackedSessionMessenger implements ManagedSessionClient {
     await this.sendQueued(sessionId, message)
   }
 
-  async sendQueued(sessionId: SessionId, message: string, directory?: string): Promise<void> {
-    await this.writeEnvelope(sessionId, {
+  async sendQueued(
+    sessionId: SessionId,
+    message: string,
+    directory?: string,
+    extra?: Record<string, unknown>,
+    createdAt?: string,
+  ): Promise<void> {
+    const now = this.clock.now()
+    await this.writeEnvelope(
       sessionId,
-      kind: "message",
-      message,
-      directory,
-      createdAt: new Date().toISOString(),
-    })
+      {
+        sessionId,
+        kind: "message",
+        message,
+        directory,
+        createdAt: createdAt ?? new Date(now).toISOString(),
+        ...(extra ? { extra } : {}),
+      },
+      now,
+    )
   }
 
   async resume(sessionId: SessionId): Promise<void> {
-    await this.writeEnvelope(sessionId, {
+    const now = this.clock.now()
+    await this.writeEnvelope(
       sessionId,
-      kind: "resume",
-      createdAt: new Date().toISOString(),
-    })
+      {
+        sessionId,
+        kind: "resume",
+        createdAt: new Date(now).toISOString(),
+      },
+      now,
+    )
   }
 
   async listPending(sessionId: SessionId): Promise<SessionEnvelope[]> {
-    const files = await this.envelopeFiles(sessionId)
-    const pending: SessionEnvelope[] = []
-    for (const file of files) {
-      const envelope = await this.readEnvelope(file)
-      if (envelope) pending.push(envelope)
-    }
-    return pending.sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+    const listed = await this.listedEnvelopes(sessionId)
+    return listed.flatMap((item) => (item.envelope ? [item.envelope] : []))
   }
 
   async consumePending(sessionId: SessionId, limit = 10): Promise<SessionEnvelope[]> {
-    const files = await this.envelopeFiles(sessionId)
-    const taken = files.slice(0, Math.max(0, limit))
+    const listed = await this.listedEnvelopes(sessionId)
+    const readable = listed.filter((item): item is ListedEnvelope & { envelope: SessionEnvelope } => !!item.envelope)
+    const taken = readable.slice(0, Math.max(0, limit))
     const pending: SessionEnvelope[] = []
-    for (const file of taken) {
-      const envelope = await this.readEnvelope(file)
-      if (envelope) pending.push(envelope)
-      await unlink(file)
+    for (const item of taken) {
+      pending.push(item.envelope)
+      await this.unlinkEnvelope(item.file)
     }
     return pending
+  }
+
+  async consumeEnvelope(sessionId: SessionId, envelope: SessionEnvelope): Promise<void> {
+    const listed = await this.listedEnvelopes(sessionId)
+    const match = listed.find((item) => item.envelope && sameEnvelope(item.envelope, envelope))
+    if (!match) return
+    await this.unlinkEnvelope(match.file)
+  }
+
+  async dropSession(sessionId: SessionId): Promise<void> {
+    try {
+      await rm(this.sessionDir(sessionId), { recursive: true, force: true })
+    } catch (error) {
+      if (!isNotFound(error)) throw error
+    }
   }
 
   async probe(): Promise<SessionProbeResult> {
@@ -104,14 +161,20 @@ export class FileBackedSessionMessenger implements ManagedSessionClient {
     }
   }
 
+  private async listedEnvelopes(sessionId: string): Promise<ListedEnvelope[]> {
+    const files = await this.envelopeFiles(sessionId)
+    const listed: ListedEnvelope[] = []
+    for (const file of files) {
+      listed.push({ file, envelope: await this.readEnvelope(file) })
+    }
+    return listed.sort(compareListed)
+  }
+
   private async envelopeFiles(sessionId: string): Promise<string[]> {
     try {
       const dir = this.sessionDir(sessionId)
       const entries = await readdir(dir)
-      return entries
-        .filter((name) => name.endsWith(".json"))
-        .map((name) => path.join(dir, name))
-        .sort()
+      return entries.filter((name) => name.endsWith(".json")).map((name) => path.join(dir, name))
     } catch (error) {
       if (isNotFound(error)) return []
       throw error
@@ -128,10 +191,19 @@ export class FileBackedSessionMessenger implements ManagedSessionClient {
     }
   }
 
-  private async writeEnvelope(sessionId: string, envelope: SessionEnvelope): Promise<void> {
+  private async unlinkEnvelope(file: string): Promise<void> {
+    try {
+      await unlink(file)
+    } catch (error) {
+      if (isNotFound(error)) return
+      console.warn("[kilo-foundation] failed to unlink managed inbox envelope", file, error)
+    }
+  }
+
+  private async writeEnvelope(sessionId: string, envelope: SessionEnvelope, now = this.clock.now()): Promise<void> {
     const dir = this.sessionDir(sessionId)
     await mkdir(dir, { recursive: true })
-    const filename = `${Date.now()}-${envelope.kind}-${crypto.randomUUID()}.json`
+    const filename = `${now}-${String(++this.seq).padStart(6, "0")}-${envelope.kind}-${crypto.randomUUID()}.json`
     await writeFile(path.join(dir, filename), `${JSON.stringify(envelope, null, 2)}\n`, "utf8")
   }
 }

--- a/packages/kilo-foundation/src/session-messaging.ts
+++ b/packages/kilo-foundation/src/session-messaging.ts
@@ -1,0 +1,85 @@
+import { mkdir, readdir, writeFile } from "node:fs/promises"
+import path from "node:path"
+import type { ManagedSessionClient, SessionId, SessionProbeResult } from "./types"
+
+export interface SessionEnvelope {
+  sessionId: SessionId
+  kind: "message" | "resume"
+  message?: string
+  createdAt: string
+}
+
+function sanitizeSessionId(sessionId: string): string {
+  const safe = sessionId.replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^\.+/, "")
+  return safe.length > 0 ? safe : "session"
+}
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error as { code: unknown }).code === "ENOENT"
+}
+
+/**
+ * Persist envelopes on disk and deliver at a safe boundary. No LLM polling.
+ */
+export class FileBackedSessionMessenger implements ManagedSessionClient {
+  constructor(private readonly inboxRoot: string) {}
+
+  private sessionDir(sessionId: string): string {
+    return path.join(this.inboxRoot, sanitizeSessionId(sessionId))
+  }
+
+  async listSessions(): Promise<SessionId[]> {
+    try {
+      const entries = await readdir(this.inboxRoot, { withFileTypes: true })
+      return entries
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+        .sort()
+    } catch (error) {
+      if (isNotFound(error)) {
+        return []
+      }
+      throw error
+    }
+  }
+
+  async createSession(title: string): Promise<SessionId> {
+    const sessionId = sanitizeSessionId(title)
+    await mkdir(this.sessionDir(sessionId), { recursive: true })
+    return sessionId
+  }
+
+  async sendMessage(sessionId: SessionId, message: string): Promise<void> {
+    await this.writeEnvelope(sessionId, {
+      sessionId,
+      kind: "message",
+      message,
+      createdAt: new Date().toISOString(),
+    })
+  }
+
+  async resume(sessionId: SessionId): Promise<void> {
+    await this.writeEnvelope(sessionId, {
+      sessionId,
+      kind: "resume",
+      createdAt: new Date().toISOString(),
+    })
+  }
+
+  async probe(): Promise<SessionProbeResult> {
+    const sessions = await this.listSessions()
+    return {
+      reachable: true,
+      status: "reachable",
+      sessionCount: sessions.length,
+      detail: "file-backed session inbox",
+    }
+  }
+
+  private async writeEnvelope(sessionId: string, envelope: SessionEnvelope): Promise<void> {
+    const dir = this.sessionDir(sessionId)
+    await mkdir(dir, { recursive: true })
+    const filename = `${Date.now()}-${envelope.kind}-${crypto.randomUUID()}.json`
+    await writeFile(path.join(dir, filename), `${JSON.stringify(envelope, null, 2)}\n`, "utf8")
+  }
+}

--- a/packages/kilo-foundation/src/session-messaging.ts
+++ b/packages/kilo-foundation/src/session-messaging.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, writeFile } from "node:fs/promises"
+import { mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises"
 import path from "node:path"
 import type { ManagedSessionClient, SessionId, SessionProbeResult } from "./types"
 
@@ -6,6 +6,7 @@ export interface SessionEnvelope {
   sessionId: SessionId
   kind: "message" | "resume"
   message?: string
+  directory?: string
   createdAt: string
 }
 
@@ -50,10 +51,15 @@ export class FileBackedSessionMessenger implements ManagedSessionClient {
   }
 
   async sendMessage(sessionId: SessionId, message: string): Promise<void> {
+    await this.sendQueued(sessionId, message)
+  }
+
+  async sendQueued(sessionId: SessionId, message: string, directory?: string): Promise<void> {
     await this.writeEnvelope(sessionId, {
       sessionId,
       kind: "message",
       message,
+      directory,
       createdAt: new Date().toISOString(),
     })
   }
@@ -66,6 +72,28 @@ export class FileBackedSessionMessenger implements ManagedSessionClient {
     })
   }
 
+  async listPending(sessionId: SessionId): Promise<SessionEnvelope[]> {
+    const files = await this.envelopeFiles(sessionId)
+    const pending: SessionEnvelope[] = []
+    for (const file of files) {
+      const envelope = await this.readEnvelope(file)
+      if (envelope) pending.push(envelope)
+    }
+    return pending.sort((left, right) => left.createdAt.localeCompare(right.createdAt))
+  }
+
+  async consumePending(sessionId: SessionId, limit = 10): Promise<SessionEnvelope[]> {
+    const files = await this.envelopeFiles(sessionId)
+    const taken = files.slice(0, Math.max(0, limit))
+    const pending: SessionEnvelope[] = []
+    for (const file of taken) {
+      const envelope = await this.readEnvelope(file)
+      if (envelope) pending.push(envelope)
+      await unlink(file)
+    }
+    return pending
+  }
+
   async probe(): Promise<SessionProbeResult> {
     const sessions = await this.listSessions()
     return {
@@ -73,6 +101,30 @@ export class FileBackedSessionMessenger implements ManagedSessionClient {
       status: "reachable",
       sessionCount: sessions.length,
       detail: "file-backed session inbox",
+    }
+  }
+
+  private async envelopeFiles(sessionId: string): Promise<string[]> {
+    try {
+      const dir = this.sessionDir(sessionId)
+      const entries = await readdir(dir)
+      return entries
+        .filter((name) => name.endsWith(".json"))
+        .map((name) => path.join(dir, name))
+        .sort()
+    } catch (error) {
+      if (isNotFound(error)) return []
+      throw error
+    }
+  }
+
+  private async readEnvelope(file: string): Promise<SessionEnvelope | undefined> {
+    try {
+      const raw = JSON.parse(await readFile(file, "utf8")) as SessionEnvelope
+      if (!raw || typeof raw.sessionId !== "string" || typeof raw.kind !== "string") return undefined
+      return raw
+    } catch {
+      return undefined
     }
   }
 

--- a/packages/kilo-foundation/src/telemetry.ts
+++ b/packages/kilo-foundation/src/telemetry.ts
@@ -1,0 +1,23 @@
+import type { GenericTelemetry } from "./types"
+
+export function createGenericTelemetry(): GenericTelemetry {
+  return {
+    coordinatorWakes: 0,
+    eventsConsumed: 0,
+    resumes: 0,
+    stallsDetected: 0,
+  }
+}
+
+export function recordCoordinatorWake(telemetry: GenericTelemetry, consumed: number): void {
+  telemetry.coordinatorWakes += 1
+  telemetry.eventsConsumed += consumed
+}
+
+export function recordResume(telemetry: GenericTelemetry): void {
+  telemetry.resumes += 1
+}
+
+export function recordStall(telemetry: GenericTelemetry): void {
+  telemetry.stallsDetected += 1
+}

--- a/packages/kilo-foundation/src/types.ts
+++ b/packages/kilo-foundation/src/types.ts
@@ -1,0 +1,85 @@
+/**
+ * Generic managed-session primitives. Safe to contribute upstream.
+ * Do not add product roles, task statuses, or milestone policy here.
+ */
+
+export type SessionId = string
+
+export type SessionActivityStatus = "idle" | "running" | "waiting" | "blocked" | "stopped"
+
+export type SessionLifecycleStatus =
+  | "unknown"
+  | "starting"
+  | "reachable"
+  | "running"
+  | "paused"
+  | "stalled"
+  | "stopped"
+  | "failed"
+
+/** Runtime status values emitted by Kilo `session.status`. */
+export type KiloRuntimeStatus = "idle" | "busy" | "retry" | "offline"
+
+export const FOUNDATION_EVENT = {
+  MESSAGE_RECEIVED: "SESSION_MESSAGE_RECEIVED",
+  STATUS_CHANGED: "SESSION_STATUS_CHANGED",
+  STALLED: "SESSION_STALLED",
+  RESUMABLE: "SESSION_RESUMABLE",
+} as const
+
+export type FoundationEventType = (typeof FOUNDATION_EVENT)[keyof typeof FOUNDATION_EVENT]
+
+export const FOUNDATION_WAKE_TYPES: ReadonlySet<FoundationEventType> = new Set([
+  FOUNDATION_EVENT.MESSAGE_RECEIVED,
+  FOUNDATION_EVENT.RESUMABLE,
+  FOUNDATION_EVENT.STALLED,
+])
+
+export interface ManagedEvent<TType extends string = string> {
+  id: string
+  type: TType
+  sessionId?: SessionId
+  payload: Record<string, unknown>
+  createdAt: string
+  consumedAt?: string
+}
+
+export type Escalation = "retry" | "debug" | "coordinator" | "human"
+
+export interface RetryPolicy {
+  workerAttempts: number
+  sameErrorRetry: number
+  reviewCycles: number
+  debugEscalation: number
+}
+
+export const GENERIC_RETRY_POLICY: RetryPolicy = {
+  workerAttempts: 2,
+  sameErrorRetry: 1,
+  reviewCycles: 3,
+  debugEscalation: 1,
+}
+
+export const DEFAULT_STALL_AFTER_MS = 15 * 60 * 1000
+
+export interface GenericTelemetry {
+  coordinatorWakes: number
+  eventsConsumed: number
+  resumes: number
+  stallsDetected: number
+}
+
+export interface SessionProbeResult {
+  reachable: boolean
+  status: SessionLifecycleStatus
+  sessionCount?: number
+  detail?: string
+}
+
+export interface ManagedSessionClient {
+  listSessions(): Promise<SessionId[]>
+  createSession(title: string): Promise<SessionId>
+  sendMessage(sessionId: SessionId, message: string): Promise<void>
+  resume(sessionId: SessionId): Promise<void>
+  probe(): Promise<SessionProbeResult>
+}

--- a/packages/kilo-foundation/src/watchdog.ts
+++ b/packages/kilo-foundation/src/watchdog.ts
@@ -1,0 +1,73 @@
+import {
+  DEFAULT_STALL_AFTER_MS,
+  GENERIC_RETRY_POLICY,
+  type Escalation,
+  type RetryPolicy,
+  type SessionActivityStatus,
+  type SessionId,
+} from "./types"
+
+export { DEFAULT_STALL_AFTER_MS }
+
+export interface SessionProgress {
+  sessionId: SessionId
+  activity: SessionActivityStatus
+  lastProgressIso: string
+  directory?: string
+}
+
+export function detectSessionStall(input: {
+  status: SessionActivityStatus
+  nowIso: string
+  lastProgressIso: string
+  stallAfterMs?: number
+}): boolean {
+  if (input.status === "idle" || input.status === "stopped") {
+    return false
+  }
+
+  const now = Date.parse(input.nowIso)
+  const lastProgress = Date.parse(input.lastProgressIso)
+  if (Number.isNaN(now) || Number.isNaN(lastProgress)) {
+    return false
+  }
+
+  const stallAfterMs = input.stallAfterMs ?? DEFAULT_STALL_AFTER_MS
+  return now - lastProgress >= stallAfterMs
+}
+
+/**
+ * Clock-based stall scan. Callers pass last-known activity from session.status
+ * events; this function does not poll an LLM or the session HTTP API.
+ */
+export function scanSessionStalls(
+  sessions: readonly SessionProgress[],
+  nowIso: string,
+  stallAfterMs?: number,
+): SessionProgress[] {
+  return sessions.filter((session) =>
+    detectSessionStall({
+      status: session.activity,
+      nowIso,
+      lastProgressIso: session.lastProgressIso,
+      stallAfterMs,
+    }),
+  )
+}
+
+export function suggestEscalation(attemptCount: number, policy: RetryPolicy = GENERIC_RETRY_POLICY): Escalation {
+  if (attemptCount < policy.workerAttempts) {
+    return "retry"
+  }
+
+  const debugUntil = policy.workerAttempts + policy.debugEscalation
+  if (attemptCount < debugUntil) {
+    return "debug"
+  }
+
+  if (attemptCount < debugUntil + 1) {
+    return "coordinator"
+  }
+
+  return "human"
+}

--- a/packages/kilo-foundation/tsconfig.json
+++ b/packages/kilo-foundation/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@tsconfig/bun/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "lib": ["ESNext"],
+    "types": ["bun"],
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/kilo-foundation/tsconfig.json
+++ b/packages/kilo-foundation/tsconfig.json
@@ -10,5 +10,5 @@
     "noUncheckedIndexedAccess": false
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/__tests__"]
 }

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -1301,6 +1301,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
     "fuzzysort": "3.1.0",
+    "@kilocode/kilo-foundation": "workspace:*",
     "@kilocode/kilo-gateway": "workspace:*",
     "@kilocode/kilo-i18n": "workspace:*",
     "@kilocode/kilo-indexing": "workspace:*",

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -53,8 +53,8 @@ import {
 import { initContextState, pushProjectSessions, reactivateProject, registerProjectSessions } from "./project/init"
 import { createLocalDiff } from "./local-diff"
 import { parseToolRequest, startFromTool, type ToolRequest } from "./tool-start"
-import { flushIdleSession } from "./managed-delivery"
-import { SessionStallWatchdog } from "./session-stall-watchdog"
+import { flushIdleSession, queueBusyAgentSend } from "./managed-delivery"
+import { SessionStallWatchdog, stallWatchdogFromEnv } from "./session-stall-watchdog"
 import { handleToolEvent } from "./tool-project"
 import { sandboxSessionMetadata } from "../shared/sandbox-session"
 import { createOrchestrationBridge } from "./orchestration-setup"
@@ -119,6 +119,7 @@ export class AgentManagerProvider implements Disposable {
   private panelSessions = new Set<string>()
   private busySessions = new Set<string>()
   private readonly stallWatchdog = new SessionStallWatchdog({
+    ...stallWatchdogFromEnv(),
     onStall: (sessionId, resumable) => this.log("session stalled", sessionId, resumable ? "resumable" : "busy"),
   })
 
@@ -569,8 +570,28 @@ export class AgentManagerProvider implements Disposable {
     if (bridge !== undefined) return bridge
     if (this.scripts.manager.intercept(m)) return null
     if (this.terminalRouter.handle(m)) return null
+    if (this.queueBusySend(m, msg)) return null
 
     return msg
+  }
+
+  private queueBusySend(m: AgentManagerInMessage, msg: Record<string, unknown>): boolean {
+    if (m.type !== "sendMessage") return false
+    const sid = m.sessionID ?? this.activeSessionId
+    const directory =
+      (typeof msg.contextDirectory === "string" && msg.contextDirectory) ||
+      (typeof m.contextDirectory === "string" && m.contextDirectory) ||
+      this.getRoot()
+    const result = queueBusyAgentSend({
+      busy: !!sid && this.busySessions.has(sid),
+      sessionId: sid,
+      directory,
+      text: m.text,
+      fileCount: m.files?.length ?? 0,
+    })
+    if (result !== "queued") return false
+    this.log("managed prompt queued", sid)
+    return true
   }
 
   private onBranchPrompt(m: AgentManagerInMessage): void {

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -53,7 +53,7 @@ import {
 import { initContextState, pushProjectSessions, reactivateProject, registerProjectSessions } from "./project/init"
 import { createLocalDiff } from "./local-diff"
 import { parseToolRequest, startFromTool, type ToolRequest } from "./tool-start"
-import { flushIdleSession, queueBusyAgentSend } from "./managed-delivery"
+import { flushIdleSession, managedInbox, queueBusyAgentSend, resumeQueuedSessions } from "./managed-delivery"
 import { SessionStallWatchdog, stallWatchdogFromEnv } from "./session-stall-watchdog"
 import { handleToolEvent } from "./tool-project"
 import { sandboxSessionMetadata } from "../shared/sandbox-session"
@@ -356,7 +356,7 @@ export class AgentManagerProvider implements Disposable {
       this.naming.idle(sid)
       try {
         const client = this.connectionService.getClient()
-        void flushIdleSession(client, sid, { snapshotInitialization: SNAPSHOT_INITIALIZATION })
+        void flushIdleSession(client, sid, { snapshotInitialization: SNAPSHOT_INITIALIZATION }, true)
           .then((n) => {
             if (n > 0) this.log("managed inbox flushed", sid, n)
           })
@@ -508,6 +508,18 @@ export class AgentManagerProvider implements Disposable {
     // are registered with their directory overrides so the recovery queries the
     // correct CLI backend Instances.
     this.panel?.sessions.recoverPendingPrompts()
+    await this.resumePersistedInbox(ctx.root)
+  }
+
+  private async resumePersistedInbox(root: string): Promise<void> {
+    managedInbox.attachPersistence(path.join(root, ".kilo", "managed-inbox"))
+    try {
+      const client = this.connectionService.getClient()
+      const n = await resumeQueuedSessions(client, { snapshotInitialization: SNAPSHOT_INITIALIZATION })
+      if (n > 0) this.log("managed inbox resumed", n)
+    } catch (err) {
+      this.log("managed inbox resume failed", err)
+    }
   }
 
   /** Initialize an expanded background project and push its state (no panel wiring). */

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -118,7 +118,9 @@ export class AgentManagerProvider implements Disposable {
   // Tracks sessions owned by this panel until they are explicitly closed.
   private panelSessions = new Set<string>()
   private busySessions = new Set<string>()
-  private readonly stallWatchdog = new SessionStallWatchdog()
+  private readonly stallWatchdog = new SessionStallWatchdog({
+    onStall: (sessionId, resumable) => this.log("session stalled", sessionId, resumable ? "resumable" : "busy"),
+  })
 
   /** Session ID most recently loaded via `loadMessages`; updated synchronously. */
   private activeSessionId: string | undefined
@@ -353,9 +355,11 @@ export class AgentManagerProvider implements Disposable {
       this.naming.idle(sid)
       try {
         const client = this.connectionService.getClient()
-        void flushIdleSession(client, sid, { snapshotInitialization: SNAPSHOT_INITIALIZATION }).catch((err) =>
-          this.log("managed inbox flush failed", err),
-        )
+        void flushIdleSession(client, sid, { snapshotInitialization: SNAPSHOT_INITIALIZATION })
+          .then((n) => {
+            if (n > 0) this.log("managed inbox flushed", sid, n)
+          })
+          .catch((err) => this.log("managed inbox flush failed", err))
       } catch {
         // Client not connected yet; queued prompts stay until the next idle event.
       }

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -53,7 +53,12 @@ import {
 import { initContextState, pushProjectSessions, reactivateProject, registerProjectSessions } from "./project/init"
 import { createLocalDiff } from "./local-diff"
 import { parseToolRequest, startFromTool, type ToolRequest } from "./tool-start"
-import { flushIdleSession, managedInbox, queueBusyAgentSend, resumeQueuedSessions } from "./managed-delivery"
+import {
+  flushIdleSession,
+  flushQueuedSessions,
+  managedInbox,
+  queueBusyAgentSend,
+} from "./managed-delivery"
 import { SessionStallWatchdog, stallWatchdogFromEnv } from "./session-stall-watchdog"
 import { handleToolEvent } from "./tool-project"
 import { sandboxSessionMetadata } from "../shared/sandbox-session"
@@ -112,6 +117,7 @@ export class AgentManagerProvider implements Disposable {
   /** Scratch set returned when no active context exists; mutations are discarded. */
   private readonly staleScratch = new Set<string>()
   private unsubDestination: (() => void) | undefined
+  private unsubConnection: (() => void) | undefined
   private destination = new DestinationState()
   private closing: Promise<void> | undefined
   private onVisibilityChange: ((visible: boolean) => void) | undefined
@@ -298,6 +304,9 @@ export class AgentManagerProvider implements Disposable {
       },
       (event) => this.onSessionLifecycle(event),
     )
+    this.unsubConnection = this.connectionService.onStateChange((state) => {
+      if (state === "connected") void this.flushPersistedInbox()
+    })
     this.stallWatchdog.start()
   }
 
@@ -320,6 +329,7 @@ export class AgentManagerProvider implements Disposable {
       if (!id) return
       this.busySessions.delete(id)
       this.stallWatchdog.forget(id)
+      managedInbox.forgetSession(id)
       const ctx = this.contexts.byLiveSession(id)
       if (!ctx) return
       ctx.removeLiveSession(id)
@@ -514,8 +524,18 @@ export class AgentManagerProvider implements Disposable {
   private async resumePersistedInbox(root: string): Promise<void> {
     managedInbox.attachPersistence(path.join(root, ".kilo", "managed-inbox"))
     try {
+      const ids = await managedInbox.hydrate()
+      if (ids.length > 0) this.log("managed inbox hydrated", ids.length)
+    } catch (err) {
+      this.log("managed inbox hydrate failed", err)
+    }
+    await this.flushPersistedInbox()
+  }
+
+  private async flushPersistedInbox(): Promise<void> {
+    try {
       const client = this.connectionService.getClient()
-      const n = await resumeQueuedSessions(client, { snapshotInitialization: SNAPSHOT_INITIALIZATION })
+      const n = await flushQueuedSessions(client, { snapshotInitialization: SNAPSHOT_INITIALIZATION })
       if (n > 0) this.log("managed inbox resumed", n)
     } catch (err) {
       this.log("managed inbox resume failed", err)
@@ -590,20 +610,62 @@ export class AgentManagerProvider implements Disposable {
   private queueBusySend(m: AgentManagerInMessage, msg: Record<string, unknown>): boolean {
     if (m.type !== "sendMessage") return false
     const sid = m.sessionID ?? this.activeSessionId
-    const directory =
-      (typeof msg.contextDirectory === "string" && msg.contextDirectory) ||
-      (typeof m.contextDirectory === "string" && m.contextDirectory) ||
-      this.getRoot()
+    const directory = this.sessionSendDirectory(sid, msg, m)
     const result = queueBusyAgentSend({
       busy: !!sid && this.busySessions.has(sid),
       sessionId: sid,
       directory,
       text: m.text,
       fileCount: m.files?.length ?? 0,
+      extra: {
+        messageID: m.messageID,
+        model: m.providerID && m.modelID ? { providerID: m.providerID, modelID: m.modelID } : undefined,
+        variant: m.variant,
+        snapshotInitialization: SNAPSHOT_INITIALIZATION,
+      },
     })
     if (result !== "queued") return false
+    if (m.messageID && sid) this.connectionService.recordMessageSessionId(m.messageID, sid)
     this.log("managed prompt queued", sid)
     return true
+  }
+
+  /**
+   * Directory the backend Instance actually owns for this session. Do not fall
+   * back to the workspace root for a worktree session — that targets the wrong
+   * Instance when the later flush runs.
+   */
+  private sessionSendDirectory(
+    sessionId: string | undefined,
+    msg: Record<string, unknown>,
+    m: AgentManagerInMessage,
+  ): string | undefined {
+    if (typeof msg.contextDirectory === "string" && msg.contextDirectory) return msg.contextDirectory
+    if ("contextDirectory" in m && typeof m.contextDirectory === "string" && m.contextDirectory) {
+      return m.contextDirectory
+    }
+    if (sessionId) {
+      const tracked = this.panel?.sessions.getSessionDirectories().get(sessionId)
+      if (tracked) return tracked
+      const state = this.getStateManager()
+      const managed = state?.getSession(sessionId)
+      if (managed?.worktreeId) {
+        const worktree = state?.getWorktree(managed.worktreeId)?.path
+        if (worktree) return worktree
+        const routed = this.routedSessionDirectory(sessionId)
+        if (routed) return routed
+        return undefined
+      }
+      const routed = this.routedSessionDirectory(sessionId)
+      if (routed) return routed
+    }
+    return this.getRoot()
+  }
+
+  private routedSessionDirectory(sessionId: string): string | undefined {
+    const projectId = this.projectScope.current()?.id ?? this.contexts.active()?.id
+    if (!projectId) return undefined
+    return this.panel?.sessions.routeSessionDirectoryFor?.({ projectId, sessionId })
   }
 
   private onBranchPrompt(m: AgentManagerInMessage): void {
@@ -1929,6 +1991,7 @@ export class AgentManagerProvider implements Disposable {
     this.unsubTool?.()
     this.unsubStatus?.()
     this.unsubSessions?.()
+    this.unsubConnection?.()
     this.unsubFont?.()
     this.unsubProjects?.()
     this.unsubDestination?.()

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -53,6 +53,8 @@ import {
 import { initContextState, pushProjectSessions, reactivateProject, registerProjectSessions } from "./project/init"
 import { createLocalDiff } from "./local-diff"
 import { parseToolRequest, startFromTool, type ToolRequest } from "./tool-start"
+import { flushIdleSession } from "./managed-delivery"
+import { SessionStallWatchdog } from "./session-stall-watchdog"
 import { handleToolEvent } from "./tool-project"
 import { sandboxSessionMetadata } from "../shared/sandbox-session"
 import { createOrchestrationBridge } from "./orchestration-setup"
@@ -65,7 +67,7 @@ import { buildKeybindingMap } from "./format-keybinding"
 import { resolveVersionModels, buildInitialMessages, type CreatedVersion } from "./multi-version"
 import { ensureSandbox } from "./sandbox-bootstrap"
 import { Semaphore } from "./semaphore"
-import { PLATFORM } from "./constants"
+import { PLATFORM, SNAPSHOT_INITIALIZATION } from "./constants"
 import { ProjectRegistry } from "./project/registry"
 import type { ProjectContext } from "./project/context"
 import { ProjectContexts } from "./project/contexts"
@@ -116,6 +118,7 @@ export class AgentManagerProvider implements Disposable {
   // Tracks sessions owned by this panel until they are explicitly closed.
   private panelSessions = new Set<string>()
   private busySessions = new Set<string>()
+  private readonly stallWatchdog = new SessionStallWatchdog()
 
   /** Session ID most recently loaded via `loadMessages`; updated synchronously. */
   private activeSessionId: string | undefined
@@ -278,7 +281,7 @@ export class AgentManagerProvider implements Disposable {
     )
     this.unsubStatus = this.connectionService.onEventFiltered(
       (event) => (event as { type?: string }).type === "session.status",
-      (event) => this.onSessionStatus(event),
+      (event, directory) => this.onSessionStatus(event, directory),
     )
     this.unsubSessions = this.connectionService.onEventFiltered(
       (event) => {
@@ -292,6 +295,7 @@ export class AgentManagerProvider implements Disposable {
       },
       (event) => this.onSessionLifecycle(event),
     )
+    this.stallWatchdog.start()
   }
 
   /**
@@ -302,13 +306,17 @@ export class AgentManagerProvider implements Disposable {
   private onSessionLifecycle(event: unknown): void {
     const ev = event as { type?: string; properties?: { info?: Session; sessionID?: string } }
     if (ev.type === "session.error") {
-      if (ev.properties?.sessionID) this.busySessions.delete(ev.properties.sessionID)
+      if (ev.properties?.sessionID) {
+        this.busySessions.delete(ev.properties.sessionID)
+        this.stallWatchdog.forget(ev.properties.sessionID)
+      }
       return
     }
     if (ev.type === "session.deleted") {
       const id = ev.properties?.sessionID
       if (!id) return
       this.busySessions.delete(id)
+      this.stallWatchdog.forget(id)
       const ctx = this.contexts.byLiveSession(id)
       if (!ctx) return
       ctx.removeLiveSession(id)
@@ -334,14 +342,23 @@ export class AgentManagerProvider implements Disposable {
     this.postToWebview({ type: "agentManager.projectSessions", projectId: ctx.id, sessions: [...ctx.sessions()] })
   }
 
-  private onSessionStatus(event: unknown): void {
+  private onSessionStatus(event: unknown, directory?: string): void {
     const props = (event as { properties?: { sessionID?: string; status?: { type?: string } } }).properties
     const sid = props?.sessionID
     const type = props?.status?.type
     if (!sid || !type) return
+    this.stallWatchdog.noteStatus(sid, type, directory)
     if (type === "idle") {
       this.busySessions.delete(sid)
       this.naming.idle(sid)
+      try {
+        const client = this.connectionService.getClient()
+        void flushIdleSession(client, sid, { snapshotInitialization: SNAPSHOT_INITIALIZATION }).catch((err) =>
+          this.log("managed inbox flush failed", err),
+        )
+      } catch {
+        // Client not connected yet; queued prompts stay until the next idle event.
+      }
       return
     }
     this.busySessions.add(sid)
@@ -952,6 +969,7 @@ export class AgentManagerProvider implements Disposable {
       {
         getWorktreeManager: () => this.getWorktreeManager(),
         getStateManager: () => this.getStateManager(),
+        getWorkspaceRoot: () => this.getRoot(),
         postToWebview: (message) => this.postToWebview(message),
         capture: (event, properties) => this.host.capture(event, properties),
         pushState: () => this.pushState(),
@@ -1877,6 +1895,7 @@ export class AgentManagerProvider implements Disposable {
     this.unsubFont?.()
     this.unsubProjects?.()
     this.unsubDestination?.()
+    this.stallWatchdog.stop()
     await this.scripts.dispose()
     this.orchestration.dispose()
     this.visiblePresence.clear()

--- a/packages/kilo-vscode/src/agent-manager/fork-handoff.ts
+++ b/packages/kilo-vscode/src/agent-manager/fork-handoff.ts
@@ -1,3 +1,4 @@
+import { promptWhenSafe } from "./managed-delivery"
 import type { KiloClient } from "@kilocode/sdk/v2/client"
 
 export interface ForkHandoffInput {
@@ -24,18 +25,11 @@ export function forkText(input: Pick<ForkHandoffInput, "directory">): string {
 }
 
 export async function recordForkHandoff(input: ForkHandoffInput): Promise<void> {
-  const payload = {
-    sessionID: input.sessionId,
-    ...(input.directory ? { directory: input.directory } : {}),
-    noReply: true,
-    parts: [
-      {
-        type: "text",
-        text: forkText(input),
-        synthetic: true,
-      },
-    ],
-  } as Parameters<KiloClient["session"]["promptAsync"]>[0]
-
-  await input.client.session.promptAsync(payload, { throwOnError: true })
+  const directory = input.directory ?? ""
+  await promptWhenSafe(input.client, {
+    sessionId: input.sessionId,
+    directory,
+    text: forkText(input),
+    extra: { noReply: true, synthetic: true },
+  })
 }

--- a/packages/kilo-vscode/src/agent-manager/managed-delivery.ts
+++ b/packages/kilo-vscode/src/agent-manager/managed-delivery.ts
@@ -1,6 +1,7 @@
 import {
-  consumeManagedBatch,
+  compactConsumed,
   enqueueManaged,
+  forgetManagedSession,
   FOUNDATION_EVENT,
   FOUNDATION_WAKE_TYPES,
   FileBackedSessionMessenger,
@@ -20,6 +21,8 @@ export interface QueuedPrompt {
   sessionId: string
   directory: string
   text: string
+  extra?: PromptAsyncExtra
+  createdAt?: string
 }
 
 /** Fields Agent Manager actually forwards into `session.promptAsync`. */
@@ -53,6 +56,46 @@ function eventKey(event: ManagedEvent): string {
   return `${event.sessionId ?? ""}:${event.type}:${String(event.payload.text ?? event.payload.kind ?? event.id)}`
 }
 
+function isMessagePrompt(event: ManagedEvent): boolean {
+  return event.type === FOUNDATION_EVENT.MESSAGE_RECEIVED && event.payload.kind === "message"
+}
+
+function extraFromUnknown(value: unknown): PromptAsyncExtra | undefined {
+  if (!value || typeof value !== "object") return undefined
+  const rec = value as Record<string, unknown>
+  const extra: PromptAsyncExtra = {}
+  if (typeof rec.messageID === "string") extra.messageID = rec.messageID
+  if (typeof rec.variant === "string") extra.variant = rec.variant
+  if (rec.noReply === true) extra.noReply = true
+  if (rec.synthetic === true) extra.synthetic = true
+  if (rec.snapshotInitialization === "wait") extra.snapshotInitialization = "wait"
+  if (rec.model && typeof rec.model === "object") {
+    const model = rec.model as Record<string, unknown>
+    if (typeof model.providerID === "string" && typeof model.modelID === "string") {
+      extra.model = { providerID: model.providerID, modelID: model.modelID }
+    }
+  }
+  return Object.keys(extra).length > 0 ? extra : undefined
+}
+
+function cloneExtra(extra?: PromptAsyncExtra): PromptAsyncExtra | undefined {
+  if (!extra) return undefined
+  return extraFromUnknown(JSON.parse(JSON.stringify(extra)))
+}
+
+function promptFromEvent(event: ManagedEvent): QueuedPrompt | undefined {
+  const text = typeof event.payload.text === "string" ? event.payload.text : undefined
+  const directory = typeof event.payload.directory === "string" ? event.payload.directory : undefined
+  if (!event.sessionId || !text || !directory || !isMessagePrompt(event)) return undefined
+  return {
+    sessionId: event.sessionId,
+    directory,
+    text,
+    extra: extraFromUnknown(event.payload.extra),
+    createdAt: event.createdAt,
+  }
+}
+
 function promptBody(sessionId: string, directory: string, text: string, extra?: PromptAsyncExtra): PromptAsyncParameters {
   const { synthetic, ...rest } = extra ?? {}
   return {
@@ -61,6 +104,11 @@ function promptBody(sessionId: string, directory: string, text: string, extra?: 
     parts: [{ type: "text", text, ...(synthetic ? { synthetic: true } : {}) }],
     ...rest,
   }
+}
+
+function persistExtra(extra?: PromptAsyncExtra): Record<string, unknown> | undefined {
+  const cloned = cloneExtra(extra)
+  return cloned as Record<string, unknown> | undefined
 }
 
 /**
@@ -81,18 +129,24 @@ export class ManagedSessionInbox {
   }
 
   async enqueuePrompt(input: QueuedPrompt, nowIso = new Date().toISOString(), persist = true): Promise<void> {
+    const extra = cloneExtra(input.extra)
     enqueueManaged(
       this.events,
       {
         id: `${input.sessionId}:${nowIso}:${this.events.length}`,
         type: FOUNDATION_EVENT.MESSAGE_RECEIVED,
         sessionId: input.sessionId,
-        payload: { text: input.text, directory: input.directory, kind: "message" },
+        payload: { text: input.text, directory: input.directory, kind: "message", extra },
         createdAt: nowIso,
       },
       eventKey,
     )
-    if (persist) await this.messenger?.sendQueued(input.sessionId, input.text, input.directory)
+    if (!persist) return
+    try {
+      await this.messenger?.sendQueued(input.sessionId, input.text, input.directory, persistExtra(extra), nowIso)
+    } catch (error) {
+      console.warn("[kilo-foundation] managed inbox persist failed", error)
+    }
   }
 
   enqueueFoundationEvent(
@@ -101,6 +155,11 @@ export class ManagedSessionInbox {
     payload: Record<string, unknown> = {},
     nowIso = new Date().toISOString(),
   ): void {
+    for (const event of this.events) {
+      if (event.sessionId === sessionId && event.type === type && event.consumedAt === undefined) {
+        event.consumedAt = nowIso
+      }
+    }
     enqueueManaged(
       this.events,
       {
@@ -112,29 +171,70 @@ export class ManagedSessionInbox {
       },
       eventKey,
     )
+    this.compact()
   }
 
   peekForSession(sessionId: string): QueuedPrompt | undefined {
-    const pending = unconsumedManaged(this.events).find((event) => event.sessionId === sessionId)
-    const text = typeof pending?.payload.text === "string" ? pending.payload.text : undefined
-    const directory = typeof pending?.payload.directory === "string" ? pending.payload.directory : undefined
-    if (!pending || !text || !directory) return undefined
-    return { sessionId, directory, text }
+    const pending = unconsumedManaged(this.events).find((event) => event.sessionId === sessionId && isMessagePrompt(event))
+    return pending ? promptFromEvent(pending) : undefined
   }
 
-  async takeForSession(sessionId: string, nowIso = new Date().toISOString()): Promise<QueuedPrompt[]> {
-    const pending = this.events.filter((event) => event.sessionId === sessionId && event.consumedAt === undefined)
-    const batch = consumeManagedBatch(pending, 10, nowIso)
-    if (batch.length > 0 && shouldWakeCoordinator(FOUNDATION_EVENT.MESSAGE_RECEIVED, FOUNDATION_WAKE_TYPES)) {
-      recordCoordinatorWake(this.telemetry, batch.length)
+  pendingSessionIds(): string[] {
+    const ids = new Set<string>()
+    for (const event of unconsumedManaged(this.events)) {
+      if (event.sessionId && isMessagePrompt(event)) ids.add(event.sessionId)
     }
-    if (batch.length > 0) await this.messenger?.consumePending(sessionId, batch.length)
-    return batch.flatMap((event) => {
-      const text = typeof event.payload.text === "string" ? event.payload.text : undefined
-      const directory = typeof event.payload.directory === "string" ? event.payload.directory : undefined
-      if (!text || !directory) return []
-      return [{ sessionId, directory, text }]
+    return [...ids]
+  }
+
+  async acknowledgeSent(prompt: QueuedPrompt, nowIso = new Date().toISOString()): Promise<void> {
+    const event = unconsumedManaged(this.events).find((item) => {
+      const queued = promptFromEvent(item)
+      return (
+        queued?.sessionId === prompt.sessionId &&
+        queued.text === prompt.text &&
+        queued.directory === prompt.directory &&
+        (!prompt.createdAt || queued.createdAt === prompt.createdAt)
+      )
     })
+    if (event) {
+      event.consumedAt = nowIso
+      if (shouldWakeCoordinator(FOUNDATION_EVENT.MESSAGE_RECEIVED, FOUNDATION_WAKE_TYPES)) {
+        recordCoordinatorWake(this.telemetry, 1)
+      }
+    }
+    try {
+      await this.messenger?.consumeEnvelope(prompt.sessionId, {
+        sessionId: prompt.sessionId,
+        kind: "message",
+        message: prompt.text,
+        directory: prompt.directory,
+        createdAt: prompt.createdAt ?? event?.createdAt ?? nowIso,
+      })
+    } catch (error) {
+      console.warn("[kilo-foundation] managed inbox consume failed", error)
+    }
+    this.compact()
+  }
+
+  async dropLastPrompt(sessionId: string, text: string): Promise<void> {
+    const pending = [...unconsumedManaged(this.events)]
+      .reverse()
+      .find((event) => event.sessionId === sessionId && isMessagePrompt(event) && event.payload.text === text)
+    const prompt = pending ? promptFromEvent(pending) : undefined
+    if (!prompt) return
+    await this.acknowledgeSent(prompt)
+  }
+
+  forgetSession(sessionId: string): void {
+    forgetManagedSession(this.events, sessionId)
+    void this.messenger?.dropSession(sessionId).catch((error) => {
+      console.warn("[kilo-foundation] managed inbox drop session failed", error)
+    })
+  }
+
+  compact(): void {
+    compactConsumed(this.events)
   }
 
   async hydrate(): Promise<string[]> {
@@ -147,7 +247,13 @@ export class ManagedSessionInbox {
       for (const envelope of pending) {
         if (envelope.kind !== "message" || !envelope.message || !envelope.directory) continue
         await this.enqueuePrompt(
-          { sessionId, directory: envelope.directory, text: envelope.message },
+          {
+            sessionId,
+            directory: envelope.directory,
+            text: envelope.message,
+            extra: extraFromUnknown(envelope.extra),
+            createdAt: envelope.createdAt,
+          },
           envelope.createdAt,
           false,
         )
@@ -177,11 +283,16 @@ export function queueBusyAgentSend(input: {
   directory?: string
   text?: string
   fileCount?: number
+  extra?: PromptAsyncExtra
 }): DeliveryResult | "pass" {
   if (!input.busy || (input.fileCount ?? 0) > 0) return "pass"
   const text = input.text?.trim()
   if (!input.sessionId || !input.directory || !text) return "pass"
-  void managedInbox.enqueuePrompt({ sessionId: input.sessionId, directory: input.directory, text })
+  void managedInbox
+    .enqueuePrompt({ sessionId: input.sessionId, directory: input.directory, text, extra: input.extra })
+    .catch((error) => {
+      console.warn("[kilo-foundation] managed inbox enqueue failed", error)
+    })
   return "queued"
 }
 
@@ -197,7 +308,12 @@ export async function promptWhenSafe(
   const lifecycle = mapKiloRuntimeStatus(await runtimeStatus(client, input.directory, input.sessionId))
   const decision = resumeDecision(lifecycle)
   if (decision === "wait") {
-    await managedInbox.enqueuePrompt({ sessionId: input.sessionId, directory: input.directory, text: input.text })
+    await managedInbox.enqueuePrompt({
+      sessionId: input.sessionId,
+      directory: input.directory,
+      text: input.text,
+      extra: input.extra,
+    })
     return "queued"
   }
   if (decision === "fail") {
@@ -221,19 +337,22 @@ export async function flushIdleSession(
     const decision = resumeDecision(mapKiloRuntimeStatus(await runtimeStatus(client, peek.directory, sessionId)))
     if (decision !== "resume") return 0
   }
-  const queued = await managedInbox.takeForSession(sessionId)
-  for (const item of queued) {
-    await client.session.promptAsync(promptBody(item.sessionId, item.directory, item.text, extra), {
+  let sent = 0
+  while (sent < 10) {
+    const item = managedInbox.peekForSession(sessionId)
+    if (!item) return sent
+    await client.session.promptAsync(promptBody(item.sessionId, item.directory, item.text, { ...extra, ...item.extra }), {
       throwOnError: true,
     })
+    await managedInbox.acknowledgeSent(item)
+    sent++
   }
-  return queued.length
+  return sent
 }
 
-export async function resumeQueuedSessions(client: PromptClient, extra?: PromptAsyncExtra): Promise<number> {
-  const sessionIds = await managedInbox.hydrate()
+export async function flushQueuedSessions(client: PromptClient, extra?: PromptAsyncExtra): Promise<number> {
   let sent = 0
-  for (const sessionId of sessionIds) {
+  for (const sessionId of managedInbox.pendingSessionIds()) {
     const n = await flushIdleSession(client, sessionId, extra)
     if (n > 0) {
       recordResume(managedInbox.telemetry)
@@ -241,4 +360,9 @@ export async function resumeQueuedSessions(client: PromptClient, extra?: PromptA
     }
   }
   return sent
+}
+
+export async function resumeQueuedSessions(client: PromptClient, extra?: PromptAsyncExtra): Promise<number> {
+  await managedInbox.hydrate()
+  return flushQueuedSessions(client, extra)
 }

--- a/packages/kilo-vscode/src/agent-manager/managed-delivery.ts
+++ b/packages/kilo-vscode/src/agent-manager/managed-delivery.ts
@@ -114,6 +114,21 @@ export async function runtimeStatus(client: PromptClient, directory: string, ses
   }
 }
 
+/** Queue a follow-up Agent Manager text send when the session is already busy. */
+export function queueBusyAgentSend(input: {
+  busy: boolean
+  sessionId?: string
+  directory?: string
+  text?: string
+  fileCount?: number
+}): DeliveryResult | "pass" {
+  if (!input.busy || (input.fileCount ?? 0) > 0) return "pass"
+  const text = input.text?.trim()
+  if (!input.sessionId || !input.directory || !text) return "pass"
+  managedInbox.enqueuePrompt({ sessionId: input.sessionId, directory: input.directory, text })
+  return "queued"
+}
+
 export async function promptWhenSafe(
   client: PromptClient,
   input: {

--- a/packages/kilo-vscode/src/agent-manager/managed-delivery.ts
+++ b/packages/kilo-vscode/src/agent-manager/managed-delivery.ts
@@ -3,10 +3,13 @@ import {
   enqueueManaged,
   FOUNDATION_EVENT,
   FOUNDATION_WAKE_TYPES,
+  FileBackedSessionMessenger,
   mapKiloRuntimeStatus,
   recordCoordinatorWake,
+  recordResume,
   resumeDecision,
   shouldWakeCoordinator,
+  unconsumedManaged,
   type ManagedEvent,
   createGenericTelemetry,
 } from "@kilocode/kilo-foundation"
@@ -24,13 +27,16 @@ export type PromptAsyncExtra = {
   model?: { providerID: string; modelID: string }
   variant?: string
   snapshotInitialization?: "wait"
+  noReply?: boolean
+  messageID?: string
+  synthetic?: boolean
 }
 
 type PromptAsyncParameters = {
   sessionID: string
   directory?: string
-  parts: Array<{ type: "text"; text: string }>
-} & PromptAsyncExtra
+  parts: Array<{ type: "text"; text: string; synthetic?: boolean }>
+} & Omit<PromptAsyncExtra, "synthetic">
 
 /**
  * Duck-typed session client. Parameter fields must be assignable to the generated
@@ -47,15 +53,34 @@ function eventKey(event: ManagedEvent): string {
   return `${event.sessionId ?? ""}:${event.type}:${String(event.payload.text ?? event.payload.kind ?? event.id)}`
 }
 
+function promptBody(sessionId: string, directory: string, text: string, extra?: PromptAsyncExtra): PromptAsyncParameters {
+  const { synthetic, ...rest } = extra ?? {}
+  return {
+    sessionID: sessionId,
+    directory,
+    parts: [{ type: "text", text, ...(synthetic ? { synthetic: true } : {}) }],
+    ...rest,
+  }
+}
+
 /**
- * In-memory managed inbox for Agent Manager. Queues prompts while a session is
- * mid-generation and flushes them when `session.status` becomes idle.
+ * Managed inbox for Agent Manager. Queues prompts while a session is
+ * mid-generation, persists them on disk, and flushes when resume is safe.
  */
 export class ManagedSessionInbox {
   readonly events: ManagedEvent[] = []
   readonly telemetry = createGenericTelemetry()
+  private messenger: FileBackedSessionMessenger | undefined
 
-  enqueuePrompt(input: QueuedPrompt, nowIso = new Date().toISOString()): void {
+  attachPersistence(inboxRoot: string): void {
+    this.messenger = new FileBackedSessionMessenger(inboxRoot)
+  }
+
+  detachPersistence(): void {
+    this.messenger = undefined
+  }
+
+  async enqueuePrompt(input: QueuedPrompt, nowIso = new Date().toISOString(), persist = true): Promise<void> {
     enqueueManaged(
       this.events,
       {
@@ -67,6 +92,7 @@ export class ManagedSessionInbox {
       },
       eventKey,
     )
+    if (persist) await this.messenger?.sendQueued(input.sessionId, input.text, input.directory)
   }
 
   enqueueFoundationEvent(
@@ -88,18 +114,48 @@ export class ManagedSessionInbox {
     )
   }
 
-  takeForSession(sessionId: string, nowIso = new Date().toISOString()): QueuedPrompt[] {
+  peekForSession(sessionId: string): QueuedPrompt | undefined {
+    const pending = unconsumedManaged(this.events).find((event) => event.sessionId === sessionId)
+    const text = typeof pending?.payload.text === "string" ? pending.payload.text : undefined
+    const directory = typeof pending?.payload.directory === "string" ? pending.payload.directory : undefined
+    if (!pending || !text || !directory) return undefined
+    return { sessionId, directory, text }
+  }
+
+  async takeForSession(sessionId: string, nowIso = new Date().toISOString()): Promise<QueuedPrompt[]> {
     const pending = this.events.filter((event) => event.sessionId === sessionId && event.consumedAt === undefined)
     const batch = consumeManagedBatch(pending, 10, nowIso)
     if (batch.length > 0 && shouldWakeCoordinator(FOUNDATION_EVENT.MESSAGE_RECEIVED, FOUNDATION_WAKE_TYPES)) {
       recordCoordinatorWake(this.telemetry, batch.length)
     }
+    if (batch.length > 0) await this.messenger?.consumePending(sessionId, batch.length)
     return batch.flatMap((event) => {
       const text = typeof event.payload.text === "string" ? event.payload.text : undefined
       const directory = typeof event.payload.directory === "string" ? event.payload.directory : undefined
       if (!text || !directory) return []
       return [{ sessionId, directory, text }]
     })
+  }
+
+  async hydrate(): Promise<string[]> {
+    if (!this.messenger) return []
+    const sessions = await this.messenger.listSessions()
+    const ids: string[] = []
+    for (const sessionId of sessions) {
+      const pending = await this.messenger.listPending(sessionId)
+      let added = false
+      for (const envelope of pending) {
+        if (envelope.kind !== "message" || !envelope.message || !envelope.directory) continue
+        await this.enqueuePrompt(
+          { sessionId, directory: envelope.directory, text: envelope.message },
+          envelope.createdAt,
+          false,
+        )
+        added = true
+      }
+      if (added) ids.push(sessionId)
+    }
+    return ids
   }
 }
 
@@ -125,7 +181,7 @@ export function queueBusyAgentSend(input: {
   if (!input.busy || (input.fileCount ?? 0) > 0) return "pass"
   const text = input.text?.trim()
   if (!input.sessionId || !input.directory || !text) return "pass"
-  managedInbox.enqueuePrompt({ sessionId: input.sessionId, directory: input.directory, text })
+  void managedInbox.enqueuePrompt({ sessionId: input.sessionId, directory: input.directory, text })
   return "queued"
 }
 
@@ -141,21 +197,15 @@ export async function promptWhenSafe(
   const lifecycle = mapKiloRuntimeStatus(await runtimeStatus(client, input.directory, input.sessionId))
   const decision = resumeDecision(lifecycle)
   if (decision === "wait") {
-    managedInbox.enqueuePrompt({ sessionId: input.sessionId, directory: input.directory, text: input.text })
+    await managedInbox.enqueuePrompt({ sessionId: input.sessionId, directory: input.directory, text: input.text })
     return "queued"
   }
   if (decision === "fail") {
     return "rejected"
   }
-  await client.session.promptAsync(
-    {
-      sessionID: input.sessionId,
-      directory: input.directory,
-      parts: [{ type: "text", text: input.text }],
-      ...input.extra,
-    },
-    { throwOnError: true },
-  )
+  await client.session.promptAsync(promptBody(input.sessionId, input.directory, input.text, input.extra), {
+    throwOnError: true,
+  })
   return "sent"
 }
 
@@ -163,18 +213,32 @@ export async function flushIdleSession(
   client: PromptClient,
   sessionId: string,
   extra?: PromptAsyncExtra,
+  force = false,
 ): Promise<number> {
-  const queued = managedInbox.takeForSession(sessionId)
+  const peek = managedInbox.peekForSession(sessionId)
+  if (!peek) return 0
+  if (!force) {
+    const decision = resumeDecision(mapKiloRuntimeStatus(await runtimeStatus(client, peek.directory, sessionId)))
+    if (decision !== "resume") return 0
+  }
+  const queued = await managedInbox.takeForSession(sessionId)
   for (const item of queued) {
-    await client.session.promptAsync(
-      {
-        sessionID: item.sessionId,
-        directory: item.directory,
-        parts: [{ type: "text", text: item.text }],
-        ...extra,
-      },
-      { throwOnError: true },
-    )
+    await client.session.promptAsync(promptBody(item.sessionId, item.directory, item.text, extra), {
+      throwOnError: true,
+    })
   }
   return queued.length
+}
+
+export async function resumeQueuedSessions(client: PromptClient, extra?: PromptAsyncExtra): Promise<number> {
+  const sessionIds = await managedInbox.hydrate()
+  let sent = 0
+  for (const sessionId of sessionIds) {
+    const n = await flushIdleSession(client, sessionId, extra)
+    if (n > 0) {
+      recordResume(managedInbox.telemetry)
+      sent += n
+    }
+  }
+  return sent
 }

--- a/packages/kilo-vscode/src/agent-manager/managed-delivery.ts
+++ b/packages/kilo-vscode/src/agent-manager/managed-delivery.ts
@@ -19,10 +19,27 @@ export interface QueuedPrompt {
   text: string
 }
 
+/** Fields Agent Manager actually forwards into `session.promptAsync`. */
+export type PromptAsyncExtra = {
+  model?: { providerID: string; modelID: string }
+  variant?: string
+  snapshotInitialization?: "wait"
+}
+
+type PromptAsyncParameters = {
+  sessionID: string
+  directory?: string
+  parts: Array<{ type: "text"; text: string }>
+} & PromptAsyncExtra
+
+/**
+ * Duck-typed session client. Parameter fields must be assignable to the generated
+ * Kilo SDK `promptAsync` body (`model` cannot be `unknown`).
+ */
 type PromptClient = {
   session: {
-    status?: (input: { directory: string }) => Promise<{ data?: Record<string, { type?: string }> }>
-    promptAsync: (input: Record<string, unknown>, opts?: { throwOnError?: boolean }) => Promise<unknown>
+    status?(input: { directory: string }): Promise<{ data?: Record<string, { type?: string }> }>
+    promptAsync(parameters: PromptAsyncParameters, opts?: { throwOnError?: boolean }): Promise<unknown>
   }
 }
 
@@ -103,7 +120,7 @@ export async function promptWhenSafe(
     sessionId: string
     directory: string
     text: string
-    extra?: Record<string, unknown>
+    extra?: PromptAsyncExtra
   },
 ): Promise<DeliveryResult> {
   const lifecycle = mapKiloRuntimeStatus(await runtimeStatus(client, input.directory, input.sessionId))
@@ -130,7 +147,7 @@ export async function promptWhenSafe(
 export async function flushIdleSession(
   client: PromptClient,
   sessionId: string,
-  extra?: Record<string, unknown>,
+  extra?: PromptAsyncExtra,
 ): Promise<number> {
   const queued = managedInbox.takeForSession(sessionId)
   for (const item of queued) {

--- a/packages/kilo-vscode/src/agent-manager/managed-delivery.ts
+++ b/packages/kilo-vscode/src/agent-manager/managed-delivery.ts
@@ -1,0 +1,148 @@
+import {
+  consumeManagedBatch,
+  enqueueManaged,
+  FOUNDATION_EVENT,
+  FOUNDATION_WAKE_TYPES,
+  mapKiloRuntimeStatus,
+  recordCoordinatorWake,
+  resumeDecision,
+  shouldWakeCoordinator,
+  type ManagedEvent,
+  createGenericTelemetry,
+} from "@kilocode/kilo-foundation"
+
+export type DeliveryResult = "sent" | "queued" | "rejected"
+
+export interface QueuedPrompt {
+  sessionId: string
+  directory: string
+  text: string
+}
+
+type PromptClient = {
+  session: {
+    status?: (input: { directory: string }) => Promise<{ data?: Record<string, { type?: string }> }>
+    promptAsync: (input: Record<string, unknown>, opts?: { throwOnError?: boolean }) => Promise<unknown>
+  }
+}
+
+function eventKey(event: ManagedEvent): string {
+  return `${event.sessionId ?? ""}:${event.type}:${String(event.payload.text ?? event.payload.kind ?? event.id)}`
+}
+
+/**
+ * In-memory managed inbox for Agent Manager. Queues prompts while a session is
+ * mid-generation and flushes them when `session.status` becomes idle.
+ */
+export class ManagedSessionInbox {
+  readonly events: ManagedEvent[] = []
+  readonly telemetry = createGenericTelemetry()
+
+  enqueuePrompt(input: QueuedPrompt, nowIso = new Date().toISOString()): void {
+    enqueueManaged(
+      this.events,
+      {
+        id: `${input.sessionId}:${nowIso}:${this.events.length}`,
+        type: FOUNDATION_EVENT.MESSAGE_RECEIVED,
+        sessionId: input.sessionId,
+        payload: { text: input.text, directory: input.directory, kind: "message" },
+        createdAt: nowIso,
+      },
+      eventKey,
+    )
+  }
+
+  enqueueFoundationEvent(
+    type: typeof FOUNDATION_EVENT.STALLED | typeof FOUNDATION_EVENT.RESUMABLE | typeof FOUNDATION_EVENT.STATUS_CHANGED,
+    sessionId: string,
+    payload: Record<string, unknown> = {},
+    nowIso = new Date().toISOString(),
+  ): void {
+    enqueueManaged(
+      this.events,
+      {
+        id: `${sessionId}:${type}:${nowIso}`,
+        type,
+        sessionId,
+        payload,
+        createdAt: nowIso,
+      },
+      eventKey,
+    )
+  }
+
+  takeForSession(sessionId: string, nowIso = new Date().toISOString()): QueuedPrompt[] {
+    const pending = this.events.filter((event) => event.sessionId === sessionId && event.consumedAt === undefined)
+    const batch = consumeManagedBatch(pending, 10, nowIso)
+    if (batch.length > 0 && shouldWakeCoordinator(FOUNDATION_EVENT.MESSAGE_RECEIVED, FOUNDATION_WAKE_TYPES)) {
+      recordCoordinatorWake(this.telemetry, batch.length)
+    }
+    return batch.flatMap((event) => {
+      const text = typeof event.payload.text === "string" ? event.payload.text : undefined
+      const directory = typeof event.payload.directory === "string" ? event.payload.directory : undefined
+      if (!text || !directory) return []
+      return [{ sessionId, directory, text }]
+    })
+  }
+}
+
+export const managedInbox = new ManagedSessionInbox()
+
+export async function runtimeStatus(client: PromptClient, directory: string, sessionId: string): Promise<string> {
+  try {
+    const result = await client.session.status?.({ directory })
+    return result?.data?.[sessionId]?.type ?? "idle"
+  } catch {
+    return "idle"
+  }
+}
+
+export async function promptWhenSafe(
+  client: PromptClient,
+  input: {
+    sessionId: string
+    directory: string
+    text: string
+    extra?: Record<string, unknown>
+  },
+): Promise<DeliveryResult> {
+  const lifecycle = mapKiloRuntimeStatus(await runtimeStatus(client, input.directory, input.sessionId))
+  const decision = resumeDecision(lifecycle)
+  if (decision === "wait") {
+    managedInbox.enqueuePrompt({ sessionId: input.sessionId, directory: input.directory, text: input.text })
+    return "queued"
+  }
+  if (decision === "fail") {
+    return "rejected"
+  }
+  await client.session.promptAsync(
+    {
+      sessionID: input.sessionId,
+      directory: input.directory,
+      parts: [{ type: "text", text: input.text }],
+      ...input.extra,
+    },
+    { throwOnError: true },
+  )
+  return "sent"
+}
+
+export async function flushIdleSession(
+  client: PromptClient,
+  sessionId: string,
+  extra?: Record<string, unknown>,
+): Promise<number> {
+  const queued = managedInbox.takeForSession(sessionId)
+  for (const item of queued) {
+    await client.session.promptAsync(
+      {
+        sessionID: item.sessionId,
+        directory: item.directory,
+        parts: [{ type: "text", text: item.text }],
+        ...extra,
+      },
+      { throwOnError: true },
+    )
+  }
+  return queued.length
+}

--- a/packages/kilo-vscode/src/agent-manager/orchestration-domain.ts
+++ b/packages/kilo-vscode/src/agent-manager/orchestration-domain.ts
@@ -5,7 +5,7 @@ import type { LocalStats, WorktreeStats } from "./GitStatsPoller"
 import type { PRStatus } from "./types"
 import type { ManagedSession, Worktree, WorktreeStateManager } from "./WorktreeStateManager"
 import { SNAPSHOT_INITIALIZATION } from "./constants"
-import { promptWhenSafe } from "./managed-delivery"
+import { promptWhenSafe, managedInbox } from "./managed-delivery"
 
 export type Activity = "idle" | "busy" | "retry" | "offline"
 export type FilterState = Activity | "waiting"
@@ -320,9 +320,8 @@ export async function prompt(input: {
   text: string
   messageID: string
   signal?: AbortSignal
-  idleTimeoutMs?: number
-}): Promise<void> {
-  if (input.signal?.aborted) return
+}): Promise<"sent" | "queued"> {
+  if (input.signal?.aborted) return "queued"
   const managed = input.state.getSession(input.sessionID)
   if (!managed)
     throw new OrchestrationError("unknown_session", "The session is not managed by this Agent Manager workspace")
@@ -344,7 +343,7 @@ export async function prompt(input: {
   if (!(await sameManagedDirectory(response.data.directory, dir))) {
     throw new OrchestrationError("cross_workspace", "The managed session belongs to a different workspace directory")
   }
-  if (input.signal?.aborted) return
+  if (input.signal?.aborted) return "queued"
   const result = await promptWhenSafe(input.client, {
     sessionId: input.sessionID,
     directory: dir,
@@ -357,6 +356,10 @@ export async function prompt(input: {
   if (result === "rejected") {
     throw new OrchestrationError("unavailable_session", "The managed session cannot accept a prompt right now")
   }
+  if (input.signal?.aborted && result === "queued") {
+    await managedInbox.dropLastPrompt(input.sessionID, input.text)
+  }
+  return result
 }
 
 export function move(input: { state: WorktreeStateManager; sessionID: string; sectionID: string | null }): void {

--- a/packages/kilo-vscode/src/agent-manager/orchestration-domain.ts
+++ b/packages/kilo-vscode/src/agent-manager/orchestration-domain.ts
@@ -5,6 +5,7 @@ import type { LocalStats, WorktreeStats } from "./GitStatsPoller"
 import type { PRStatus } from "./types"
 import type { ManagedSession, Worktree, WorktreeStateManager } from "./WorktreeStateManager"
 import { SNAPSHOT_INITIALIZATION } from "./constants"
+import { promptWhenSafe } from "./managed-delivery"
 
 export type Activity = "idle" | "busy" | "retry" | "offline"
 export type FilterState = Activity | "waiting"
@@ -343,41 +344,19 @@ export async function prompt(input: {
   if (!(await sameManagedDirectory(response.data.directory, dir))) {
     throw new OrchestrationError("cross_workspace", "The managed session belongs to a different workspace directory")
   }
-  await waitForIdle(input.client, dir, input.sessionID, input.signal, input.idleTimeoutMs ?? 30_000)
   if (input.signal?.aborted) return
-  await input.client.session.promptAsync(
-    {
-      sessionID: input.sessionID,
-      directory: dir,
+  const result = await promptWhenSafe(input.client, {
+    sessionId: input.sessionID,
+    directory: dir,
+    text: input.text,
+    extra: {
       messageID: `msg_agent_manager_${input.messageID}`,
-      parts: [{ type: "text", text: input.text }],
       snapshotInitialization: SNAPSHOT_INITIALIZATION,
     },
-    { throwOnError: true },
-  )
-}
-
-async function waitForIdle(
-  client: KiloClient,
-  directory: string,
-  sessionID: string,
-  signal: AbortSignal | undefined,
-  timeout: number,
-  start = Date.now(),
-): Promise<void> {
-  if (signal?.aborted) return
-  const status = await client.session.status({ directory })
-  if (status.error) throw new OrchestrationError("host_error", "The managed session status could not be read")
-  const activity = status.data?.[sessionID]?.type ?? "idle"
-  if (activity === "idle") return
-  if (Date.now() - start >= timeout) {
-    throw new OrchestrationError(
-      "unavailable_session",
-      `The managed session is still ${activity}; only idle sessions can be prompted`,
-    )
+  })
+  if (result === "rejected") {
+    throw new OrchestrationError("unavailable_session", "The managed session cannot accept a prompt right now")
   }
-  await new Promise<void>((resolve) => setTimeout(resolve, 250))
-  return waitForIdle(client, directory, sessionID, signal, timeout, start)
 }
 
 export function move(input: { state: WorktreeStateManager; sessionID: string; sectionID: string | null }): void {

--- a/packages/kilo-vscode/src/agent-manager/promotion-handoff.ts
+++ b/packages/kilo-vscode/src/agent-manager/promotion-handoff.ts
@@ -1,3 +1,4 @@
+import { promptWhenSafe } from "./managed-delivery"
 import type { KiloClient } from "@kilocode/sdk/v2/client"
 
 export interface PromoteHandoffInput {
@@ -18,18 +19,10 @@ export function handoffText(input: Omit<PromoteHandoffInput, "client" | "session
 }
 
 export async function recordPromotionHandoff(input: PromoteHandoffInput): Promise<void> {
-  const payload = {
-    sessionID: input.sessionId,
+  await promptWhenSafe(input.client, {
+    sessionId: input.sessionId,
     directory: input.directory,
-    noReply: true,
-    parts: [
-      {
-        type: "text",
-        text: handoffText(input),
-        synthetic: true,
-      },
-    ],
-  } as Parameters<KiloClient["session"]["promptAsync"]>[0]
-
-  await input.client.session.promptAsync(payload, { throwOnError: true })
+    text: handoffText(input),
+    extra: { noReply: true, synthetic: true },
+  })
 }

--- a/packages/kilo-vscode/src/agent-manager/session-stall-watchdog.ts
+++ b/packages/kilo-vscode/src/agent-manager/session-stall-watchdog.ts
@@ -12,6 +12,19 @@ import { managedInbox } from "./managed-delivery"
 
 const DEFAULT_SCAN_EVERY_MS = 60_000
 
+function positiveIntEnv(name: string): number | undefined {
+  const parsed = Number.parseInt(process.env[name] ?? "", 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
+}
+
+/** Optional live-check overrides. Unset values keep the 15m / 60s defaults. */
+export function stallWatchdogFromEnv(): Pick<SessionStallWatchdogOptions, "stallAfterMs" | "scanEveryMs"> {
+  return {
+    stallAfterMs: positiveIntEnv("KILO_STALL_AFTER_MS"),
+    scanEveryMs: positiveIntEnv("KILO_STALL_SCAN_EVERY_MS"),
+  }
+}
+
 export interface SessionStallWatchdogOptions {
   stallAfterMs?: number
   scanEveryMs?: number

--- a/packages/kilo-vscode/src/agent-manager/session-stall-watchdog.ts
+++ b/packages/kilo-vscode/src/agent-manager/session-stall-watchdog.ts
@@ -1,0 +1,126 @@
+import {
+  DEFAULT_STALL_AFTER_MS,
+  FOUNDATION_EVENT,
+  canSafelyResume,
+  mapKiloRuntimeActivity,
+  mapKiloRuntimeStatus,
+  recordStall,
+  scanSessionStalls,
+  type SessionProgress,
+} from "@kilocode/kilo-foundation"
+import { managedInbox } from "./managed-delivery"
+
+const DEFAULT_SCAN_EVERY_MS = 60_000
+
+export interface SessionStallWatchdogOptions {
+  stallAfterMs?: number
+  scanEveryMs?: number
+  now?: () => Date
+  setIntervalFn?: typeof setInterval
+  clearIntervalFn?: typeof clearInterval
+}
+
+/**
+ * Clock-based stall scan for Agent Manager. Last progress comes from
+ * `session.status` SSE events. Does not poll an LLM or session HTTP API.
+ */
+export class SessionStallWatchdog {
+  private readonly sessions = new Map<string, SessionProgress>()
+  private readonly reported = new Set<string>()
+  private readonly stallAfterMs: number
+  private readonly scanEveryMs: number
+  private readonly now: () => Date
+  private readonly setIntervalFn: typeof setInterval
+  private readonly clearIntervalFn: typeof clearInterval
+  private timer: ReturnType<typeof setInterval> | undefined
+
+  constructor(opts: SessionStallWatchdogOptions = {}) {
+    this.stallAfterMs = opts.stallAfterMs ?? DEFAULT_STALL_AFTER_MS
+    this.scanEveryMs = opts.scanEveryMs ?? DEFAULT_SCAN_EVERY_MS
+    this.now = opts.now ?? (() => new Date())
+    this.setIntervalFn = opts.setIntervalFn ?? setInterval
+    this.clearIntervalFn = opts.clearIntervalFn ?? clearInterval
+  }
+
+  noteStatus(sessionId: string, runtimeType: string, directory?: string, nowIso = this.now().toISOString()): void {
+    const activity = mapKiloRuntimeActivity(runtimeType)
+    this.reported.delete(sessionId)
+    if (activity === "idle" || activity === "stopped") {
+      this.sessions.delete(sessionId)
+      return
+    }
+    this.sessions.set(sessionId, {
+      sessionId,
+      activity,
+      lastProgressIso: nowIso,
+      directory,
+    })
+  }
+
+  forget(sessionId: string): void {
+    this.sessions.delete(sessionId)
+    this.reported.delete(sessionId)
+  }
+
+  scan(nowIso = this.now().toISOString()): SessionProgress[] {
+    const stalled = scanSessionStalls([...this.sessions.values()], nowIso, this.stallAfterMs)
+    for (const session of stalled) {
+      if (this.reported.has(session.sessionId)) continue
+      this.reported.add(session.sessionId)
+      recordStall(managedInbox.telemetry)
+      managedInbox.enqueueFoundationEvent(
+        FOUNDATION_EVENT.STALLED,
+        session.sessionId,
+        {
+          lastProgressIso: session.lastProgressIso,
+          directory: session.directory,
+          kind: "stall",
+        },
+        nowIso,
+      )
+      if (resumableAfterStall(session.activity)) {
+        managedInbox.enqueueFoundationEvent(
+          FOUNDATION_EVENT.RESUMABLE,
+          session.sessionId,
+          {
+            directory: session.directory,
+            kind: "resume",
+          },
+          nowIso,
+        )
+      }
+    }
+    return stalled
+  }
+
+  start(): void {
+    if (this.timer) return
+    this.timer = this.setIntervalFn(() => {
+      this.scan()
+    }, this.scanEveryMs)
+  }
+
+  stop(): void {
+    if (!this.timer) return
+    this.clearIntervalFn(this.timer)
+    this.timer = undefined
+  }
+}
+
+function mapActivityToRuntime(activity: SessionProgress["activity"]): string {
+  switch (activity) {
+    case "blocked":
+      return "offline"
+    case "waiting":
+      return "retry"
+    case "running":
+      return "busy"
+    default:
+      return "idle"
+  }
+}
+
+/** Resume only for paused/offline stalls, never while still running. */
+export function resumableAfterStall(activity: SessionProgress["activity"]): boolean {
+  return canSafelyResume(mapKiloRuntimeStatus(mapActivityToRuntime(activity)))
+}

--- a/packages/kilo-vscode/src/agent-manager/session-stall-watchdog.ts
+++ b/packages/kilo-vscode/src/agent-manager/session-stall-watchdog.ts
@@ -18,6 +18,7 @@ export interface SessionStallWatchdogOptions {
   now?: () => Date
   setIntervalFn?: typeof setInterval
   clearIntervalFn?: typeof clearInterval
+  onStall?: (sessionId: string, resumable: boolean) => void
 }
 
 /**
@@ -32,6 +33,7 @@ export class SessionStallWatchdog {
   private readonly now: () => Date
   private readonly setIntervalFn: typeof setInterval
   private readonly clearIntervalFn: typeof clearInterval
+  private readonly onStall?: (sessionId: string, resumable: boolean) => void
   private timer: ReturnType<typeof setInterval> | undefined
 
   constructor(opts: SessionStallWatchdogOptions = {}) {
@@ -40,6 +42,7 @@ export class SessionStallWatchdog {
     this.now = opts.now ?? (() => new Date())
     this.setIntervalFn = opts.setIntervalFn ?? setInterval
     this.clearIntervalFn = opts.clearIntervalFn ?? clearInterval
+    this.onStall = opts.onStall
   }
 
   noteStatus(sessionId: string, runtimeType: string, directory?: string, nowIso = this.now().toISOString()): void {
@@ -78,7 +81,8 @@ export class SessionStallWatchdog {
         },
         nowIso,
       )
-      if (resumableAfterStall(session.activity)) {
+      const resumable = resumableAfterStall(session.activity)
+      if (resumable) {
         managedInbox.enqueueFoundationEvent(
           FOUNDATION_EVENT.RESUMABLE,
           session.sessionId,
@@ -89,6 +93,7 @@ export class SessionStallWatchdog {
           nowIso,
         )
       }
+      this.onStall?.(session.sessionId, resumable)
     }
     return stalled
   }

--- a/packages/kilo-vscode/src/agent-manager/tool-start.ts
+++ b/packages/kilo-vscode/src/agent-manager/tool-start.ts
@@ -107,10 +107,10 @@ function versionedLabel(base: string | undefined, index: number, total: number):
   return base
 }
 
-async function prompt(client: KiloClient, sid: string, dir: string, task: ToolTask) {
+async function prompt(client: KiloClient, sid: string, dir: string, task: ToolTask, log: ToolDeps["log"]) {
   const body = text(task)
   if (!body) return
-  await promptWhenSafe(client, {
+  const result = await promptWhenSafe(client, {
     sessionId: sid,
     directory: dir,
     text: body,
@@ -120,6 +120,7 @@ async function prompt(client: KiloClient, sid: string, dir: string, task: ToolTa
       snapshotInitialization: SNAPSHOT_INITIALIZATION,
     },
   })
+  if (result !== "sent") log("managed prompt", result, sid)
 }
 
 async function local(deps: ToolDeps, client: KiloClient, task: ToolTask, directory?: string, source?: ToolSource) {
@@ -155,7 +156,7 @@ async function local(deps: ToolDeps, client: KiloClient, task: ToolTask, directo
   deps.push()
   deps.getPanel()?.sessions.registerSession(session)
   if (wt) deps.post({ type: "agentManager.sessionAdded", sessionId: session.id, worktreeId: wt.id })
-  await prompt(client, session.id, target, task)
+  await prompt(client, session.id, target, task, deps.log)
   deps.capture("Agent Manager Session Started", {
     source: PLATFORM,
     sessionId: session.id,
@@ -208,7 +209,7 @@ async function worktree(
   deps.registerWorktreeSession(session.id, created.result.path)
   deps.notifyReady(session.id, created.result, created.worktree.id)
   deps.getPanel()?.sessions.registerSession(session)
-  await prompt(client, session.id, created.result.path, task)
+  await prompt(client, session.id, created.result.path, task, deps.log)
   deps.capture("Agent Manager Session Started", {
     source: PLATFORM,
     sessionId: session.id,

--- a/packages/kilo-vscode/src/agent-manager/tool-start.ts
+++ b/packages/kilo-vscode/src/agent-manager/tool-start.ts
@@ -5,6 +5,7 @@ import type { WorktreeStateManager } from "./WorktreeStateManager"
 import type { PanelContext } from "./host"
 import { PLATFORM, SNAPSHOT_INITIALIZATION } from "./constants"
 import { sameDirectory } from "../kilo-provider-utils"
+import { promptWhenSafe } from "./managed-delivery"
 
 const LABEL_MAX = 28
 const PREFIX = new Set(["feat", "fix", "chore", "bug", "issue", "task", "branch"])
@@ -109,17 +110,16 @@ function versionedLabel(base: string | undefined, index: number, total: number):
 async function prompt(client: KiloClient, sid: string, dir: string, task: ToolTask) {
   const body = text(task)
   if (!body) return
-  await client.session.promptAsync(
-    {
-      sessionID: sid,
-      directory: dir,
-      parts: [{ type: "text", text: body }],
+  await promptWhenSafe(client, {
+    sessionId: sid,
+    directory: dir,
+    text: body,
+    extra: {
       model: task.model,
       variant: task.variant,
       snapshotInitialization: SNAPSHOT_INITIALIZATION,
     },
-    { throwOnError: true },
-  )
+  })
 }
 
 async function local(deps: ToolDeps, client: KiloClient, task: ToolTask, directory?: string, source?: ToolSource) {

--- a/packages/kilo-vscode/src/agent-manager/worktree-create.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-create.ts
@@ -59,9 +59,9 @@ export async function createWorktreeOnDisk(
     ? undefined
     : await resolveBaseBranch(ctx, manager, state, opts?.baseBranch)
 
-  let result: CreateWorktreeResult
+  let created: CreateWorktreeResult | undefined
   try {
-    result = await manager.createWorktree({
+    created = await manager.createWorktree({
       prompt: opts?.name || "kilo",
       baseBranch: effectiveBase ?? opts?.baseBranch,
       baseRef: opts?.baseRef,
@@ -72,11 +72,18 @@ export async function createWorktreeOnDisk(
     if (workspaceRoot) {
       assertSessionIsolation({
         workspaceRoot,
-        sessionDirectory: result.path,
+        sessionDirectory: created.path,
         isolated: true,
       })
     }
   } catch (error) {
+    if (created) {
+      try {
+        await manager.removeWorktree(created.path, created.branch)
+      } catch (cleanup) {
+        ctx.log("Failed to roll back isolated worktree:", cleanup)
+      }
+    }
     const msg = error instanceof Error ? error.message : String(error)
     ctx.postToWebview({
       type: "agentManager.worktreeSetup",
@@ -91,6 +98,8 @@ export async function createWorktreeOnDisk(
     })
     return null
   }
+
+  const result = created
 
   const worktree = state.addWorktree({
     branch: result.branch,

--- a/packages/kilo-vscode/src/agent-manager/worktree-create.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-create.ts
@@ -4,6 +4,7 @@ import { chooseBaseBranch } from "./base-branch"
 import { classifyWorktreeError } from "./git-import"
 import { PLATFORM } from "./constants"
 import type { AgentManagerOutMessage } from "./types"
+import { assertSessionIsolation } from "@kilocode/kilo-foundation"
 
 export type CreateWorktreeOnDiskOptions = {
   groupId?: string
@@ -23,6 +24,7 @@ export type CreateWorktreeOnDiskResult = {
 export interface CreateWorktreeOnDiskContext {
   getWorktreeManager: () => WorktreeManager | undefined
   getStateManager: () => WorktreeStateManager | undefined
+  getWorkspaceRoot?: () => string | undefined
   postToWebview: (message: AgentManagerOutMessage) => void
   capture: (event: string, properties?: Record<string, unknown>) => void
   pushState: () => void
@@ -66,6 +68,14 @@ export async function createWorktreeOnDisk(
       branchName: opts?.branchName,
       existingBranch: opts?.existingBranch,
     })
+    const workspaceRoot = ctx.getWorkspaceRoot?.()
+    if (workspaceRoot) {
+      assertSessionIsolation({
+        workspaceRoot,
+        sessionDirectory: result.path,
+        isolated: true,
+      })
+    }
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error)
     ctx.postToWebview({

--- a/packages/kilo-vscode/tests/unit/agent-manager-orchestration-domain.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-orchestration-domain.test.ts
@@ -4,6 +4,7 @@ import * as os from "os"
 import * as path from "path"
 import type { KiloClient, Session } from "@kilocode/sdk/v2/client"
 import { OrchestrationError, overview, prompt } from "../../src/agent-manager/orchestration-domain"
+import { managedInbox } from "../../src/agent-manager/managed-delivery"
 import { WorktreeStateManager } from "../../src/agent-manager/WorktreeStateManager"
 import type { PRStatus as AgentManagerPRStatus } from "../../src/agent-manager/types"
 
@@ -24,6 +25,7 @@ describe("Agent Manager orchestration domain", () => {
   })
 
   afterEach(async () => {
+    managedInbox.events.length = 0
     await state.flush()
     fs.rmSync(root, { recursive: true, force: true })
   })
@@ -202,26 +204,25 @@ describe("Agent Manager orchestration domain", () => {
     )
   })
 
-  it("waits for a busy managed session to become idle before prompting", async () => {
+  it("queues a busy managed session instead of polling for idle", async () => {
     const managed = state.addWorktree({ branch: "fix/wait", path: worktree, parentBranch: "main" })
     state.addSession("ses_wait", managed.id)
-    let calls = 0
     const promptAsync = mock(async () => ({ data: undefined }))
     const client = {
       session: {
         get: mock(async () => ({ data: { id: "ses_wait", directory: worktree, title: "Wait" } as Session })),
-        status: mock(async () => ({ data: calls++ === 0 ? { ses_wait: { type: "busy" } } : {} })),
+        status: mock(async () => ({ data: { ses_wait: { type: "busy" } } })),
         promptAsync,
       },
     } as unknown as KiloClient
 
     await prompt({ client, root, state, sessionID: "ses_wait", text: "Continue", messageID: "amr_wait" })
 
-    expect(client.session.status).toHaveBeenCalledTimes(2)
-    expect(promptAsync).toHaveBeenCalledTimes(1)
+    expect(promptAsync).not.toHaveBeenCalled()
+    expect(managedInbox.peekForSession("ses_wait")?.text).toBe("Continue")
   })
 
-  it("rejects unknown, stale, cross-workspace, and busy targets", async () => {
+  it("rejects unknown, stale, and cross-workspace targets", async () => {
     const managed = state.addWorktree({ branch: "fix/errors", path: worktree, parentBranch: "main" })
     state.addSession("ses_target", managed.id)
     const promptAsync = mock(async () => ({ data: undefined }))
@@ -243,26 +244,6 @@ describe("Agent Manager orchestration domain", () => {
     ).rejects.toMatchObject({
       code: "cross_workspace",
     } satisfies Partial<OrchestrationError>)
-    ;(client.session.get as ReturnType<typeof mock>).mockImplementation(async () => ({
-      data: { id: "ses_target", directory: worktree, title: "Target" } as Session,
-    }))
-    ;(client.session.status as ReturnType<typeof mock>).mockImplementation(async () => ({
-      data: { ses_target: { type: "busy" } },
-    }))
-    await expect(
-      prompt({
-        client,
-        root,
-        state,
-        sessionID: "ses_target",
-        text: "Continue",
-        messageID: "amr_busy",
-        idleTimeoutMs: 0,
-      }),
-    ).rejects.toMatchObject({
-      code: "unavailable_session",
-    } satisfies Partial<OrchestrationError>)
-
     fs.rmSync(worktree, { recursive: true, force: true })
     await expect(
       prompt({ client, root, state, sessionID: "ses_target", text: "Continue", messageID: "amr_stale" }),

--- a/packages/kilo-vscode/tests/unit/agent-manager-orchestration-domain.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-orchestration-domain.test.ts
@@ -189,7 +189,9 @@ describe("Agent Manager orchestration domain", () => {
       },
     } as unknown as KiloClient
 
-    await prompt({ client, root, state, sessionID: "ses_target", text: "Continue", messageID: "amr_prompt" })
+    expect(await prompt({ client, root, state, sessionID: "ses_target", text: "Continue", messageID: "amr_prompt" })).toBe(
+      "sent",
+    )
 
     expect(get).toHaveBeenCalledWith({ sessionID: "ses_target", directory: worktree })
     expect(promptAsync).toHaveBeenCalledWith(
@@ -216,7 +218,9 @@ describe("Agent Manager orchestration domain", () => {
       },
     } as unknown as KiloClient
 
-    await prompt({ client, root, state, sessionID: "ses_wait", text: "Continue", messageID: "amr_wait" })
+    expect(await prompt({ client, root, state, sessionID: "ses_wait", text: "Continue", messageID: "amr_wait" })).toBe(
+      "queued",
+    )
 
     expect(promptAsync).not.toHaveBeenCalled()
     expect(managedInbox.peekForSession("ses_wait")?.text).toBe("Continue")

--- a/packages/kilo-vscode/tests/unit/managed-delivery.test.ts
+++ b/packages/kilo-vscode/tests/unit/managed-delivery.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { flushIdleSession, managedInbox, promptWhenSafe } from "../../src/agent-manager/managed-delivery"
+import { flushIdleSession, managedInbox, promptWhenSafe, queueBusyAgentSend } from "../../src/agent-manager/managed-delivery"
 
 describe("managed session delivery", () => {
   afterEach(() => {
@@ -47,5 +47,44 @@ describe("managed session delivery", () => {
     expect(await flushIdleSession(idle, "s1")).toBe(1)
     expect(sent).toEqual(["hold"])
     expect(await flushIdleSession(idle, "s1")).toBe(0)
+  })
+
+  test("queueBusyAgentSend holds a follow-up text send until flushIdleSession", async () => {
+    expect(
+      queueBusyAgentSend({
+        busy: true,
+        sessionId: "s1",
+        directory: "/repo",
+        text: "next",
+      }),
+    ).toBe("queued")
+    expect(
+      queueBusyAgentSend({
+        busy: false,
+        sessionId: "s1",
+        directory: "/repo",
+        text: "skip",
+      }),
+    ).toBe("pass")
+    expect(
+      queueBusyAgentSend({
+        busy: true,
+        sessionId: "s1",
+        directory: "/repo",
+        text: "attachment",
+        fileCount: 1,
+      }),
+    ).toBe("pass")
+
+    const sent: string[] = []
+    const idle = {
+      session: {
+        promptAsync: async (input: { parts: Array<{ text: string }> }) => {
+          sent.push(input.parts[0]?.text ?? "")
+        },
+      },
+    }
+    expect(await flushIdleSession(idle, "s1")).toBe(1)
+    expect(sent).toEqual(["next"])
   })
 })

--- a/packages/kilo-vscode/tests/unit/managed-delivery.test.ts
+++ b/packages/kilo-vscode/tests/unit/managed-delivery.test.ts
@@ -1,20 +1,21 @@
-import { describe, expect, test } from "bun:test"
-import { ManagedSessionInbox, promptWhenSafe } from "../../src/agent-manager/managed-delivery"
+import { afterEach, describe, expect, test } from "bun:test"
+import { flushIdleSession, managedInbox, promptWhenSafe } from "../../src/agent-manager/managed-delivery"
 
 describe("managed session delivery", () => {
+  afterEach(() => {
+    managedInbox.events.length = 0
+  })
+
   test("sends immediately when status is missing (idle default)", async () => {
-    const promptAsync = async () => ({})
-    const client = { session: { promptAsync } }
     const sent: string[] = []
-    const wrapped = {
+    const client = {
       session: {
         promptAsync: async (input: { parts: Array<{ text: string }> }) => {
           sent.push(input.parts[0]?.text ?? "")
-          return promptAsync()
         },
       },
     }
-    const result = await promptWhenSafe(wrapped, {
+    const result = await promptWhenSafe(client, {
       sessionId: "s1",
       directory: "/repo",
       text: "hello",
@@ -23,15 +24,9 @@ describe("managed session delivery", () => {
     expect(sent).toEqual(["hello"])
   })
 
-  test("queues while busy and flushes the same text later", async () => {
-    const inbox = new ManagedSessionInbox()
-    inbox.enqueuePrompt({ sessionId: "s1", directory: "/repo", text: "later" })
-    expect(inbox.takeForSession("s1")).toEqual([{ sessionId: "s1", directory: "/repo", text: "later" }])
-    expect(inbox.takeForSession("s1")).toEqual([])
-  })
-
-  test("queues promptWhenSafe when the session is busy", async () => {
-    const client = {
+  test("queues promptWhenSafe while busy then flushIdleSession sends the same text", async () => {
+    const sent: string[] = []
+    const busy = {
       session: {
         status: async () => ({ data: { s1: { type: "busy" as const } } }),
         promptAsync: async () => {
@@ -39,10 +34,18 @@ describe("managed session delivery", () => {
         },
       },
     }
-    const { managedInbox } = await import("../../src/agent-manager/managed-delivery")
-    const before = managedInbox.events.length
-    const result = await promptWhenSafe(client, { sessionId: "s1", directory: "/repo", text: "hold" })
-    expect(result).toBe("queued")
-    expect(managedInbox.events.length).toBeGreaterThan(before)
+    expect(await promptWhenSafe(busy, { sessionId: "s1", directory: "/repo", text: "hold" })).toBe("queued")
+
+    const idle = {
+      session: {
+        status: async () => ({ data: { s1: { type: "idle" as const } } }),
+        promptAsync: async (input: { parts: Array<{ text: string }> }) => {
+          sent.push(input.parts[0]?.text ?? "")
+        },
+      },
+    }
+    expect(await flushIdleSession(idle, "s1")).toBe(1)
+    expect(sent).toEqual(["hold"])
+    expect(await flushIdleSession(idle, "s1")).toBe(0)
   })
 })

--- a/packages/kilo-vscode/tests/unit/managed-delivery.test.ts
+++ b/packages/kilo-vscode/tests/unit/managed-delivery.test.ts
@@ -1,9 +1,19 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { flushIdleSession, managedInbox, promptWhenSafe, queueBusyAgentSend } from "../../src/agent-manager/managed-delivery"
+import { mkdtempSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import {
+  flushIdleSession,
+  managedInbox,
+  promptWhenSafe,
+  queueBusyAgentSend,
+  resumeQueuedSessions,
+} from "../../src/agent-manager/managed-delivery"
 
 describe("managed session delivery", () => {
   afterEach(() => {
     managedInbox.events.length = 0
+    managedInbox.detachPersistence()
   })
 
   test("sends immediately when status is missing (idle default)", async () => {
@@ -86,5 +96,35 @@ describe("managed session delivery", () => {
     }
     expect(await flushIdleSession(idle, "s1")).toBe(1)
     expect(sent).toEqual(["next"])
+  })
+
+  test("persists queued prompts and resumes them when idle", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "managed-inbox-"))
+    managedInbox.attachPersistence(root)
+    expect(await promptWhenSafe(
+      {
+        session: {
+          status: async () => ({ data: { s1: { type: "busy" as const } } }),
+          promptAsync: async () => {
+            throw new Error("must not send while busy")
+          },
+        },
+      },
+      { sessionId: "s1", directory: "/repo", text: "later" },
+    )).toBe("queued")
+
+    managedInbox.events.length = 0
+    const sent: string[] = []
+    const idle = {
+      session: {
+        status: async () => ({ data: { s1: { type: "idle" as const } } }),
+        promptAsync: async (input: { parts: Array<{ text: string }> }) => {
+          sent.push(input.parts[0]?.text ?? "")
+        },
+      },
+    }
+    expect(await resumeQueuedSessions(idle)).toBe(1)
+    expect(sent).toEqual(["later"])
+    expect(managedInbox.telemetry.resumes).toBeGreaterThan(0)
   })
 })

--- a/packages/kilo-vscode/tests/unit/managed-delivery.test.ts
+++ b/packages/kilo-vscode/tests/unit/managed-delivery.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test"
 import { mkdtempSync } from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
+import { FOUNDATION_EVENT } from "@kilocode/kilo-foundation"
 import {
   flushIdleSession,
   managedInbox,
@@ -101,17 +102,19 @@ describe("managed session delivery", () => {
   test("persists queued prompts and resumes them when idle", async () => {
     const root = mkdtempSync(path.join(tmpdir(), "managed-inbox-"))
     managedInbox.attachPersistence(root)
-    expect(await promptWhenSafe(
-      {
-        session: {
-          status: async () => ({ data: { s1: { type: "busy" as const } } }),
-          promptAsync: async () => {
-            throw new Error("must not send while busy")
+    expect(
+      await promptWhenSafe(
+        {
+          session: {
+            status: async () => ({ data: { s1: { type: "busy" as const } } }),
+            promptAsync: async () => {
+              throw new Error("must not send while busy")
+            },
           },
         },
-      },
-      { sessionId: "s1", directory: "/repo", text: "later" },
-    )).toBe("queued")
+        { sessionId: "s1", directory: "/repo", text: "later" },
+      ),
+    ).toBe("queued")
 
     managedInbox.events.length = 0
     const sent: string[] = []
@@ -126,5 +129,98 @@ describe("managed session delivery", () => {
     expect(await resumeQueuedSessions(idle)).toBe(1)
     expect(sent).toEqual(["later"])
     expect(managedInbox.telemetry.resumes).toBeGreaterThan(0)
+  })
+
+  test("does not let a stall event block later queued prompts", async () => {
+    managedInbox.enqueueFoundationEvent(FOUNDATION_EVENT.STALLED, "s1", { kind: "stall" })
+    expect(
+      queueBusyAgentSend({
+        busy: true,
+        sessionId: "s1",
+        directory: "/repo",
+        text: "after-stall",
+      }),
+    ).toBe("queued")
+    expect(managedInbox.peekForSession("s1")?.text).toBe("after-stall")
+
+    const sent: Array<{ text: string; extra?: unknown }> = []
+    const idle = {
+      session: {
+        promptAsync: async (input: { parts: Array<{ text: string }> }) => {
+          sent.push({ text: input.parts[0]?.text ?? "" })
+        },
+      },
+    }
+    expect(await flushIdleSession(idle, "s1", undefined, true)).toBe(1)
+    expect(sent).toEqual([{ text: "after-stall" }])
+  })
+
+  test("keeps a queued prompt when flush send fails", async () => {
+    expect(
+      queueBusyAgentSend({
+        busy: true,
+        sessionId: "s1",
+        directory: "/wt",
+        text: "keep-me",
+        extra: { messageID: "msg_keep" },
+      }),
+    ).toBe("queued")
+    const idle = {
+      session: {
+        promptAsync: async () => {
+          throw new Error("backend down")
+        },
+      },
+    }
+    await expect(flushIdleSession(idle, "s1", undefined, true)).rejects.toThrow("backend down")
+    expect(managedInbox.peekForSession("s1")?.text).toBe("keep-me")
+    expect(managedInbox.peekForSession("s1")?.extra?.messageID).toBe("msg_keep")
+  })
+
+  test("flushes queued extra fields instead of dropping them", async () => {
+    expect(
+      await promptWhenSafe(
+        {
+          session: {
+            status: async () => ({ data: { s1: { type: "busy" as const } } }),
+            promptAsync: async () => {
+              throw new Error("must not send while busy")
+            },
+          },
+        },
+        {
+          sessionId: "s1",
+          directory: "/repo",
+          text: "handoff",
+          extra: { noReply: true, synthetic: true, messageID: "msg_handoff" },
+        },
+      ),
+    ).toBe("queued")
+
+    const sent: Array<Record<string, unknown>> = []
+    const idle = {
+      session: {
+        promptAsync: async (input: Record<string, unknown>) => {
+          sent.push(input)
+        },
+      },
+    }
+    expect(await flushIdleSession(idle, "s1", { snapshotInitialization: "wait" }, true)).toBe(1)
+    expect(sent[0]).toMatchObject({
+      sessionID: "s1",
+      directory: "/repo",
+      messageID: "msg_handoff",
+      noReply: true,
+      snapshotInitialization: "wait",
+      parts: [{ type: "text", text: "handoff", synthetic: true }],
+    })
+  })
+
+  test("forgetSession drops stalled events so the inbox cannot grow forever", () => {
+    managedInbox.enqueueFoundationEvent(FOUNDATION_EVENT.STALLED, "s1")
+    managedInbox.enqueueFoundationEvent(FOUNDATION_EVENT.RESUMABLE, "s1")
+    expect(managedInbox.events.length).toBeGreaterThan(0)
+    managedInbox.forgetSession("s1")
+    expect(managedInbox.events).toEqual([])
   })
 })

--- a/packages/kilo-vscode/tests/unit/managed-delivery.test.ts
+++ b/packages/kilo-vscode/tests/unit/managed-delivery.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test"
+import { ManagedSessionInbox, promptWhenSafe } from "../../src/agent-manager/managed-delivery"
+
+describe("managed session delivery", () => {
+  test("sends immediately when status is missing (idle default)", async () => {
+    const promptAsync = async () => ({})
+    const client = { session: { promptAsync } }
+    const sent: string[] = []
+    const wrapped = {
+      session: {
+        promptAsync: async (input: { parts: Array<{ text: string }> }) => {
+          sent.push(input.parts[0]?.text ?? "")
+          return promptAsync()
+        },
+      },
+    }
+    const result = await promptWhenSafe(wrapped, {
+      sessionId: "s1",
+      directory: "/repo",
+      text: "hello",
+    })
+    expect(result).toBe("sent")
+    expect(sent).toEqual(["hello"])
+  })
+
+  test("queues while busy and flushes the same text later", async () => {
+    const inbox = new ManagedSessionInbox()
+    inbox.enqueuePrompt({ sessionId: "s1", directory: "/repo", text: "later" })
+    expect(inbox.takeForSession("s1")).toEqual([{ sessionId: "s1", directory: "/repo", text: "later" }])
+    expect(inbox.takeForSession("s1")).toEqual([])
+  })
+
+  test("queues promptWhenSafe when the session is busy", async () => {
+    const client = {
+      session: {
+        status: async () => ({ data: { s1: { type: "busy" as const } } }),
+        promptAsync: async () => {
+          throw new Error("must not send while busy")
+        },
+      },
+    }
+    const { managedInbox } = await import("../../src/agent-manager/managed-delivery")
+    const before = managedInbox.events.length
+    const result = await promptWhenSafe(client, { sessionId: "s1", directory: "/repo", text: "hold" })
+    expect(result).toBe("queued")
+    expect(managedInbox.events.length).toBeGreaterThan(before)
+  })
+})

--- a/packages/kilo-vscode/tests/unit/session-stall-watchdog.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-stall-watchdog.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { FOUNDATION_EVENT } from "@kilocode/kilo-foundation"
 import { managedInbox } from "../../src/agent-manager/managed-delivery"
-import { SessionStallWatchdog, resumableAfterStall } from "../../src/agent-manager/session-stall-watchdog"
+import { SessionStallWatchdog, resumableAfterStall, stallWatchdogFromEnv } from "../../src/agent-manager/session-stall-watchdog"
 
 describe("session stall watchdog", () => {
   afterEach(() => {
@@ -40,5 +40,20 @@ describe("session stall watchdog", () => {
     watchdog.noteStatus("s2", "offline", "/repo", "2026-08-16T12:00:00.000Z")
     watchdog.scan("2026-08-16T12:02:00.000Z")
     expect(managedInbox.events.some((event) => event.type === FOUNDATION_EVENT.RESUMABLE)).toBe(true)
+  })
+
+  test("stallWatchdogFromEnv reads positive KILO_STALL_* overrides", () => {
+    const after = process.env.KILO_STALL_AFTER_MS
+    const scan = process.env.KILO_STALL_SCAN_EVERY_MS
+    process.env.KILO_STALL_AFTER_MS = "20000"
+    process.env.KILO_STALL_SCAN_EVERY_MS = "5000"
+    try {
+      expect(stallWatchdogFromEnv()).toEqual({ stallAfterMs: 20_000, scanEveryMs: 5_000 })
+    } finally {
+      if (after === undefined) delete process.env.KILO_STALL_AFTER_MS
+      else process.env.KILO_STALL_AFTER_MS = after
+      if (scan === undefined) delete process.env.KILO_STALL_SCAN_EVERY_MS
+      else process.env.KILO_STALL_SCAN_EVERY_MS = scan
+    }
   })
 })

--- a/packages/kilo-vscode/tests/unit/session-stall-watchdog.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-stall-watchdog.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { FOUNDATION_EVENT } from "@kilocode/kilo-foundation"
+import { managedInbox } from "../../src/agent-manager/managed-delivery"
+import { SessionStallWatchdog, resumableAfterStall } from "../../src/agent-manager/session-stall-watchdog"
+
+describe("session stall watchdog", () => {
+  afterEach(() => {
+    managedInbox.events.length = 0
+    managedInbox.telemetry.stallsDetected = 0
+  })
+
+  test("does not stall an idle session", () => {
+    const watchdog = new SessionStallWatchdog({ stallAfterMs: 1000 })
+    watchdog.noteStatus("s1", "busy", "/repo", "2026-08-16T12:00:00.000Z")
+    watchdog.noteStatus("s1", "idle", "/repo", "2026-08-16T12:00:01.000Z")
+    expect(watchdog.scan("2026-08-16T12:20:00.000Z")).toEqual([])
+  })
+
+  test("enqueues SESSION_STALLED once for a silent busy session", () => {
+    const watchdog = new SessionStallWatchdog({ stallAfterMs: 60_000 })
+    watchdog.noteStatus("s1", "busy", "/repo", "2026-08-16T12:00:00.000Z")
+    const first = watchdog.scan("2026-08-16T12:02:00.000Z")
+    const second = watchdog.scan("2026-08-16T12:03:00.000Z")
+    expect(first.map((item) => item.sessionId)).toEqual(["s1"])
+    expect(second.map((item) => item.sessionId)).toEqual(["s1"])
+    expect(managedInbox.events.filter((event) => event.type === FOUNDATION_EVENT.STALLED)).toHaveLength(1)
+    expect(managedInbox.telemetry.stallsDetected).toBe(1)
+    expect(managedInbox.events.some((event) => event.type === FOUNDATION_EVENT.RESUMABLE)).toBe(false)
+  })
+
+  test("marks offline stalls resumable without treating busy as resumable", () => {
+    expect(resumableAfterStall("running")).toBe(false)
+    expect(resumableAfterStall("blocked")).toBe(true)
+    const watchdog = new SessionStallWatchdog({ stallAfterMs: 60_000 })
+    watchdog.noteStatus("s2", "offline", "/repo", "2026-08-16T12:00:00.000Z")
+    watchdog.scan("2026-08-16T12:02:00.000Z")
+    expect(managedInbox.events.some((event) => event.type === FOUNDATION_EVENT.RESUMABLE)).toBe(true)
+  })
+})

--- a/packages/kilo-vscode/tests/unit/session-stall-watchdog.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-stall-watchdog.test.ts
@@ -17,7 +17,11 @@ describe("session stall watchdog", () => {
   })
 
   test("enqueues SESSION_STALLED once for a silent busy session", () => {
-    const watchdog = new SessionStallWatchdog({ stallAfterMs: 60_000 })
+    const stalled: Array<{ sessionId: string; resumable: boolean }> = []
+    const watchdog = new SessionStallWatchdog({
+      stallAfterMs: 60_000,
+      onStall: (sessionId, resumable) => stalled.push({ sessionId, resumable }),
+    })
     watchdog.noteStatus("s1", "busy", "/repo", "2026-08-16T12:00:00.000Z")
     const first = watchdog.scan("2026-08-16T12:02:00.000Z")
     const second = watchdog.scan("2026-08-16T12:03:00.000Z")
@@ -26,6 +30,7 @@ describe("session stall watchdog", () => {
     expect(managedInbox.events.filter((event) => event.type === FOUNDATION_EVENT.STALLED)).toHaveLength(1)
     expect(managedInbox.telemetry.stallsDetected).toBe(1)
     expect(managedInbox.events.some((event) => event.type === FOUNDATION_EVENT.RESUMABLE)).toBe(false)
+    expect(stalled).toEqual([{ sessionId: "s1", resumable: false }])
   })
 
   test("marks offline stalls resumable without treating busy as resumable", () => {

--- a/packages/kilo-vscode/tests/unit/worktree-create-isolation.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-create-isolation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test"
+import { createWorktreeOnDisk, type CreateWorktreeOnDiskContext } from "../../src/agent-manager/worktree-create"
+import type { CreateWorktreeResult, WorktreeManager } from "../../src/agent-manager/WorktreeManager"
+import type { WorktreeStateManager } from "../../src/agent-manager/WorktreeStateManager"
+
+describe("createWorktreeOnDisk isolation", () => {
+  test("rolls back a created worktree when isolation fails", async () => {
+    const removed: string[] = []
+    const created: CreateWorktreeResult = {
+      path: "C:\\repo",
+      branch: "kilo/wt-1",
+      parentBranch: "main",
+      remote: undefined,
+      startPointSource: "local-branch",
+    }
+    const manager = {
+      createWorktree: async () => created,
+      removeWorktree: async (worktreePath: string) => {
+        removed.push(worktreePath)
+      },
+      branchExists: async () => true,
+    } as unknown as WorktreeManager
+    const state = {
+      getDefaultBaseBranch: () => undefined,
+      addWorktree: () => {
+        throw new Error("must not register an isolated root worktree")
+      },
+    } as unknown as WorktreeStateManager
+    const posted: unknown[] = []
+    const ctx: CreateWorktreeOnDiskContext = {
+      getWorktreeManager: () => manager,
+      getStateManager: () => state,
+      getWorkspaceRoot: () => "C:\\repo",
+      postToWebview: (message) => {
+        posted.push(message)
+      },
+      capture: () => undefined,
+      pushState: () => undefined,
+      log: () => undefined,
+    }
+
+    expect(await createWorktreeOnDisk(ctx)).toBeNull()
+    expect(removed).toEqual(["C:\\repo"])
+    expect(posted.some((message) => (message as { type?: string }).type === "agentManager.worktreeSetup")).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Add `@kilocode/kilo-foundation`: generic managed-session primitives (inbox, file-backed messenger, safe resume, isolation, stall/watchdog, telemetry). No product-specific team roles or task statuses.
- Agent Manager queues `promptAsync` while a session is busy (chat follow-ups, fork/promote handoff, orchestration) instead of sending mid-generation or HTTP-polling for idle.
- Persist queued prompts under `.kilo/managed-inbox/` and flush them when the session is idle / after reconnect.
- Clock-based stall watchdog from SSE `session.status` (optional `KILO_STALL_AFTER_MS` / `KILO_STALL_SCAN_EVERY_MS`). No LLM status polling.

## Test plan
- [ ] `bun test` in `packages/kilo-foundation`
- [ ] `bun test` in `packages/kilo-vscode` for `managed-delivery`, `session-stall-watchdog`, `fork-handoff`, `promotion-handoff`, `agent-manager-orchestration-domain`, `agent-manager-tool-start`
- [ ] In Agent Manager, send a follow-up while a session is busy → prompt is queued, then flushed on idle
- [ ] Reload the window with a queued prompt still on disk → it resumes when idle
