### PR TITLE
fix(cli): accept JWT share tokens when importing sessions

### DIFF
--- a/.changeset/fix-import-jwt-share-url.md
+++ b/.changeset/fix-import-jwt-share-url.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Accept JWT share tokens when importing a session from a Kilo share URL.

--- a/packages/opencode/src/cli/cmd/import.ts
+++ b/packages/opencode/src/cli/cmd/import.ts
@@ -26,10 +26,19 @@ export type ShareData =
   | { type: "model"; data: unknown }
 
 // kilocode_change start
-/** Extract share ID from a Kilo share URL like https://app.kilo.ai/s/abc123 */
+/** Extract share token from a Kilo share URL like https://app.kilo.ai/s/<jwt> */
 export function parseShareUrl(url: string): string | null {
-  const match = url.match(/^https?:\/\/app\.kilo\.ai\/s\/([a-zA-Z0-9_-]+)$/)
-  return match ? match[1] : null
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null
+    if (parsed.hostname !== "app.kilo.ai") return null
+    const match = parsed.pathname.match(/^\/s\/([^/]+)$/)
+    if (!match) return null
+    const token = decodeURIComponent(match[1]).trim()
+    return token || null
+  } catch {
+    return null
+  }
 }
 // kilocode_change end
 

--- a/packages/opencode/src/cli/cmd/import.ts
+++ b/packages/opencode/src/cli/cmd/import.ts
@@ -28,17 +28,8 @@ export type ShareData =
 // kilocode_change start
 /** Extract share token from a Kilo share URL like https://app.kilo.ai/s/<jwt> */
 export function parseShareUrl(url: string): string | null {
-  try {
-    const parsed = new URL(url)
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null
-    if (parsed.hostname !== "app.kilo.ai") return null
-    const match = parsed.pathname.match(/^\/s\/([^/]+)$/)
-    if (!match) return null
-    const token = decodeURIComponent(match[1]).trim()
-    return token || null
-  } catch {
-    return null
-  }
+  const match = url.match(/^https?:\/\/app\.kilo\.ai\/s\/([A-Za-z0-9_.-]+)$/)
+  return match ? match[1] : null
 }
 // kilocode_change end
 

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -1068,12 +1068,12 @@ export namespace KiloSessions {
       throw new Error(`Unable to share session ${sessionId}: ${response.status} ${response.statusText}`)
     }
 
-    const result = (await response.json()) as { public_id?: string }
-    if (!result.public_id) {
-      throw new Error(`Unable to share session ${sessionId}: server did not return a public id`)
+    const result = (await response.json()) as { share_token?: string }
+    if (!result.share_token) {
+      throw new Error(`Unable to share session ${sessionId}: server did not return a share token`)
     }
 
-    const url = `https://app.kilo.ai/s/${result.public_id}`
+    const url = `https://app.kilo.ai/s/${result.share_token}`
 
     await save(sessionId, {
       ...current,

--- a/packages/opencode/test/cli/import.test.ts
+++ b/packages/opencode/test/cli/import.test.ts
@@ -51,11 +51,13 @@ test("parses valid Kilo share URLs", () => {
   )
   expect(parseShareUrl("https://app.kilo.ai/s/Jsj3hNIW")).toBe("Jsj3hNIW")
   expect(parseShareUrl("https://app.kilo.ai/s/test_id-123")).toBe("test_id-123")
+  // kilocode_change start
   expect(
     parseShareUrl(
       "https://app.kilo.ai/s/eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzZXNfMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMiJ9.signature",
     ),
   ).toBe("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzZXNfMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMiJ9.signature")
+  // kilocode_change end
 })
 
 test("rejects invalid URLs", () => {

--- a/packages/opencode/test/cli/import.test.ts
+++ b/packages/opencode/test/cli/import.test.ts
@@ -51,6 +51,11 @@ test("parses valid Kilo share URLs", () => {
   )
   expect(parseShareUrl("https://app.kilo.ai/s/Jsj3hNIW")).toBe("Jsj3hNIW")
   expect(parseShareUrl("https://app.kilo.ai/s/test_id-123")).toBe("test_id-123")
+  expect(
+    parseShareUrl(
+      "https://app.kilo.ai/s/eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzZXNfMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMiJ9.signature",
+    ),
+  ).toBe("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzZXNfMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMiJ9.signature")
 })
 
 test("rejects invalid URLs", () => {

--- a/packages/opencode/test/kilocode/session-share.test.ts
+++ b/packages/opencode/test/kilocode/session-share.test.ts
@@ -31,7 +31,7 @@ it.instance("shares and unshares sessions through Kilo public URLs", () => {
       const url = String(input)
       urls.push(url)
       if (url.endsWith("/api/user")) return new Response("{}", { status: 200 })
-      if (url.endsWith("/share")) return Response.json({ public_id: "public-1" })
+      if (url.endsWith("/share")) return Response.json({ share_token: "public-1" })
       if (url.endsWith("/unshare")) return new Response(null, { status: 200 })
       return new Response("{}", { status: 200 })
     },


### PR DESCRIPTION
## What

Cloud PR https://github.com/Kilo-Org/cloud/pull/5300 replaced `/s/{public_id}` with purpose-bound JWT share tokens. `kilo import https://app.kilo.ai/s/<token>` then failed with `Invalid URL format. Expected: https://app.kilo.ai/s/<id>` because the parser only allowed `[A-Za-z0-9_-]`.

## Why

JWTs contain `.`. Import needs to accept the new share URL, and `share()` needs to read `share_token` from ingest instead of `public_id`.

## Changes

- Parse any non-empty `/s/<token>` path on `app.kilo.ai`
- Build share URLs from `share_token`
- Cover JWT import parsing and the updated share response

## Verification

- `bun test ./test/cli/import.test.ts ./test/kilocode/session-share.test.ts` from `packages/opencode/`
- `bun run typecheck` from `packages/opencode/`