### PR TITLE
fix(vscode): persist snapshot setting per project

### DIFF
--- a/.changeset/project-snapshot-settings.md
+++ b/.changeset/project-snapshot-settings.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Persist the Checkpoints setting per project so disabling snapshots remains effective after restarting VS Code.

--- a/packages/kilo-vscode/tests/unit/config-scope.test.ts
+++ b/packages/kilo-vscode/tests/unit/config-scope.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from "bun:test"
 import { splitConfigByScope } from "../../webview-ui/src/utils/config-scope"
 
 describe("splitConfigByScope", () => {
+  it("writes snapshot configuration to project config", () => {
+    const split = splitConfigByScope({ snapshot: false })
+
+    expect(split.global).toEqual({})
+    expect(split.project).toEqual({ snapshot: false })
+  })
+
   it("keeps indexing configuration out of project config", () => {
     const split = splitConfigByScope({
       indexing: {

--- a/packages/kilo-vscode/webview-ui/src/utils/config-scope.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/config-scope.ts
@@ -1,9 +1,9 @@
 import type { Config } from "../types/messages"
 
 // Top-level config keys that persist to the project's kilo.json rather than the
-// global one. Settings that are inherently per-repository (e.g. commit message
-// conventions) belong here so they don't leak across workspaces.
-const PROJECT_SCOPED_KEYS: ReadonlySet<string> = new Set(["commit_message"])
+// global one. Settings that are inherently per-repository (e.g. snapshots and
+// commit message conventions) belong here so they don't leak across workspaces.
+const PROJECT_SCOPED_KEYS: ReadonlySet<string> = new Set(["commit_message", "snapshot"])
 export function splitConfigByScope(draft: Partial<Config>) {
   const global: Record<string, unknown> = {}
   const project: Record<string, unknown> = {}


### PR DESCRIPTION
The Checkpoints setting was saved through the generic config path, but `snapshot` was not included in the project-scoped key set. As a result, disabling snapshots from Settings wrote `snapshot: false` to the global config, where a project-level override could take precedence again after restarting VS Code.

Classify `snapshot` as project-scoped and add a regression test covering the split. This makes the Settings toggle persist in the workspace `kilo.jsonc` and remain effective across restarts.

Fixes #13134