### PR TITLE
refactor(gateway): remove Alibaba and Mistral adapters

### DIFF
--- a/.changeset/remove-alibaba-mistral-gateway-providers.md
+++ b/.changeset/remove-alibaba-mistral-gateway-providers.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-gateway": major
+---
+
+Remove Alibaba and Mistral as native AI SDK providers from Kilo Gateway.

--- a/bun.lock
+++ b/bun.lock
@@ -283,9 +283,7 @@
       "name": "@kilocode/kilo-gateway",
       "version": "7.4.22",
       "dependencies": {
-        "@ai-sdk/alibaba": "1.0.17",
         "@ai-sdk/anthropic": "3.0.82",
-        "@ai-sdk/mistral": "3.0.27",
         "@ai-sdk/openai": "3.0.88",
         "@ai-sdk/openai-compatible": "2.0.48",
         "@clack/prompts": "1.0.0-alpha.1",
@@ -5136,8 +5134,6 @@
 
     "@kilocode/kilo-docs/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "@kilocode/kilo-gateway/@ai-sdk/mistral": ["@ai-sdk/mistral@3.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.21" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZXe7nZQgliDdjz5ufH5RKpHWxbN72AzmzzKGbF/z+0K9GN5tUCnftrQRvTRFHA5jAzTapcm2BEevmGLVbMkW+A=="],
-
     "@kilocode/kilo-indexing/glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "@kilocode/kilo-indexing/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
@@ -5784,10 +5780,6 @@
 
     "@joshwooding/vite-plugin-react-docgen-typescript/glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
-    "@kilocode/kilo-gateway/@ai-sdk/mistral/@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
-
-    "@kilocode/kilo-gateway/@ai-sdk/mistral/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
-
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "@npmcli/package-json/glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
@@ -6185,8 +6177,6 @@
     "@eslint/config-array/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@eslint/eslintrc/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "@kilocode/kilo-gateway/@ai-sdk/mistral/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@manypkg/find-root/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 

