### PR TITLE
test(cli): reset session export eligibility after tests

### DIFF
--- a/packages/opencode/test/kilocode/session-export/eligibility.test.ts
+++ b/packages/opencode/test/kilocode/session-export/eligibility.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from "bun:test"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { isEligible, setKillSwitch, resetEligibility, type OrgState } from "@/kilocode/session-export/eligibility"
 
 const base = {
@@ -11,6 +11,7 @@ const base = {
 
 describe("isEligible", () => {
   beforeEach(() => resetEligibility())
+  afterEach(() => resetEligibility())
 
   test("free Kilo Gateway personal context is eligible", () => {
     expect(isEligible(base)).toBe(true)


### PR DESCRIPTION
The session export eligibility tests mutate a process-wide kill switch. The final kill-switch case left that state enabled, so later tests in the shared fast-tier process rejected eligible capture requests and waited for baseline events that could never be emitted.

Reset eligibility after every test that can mutate it. The suite still resets before each case for a known starting state, while teardown now ensures the test file does not leak its state to other files. This keeps session export tests safe to run together in one process without increasing timeouts or making unrelated tests compensate for foreign state.