### PR TITLE
fix(cli): preserve Kilo upgrade version lookup

### DIFF
--- a/.changeset/restore-kilo-upgrade-version-lookup.md
+++ b/.changeset/restore-kilo-upgrade-version-lookup.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep `kilo upgrade` on the Kilo CLI release channel when GitHub's latest release is a JetBrains release.

--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -21,6 +21,7 @@ import {
   Release as KiloRelease,
   Scoop as KiloScoop,
 } from "@/kilocode/installation"
+import { latest as kiloLatest } from "@/kilocode/installation/latest"
 // kilocode_change end
 import { InstallationEvent } from "@opencode-ai/schema/installation-event"
 
@@ -70,7 +71,6 @@ export class UpgradeFailedError extends Schema.TaggedErrorClass<UpgradeFailedErr
 }
 
 // Response schemas for external version APIs
-const GitHubRelease = Schema.Struct({ tag_name: Schema.String })
 const NpmPackage = Schema.Struct({ version: Schema.String })
 const BrewFormula = Schema.Struct({
   versions: Schema.Struct({ stable: Schema.String }),
@@ -302,19 +302,7 @@ const layer: Layer.Layer<Service, never, HttpClient.HttpClient | AppProcess.Serv
           return data.version
         }
 
-        // kilocode_change start - curl/unknown fallback: resolve from the public npm
-        // dist-tag instead of GitHub /releases/latest, which is polluted by non-CLI
-        // (e.g. JetBrains) releases and returns a tag like "jetbrains/v7.0.4" that
-        // breaks version resolution. Use the public registry directly: a curl-
-        // installed binary is not tied to any project's npm config.
-        const response = yield* httpOk.execute(
-          HttpClientRequest.get(`https://registry.npmjs.org/${KiloNpm.path}/${InstallationChannel}`).pipe(
-            HttpClientRequest.acceptJson,
-          ),
-        )
-        const data = yield* HttpClientResponse.schemaBodyJson(NpmPackage)(response)
-        return data.version
-        // kilocode_change end
+        return yield* kiloLatest(httpOk, KiloNpm.path, InstallationChannel) // kilocode_change
       }, Effect.orDie),
       upgrade: Effect.fn("Installation.upgrade")(function* (m: Method, target: string) {
         let upgradeResult: { code: number; stdout: string; stderr: string } | undefined

--- a/packages/opencode/src/kilocode/installation/latest.ts
+++ b/packages/opencode/src/kilocode/installation/latest.ts
@@ -1,0 +1,14 @@
+import { Effect, Schema } from "effect"
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+
+const Package = Schema.Struct({ version: Schema.String })
+
+export function latest(http: HttpClient.HttpClient, path: string, channel: string) {
+  return Effect.gen(function* () {
+    const response = yield* http.execute(
+      HttpClientRequest.get(`https://registry.npmjs.org/${path}/${channel}`).pipe(HttpClientRequest.acceptJson),
+    )
+    const data = yield* HttpClientResponse.schemaBodyJson(Package)(response)
+    return data.version
+  })
+}

--- a/packages/opencode/src/kilocode/installation/latest.ts
+++ b/packages/opencode/src/kilocode/installation/latest.ts
@@ -3,6 +3,8 @@ import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstab
 
 const Package = Schema.Struct({ version: Schema.String })
 
+// GitHub's latest Kilo release can be a JetBrains release, not a CLI release.
+// Use the public npm channel so curl installs resolve only Kilo CLI versions.
 export function latest(http: HttpClient.HttpClient, path: string, channel: string) {
   return Effect.gen(function* () {
     const response = yield* http.execute(

--- a/packages/opencode/test/kilocode/installation/upgrade.test.ts
+++ b/packages/opencode/test/kilocode/installation/upgrade.test.ts
@@ -64,14 +64,18 @@ describe("Kilo installation upgrade", () => {
       () => "",
       (request) => {
         release.push(request.url)
+        if (request.url === "https://api.github.com/repos/Kilo-Org/kilocode/releases/latest") {
+          return json({ tag_name: "jetbrains/v7.0.16" })
+        }
         return json({ version: "8.8.8" })
       },
     ),
-  ).effect("reads fallback versions from the Kilo npm registry", () =>
+  ).effect("does not use polluted GitHub release tags for fallback versions", () =>
     Effect.gen(function* () {
       const result = yield* Installation.Service.use((svc) => svc.latest("unknown"))
       expect(result).toBe("8.8.8")
       expect(release).toContain(`https://registry.npmjs.org/@kilocode%2fcli/${InstallationChannel}`)
+      expect(release).not.toContain("https://api.github.com/repos/Kilo-Org/kilocode/releases/latest")
     }),
   )
 


### PR DESCRIPTION
## Problem

`kilo upgrade` can resolve the wrong target when GitHub's `releases/latest` points to a JetBrains release such as `jetbrains/v7.0.16`. The curl installer then receives a non-CLI tag and fails instead of upgrading the Kilo CLI.

## Regression history

- PR #12167 originally fixed this by resolving curl upgrade versions from the Kilo npm dist-tag instead of GitHub `releases/latest`.
- PR #12460 later regressed the behavior while merging OpenCode v1.17.6-v1.17.9, restoring the upstream GitHub release lookup and removing the Kilo installation override.
- PR #12695 restored the Kilo-specific lookup during the following OpenCode merge, but the history showed that the behavior could be overwritten again by future upstream conflict resolution.

## Change

Keep the Kilo curl/unknown fallback in Kilo-owned code and leave the shared installation service with a minimal marked integration point. Add a regression test that simulates GitHub returning `jetbrains/v7.0.16` and verifies that the Kilo npm registry supplies the version without requesting the polluted GitHub endpoint.

This makes the behavior explicit in Kilo-owned code and causes CI to catch any future OpenCode merge that restores the upstream lookup.