### PR TITLE
ci: skip JS typecheck for JetBrains-only changes

### DIFF
--- a/.github/workflows/publish-jetbrains-bundled.yml
+++ b/.github/workflows/publish-jetbrains-bundled.yml
@@ -116,17 +116,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Install build tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y patchelf zip unzip
-          curl --fail --location \
-            https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz \
-            --output "$RUNNER_TEMP/zig.tar.xz"
-          echo "473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982  $RUNNER_TEMP/zig.tar.xz" | sha256sum --check --status
-          tar -xJf "$RUNNER_TEMP/zig.tar.xz" -C "$RUNNER_TEMP"
-          echo "$RUNNER_TEMP/zig-linux-x86_64-0.14.0" >> "$GITHUB_PATH"
-
       - name: Validate signing secrets
         run: |
           missing=0

--- a/.github/workflows/publish-jetbrains.yml
+++ b/.github/workflows/publish-jetbrains.yml
@@ -99,17 +99,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Install build tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y patchelf zip
-          curl --fail --location \
-            https://ziglang.org/download/0.14.0/zig-linux-x86_64-0.14.0.tar.xz \
-            --output "$RUNNER_TEMP/zig.tar.xz"
-          echo "473ec26806133cf4d1918caf1a410f8403a13d979726a9045b421b685031a982  $RUNNER_TEMP/zig.tar.xz" | sha256sum --check --status
-          tar -xJf "$RUNNER_TEMP/zig.tar.xz" -C "$RUNNER_TEMP"
-          echo "$RUNNER_TEMP/zig-linux-x86_64-0.14.0" >> "$GITHUB_PATH"
-
       - name: Validate publishing secrets
         run: |
           missing=0

--- a/.github/workflows/test-jetbrains.yml
+++ b/.github/workflows/test-jetbrains.yml
@@ -35,6 +35,7 @@ jobs:
               - '**'
               - '!.changeset/**'
               - '!.kilo/plans/**'
+              - '!packages/opencode/**'
               - '!packages/kilo-vscode/**'
               - '!packages/kilo-docs/**'
 

--- a/.github/workflows/test-jetbrains.yml
+++ b/.github/workflows/test-jetbrains.yml
@@ -34,6 +34,7 @@ jobs:
             jetbrains:
               - '**'
               - '!.changeset/**'
+              - '!.kilo/plans/**'
               - '!packages/kilo-vscode/**'
               - '!packages/kilo-docs/**'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
             general:
               - '**'
               - '!.changeset/**'
+              - '!.kilo/plans/**'
               - '!packages/kilo-jetbrains/**'
               - '!packages/kilo-vscode/**'
               - '!packages/kilo-docs/**'

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -36,6 +36,7 @@ jobs:
               - '**'
               - '!.changeset/**'
               - '!.kilo/plans/**'
+              - '!packages/opencode/**'
               - '!packages/kilo-vscode/**'
               - '!packages/kilo-docs/**'
   # kilocode_change end

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -30,10 +30,12 @@ jobs:
             javascript:
               - '**'
               - '!.changeset/**'
+              - '!.kilo/plans/**'
               - '!packages/kilo-jetbrains/**'
             jetbrains:
               - '**'
               - '!.changeset/**'
+              - '!.kilo/plans/**'
               - '!packages/kilo-vscode/**'
               - '!packages/kilo-docs/**'
   # kilocode_change end

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -8,8 +8,40 @@ on:
   workflow_dispatch:
 
 jobs:
+  # kilocode_change start
+  changes:
+    name: detect typecheck changes
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      javascript: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.javascript }}
+      jetbrains: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.jetbrains }}
+    steps:
+      - name: Checkout repository
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@v6
+
+      - name: Detect typecheck changes
+        if: github.event_name != 'workflow_dispatch'
+        id: filter
+        uses: Kilo-Org/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c # v3
+        with:
+          predicate-quantifier: every
+          filters: |
+            javascript:
+              - '**'
+              - '!.changeset/**'
+              - '!packages/kilo-jetbrains/**'
+            jetbrains:
+              - '**'
+              - '!.changeset/**'
+              - '!packages/kilo-vscode/**'
+              - '!packages/kilo-docs/**'
+  # kilocode_change end
+
   typecheck-js:
     name: typecheck-js
+    needs: changes # kilocode_change
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.javascript == 'true' # kilocode_change
     runs-on: blacksmith-4vcpu-ubuntu-2404 # kilocode_change
     steps:
       - name: Checkout repository
@@ -27,33 +59,10 @@ jobs:
       # kilocode_change end
 
   # kilocode_change start
-  jetbrains-changes:
-    name: detect JetBrains changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    outputs:
-      jetbrains: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.jetbrains }}
-    steps:
-      - name: Checkout repository
-        if: github.event_name != 'workflow_dispatch'
-        uses: actions/checkout@v6
-
-      - name: Detect JetBrains changes
-        if: github.event_name != 'workflow_dispatch'
-        id: filter
-        uses: Kilo-Org/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c # v3
-        with:
-          predicate-quantifier: every
-          filters: |
-            jetbrains:
-              - '**'
-              - '!.changeset/**'
-              - '!packages/kilo-vscode/**'
-              - '!packages/kilo-docs/**'
-
   typecheck-jetbrains:
     name: typecheck-jetbrains
