### PR TITLE
test(core): make project copy cleanup idempotent

### DIFF
--- a/packages/core/test/project-copy.test.ts
+++ b/packages/core/test/project-copy.test.ts
@@ -361,7 +361,7 @@ describe("ProjectCopy", () => {
   it.live("refresh ignores existing directories that are no longer git checkouts", () =>
     Effect.gen(function* () {
       const input = yield* setup()
-      yield* Effect.promise(() => fs.rm(path.join(input.sourceDirectory, ".git"), { recursive: true }))
+      yield* Effect.promise(() => fs.rm(path.join(input.sourceDirectory, ".git"), { recursive: true, force: true })) // kilocode_change
       const copy = yield* ProjectCopy.Service
 
       yield* copy.refresh({ projectID: input.projectID })


### PR DESCRIPTION
The ProjectCopy regression test removes its temporary checkout's `.git` directory to verify refresh behavior after Git metadata disappears. The removal was not idempotent, so macOS CI could fail before the behavior under test with `ENOENT` when cleanup raced with temporary filesystem teardown.

Use forced recursive removal for that deliberately absent-tolerant test setup. This preserves the regression scenario while preventing unrelated cleanup races from failing Core CI.
