### PR TITLE
fix(cli): persist snapshot disable across restarts

### DIFF
--- a/.changeset/persist-snapshot-disable.md
+++ b/.changeset/persist-snapshot-disable.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Persist disabling snapshots from the slow-repo prompt across restarts.

--- a/packages/opencode/src/kilocode/snapshot/track.ts
+++ b/packages/opencode/src/kilocode/snapshot/track.ts
@@ -49,9 +49,11 @@ import { PartID as PartIDSchema } from "@/session/schema"
 import type { MessageV2 } from "@/session/message-v2"
 import { KiloPartLifecycle } from "@/kilocode/session/part-lifecycle"
 import { KilocodeConfig } from "@/kilocode/config/config"
+import { capture } from "@/kilocode/instance"
 import { ConfigParse } from "@/config/parse"
 import * as Log from "@opencode-ai/core/util/log"
 import { iife } from "@/util/iife"
+import { EffectBridge } from "@/effect/bridge"
 import { makeRuntime } from "@/effect/run-service"
 import type { Config } from "@/config/config"
 // Avoid an eager `import { Session }` here: session/index.ts indirectly
@@ -473,7 +475,9 @@ export namespace KiloSnapshotTrack {
 
             if (answer === "disable") {
               log.info("user chose to disable snapshot for this project")
-              yield* Effect.promise(() =>
+              // Restore instance context across the Promise boundary; Effect.promise
+              // drops it, and persistDisable needs the project directory.
+              yield* EffectBridge.fromPromise(() =>
                 hooks.persistDisable().catch((err) => {
                   log.error("failed to persist snapshot:false to project config", { err })
                 }),
@@ -631,8 +635,11 @@ export namespace KiloSnapshotTrack {
     },
 
     async persistDisable() {
-      const directory = await currentDirectory()
-      if (!directory) return
+      const ctx = capture()
+      if (!ctx) {
+        log.error("persistDisable: no instance directory; snapshot:false was not written to project config")
+        return
+      }
       // Every field on Config.Info is Schema.optional(...), so a single-key
       // object is structurally a valid Config.Info — no cast needed.
       const patch: Config.Info = { snapshot: false }
@@ -640,8 +647,8 @@ export namespace KiloSnapshotTrack {
         Effect.gen(function* () {
           yield* KilocodeConfig.updateProjectConfig({
             fs,
-            directory: directory.directory,
-            worktree: directory.worktree,
+            directory: ctx.directory,
+            worktree: ctx.worktree,
             config: patch,
             read: (file) =>
               fs.readFileString(file).pipe(
@@ -680,19 +687,5 @@ export namespace KiloSnapshotTrack {
       })
       return applyEdits(out, edits)
     }, input)
-  }
-
-  /**
-   * Resolve the active instance directory/worktree. Runs via `Instance.current`
-   * when available; returns undefined outside of an instance context (e.g. in
-   * tests that bypass the runtime).
-   */
-  async function currentDirectory(): Promise<{ directory: string; worktree?: string } | undefined> {
-    const { Instance } = await import("@/kilocode/instance")
-    try {
-      return { directory: Instance.directory, worktree: Instance.worktree }
-    } catch {
-      return undefined
-    }
   }
 }

--- a/packages/opencode/test/kilocode/snapshot-track-timeout.test.ts
+++ b/packages/opencode/test/kilocode/snapshot-track-timeout.test.ts
@@ -7,9 +7,11 @@
 import { describe, expect, test } from "bun:test"
 import { Deferred, Duration, Effect, Fiber } from "effect"
 import * as TestClock from "effect/testing/TestClock"
+import path from "path"
 import { PartID, type MessageID, type SessionID } from "../../src/session/schema"
 import { KiloSnapshotTrack } from "../../src/kilocode/snapshot/track"
 import { KiloPartLifecycle } from "../../src/kilocode/session/part-lifecycle"
+import { TestInstance } from "../fixture/fixture"
 import { awaitWithTimeout, it } from "../lib/effect"
 
 const SESSION = "ses_test" as SessionID
@@ -946,6 +948,46 @@ describe("KiloSnapshotTrack progress indicator", () => {
     }
     // At least two different frames should have been rendered during the run.
     expect(frames.size).toBeGreaterThanOrEqual(2)
+  })
+})
+
+describe("KiloSnapshotTrack persistDisable", () => {
+  it.instance(
+    "disable writes snapshot:false to the project config",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const state = KiloSnapshotTrack.makeState()
+        const hooks: KiloSnapshotTrack.Hooks = {
+          ...KiloSnapshotTrack.defaultHooks,
+          async ask() {
+            return "disable"
+          },
+          async startProgress() {},
+          async updateProgress() {},
+          async endProgress() {},
+        }
+
+        yield* KiloSnapshotTrack.wrap({
+          inner: hangInner(),
+          state,
+          sessionID: SESSION,
+          messageID: MESSAGE,
+          hooks,
+          timeoutMs: 10,
+          progressDelayMs: 2,
+        })
+
+        const file = path.join(test.directory, ".kilo", "kilo.jsonc")
+        const text = yield* Effect.tryPromise(() => Bun.file(file).text())
+        expect(JSON.parse(text).snapshot).toBe(false)
+        expect(state.disabledForSession).toBe(true)
+      }),
+    { git: true },
+  )
+
+  test("persistDisable without instance context does not throw", async () => {
+    await KiloSnapshotTrack.defaultHooks.persistDisable()
   })
 })
 


### PR DESCRIPTION
The slow-repo prompt wrote snapshot:false outside the Effect fiber, so the project config was skipped and snapshots came back after a VS Code restart.

## Issue

Addresses #13134 (slow-repo / chat prompt path only).
This does **not** change the settings-panel `snapshot: false` save path. If that path still fails after restart, keep #13134 open or file a follow-up.

## Context

On a slow repo, the snapshot init prompt offers **Disable for this project**. That choice is supposed to write `"snapshot": false` to `.kilo/kilo.jsonc` so later sessions stay off.
The write ran through `Effect.promise(...)`. That drops `InstanceRef` / ALS across the Promise boundary. `persistDisable` then could not see the project directory, skipped the file write, and only flipped the in-memory session flag. After a VS Code restart, snapshots came back.

## Implementation

Keep the existing “write the project file, do not call `Config.update()`” design so the live turn is not disposed.
Two small changes:

1. Call `hooks.persistDisable()` with `EffectBridge.fromPromise` so instance context survives the Promise boundary (same pattern as other kilo Effect/Promise edges).
2. Capture `InstanceContext` synchronously at the start of `persistDisable` via `capture()`, before any `await`. If there is no instance, log an error instead of returning silently.

No settings-panel or `Config.update()` changes.

## Screenshots / Video

N/A — no visual changes.

## How to Test
### Manual/local verification

- Agent: `bun test ./test/kilocode/snapshot-track-timeout.test.ts` from `packages/opencode/` — passed, including the new persistDisable cases.
- Agent: `bun run typecheck` for `@kilocode/cli` — passed.
- Human: local `git push` pre-push ran `bun turbo typecheck --filter=!@kilocode/kilo-jetbrains` — passed (29/29). JetBrains typecheck failed afterward on a CloudFront DNS fetch for `rpc-compiler-plugin`; unrelated to this diff.

### Reviewer test steps

1. Open a large/slow git repo in VS Code so the snapshot init prompt appears.
2. Choose **Disable for this project**.
3. Confirm `.kilo/kilo.jsonc` contains `"snapshot": false`.
4. Reload the VS Code window (or restart VS Code) and confirm snapshots stay disabled for that project.
5. Optional: run from `packages/opencode/`:
   `bun test ./test/kilocode/snapshot-track-timeout.test.ts`

### Blocked checks and substitute verification

- Full `bun turbo typecheck --filter=@kilocode/kilo-jetbrains` was not completed on the author’s machine because Gradle could not resolve `com.jetbrains.fleet:rpc-compiler-plugin` (CloudFront DNS). This PR does not touch `packages/kilo-jetbrains/`. Substitute: CLI typecheck + the persistDisable regression tests above.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
