### PR TITLE
fix(vscode): remove multi-project trust toggle

### DIFF
--- a/.changeset/remove-agent-manager-project-trust.md
+++ b/.changeset/remove-agent-manager-project-trust.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Remove the separate trust action from Agent Manager multi-project repositories. Added projects are now immediately available, while VS Code workspace trust still protects setup and run scripts.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -3623,7 +3623,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
     if (!this.extensionContext) return undefined
     const project = registeredProjects(this.extensionContext).find((item) => samePath(item.root, root))
-    if (!project?.trusted || !existsSync(project.root)) return undefined
+    if (!project || !existsSync(project.root)) return undefined
     return { id: project.id, root: project.root, generation: 0, pinned: false }
   }
 
@@ -3633,7 +3633,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
     if (!this.extensionContext) return false
     const current = registeredProjects(this.extensionContext).find((item) => item.id === project.id)
-    return !!current?.trusted && samePath(current.root, project.root) && existsSync(current.root)
+    return !!current && samePath(current.root, project.root) && existsSync(current.root)
   }
 
   private setMaxCost(value: unknown): number {

--- a/packages/kilo-vscode/src/agent-manager/project/context.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/context.ts
@@ -14,9 +14,8 @@
  *   created on demand (expand/select), never eagerly at panel open.
  * - Only the active context gets full Git/PR polling; the pollers follow the
  *   active context through the provider's accessors.
- * - Non-pinned contexts require the multi-project flag and registry trust
- *   before they can be expanded or activated. Trust is checked here, before
- *   any state load that could write git metadata.
+ * - Non-pinned contexts require the multi-project flag before they can be
+ *   expanded or activated.
  */
 
 import * as fs from "fs"

--- a/packages/kilo-vscode/src/agent-manager/project/contexts.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/contexts.ts
@@ -22,7 +22,6 @@ export interface ProjectSnapshot {
   active: boolean
   expanded: boolean
   initialized: boolean
-  trusted: boolean
   missing: boolean
 }
 
@@ -34,8 +33,6 @@ interface ContextsOptions {
     get(id: string): StoredProject | undefined
     expanded?(id: string): boolean | undefined
   }
-  /** Registry trust lookup for non-pinned projects. */
-  trusted: (id: string) => boolean
   /** Whether the multi-project experiment is enabled. */
   enabled: () => boolean
   remove?: (id: string) => void
@@ -78,7 +75,7 @@ export class ProjectContexts {
     return this.ensure(stored.id, stored.root, false)
   }
 
-  /** The active context. Defaults to the pinned project, or the first trusted registry project without a workspace. */
+  /** The active context. Defaults to the pinned project, or the first registry project without a workspace. */
   active(): ProjectContext | undefined {
     if (this.activeId) return this.contexts.get(this.activeId)
     const pinned = this.pinned()
@@ -88,7 +85,7 @@ export class ProjectContexts {
       return pinned
     }
     if (!this.opts.enabled()) return undefined
-    const first = this.opts.registry.list().find((p) => this.opts.trusted(p.id))
+    const first = this.opts.registry.list()[0]
     if (!first) return undefined
     const ctx = this.ensure(first.id, first.root, false)
     this.activeId = ctx.id
@@ -135,7 +132,7 @@ export class ProjectContexts {
     return this.resolveCtx(id)
   }
 
-  /** Whether a project may be shown or initialized: known, flag-gated, and trusted. */
+  /** Whether a project may be shown or initialized: known and flag-gated. */
   usable(id: string): ProjectContext | undefined {
     return this.usableCtx(id)
   }
@@ -197,7 +194,6 @@ export class ProjectContexts {
     if (!ctx) return undefined
     if (ctx.pinned) return ctx
     if (!this.opts.enabled()) return undefined
-    if (!this.opts.trusted(id)) return undefined
     return ctx
   }
 
@@ -261,7 +257,6 @@ export class ProjectContexts {
       active: this.isActive(id),
       expanded: !missing && this.isExpanded(id),
       initialized: ctx?.loaded ?? false,
-      trusted: pinned || (stored?.trusted ?? false),
       missing,
     }
   }

--- a/packages/kilo-vscode/src/agent-manager/project/hydrate.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/hydrate.ts
@@ -28,7 +28,7 @@ interface Hooks {
 /** Ensure every expanded background project has current state in the webview. */
 export function hydrateExpanded(projects: readonly ProjectSnapshot[], hooks: Hooks): void {
   for (const project of projects) {
-    if (project.active || !project.expanded || !project.trusted || project.missing) continue
+    if (project.active || !project.expanded || project.missing) continue
     const ctx = hooks.expand(project.id)
     if (!ctx) continue
     if (ctx.lifecycle === "ready") hooks.push(ctx)

--- a/packages/kilo-vscode/src/agent-manager/project/messages.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/messages.ts
@@ -3,7 +3,7 @@
  *
  * Extracted from AgentManagerProvider (file-size cap) and kept free of VS Code
  * imports so the flows are unit-testable. All handlers fail closed: unknown
- * projects, untrusted projects, and disabled experiments leave state untouched.
+ * projects and disabled experiments leave state untouched.
  */
 
 import simpleGit from "simple-git"
@@ -66,10 +66,6 @@ export async function handleProjectMessage(m: AgentManagerInMessage, deps: Proje
     await setExpanded(m.projectId, m.expanded, deps)
     return true
   }
-  if (m.type === "agentManager.trustProject") {
-    await trustProject(m.projectId, deps)
-    return true
-  }
   return false
 }
 
@@ -77,7 +73,7 @@ async function activateSelection(requested: SidebarTarget, deps: ProjectMessageD
   if (disabled(deps)) return
   const ctx = deps.contexts.resolve(requested.projectId)
   if (!ctx || !deps.contexts.usable(requested.projectId)) {
-    deps.error("The project is unavailable. Trust it first or check that the repository still exists.")
+    deps.error("The project is unavailable. Check that the repository still exists.")
     return
   }
   const result = await deps.ready(ctx)
@@ -109,7 +105,7 @@ function finish(target: SidebarTarget, deps: ProjectMessageDeps): void {
   const previous = deps.contexts.active()?.id
   const activated = deps.contexts.activate(target.projectId)
   if (!activated) {
-    deps.error("The project is unavailable. Trust it first or check that the repository still exists.")
+    deps.error("The project is unavailable. Check that the repository still exists.")
     return
   }
   activated.peekState()?.setActiveTarget(target)
@@ -179,7 +175,7 @@ function selectProject(id: string, deps: ProjectMessageDeps): void {
   if (disabled(deps)) return
   const ctx = deps.contexts.activate(id)
   if (!ctx) {
-    deps.error("The project is unavailable. Trust it first or check that the repository still exists.")
+    deps.error("The project is unavailable. Check that the repository still exists.")
     deps.push()
     return
   }
@@ -200,11 +196,5 @@ async function setExpanded(id: string, expanded: boolean, deps: ProjectMessageDe
     if (next) deps.expand(next)
   }
   if (!expanded) deps.contexts.collapse(id)
-  deps.push()
-}
-
-async function trustProject(id: string, deps: ProjectMessageDeps): Promise<void> {
-  if (disabled(deps)) return
-  await deps.registry.setTrusted(id, true)
   deps.push()
 }

--- a/packages/kilo-vscode/src/agent-manager/project/pollers.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/pollers.ts
@@ -122,13 +122,13 @@ export class ProjectPollers {
 
   /**
    * Reconcile pollers with the current expanded set: start pollers for
-   * expanded, trusted, non-active projects whose state is initialized, and
+   * expanded, non-active projects whose state is initialized, and
    * stop pollers for projects that were collapsed, removed, or activated.
    */
   sync(contexts: ProjectContexts): void {
     const wanted = new Set<string>()
     for (const snap of contexts.snapshots()) {
-      if (snap.active || !snap.expanded || !snap.trusted || snap.missing) continue
+      if (snap.active || !snap.expanded || snap.missing) continue
       const ctx = contexts.get(snap.id)
       if (!ctx?.peekState()) continue
       wanted.add(snap.id)

--- a/packages/kilo-vscode/src/agent-manager/project/registry.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/registry.ts
@@ -28,8 +28,6 @@ export interface StoredProject {
   /** Optional user-facing display name. */
   label?: string
   order: number
-  /** Whether project-controlled scripts may execute for this project. */
-  trusted: boolean
   addedAt: string
   /** Whether this project accordion should render its body. */
   expanded?: boolean
@@ -61,7 +59,6 @@ function valid(entry: unknown): entry is StoredProject {
     typeof e.id === "string" &&
     typeof e.root === "string" &&
     typeof e.order === "number" &&
-    typeof e.trusted === "boolean" &&
     typeof e.addedAt === "string" &&
     (e.expanded === undefined || typeof e.expanded === "boolean")
   )
@@ -165,7 +162,6 @@ export class ProjectRegistry {
       root: input.root,
       label: input.label,
       order,
-      trusted: false,
       addedAt: new Date().toISOString(),
     }
     await this.write([...current.projects, project], current.pinnedExpanded)
@@ -184,20 +180,6 @@ export class ProjectRegistry {
     const pinnedExpanded = { ...current.pinnedExpanded }
     delete pinnedExpanded[id]
     await this.write(next, pinnedExpanded)
-    return true
-  }
-
-  setTrusted(id: string, trusted: boolean): Promise<boolean> {
-    return this.run(() => this.doSetTrusted(id, trusted))
-  }
-
-  private async doSetTrusted(id: string, trusted: boolean): Promise<boolean> {
-    const current = this.fresh()
-    if (!current.projects.find((p) => p.id === id)) return false
-    await this.write(
-      current.projects.map((p) => (p.id === id ? { ...p, trusted } : p)),
-      current.pinnedExpanded,
-    )
     return true
   }
 

--- a/packages/kilo-vscode/src/agent-manager/project/wiring.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/wiring.ts
@@ -49,7 +49,6 @@ export function createProjectWiring(opts: {
   const contexts = new ProjectContexts({
     workspaceRoot: () => opts.host.workspacePath(),
     registry,
-    trusted: (id) => registry.get(id)?.trusted === true,
     enabled: () => opts.host.multiProject(),
     remove: (id) => opts.host.unregisterProjectRoutes(id),
     deps: { log: opts.output, git: opts.git },

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -510,12 +510,6 @@ interface SetProjectExpandedIn {
   expanded: boolean
 }
 
-/** Grant a project permission to run project-controlled scripts and load state. */
-interface TrustProjectIn {
-  type: "agentManager.trustProject"
-  projectId: string
-}
-
 interface DeleteWorktreeIn {
   type: "agentManager.deleteWorktree"
   projectId?: string
@@ -1024,7 +1018,6 @@ export type AgentManagerInMessage =
   | ActivateSelectionIn
   | RememberTargetIn
   | SetProjectExpandedIn
-  | TrustProjectIn
   | DeleteWorktreeIn
   | RemoveStaleWorktreeIn
   | PromoteSessionIn

--- a/packages/kilo-vscode/src/indexing-consent.ts
+++ b/packages/kilo-vscode/src/indexing-consent.ts
@@ -96,14 +96,8 @@ export function indexingConsentStore(context: vscode.ExtensionContext): Indexing
 }
 
 export function registeredProjects(context: vscode.ExtensionContext) {
-  return (
-    new ProjectRegistry({
-      read: () => context.globalState.get("agentManager.projects"),
-      write: (value) => Promise.resolve(context.globalState.update("agentManager.projects", value)),
-    })
-      .list()
-      // Consent must never be offered for a repository the user has not trusted:
-      // enabling indexing sends the directory to the backend for reading.
-      .filter((project) => project.trusted)
-  )
+  return new ProjectRegistry({
+    read: () => context.globalState.get("agentManager.projects"),
+    write: (value) => Promise.resolve(context.globalState.update("agentManager.projects", value)),
+  }).list()
 }

--- a/packages/kilo-vscode/tests/unit/agent-manager-new-worktree-project.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-new-worktree-project.test.ts
@@ -41,11 +41,7 @@ describe("Agent Manager New Worktree project targeting", () => {
   })
 
   it("defines project labels in every Agent Manager locale", () => {
-    const keys = [
-      "agentManager.dialog.project.select",
-      "agentManager.dialog.project.untrusted",
-      "agentManager.dialog.project.missing",
-    ]
+    const keys = ["agentManager.dialog.project.select", "agentManager.dialog.project.missing"]
     const locales = readdirSync(join(root, "webview-ui", "agent-manager", "i18n")).filter((file) =>
       file.endsWith(".ts"),
     )

--- a/packages/kilo-vscode/tests/unit/agent-project-contexts.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-project-contexts.test.ts
@@ -7,12 +7,11 @@ import type { WorktreeStateManager } from "../../src/agent-manager/WorktreeState
 const WORKSPACE = "/repo/main"
 const PINNED = projectIdFor(WORKSPACE)
 
-function stored(id: string, trusted = false): StoredProject {
+function stored(id: string): StoredProject {
   return {
     id,
     root: `/repo/${id}`,
     order: 1,
-    trusted,
     addedAt: new Date().toISOString(),
   }
 }
@@ -30,7 +29,6 @@ function setup(
   const contexts = new ProjectContexts({
     workspaceRoot: () => opts.workspace,
     registry,
-    trusted: (id) => registry.get(id)?.trusted === true,
     enabled: () => opts.enabled ?? false,
     deps: {
       log: () => {},
@@ -58,28 +56,21 @@ describe("ProjectContexts", () => {
     expect(contexts.active()).toBeUndefined()
   })
 
-  it("falls back to the first trusted registry project without a workspace", () => {
-    const extra = stored("prj-extra", true)
+  it("falls back to the first registry project without a workspace", () => {
+    const extra = stored("prj-extra")
     const { contexts } = setup({ enabled: true, projects: [extra] })
     expect(contexts.active()?.id).toBe("prj-extra")
   })
 
   it("rejects activating registry projects when the flag is off", () => {
-    const extra = stored("prj-extra", true)
+    const extra = stored("prj-extra")
     const { contexts } = setup({ workspace: WORKSPACE, enabled: false, projects: [extra] })
     expect(contexts.activate("prj-extra")).toBeUndefined()
     expect(contexts.active()?.id).toBe(PINNED)
   })
 
-  it("rejects activating untrusted projects", () => {
-    const extra = stored("prj-extra", false)
-    const { contexts } = setup({ workspace: WORKSPACE, enabled: true, projects: [extra] })
-    expect(contexts.activate("prj-extra")).toBeUndefined()
-    expect(contexts.active()?.id).toBe(PINNED)
-  })
-
-  it("activates trusted projects without changing accordion expansion", () => {
-    const extra = stored("prj-extra", true)
+  it("activates registered projects", () => {
+    const extra = stored("prj-extra")
     const { contexts } = setup({ workspace: WORKSPACE, enabled: true, projects: [extra] })
     const ctx = contexts.activate("prj-extra")
     expect(ctx?.root).toBe("/repo/prj-extra")
@@ -88,7 +79,7 @@ describe("ProjectContexts", () => {
   })
 
   it("keeps explicit accordion expansion unchanged after switching", () => {
-    const extra = stored("prj-extra", true)
+    const extra = stored("prj-extra")
     const { contexts } = setup({ workspace: WORKSPACE, enabled: true, projects: [extra] })
     contexts.active()
     contexts.expand("prj-extra")
@@ -100,7 +91,7 @@ describe("ProjectContexts", () => {
   })
 
   it("expands without changing the active project", () => {
-    const extra = stored("prj-extra", true)
+    const extra = stored("prj-extra")
     const { contexts } = setup({ workspace: WORKSPACE, enabled: true, projects: [extra] })
     expect(contexts.expand("prj-extra")?.id).toBe("prj-extra")
     expect(contexts.active()?.id).toBe(PINNED)
@@ -108,7 +99,7 @@ describe("ProjectContexts", () => {
   })
 
   it("allows accordion collapse independently from active detail selection", () => {
-    const extra = stored("prj-extra", true)
+    const extra = stored("prj-extra")
     const { contexts } = setup({ workspace: WORKSPACE, enabled: true, projects: [extra] })
     contexts.activate("prj-extra")
     contexts.collapse("prj-extra")
@@ -117,7 +108,7 @@ describe("ProjectContexts", () => {
   })
 
   it("removes projects and falls back to the pinned project", async () => {
-    const extra = stored("prj-extra", true)
+    const extra = stored("prj-extra")
     const { contexts } = setup({ workspace: WORKSPACE, enabled: true, projects: [extra] })
     contexts.activate("prj-extra")
     await contexts.remove("prj-extra")
@@ -171,7 +162,7 @@ describe("ProjectContexts", () => {
   })
 
   it("isolates services between projects", () => {
-    const extra = stored("prj-extra", true)
+    const extra = stored("prj-extra")
     const { contexts, created } = setup({ workspace: WORKSPACE, enabled: true, projects: [extra] })
     contexts.active()!.stateManager()
     contexts.activate("prj-extra")!.stateManager()
@@ -184,7 +175,6 @@ describe("ProjectContexts", () => {
     const dynamic = new ProjectContexts({
       workspaceRoot: () => ws.root,
       registry: { list: () => [], get: () => undefined },
-      trusted: () => false,
       enabled: () => false,
       deps: { log: () => {}, exists: () => true },
     })
@@ -199,13 +189,12 @@ describe("ProjectContexts", () => {
   })
 
   it("snapshots pinned first with registry projects in order", () => {
-    const extra = stored("prj-extra", true)
+    const extra = stored("prj-extra")
     const { contexts } = setup({ workspace: WORKSPACE, enabled: true, projects: [extra] })
     const list = contexts.snapshots()
     expect(list.map((p) => p.id)).toEqual([PINNED, "prj-extra"])
     expect(list[0]!.pinned).toBe(true)
     expect(list[0]!.active).toBe(true)
-    expect(list[0]!.trusted).toBe(true)
     expect(list[1]!.label).toBe("prj-extra")
     expect(list[1]!.initialized).toBe(false)
   })
@@ -217,7 +206,7 @@ describe("ProjectContexts", () => {
   })
 
   it("hydrates persisted project expansion without initializing the project", () => {
-    const extra = stored("prj-extra", true)
+    const extra = stored("prj-extra")
     const { contexts } = setup({
       workspace: WORKSPACE,
       enabled: true,
@@ -239,13 +228,13 @@ describe("ProjectContexts", () => {
   })
 
   it("hides registry projects from snapshots when the flag is off", () => {
-    const extra = stored("prj-extra", true)
+    const extra = stored("prj-extra")
     const { contexts } = setup({ workspace: WORKSPACE, enabled: false, projects: [extra] })
     expect(contexts.snapshots().map((p) => p.id)).toEqual([PINNED])
   })
 
   it("returns active ownership to pinned Local when multi-project is disabled", () => {
-    const extra = stored("prj-extra", true)
+    const extra = stored("prj-extra")
     const { contexts } = setup({ workspace: WORKSPACE, enabled: true, projects: [extra] })
     const secondary = contexts.expand("prj-extra")!
     contexts.activate("prj-extra")
@@ -260,7 +249,7 @@ describe("ProjectContexts", () => {
   })
 
   it("dedupes registry entries that match the pinned project", () => {
-    const dupe = stored(PINNED, true)
+    const dupe = stored(PINNED)
     const { contexts } = setup({ workspace: WORKSPACE, enabled: true, projects: [dupe] })
     expect(contexts.snapshots().map((p) => p.id)).toEqual([PINNED])
   })

--- a/packages/kilo-vscode/tests/unit/agent-project-hydrate.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-project-hydrate.test.ts
@@ -19,7 +19,6 @@ function snapshot(id: string, over: Partial<ProjectSnapshot> = {}): ProjectSnaps
     active: false,
     expanded: true,
     initialized: false,
-    trusted: true,
     missing: false,
     ...over,
   }
@@ -77,17 +76,10 @@ describe("hydrateExpanded", () => {
     expect(hooks.inited).toEqual([])
   })
 
-  it("skips collapsed, untrusted, and missing projects", () => {
-    const all = contexts(["collapsed", "untrusted", "missing"])
+  it("skips collapsed and missing projects", () => {
+    const all = contexts(["collapsed", "missing"])
     const hooks = all.hooks()
-    hydrateExpanded(
-      [
-        snapshot("collapsed", { expanded: false }),
-        snapshot("untrusted", { trusted: false }),
-        snapshot("missing", { missing: true }),
-      ],
-      hooks,
-    )
+    hydrateExpanded([snapshot("collapsed", { expanded: false }), snapshot("missing", { missing: true })], hooks)
     expect(hooks.pushed).toEqual([])
     expect(hooks.inited).toEqual([])
   })

--- a/packages/kilo-vscode/tests/unit/agent-project-messages.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-project-messages.test.ts
@@ -30,7 +30,6 @@ function setup(opts: { enabled?: boolean; workspace?: string } = {}) {
   const contexts = new ProjectContexts({
     workspaceRoot: () => opts.workspace ?? WORKSPACE,
     registry,
-    trusted: (id) => registry.get(id)?.trusted === true,
     enabled: () => opts.enabled ?? true,
     deps: { log: () => {}, exists: (dir) => fs.existsSync(dir) },
   })
@@ -90,13 +89,12 @@ describe("handleProjectMessage", () => {
       msg("agentManager.removeProject", { projectId: "prj-x" }),
       msg("agentManager.selectProject", { projectId: "prj-x" }),
       msg("agentManager.setProjectExpanded", { projectId: "prj-x", expanded: true }),
-      msg("agentManager.trustProject", { projectId: "prj-x" }),
     ]) {
       await handleProjectMessage(m, deps)
     }
     expect(calls.pick).toBe(0)
     expect(calls.activate).toEqual([])
-    expect(calls.error.length).toBe(5)
+    expect(calls.error.length).toBe(4)
   })
 
   it("adds a picked git repository to the registry", async () => {
@@ -107,7 +105,6 @@ describe("handleProjectMessage", () => {
     const id = projectIdFor(repo)
     const project = registry.get(id)
     expect(project?.root).toBe(repo)
-    expect(project?.trusted).toBe(false)
     expect(calls.push).toBe(1)
     expect(calls.error).toEqual([])
   })
@@ -146,25 +143,20 @@ describe("handleProjectMessage", () => {
     expect(calls.push).toBe(0)
   })
 
-  it("blocks selecting an untrusted project until trusted", async () => {
+  it("selects a registered project without a separate trust step", async () => {
     const repo = gitRepo()
     const { deps, registry, calls, pick } = setup()
     const id = projectIdFor(repo)
     await registry.add({ id, root: repo })
     await handleProjectMessage(msg("agentManager.selectProject", { projectId: id }), deps)
-    expect(calls.activate).toEqual([])
-    expect(calls.error.length).toBe(1)
-    await handleProjectMessage(msg("agentManager.trustProject", { projectId: id }), deps)
-    await handleProjectMessage(msg("agentManager.selectProject", { projectId: id }), deps)
     expect(calls.activate).toEqual([id])
   })
 
-  it("initializes trusted projects on expand", async () => {
+  it("initializes projects on expand", async () => {
     const repo = gitRepo()
     const { deps, registry, calls } = setup()
     const id = projectIdFor(repo)
     await registry.add({ id, root: repo })
-    await registry.setTrusted(id, true)
     await handleProjectMessage(msg("agentManager.setProjectExpanded", { projectId: id, expanded: true }), deps)
     expect(calls.expand).toEqual([id])
     await handleProjectMessage(msg("agentManager.setProjectExpanded", { projectId: id, expanded: false }), deps)
@@ -176,8 +168,6 @@ describe("handleProjectMessage", () => {
     const { deps, registry, storage, calls } = setup()
     const id = projectIdFor(repo)
     await registry.add({ id, root: repo })
-    await registry.setTrusted(id, true)
-
     await handleProjectMessage(msg("agentManager.setProjectExpanded", { projectId: id, expanded: true }), deps)
 
     const restored = new ProjectRegistry(storage)
@@ -201,13 +191,13 @@ describe("handleProjectMessage", () => {
     expect(registry.list()).toEqual([])
   })
 
-  it("does not initialize untrusted projects on expand", async () => {
+  it("does not initialize missing projects on expand", async () => {
     const repo = gitRepo()
     const { deps, registry, calls } = setup()
     const id = projectIdFor(repo)
     await registry.add({ id, root: repo })
     await handleProjectMessage(msg("agentManager.setProjectExpanded", { projectId: id, expanded: true }), deps)
-    expect(calls.expand).toEqual([])
+    expect(calls.expand).toEqual([id])
   })
 
   it("removes projects without touching the pinned fallback", async () => {
@@ -215,7 +205,6 @@ describe("handleProjectMessage", () => {
     const { deps, registry, contexts, calls } = setup()
     const id = projectIdFor(repo)
     await registry.add({ id, root: repo })
-    await registry.setTrusted(id, true)
     await handleProjectMessage(msg("agentManager.selectProject", { projectId: id }), deps)
     await handleProjectMessage(msg("agentManager.removeProject", { projectId: id }), deps)
     expect(registry.get(id)).toBeUndefined()

--- a/packages/kilo-vscode/tests/unit/agent-project-pollers.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-project-pollers.test.ts
@@ -9,8 +9,8 @@ import type { WorktreeStateManager } from "../../src/agent-manager/WorktreeState
 const WORKSPACE = "/repo/main"
 const PINNED = projectIdFor(WORKSPACE)
 
-function stored(id: string, trusted = true): StoredProject {
-  return { id, root: `/repo/${id}`, order: 1, trusted, addedAt: new Date().toISOString() }
+function stored(id: string): StoredProject {
+  return { id, root: `/repo/${id}`, order: 1, addedAt: new Date().toISOString() }
 }
 
 function setup(projects: StoredProject[], opts: { enabled?: boolean } = {}) {
@@ -20,7 +20,6 @@ function setup(projects: StoredProject[], opts: { enabled?: boolean } = {}) {
       list: () => projects,
       get: (id) => projects.find((p) => p.id === id),
     },
-    trusted: (id) => projects.find((p) => p.id === id)?.trusted === true,
     enabled: () => opts.enabled ?? true,
     deps: {
       log: () => {},
@@ -83,7 +82,7 @@ function fakes() {
 }
 
 describe("ProjectPollers", () => {
-  it("starts pollers for an expanded trusted background project", () => {
+  it("starts pollers for an expanded background project", () => {
     const extra = stored("prj-extra")
     const contexts = setup([extra])
     expand(contexts, "prj-extra")

--- a/packages/kilo-vscode/tests/unit/agent-project-selection.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-project-selection.test.ts
@@ -10,8 +10,8 @@ import type { WorktreeStateManager } from "../../src/agent-manager/WorktreeState
 const WORKSPACE = "/repo/main"
 const PINNED = projectIdFor(WORKSPACE)
 
-function stored(id: string, trusted = true): StoredProject {
-  return { id, root: `/repo/${id}`, order: 1, trusted, addedAt: new Date().toISOString() }
+function stored(id: string): StoredProject {
+  return { id, root: `/repo/${id}`, order: 1, addedAt: new Date().toISOString() }
 }
 
 function fakeState(persisted?: { current?: unknown }) {
@@ -35,7 +35,7 @@ function setup(
   } = {},
 ) {
   const extra = "prj-extra"
-  const projects = [stored(extra, true)]
+  const projects = [stored(extra)]
   const registry = {
     list: () => projects,
     get: (id: string) => projects.find((p) => p.id === id),
@@ -43,7 +43,6 @@ function setup(
   const contexts = new ProjectContexts({
     workspaceRoot: () => opts.workspace ?? WORKSPACE,
     registry,
-    trusted: (id) => registry.get(id)?.trusted === true,
     enabled: () => opts.enabled ?? true,
     deps: {
       log: () => {},

--- a/packages/kilo-vscode/tests/unit/navigate.test.ts
+++ b/packages/kilo-vscode/tests/unit/navigate.test.ts
@@ -629,7 +629,6 @@ describe("createProjectNav", () => {
       active: id === "A",
       expanded,
       initialized: true,
-      trusted: true,
       missing: false,
     }) as AgentProjectSnapshot
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -745,7 +745,6 @@ export const NewWorktreeDialog: Component<{
                     setProjectOpen(false)
                   }}
                   labels={{
-                    untrusted: t("agentManager.dialog.project.untrusted"),
                     missing: t("agentManager.dialog.project.missing"),
                   }}
                 />

--- a/packages/kilo-vscode/webview-ui/agent-manager/ProjectList.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ProjectList.tsx
@@ -212,7 +212,6 @@ export const ProjectList: Component<Props> = (props) => {
         })
       }
       onRemove={(projectId) => vscode.postMessage({ type: "agentManager.removeProject", projectId })}
-      onTrust={(projectId) => vscode.postMessage({ type: "agentManager.trustProject", projectId })}
       onExpand={(projectId, expanded) =>
         vscode.postMessage({ type: "agentManager.setProjectExpanded", projectId, expanded })
       }

--- a/packages/kilo-vscode/webview-ui/agent-manager/ProjectSelect.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ProjectSelect.tsx
@@ -10,22 +10,17 @@ interface ProjectSelectProps {
   projects: AgentProjectSnapshot[]
   selected?: string
   onSelect: (id: string) => void
-  labels: { untrusted: string; missing: string }
+  labels: { missing: string }
 }
 
 export const ProjectSelect: Component<ProjectSelectProps> = (props) => (
   <div class="am-dropdown-list">
     <For each={props.projects}>
       {(project) => {
-        const blocked = () => !project.trusted || project.missing
-        const hint = () => {
-          if (project.missing) return props.labels.missing
-          if (!project.trusted) return props.labels.untrusted
-          return project.root
-        }
+        const blocked = () => project.missing
+        const hint = () => (project.missing ? props.labels.missing : project.root)
         const icon = () => {
           if (project.missing) return "warning" as const
-          if (!project.trusted) return "lock" as const
           return "folder" as const
         }
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/ProjectsSection.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ProjectsSection.tsx
@@ -13,7 +13,6 @@ interface ProjectsSectionProps {
   onAdd: () => void
   onSelect: (id: string) => void
   onRemove: (id: string) => void
-  onTrust: (id: string) => void
   onExpand: (id: string, expanded: boolean) => void
   count: (id: string) => number | undefined
   tools?: JSX.Element
@@ -67,12 +66,6 @@ export const ProjectsSection: Component<ProjectsSectionProps> = (props) => (
                     <Show when={project().missing}>
                       <Icon name="warning" size="small" />
                     </Show>
-                    <Show when={!project().trusted && !project().missing}>
-                      <span class="am-project-trust">
-                        <Icon name="lock" size="small" />
-                        {props.t("agentManager.project.trust")}
-                      </span>
-                    </Show>
                   </>
                 }
                 actions={
@@ -91,13 +84,9 @@ export const ProjectsSection: Component<ProjectsSectionProps> = (props) => (
                 }
                 onToggle={() => {
                   if (project().missing) return
-                  if (!project().trusted) {
-                    props.onTrust(project().id)
-                    return
-                  }
                   const expanded = !project().expanded
                   props.onExpand(project().id, expanded)
-                  if (!project().active && project().trusted) props.onSelect(project().id)
+                  if (!project().active) props.onSelect(project().id)
                 }}
               />
               <Show when={project().expanded}>

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -387,15 +387,6 @@ html[data-theme="kilo-vscode"]
   color: var(--text-weak);
 }
 
-.am-project-trust {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  flex-shrink: 0;
-  font-size: var(--font-size-small);
-  color: var(--text-weak);
-}
-
 .am-project-body {
   display: flex;
   flex-direction: column;

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "المشاريع",
   "agentManager.project.add": "إضافة مشروع",
   "agentManager.project.remove": "إزالة من Agent Manager",
-  "agentManager.project.trust": "وثوق",
   "agentManager.project.missing": "المستودع غير موجود",
   "agentManager.notGitRepo": "ليس مستودع git",
   "agentManager.worktree.settings": "إعدادات Worktree",
@@ -115,7 +114,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "إزالة Worktree القديم",
 
   "agentManager.dialog.project.select": "اختيار مشروع",
-  "agentManager.dialog.project.untrusted": "يُرجى الوثوق بهذا المشروع من الشريط الجانبي أولًا",
   "agentManager.dialog.project.missing": "المستودع غير موجود",
   "agentManager.dialog.openWorktree": "شجرة عمل جديدة",
   "agentManager.dialog.configureWorktree": "تكوين Worktree جديد...",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "PROJETOS",
   "agentManager.project.add": "Adicionar projeto",
   "agentManager.project.remove": "Remover do Agent Manager",
-  "agentManager.project.trust": "Confiar",
   "agentManager.project.missing": "Repositório não encontrado",
   "agentManager.notGitRepo": "Não é um repositório git",
   "agentManager.worktree.settings": "Configurações do Worktree",
@@ -117,7 +116,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "Remover Worktree obsoleto",
 
   "agentManager.dialog.project.select": "Selecionar projeto",
-  "agentManager.dialog.project.untrusted": "Primeiro, confie neste projeto na barra lateral",
   "agentManager.dialog.project.missing": "Repositório não encontrado",
   "agentManager.dialog.openWorktree": "Novo Worktree",
   "agentManager.dialog.configureWorktree": "Configurar Novo Worktree...",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "PROJEKTI",
   "agentManager.project.add": "Dodaj projekat",
   "agentManager.project.remove": "Ukloni iz Agent Manager-a",
-  "agentManager.project.trust": "Vjeruj",
   "agentManager.project.missing": "Repozitorij nije pronađen",
   "agentManager.notGitRepo": "Nije git repozitorij",
   "agentManager.worktree.settings": "Postavke Worktree-a",
@@ -117,7 +116,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "Ukloni zastarjeli Worktree",
 
   "agentManager.dialog.project.select": "Odaberi projekat",
-  "agentManager.dialog.project.untrusted": "Prvo vjeruj ovom projektu na bočnoj traci",
   "agentManager.dialog.project.missing": "Repozitorij nije pronađen",
   "agentManager.dialog.openWorktree": "Novi worktree",
   "agentManager.dialog.configureWorktree": "Konfiguriši Novi Worktree...",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "PROJEKTER",
   "agentManager.project.add": "Tilføj projekt",
   "agentManager.project.remove": "Fjern fra Agent Manager",
-  "agentManager.project.trust": "Godkend",
   "agentManager.project.missing": "Repository ikke fundet",
   "agentManager.notGitRepo": "Ikke et git-repository",
   "agentManager.worktree.settings": "Worktree-indstillinger",
@@ -118,7 +117,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "Fjern forældet Worktree",
 
   "agentManager.dialog.project.select": "Vælg projekt",
-  "agentManager.dialog.project.untrusted": "Godkend først dette projekt i sidepanelet",
   "agentManager.dialog.project.missing": "Repository ikke fundet",
   "agentManager.dialog.openWorktree": "Ny Worktree",
   "agentManager.dialog.configureWorktree": "Konfigurer Nyt Worktree...",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "PROJEKTE",
   "agentManager.project.add": "Projekt hinzufügen",
   "agentManager.project.remove": "Aus Agent Manager entfernen",
-  "agentManager.project.trust": "Vertrauen",
   "agentManager.project.missing": "Repository nicht gefunden",
   "agentManager.notGitRepo": "Kein Git-Repository",
   "agentManager.worktree.settings": "Worktree-Einstellungen",
@@ -119,7 +118,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "Veralteten Worktree entfernen",
 
   "agentManager.dialog.project.select": "Projekt auswählen",
-  "agentManager.dialog.project.untrusted": "Vertrauen Sie diesem Projekt zuerst in der Seitenleiste",
   "agentManager.dialog.project.missing": "Repository nicht gefunden",
   "agentManager.dialog.openWorktree": "Neuer Worktree",
   "agentManager.dialog.configureWorktree": "Neuen Worktree konfigurieren...",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "PROJECTS",
   "agentManager.project.add": "Add project",
   "agentManager.project.remove": "Remove from Agent Manager",
-  "agentManager.project.trust": "Trust",
   "agentManager.project.missing": "Repository not found",
   "agentManager.notGitRepo": "Not a git repository",
 
@@ -126,7 +125,6 @@ export const dict = {
   "agentManager.dialog.tab.import": "Import",
   "agentManager.dialog.namePlaceholder": "Worktree name (optional)",
   "agentManager.dialog.project.select": "Select project",
-  "agentManager.dialog.project.untrusted": "Trust this project in the sidebar first",
   "agentManager.dialog.project.missing": "Repository not found",
   "agentManager.dialog.promptPlaceholder.mac": "Type a message (\u2318Enter to send)",
   "agentManager.dialog.promptPlaceholder.other": "Type a message (Ctrl+Enter to send)",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "PROYECTOS",
   "agentManager.project.add": "Añadir proyecto",
   "agentManager.project.remove": "Eliminar de Agent Manager",
-  "agentManager.project.trust": "Confiar",
   "agentManager.project.missing": "Repositorio no encontrado",
   "agentManager.notGitRepo": "No es un repositorio git",
   "agentManager.worktree.settings": "Configuración de Worktree",
@@ -118,7 +117,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "Eliminar Worktree obsoleto",
 
   "agentManager.dialog.project.select": "Seleccionar proyecto",
-  "agentManager.dialog.project.untrusted": "Confía primero en este proyecto desde la barra lateral",
   "agentManager.dialog.project.missing": "Repositorio no encontrado",
   "agentManager.dialog.openWorktree": "Nuevo Worktree",
   "agentManager.dialog.configureWorktree": "Configurar Nuevo Worktree...",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "پروژه‌ها",
   "agentManager.project.add": "افزودن پروژه",
   "agentManager.project.remove": "حذف از Agent Manager",
-  "agentManager.project.trust": "اعتماد",
   "agentManager.project.missing": "مخزن یافت نشد",
   "agentManager.notGitRepo": "این یک مخزن git نیست",
 
@@ -122,7 +121,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "حذف Worktree قدیمی",
 
   "agentManager.dialog.project.select": "انتخاب پروژه",
-  "agentManager.dialog.project.untrusted": "ابتدا در نوار کناری به این پروژه اعتماد کنید",
   "agentManager.dialog.project.missing": "مخزن یافت نشد",
   "agentManager.dialog.openWorktree": "Worktree جدید",
   "agentManager.dialog.tab.new": "جدید",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "PROJETS",
   "agentManager.project.add": "Ajouter un projet",
   "agentManager.project.remove": "Retirer d'Agent Manager",
-  "agentManager.project.trust": "Approuver",
   "agentManager.project.missing": "Dépôt introuvable",
   "agentManager.notGitRepo": "Ce n'est pas un dépôt git",
   "agentManager.worktree.settings": "Paramètres du Worktree",
@@ -118,7 +117,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "Supprimer le Worktree obsolète",
 
   "agentManager.dialog.project.select": "Sélectionner un projet",
-  "agentManager.dialog.project.untrusted": "Approuvez d'abord ce projet dans la barre latérale",
   "agentManager.dialog.project.missing": "Dépôt introuvable",
   "agentManager.dialog.openWorktree": "Nouveau worktree",
   "agentManager.dialog.configureWorktree": "Configurer un Nouveau Worktree...",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "PROGETTI",
   "agentManager.project.add": "Aggiungi progetto",
   "agentManager.project.remove": "Rimuovi da Agent Manager",
-  "agentManager.project.trust": "Fidati",
   "agentManager.project.missing": "Repository non trovata",
   "agentManager.notGitRepo": "Non è una repository git",
 
@@ -124,7 +123,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "Rimuovi worktree obsoleto",
 
   "agentManager.dialog.project.select": "Seleziona progetto",
-  "agentManager.dialog.project.untrusted": "Prima, fidati di questo progetto nella barra laterale",
   "agentManager.dialog.project.missing": "Repository non trovata",
   "agentManager.dialog.openWorktree": "Nuovo worktree",
   "agentManager.dialog.tab.new": "Nuovo",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "プロジェクト",
   "agentManager.project.add": "プロジェクトを追加",
   "agentManager.project.remove": "Agent Managerから削除",
-  "agentManager.project.trust": "信頼する",
   "agentManager.project.missing": "リポジトリが見つかりません",
   "agentManager.notGitRepo": "gitリポジトリではありません",
   "agentManager.worktree.settings": "Worktree設定",
@@ -118,7 +117,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "無効な Worktree を削除",
 
   "agentManager.dialog.project.select": "プロジェクトを選択",
-  "agentManager.dialog.project.untrusted": "まずサイドバーでこのプロジェクトを信頼してください",
   "agentManager.dialog.project.missing": "リポジトリが見つかりません",
   "agentManager.dialog.openWorktree": "新規ワークツリー",
   "agentManager.dialog.configureWorktree": "新規 Worktree の構成...",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "프로젝트",
   "agentManager.project.add": "프로젝트 추가",
   "agentManager.project.remove": "Agent Manager에서 제거",
-  "agentManager.project.trust": "신뢰",
   "agentManager.project.missing": "저장소를 찾을 수 없음",
   "agentManager.notGitRepo": "git 저장소가 아닙니다",
   "agentManager.worktree.settings": "Worktree 설정",
@@ -116,7 +115,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "오래된 Worktree 제거",
 
   "agentManager.dialog.project.select": "프로젝트 선택",
-  "agentManager.dialog.project.untrusted": "먼저 사이드바에서 이 프로젝트를 신뢰하세요",
   "agentManager.dialog.project.missing": "저장소를 찾을 수 없음",
   "agentManager.dialog.openWorktree": "새 워크트리",
   "agentManager.dialog.configureWorktree": "새 Worktree 구성...",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "PROJECTEN",
   "agentManager.project.add": "Project toevoegen",
   "agentManager.project.remove": "Verwijderen uit Agent Manager",
-  "agentManager.project.trust": "Vertrouwen",
   "agentManager.project.missing": "Repository niet gevonden",
   "agentManager.notGitRepo": "Geen git repository",
 
@@ -123,7 +122,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "Verouderde worktree verwijderen",
 
   "agentManager.dialog.project.select": "Project selecteren",
-  "agentManager.dialog.project.untrusted": "Vertrouw dit project eerst in de zijbalk",
   "agentManager.dialog.project.missing": "Repository niet gevonden",
   "agentManager.dialog.openWorktree": "Nieuwe worktree",
   "agentManager.dialog.configureWorktree": "Nieuwe Worktree Configureren...",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "PROSJEKTER",
   "agentManager.project.add": "Legg til prosjekt",
   "agentManager.project.remove": "Fjern fra Agent Manager",
-  "agentManager.project.trust": "Stol på",
   "agentManager.project.missing": "Repository ikke funnet",
   "agentManager.notGitRepo": "Ikke et git-repositorium",
   "agentManager.worktree.settings": "Worktree-innstillinger",
@@ -116,7 +115,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "Fjern utdatert Worktree",
 
   "agentManager.dialog.project.select": "Velg prosjekt",
-  "agentManager.dialog.project.untrusted": "Stol på dette prosjektet i sidepanelet først",
   "agentManager.dialog.project.missing": "Repository ikke funnet",
   "agentManager.dialog.openWorktree": "Ny worktree",
   "agentManager.dialog.configureWorktree": "Konfigurer Nytt Worktree...",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "PROJEKTY",
   "agentManager.project.add": "Dodaj projekt",
   "agentManager.project.remove": "Usuń z Agent Manager",
-  "agentManager.project.trust": "Zaufaj",
   "agentManager.project.missing": "Nie znaleziono repozytorium",
   "agentManager.notGitRepo": "Nie jest repozytorium git",
   "agentManager.worktree.settings": "Ustawienia Worktree",
@@ -118,7 +117,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "Usuń nieaktualny Worktree",
 
   "agentManager.dialog.project.select": "Wybierz projekt",
-  "agentManager.dialog.project.untrusted": "Najpierw zaufaj temu projektowi na pasku bocznym",
   "agentManager.dialog.project.missing": "Nie znaleziono repozytorium",
   "agentManager.dialog.openWorktree": "Nowy Worktree",
   "agentManager.dialog.configureWorktree": "Skonfiguruj Nowe Worktree...",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "ПРОЕКТЫ",
   "agentManager.project.add": "Добавить проект",
   "agentManager.project.remove": "Удалить из Agent Manager",
-  "agentManager.project.trust": "Доверять",
   "agentManager.project.missing": "Репозиторий не найден",
   "agentManager.notGitRepo": "Не является git-репозиторием",
   "agentManager.worktree.settings": "Настройки Worktree",
@@ -118,7 +117,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "Удалить устаревший Worktree",
 
   "agentManager.dialog.project.select": "Выбрать проект",
-  "agentManager.dialog.project.untrusted": "Сначала подтвердите доверие к этому проекту на боковой панели",
   "agentManager.dialog.project.missing": "Репозиторий не найден",
   "agentManager.dialog.openWorktree": "Новый worktree",
   "agentManager.dialog.configureWorktree": "Настроить новое Worktree...",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "โปรเจกต์",
   "agentManager.project.add": "เพิ่มโปรเจกต์",
   "agentManager.project.remove": "ลบออกจาก Agent Manager",
-  "agentManager.project.trust": "เชื่อถือ",
   "agentManager.project.missing": "ไม่พบ Repository",
   "agentManager.notGitRepo": "ไม่ใช่ git repository",
   "agentManager.worktree.settings": "ตั้งค่า Worktree",
@@ -113,7 +112,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "ลบ Worktree ที่ล้าสมัย",
 
   "agentManager.dialog.project.select": "เลือกโปรเจกต์",
-  "agentManager.dialog.project.untrusted": "โปรดเชื่อถือโปรเจกต์นี้ในแถบด้านข้างก่อน",
   "agentManager.dialog.project.missing": "ไม่พบ Repository",
   "agentManager.dialog.openWorktree": "Worktree ใหม่",
   "agentManager.dialog.configureWorktree": "กำหนดค่า Worktree ใหม่...",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "PROJELER",
   "agentManager.project.add": "Proje ekle",
   "agentManager.project.remove": "Agent Manager'dan kaldır",
-  "agentManager.project.trust": "Güven",
   "agentManager.project.missing": "Depo bulunamadı",
   "agentManager.notGitRepo": "Bir git deposu değil",
 
@@ -124,7 +123,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "Eskimiş worktree'yi kaldır",
 
   "agentManager.dialog.project.select": "Proje seç",
-  "agentManager.dialog.project.untrusted": "Önce kenar çubuğunda bu projeye güvenin",
   "agentManager.dialog.project.missing": "Depo bulunamadı",
   "agentManager.dialog.openWorktree": "Yeni Worktree",
   "agentManager.dialog.configureWorktree": "Yeni Worktree Yapılandır...",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "ПРОЄКТИ",
   "agentManager.project.add": "Додати проєкт",
   "agentManager.project.remove": "Видалити з Agent Manager",
-  "agentManager.project.trust": "Довіряти",
   "agentManager.project.missing": "Репозиторій не знайдено",
   "agentManager.notGitRepo": "Не є git-репозиторієм",
 
@@ -125,7 +124,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "Видалити застаріле робоче дерево",
 
   "agentManager.dialog.project.select": "Вибрати проєкт",
-  "agentManager.dialog.project.untrusted": "Спочатку підтвердьте, що довіряєте цьому проєкту, на бічній панелі",
   "agentManager.dialog.project.missing": "Репозиторій не знайдено",
   "agentManager.dialog.openWorktree": "Нове робоче дерево",
   "agentManager.dialog.configureWorktree": "Налаштувати нове Worktree...",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "项目",
   "agentManager.project.add": "添加项目",
   "agentManager.project.remove": "从 Agent Manager 移除",
-  "agentManager.project.trust": "信任",
   "agentManager.project.missing": "未找到仓库",
   "agentManager.notGitRepo": "不是 git 仓库",
   "agentManager.worktree.settings": "Worktree 设置",
@@ -112,7 +111,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "移除失效 Worktree",
 
   "agentManager.dialog.project.select": "选择项目",
-  "agentManager.dialog.project.untrusted": "请先在侧边栏中信任此项目",
   "agentManager.dialog.project.missing": "未找到仓库",
   "agentManager.dialog.openWorktree": "新建工作树",
   "agentManager.dialog.configureWorktree": "配置新 Worktree...",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -7,7 +7,6 @@ export const dict = {
   "agentManager.projects": "專案",
   "agentManager.project.add": "新增專案",
   "agentManager.project.remove": "從 Agent Manager 移除",
-  "agentManager.project.trust": "信任",
   "agentManager.project.missing": "找不到儲存庫",
   "agentManager.notGitRepo": "不是 git 儲存庫",
   "agentManager.worktree.settings": "Worktree 設定",
@@ -112,7 +111,6 @@ export const dict = {
   "agentManager.dialog.removeStaleWorktree.confirm": "移除失效 Worktree",
 
   "agentManager.dialog.project.select": "選擇專案",
-  "agentManager.dialog.project.untrusted": "請先在側邊欄信任此專案",
   "agentManager.dialog.project.missing": "找不到儲存庫",
   "agentManager.dialog.openWorktree": "新建工作樹",
   "agentManager.dialog.configureWorktree": "配置新 Worktree...",

--- a/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
@@ -1122,7 +1122,6 @@ const projectPickerProjects: AgentProjectSnapshot[] = [
     active: true,
     expanded: true,
     initialized: true,
-    trusted: true,
     missing: false,
   },
   {
@@ -1133,18 +1132,6 @@ const projectPickerProjects: AgentProjectSnapshot[] = [
     active: false,
     expanded: false,
     initialized: true,
-    trusted: true,
-    missing: false,
-  },
-  {
-    id: "project-untrusted",
-    root: "/workspace/sample-app",
-    label: "sample-app",
-    pinned: false,
-    active: false,
-    expanded: false,
-    initialized: false,
-    trusted: false,
     missing: false,
   },
 ]
@@ -1196,10 +1183,7 @@ export const NewWorktreeProjectDropdown: Story = {
                           projects={projectPickerProjects}
                           selected="project-main"
                           onSelect={() => undefined}
-                          labels={{
-                            untrusted: "Trust this project in the sidebar first",
-                            missing: "Repository not found",
-                          }}
+                          labels={{ missing: "Repository not found" }}
                         />
                       </DeferredPopover>
                     </div>
@@ -1355,7 +1339,6 @@ const projectA: AgentProjectSnapshot = {
   active: true,
   expanded: true,
   initialized: true,
-  trusted: true,
   missing: false,
 }
 const projectB: AgentProjectSnapshot = {
@@ -1366,7 +1349,6 @@ const projectB: AgentProjectSnapshot = {
   active: false,
   expanded: true,
   initialized: true,
-  trusted: true,
   missing: false,
 }
 

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -763,7 +763,6 @@ export interface AgentProjectSnapshot {
   active: boolean
   expanded: boolean
   initialized: boolean
-  trusted: boolean
   missing: boolean
 }
 

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -758,12 +758,6 @@ export interface SetProjectExpandedMessage {
   expanded: boolean
 }
 
-// Grant a project permission to run project-controlled scripts and load state
-export interface TrustProjectMessage {
-  type: "agentManager.trustProject"
-  projectId: string
-}
-
 // Configure worktree setup script
 export interface ConfigureSetupScriptRequest {
   type: "agentManager.configureSetupScript"
@@ -1522,7 +1516,6 @@ export type WebviewMessage =
   | ActivateSelectionMessage
   | RememberTargetMessage
   | SetProjectExpandedMessage
-  | TrustProjectMessage
   | ConfigureSetupScriptRequest
   | ConfigureRunScriptRequest
   | RunScriptRequest


### PR DESCRIPTION
Adding a repository through the Agent Manager project picker already expresses intent to let Agent Manager access that project. The separate per-project trust action made added repositories appear blocked and required an unrelated second step before they could be used.\n\nThis change removes the project-level trust state and UI. Added repositories are immediately available for selection, expansion, hydration, polling, and indexing consent. VS Code workspace trust remains the execution boundary for setup and run scripts, so removing the project-list toggle does not weaken script execution protection.