--- a/packages/kilo-gateway/package.json
+++ b/packages/kilo-gateway/package.json
@@ -33,11 +33,9 @@
   },
   "dependencies": {
     "@kilocode/plugin": "workspace:*",
-    "@ai-sdk/alibaba": "1.0.17",
     "@ai-sdk/anthropic": "3.0.82",
     "@ai-sdk/openai": "3.0.88",
     "@ai-sdk/openai-compatible": "2.0.48",
-    "@ai-sdk/mistral": "3.0.27",
     "@openrouter/ai-sdk-provider": "2.9.0",
     "@clack/prompts": "1.0.0-alpha.1",
     "ai": "catalog:",

--- a/packages/kilo-gateway/src/api/constants.ts
+++ b/packages/kilo-gateway/src/api/constants.ts
@@ -101,9 +101,7 @@ export const PROMPTS = [
 ] as const
 
 export const AI_SDK_PROVIDERS = [
-  "alibaba",
   "anthropic",
-  "mistral",
   "openai",
   "openai-compatible",
   "openrouter",

--- a/packages/kilo-gateway/src/provider.ts
+++ b/packages/kilo-gateway/src/provider.ts
@@ -1,9 +1,7 @@
 import { createOpenRouter } from "@openrouter/ai-sdk-provider"
-import { createAlibaba } from "@ai-sdk/alibaba"
 import { createAnthropic } from "@ai-sdk/anthropic"
 import { createOpenAI } from "@ai-sdk/openai"
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
-import { createMistral } from "@ai-sdk/mistral"
 import type { KiloProvider, KiloProviderOptions } from "./types.js"
 import { getApiKey } from "./auth/token.js"
 import { buildKiloHeaders, getDefaultHeaders } from "./headers.js"
@@ -78,11 +76,9 @@ export function createKilo(options: KiloProviderOptions = {}): KiloProvider {
   }
 
   const openrouter = createOpenRouter(sdkOptions)
-  const alibaba = createAlibaba(sdkOptions)
   const anthropic = createAnthropic(sdkOptions)
   const openai = createOpenAI(sdkOptions)
   const openaiCompatible = createOpenAICompatible({ ...sdkOptions, name: "openaiCompatible" })
-  const mistral = createMistral(sdkOptions)
 
   return {
     languageModel(modelId) {
@@ -97,14 +93,8 @@ export function createKilo(options: KiloProviderOptions = {}): KiloProvider {
     imageModel(modelId) {
       return openrouter.imageModel(modelId)
     },
-    alibaba(modelId) {
-      return alibaba(modelId)
-    },
     anthropic(modelId) {
       return GatewayMetadata.wrap(anthropic(modelId))
-    },
-    mistral(modelId) {
-      return mistral(modelId)
     },
     openai(modelId) {
       return GatewayMetadata.wrap(openai(modelId))

--- a/packages/kilo-gateway/src/types.ts
+++ b/packages/kilo-gateway/src/types.ts
@@ -174,9 +174,7 @@ export interface ProviderInfo {
 }
 
 export type KiloProvider = Provider & {
-  alibaba(modelId: string): LanguageModel
   anthropic(modelId: string): LanguageModel
-  mistral(modelId: string): LanguageModel
   openai(modelId: string): LanguageModel
   openaiCompatible(modelId: string): LanguageModel
 }

--- a/packages/opencode/src/kilocode/provider-options.ts
+++ b/packages/opencode/src/kilocode/provider-options.ts
@@ -1,6 +1,4 @@
-import type { AlibabaProviderOptions } from "@ai-sdk/alibaba"
 import type { AnthropicProviderOptions } from "@ai-sdk/anthropic"
-import type { MistralLanguageModelOptions } from "@ai-sdk/mistral"
 import type { OpenAIResponsesProviderOptions } from "@ai-sdk/openai"
 import type { OpenAICompatibleProviderOptions } from "@ai-sdk/openai-compatible"
 import type { OpenRouterProviderOptions } from "@openrouter/ai-sdk-provider"
@@ -27,11 +25,5 @@ export function kiloProviderOptions(options: { [x: string]: any }) {
       openrouter.reasoning && "effort" in openrouter.reasoning ? openrouter.reasoning?.effort : undefined,
     textVerbosity: openrouter.verbosity,
   } satisfies OpenAICompatibleProviderOptions
-  result.alibaba = {
-    enableThinking: openrouter.reasoning?.enabled,
-  } satisfies AlibabaProviderOptions
-  result.mistral = {
-    reasoningEffort: openrouter.reasoning?.enabled ? "high" : undefined,
-  } satisfies MistralLanguageModelOptions
   return result
 }

--- a/packages/opencode/src/kilocode/provider/provider.ts
+++ b/packages/opencode/src/kilocode/provider/provider.ts
@@ -205,9 +205,7 @@ export function kiloCustomLoaders(dep: CustomDep): Record<string, CustomLoader> 
         options,
         async getModel(sdk: KiloProvider, modelID: string) {
           const provider = input.models[modelID]?.ai_sdk_provider
-          if (provider === "alibaba") return sdk.alibaba(modelID)
           if (provider === "anthropic") return sdk.anthropic(modelID)
-          if (provider === "mistral") return sdk.mistral(modelID)
           if (provider === "openai") return sdk.openai(modelID)
           if (provider === "openai-compatible") return sdk.openaiCompatible(modelID)
           return sdk.languageModel(modelID)

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2396,7 +2396,7 @@ export type ProviderConfig = {
       family?: string
       prompt?: "codex" | "gemini" | "beast" | "anthropic" | "trinity" | "anthropic_without_todo" | "ling" | "gpt55"
       isFree?: boolean
-      ai_sdk_provider?: "alibaba" | "anthropic" | "mistral" | "openai" | "openai-compatible" | "openrouter"
+      ai_sdk_provider?: "anthropic" | "openai" | "openai-compatible" | "openrouter"
       release_date?: string
       attachment?: boolean
       reasoning?: boolean
@@ -2813,7 +2813,7 @@ export type Model = {
   autoRouting?: {
     models: Array<string>
   }
-  ai_sdk_provider?: "alibaba" | "anthropic" | "mistral" | "openai" | "openai-compatible" | "openrouter"
+  ai_sdk_provider?: "anthropic" | "openai" | "openai-compatible" | "openrouter"
 }
 
 export type Provider = {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -33105,7 +33105,7 @@
                 },
                 "ai_sdk_provider": {
                   "type": "string",
-                  "enum": ["alibaba", "anthropic", "mistral", "openai", "openai-compatible", "openrouter"]
+                  "enum": ["anthropic", "openai", "openai-compatible", "openrouter"]
                 },
                 "release_date": {
                   "type": "string"
@@ -34316,7 +34316,7 @@
           },
           "ai_sdk_provider": {
             "type": "string",
-            "enum": ["alibaba", "anthropic", "mistral", "openai", "openai-compatible", "openrouter"]
+            "enum": ["anthropic", "openai", "openai-compatible", "openrouter"]
           }
         },
         "required": [


### PR DESCRIPTION
Remove Alibaba and Mistral as native Kilo Gateway AI SDK adapters, including their routing metadata, provider-specific option translation, generated schema values, and gateway package dependencies.

The independent direct Mistral autocomplete/FIM integration and general BYOK providers remain unchanged.