### PR TITLE
fix(cli): clarify background process waits

### DIFF
--- a/.changeset/blocking-shell-waits.md
+++ b/.changeset/blocking-shell-waits.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep one-time waits in the blocking shell tool instead of tracking them as background processes.

--- a/packages/opencode/src/kilocode/tool/background-process.txt
+++ b/packages/opencode/src/kilocode/tool/background-process.txt
@@ -1,6 +1,8 @@
 Run and manage long-running background processes.
 
-Use this tool for development servers, file watchers, local services, and commands that are expected to keep running, such as `npm run dev`, `next dev`, `vite`, `bun --watch`, or test watchers.
+Use this tool only for processes that must keep running independently after this tool call returns, such as development servers, file watchers, local services, and test watchers (`npm run dev`, `next dev`, `vite`, or `bun --watch`).
+
+This tool cannot wait: `start` returns immediately and never blocks your turn. Do not start `sleep`, timers, cooldowns, delays, or polling loops with this tool. To wait a fixed time before your next action, run the wait as a normal blocking shell command and set its `timeout` higher than the wait.
 
 Do not use the shell tool with `&`, `nohup`, `disown`, `setsid`, `Start-Process`, or similar backgrounding patterns. Processes started with this tool are tracked and shown in the CLI sidebar.
 


### PR DESCRIPTION
The background process tool description did not clearly distinguish a persistent process from a blocking wait. This caused agents to launch `sleep` as a tracked background process, which returned immediately and led to repeated status checks instead of blocking the turn.

Clarify that `start` returns immediately and reserve the tool for processes that must continue independently. Explicitly direct fixed waits to a normal blocking shell command with a sufficient timeout.