-    needs: jetbrains-changes
-    if: github.event_name == 'workflow_dispatch' || needs.jetbrains-changes.outputs.jetbrains == 'true'
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.jetbrains == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
@@ -82,21 +91,27 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - typecheck-js
-      - jetbrains-changes
+      - changes
       - typecheck-jetbrains
     if: always()
     steps:
       - name: Verify typecheck jobs passed
         run: |
+          echo "changes=${{ needs.changes.result }}"
+          echo "javascript=${{ needs.changes.outputs.javascript }}"
           echo "typecheck-js=${{ needs.typecheck-js.result }}"
-          echo "jetbrains-changes=${{ needs.jetbrains-changes.result }}"
           echo "typecheck-jetbrains=${{ needs.typecheck-jetbrains.result }}"
-          test "${{ needs.typecheck-js.result }}" = "success"
-          test "${{ needs.jetbrains-changes.result }}" = "success"
-          if [ "${{ needs.jetbrains-changes.outputs.jetbrains }}" = "true" ]; then
+          test "${{ needs.changes.result }}" = "success"
+          if [ "${{ needs.changes.outputs.javascript }}" = "true" ]; then
+            test "${{ needs.typecheck-js.result }}" = "success"
+          else
+            test "${{ needs.changes.outputs.javascript }}" = "false"
+            test "${{ needs.typecheck-js.result }}" = "skipped"
+          fi
+          if [ "${{ needs.changes.outputs.jetbrains }}" = "true" ]; then
             test "${{ needs.typecheck-jetbrains.result }}" = "success"
           else
-            test "${{ needs.jetbrains-changes.outputs.jetbrains }}" = "false"
+            test "${{ needs.changes.outputs.jetbrains }}" = "false"
             test "${{ needs.typecheck-jetbrains.result }}" = "skipped"
           fi
   # kilocode_change end

--- a/packages/kilo-jetbrains/AGENTS.md
+++ b/packages/kilo-jetbrains/AGENTS.md
@@ -18,6 +18,10 @@
 - `packages/kilo-jetbrains/gradle.properties` `kilo.cli.pinned` ↔ Gradle and release-script gates
 - `.kilo/skills/release-jetbrains/script/check-pin.ts` / `set-pin.ts` ↔ release skill and CLI pin documentation
 
+### PR Hygiene
+
+- Do not include `.kilo/plans/**` files in JetBrains commits or PRs unless the user explicitly asks to publish plan files.
+
 ## IntelliJ Platform Source Lookup
 
 When looking for IntelliJ Platform API usage, implementation examples, extension points, services, actions, inspections, PSI/VFS/editor behavior, or plugin patterns, prefer real IntelliJ source code over Gradle caches, downloaded jars, generated parser artifacts, or decompiled classes.


### PR DESCRIPTION
## What
- Add a shared typecheck changes job that gates JS/VS Code/CLI typecheck work separately from JetBrains typecheck work.
- Keep manual dispatch running both paths.
- Ignore `.kilo/plans/**` in test/typecheck path filters so implementation-neutral planning docs do not trigger CLI/JS or JetBrains CI.
- Skip JetBrains typecheck/tests for CLI-only changes, because JetBrains pinned mode generates against the published pinned CLI release instead of the PR's local `packages/opencode/**` source.
- Add JetBrains PR hygiene guidance not to include `.kilo/plans/**` files unless explicitly requested.
- Remove JetBrains release workflow setup for local CLI build tools, since production JetBrains builds use the pinned release CLI instead of compiling CLI assets.

## Why
JetBrains-only PRs already skip general unit tests, but still ran the JS typecheck/build path. The new gate keeps the required typecheck check green while avoiding unrelated CLI/VS Code work for JetBrains-only changes.

Plan files under `.kilo/plans/**` are planning artifacts, not executable code or config. Excluding them prevents a JetBrains PR with committed plan docs from accidentally re-enabling the full CLI test matrix.

## Safety Matrix
| Scenario | JS typecheck | JetBrains typecheck | CLI tests | Correct? |
|---|---|---|---|---|
| Only `packages/kilo-jetbrains/**` | skipped | runs | skipped | Yes |
| Only `packages/kilo-vscode/**` or `packages/kilo-docs/**` | runs | skipped | skipped | Yes |
| CLI / `packages/opencode/**` | runs | skipped | runs | Yes; JetBrains uses pinned CLI, so local CLI changes do not affect the JetBrains build |
| Shared root / workflows | runs | runs | runs | Yes |
| `.changeset/**` only | skipped | skipped | skipped | Yes; release notes only |
| `.kilo/plans/**` only | skipped | skipped | skipped | Yes; planning docs only |
| `packages/kilo-jetbrains/**` + `.kilo/plans/**` | skipped | runs | skipped | Yes |

JetBrains typecheck is intentionally decoupled from local CLI source in pinned mode: it downloads the published pinned CLI release and generates against that OpenAPI spec, not the PR's `packages/opencode/` source.

## Validation
- `bun run script/check-workflows.ts`
- `bun run script/check-opencode-annotations.ts --worktree`
- `bun run script/check-md-table-padding.ts packages/kilo-jetbrains/AGENTS.md`
- Ruby YAML parse for edited workflow files
- `git diff --check` for edited workflow files
- Push hook: `bun turbo typecheck --filter=!@kilocode/kilo-jetbrains`
- Push hook: `bun turbo typecheck --filter=@kilocode/kilo-jetbrains`

Note: actionlint is not installed locally.