### PR TITLE
fix(vscode): remove PR sidebar scroll button

### DIFF
--- a/.changeset/remove-pr-sidebar-scroll-button.md
+++ b/.changeset/remove-pr-sidebar-scroll-button.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Remove the floating scroll-to-top button from the Agent Manager PR sidebar.

--- a/packages/kilo-vscode/webview-ui/agent-manager/pr/PRPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/pr/PRPanel.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource solid-js */
-import { Component, Show, createSignal } from "solid-js"
+import { Component, Show } from "solid-js"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import type { WorktreeState } from "../../src/types/messages"
@@ -22,18 +22,7 @@ interface PRPanelProps {
 }
 
 export const PRPanel: Component<PRPanelProps> = (props) => {
-  let bodyRef: HTMLDivElement | undefined
   let commentsRef: HTMLDivElement | undefined
-  const [showScrollTop, setShowScrollTop] = createSignal(false)
-
-  function onScroll(e: Event) {
-    const el = e.target as HTMLDivElement
-    setShowScrollTop(el.scrollTop > 100)
-  }
-
-  function scrollToTop() {
-    bodyRef?.scrollTo({ top: 0, behavior: "smooth" })
-  }
 
   function jumpToComments() {
     commentsRef?.scrollIntoView({ behavior: "smooth", block: "start" })
@@ -63,7 +52,7 @@ export const PRPanel: Component<PRPanelProps> = (props) => {
         </div>
       </div>
       <div class="am-pr-panel-body-wrap">
-        <div class="am-pr-panel-body" ref={bodyRef} onScroll={onScroll}>
+        <div class="am-pr-panel-body">
           <PRSummary pr={props.pr} onJumpToComments={jumpToComments} />
           <PROverview pr={props.pr} worktree={props.worktree} />
           <Show when={(props.pr.reviewers ?? []).length > 0}>
@@ -81,13 +70,6 @@ export const PRPanel: Component<PRPanelProps> = (props) => {
             )}
           </Show>
         </div>
-        <Show when={showScrollTop()}>
-          <Tooltip value="Scroll to top" placement="left">
-            <button class="am-pr-scroll-top" onClick={scrollToTop}>
-              ↑
-            </button>
-          </Tooltip>
-        </Show>
       </div>
     </div>
   )

--- a/packages/kilo-vscode/webview-ui/agent-manager/pr/pr-panel.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/pr/pr-panel.css
@@ -80,28 +80,6 @@
   overflow-anchor: none;
 }
 
-.am-pr-scroll-top {
-  position: absolute;
-  bottom: 16px;
-  right: 16px;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  border: 1px solid var(--vscode-foreground);
-  background: var(--vscode-editor-background);
-  color: var(--vscode-foreground);
-  cursor: pointer;
-  font-size: var(--kilo-font-size-14);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  opacity: 0.6;
-}
-
-.am-pr-scroll-top:hover {
-  opacity: 1;
-}
-
 .am-pr-panel-section {
   padding: 4px 12px;
 }


### PR DESCRIPTION
## Summary

Remove the floating scroll-to-top button from the Agent Manager PR sidebar. The panel keeps normal scrolling and comment navigation without the extra overlay control.

## Screenshot

The updated PR sidebar after scrolling, with the floating button removed:
