### PR TITLE
fix(agent-manager): keep subagent descriptions out of worktree titles

### DIFF
--- a/.changeset/quiet-worktrees-filter.md
+++ b/.changeset/quiet-worktrees-filter.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent subagent descriptions from appearing as Agent Manager worktree titles.

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -321,6 +321,7 @@ export class AgentManagerProvider implements Disposable {
     // throw here would escape into the SSE dispatch loop and starve the other
     // listeners (there is no per-listener error isolation).
     if (!info?.time || !dir) return
+    if (info.parentID !== undefined && info.parentID !== null) return
     const ctx = this.contexts.byDirectory(dir)
     if (!ctx || ctx.lifecycle !== "ready") return
     const state = ctx.peekState()

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -320,8 +320,7 @@ export class AgentManagerProvider implements Disposable {
     // Session events from sync or older backends can lack time/directory; a
     // throw here would escape into the SSE dispatch loop and starve the other
     // listeners (there is no per-listener error isolation).
-    if (!info?.time || !dir) return
-    if (info.parentID !== undefined && info.parentID !== null) return
+    if (!info?.time || !dir || (info.parentID !== undefined && info.parentID !== null)) return
     const ctx = this.contexts.byDirectory(dir)
     if (!ctx || ctx.lifecycle !== "ready") return
     const state = ctx.peekState()

--- a/packages/kilo-vscode/src/agent-manager/project/init.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/init.ts
@@ -182,6 +182,7 @@ export async function collectProjectSessions(
   const out: ProjectSessionView[] = []
   for (const { dir, worktreeId, items } of byDir) {
     for (const s of items) {
+      if (s.parentID !== undefined && s.parentID !== null) continue
       if (seen.has(s.id)) continue
       seen.add(s.id)
       sessions.setSessionDirectory(s.id, dir)

--- a/packages/kilo-vscode/tests/unit/agent-project-sessions.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-project-sessions.test.ts
@@ -148,6 +148,18 @@ describe("Agent Manager per-project session discovery", () => {
     expect(out.find((s) => s.id === "ses-root")?.title).toBe("Session ses-root")
   })
 
+  it("does not expose child sessions as project sidebar sessions", async () => {
+    const wt: Worktree = { id: "wt-1", branch: "fix", path: WT_PATH, parentBranch: "main", createdAt: "" }
+    const ctx = makeContext(ROOT, fakeState([wt]))
+    const rootSession = mkSession("ses-root", WT_PATH)
+    const child = { ...mkSession("ses-child", WT_PATH), parentID: rootSession.id }
+    const { listing } = recordingListing({ [ROOT]: [], [WT_PATH]: [child, rootSession] })
+
+    const out = await collectProjectSessions(ctx, listing)
+
+    expect(out.map((s) => s.id)).toEqual(["ses-root"])
+  })
+
   it("does not list or include sessions from unrelated-project directories", async () => {
     const wt: Worktree = { id: "wt-1", branch: "fix", path: WT_PATH, parentBranch: "main", createdAt: "" }
     const ctx = makeContext(ROOT, fakeState([wt]))

--- a/packages/kilo-vscode/tests/unit/project-session-filter.test.ts
+++ b/packages/kilo-vscode/tests/unit/project-session-filter.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test"
+import { rootSessions } from "../../webview-ui/agent-manager/project/session-filter"
+import type { ProjectSessionInfo } from "../../webview-ui/src/types/messages"
+
+const session = (id: string, worktreeId: string | null, parentID: string | null): ProjectSessionInfo => ({
+  id,
+  worktreeId,
+  parentID,
+  title: id,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+})
+
+describe("rootSessions", () => {
+  it("ignores child sessions when selecting a worktree label", () => {
+    const sessions = [session("child", "wt-1", "root"), session("root", "wt-1", null), session("other", "wt-2", null)]
+
+    expect(rootSessions(sessions, "wt-1").map((item) => item.id)).toEqual(["root"])
+  })
+
+  it("filters subagents from the local session list too", () => {
+    const sessions = [session("child", null, "root"), session("root", null, null)]
+
+    expect(rootSessions(sessions, null).map((item) => item.id)).toEqual(["root"])
+  })
+})

--- a/packages/kilo-vscode/webview-ui/agent-manager/ProjectSidebarBody.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ProjectSidebarBody.tsx
@@ -33,6 +33,7 @@ import { ConstrainDragXAxis } from "./constrain-drag-x"
 import { createProjectStore, type ProjectStore } from "./project/store"
 import { randomColor } from "./section-colors"
 import { projectSidebarOrder, projectWorktreeRow } from "./project-local-navigation"
+import { rootSessions } from "./project/session-filter"
 
 const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent)
 
@@ -94,8 +95,7 @@ export const ProjectSidebarBody: Component<Props> = (props) => {
     pendingTimer = setTimeout(() => setPending(undefined), 2500)
   }
   const state = () => props.state
-  const sessions = (worktreeId: string | null) =>
-    (props.sessions ?? []).filter((item) => item.worktreeId === worktreeId)
+  const sessions = (worktreeId: string | null) => rootSessions(props.sessions ?? [], worktreeId)
   const active = () => props.selectedProject === props.project.id
   const runs = () => store.runStatuses()
   const sections = () => store.sections()

--- a/packages/kilo-vscode/webview-ui/agent-manager/project/session-filter.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/project/session-filter.ts
@@ -1,0 +1,6 @@
+import type { ProjectSessionInfo } from "../../src/types/messages"
+import { isKnownRootSession } from "../navigate"
+
+export function rootSessions(sessions: ProjectSessionInfo[], worktreeId: string | null): ProjectSessionInfo[] {
+  return sessions.filter((session) => session.worktreeId === worktreeId && isKnownRootSession(session))
+}

--- a/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
@@ -1389,6 +1389,7 @@ const projectSession = (
 ): ProjectSessionInfo => ({
   id,
   worktreeId,
+  parentID: null,
   title,
   createdAt: "2026-07-19T09:00:00Z",
   updatedAt,


### PR DESCRIPTION
## Issue

No existing issue identified.

## Context

Multi-project Agent Manager can display a task subagent description as the title of its parent worktree. Child sessions are inserted into the live project session cache, where the sidebar uses session titles as the fallback worktree label.

## Implementation

Only root sessions are admitted to project session discovery, live lifecycle updates, and multi-project sidebar grouping. Explicit worktree labels remain unchanged. This keeps child sessions available to their owning backend flow without allowing their descriptions to participate in worktree naming.

## Screenshots / Video

Not applicable. This is a data filtering fix; the isolated Agent Manager self-test verified the affected sidebar state.

## How to Test

### Manual/local verification

- Agent-run isolated VS Code self-test reproduced the managed worktree state and confirmed child descriptions no longer appeared as worktree titles after rebuilding the extension.
- Agent-run focused Agent Manager unit tests cover child-first session ordering and local/worktree filtering.

### Reviewer test steps

1. Open Agent Manager with a managed worktree that has a root session and task-tool subagent sessions.
2. Confirm the worktree title remains the root or explicit worktree label and the branch remains the subtitle.
3. Confirm subagent transcript tabs and session activity continue to work normally.

### Blocked checks and substitute verification

-

## Checklist

- [x] Issue linked above, or exception explained: no existing issue identified.
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.