### PR TITLE
fix(vscode): keep tool output actions visible

### DIFF
--- a/.changeset/fix-tool-output-actions.md
+++ b/.changeset/fix-tool-output-actions.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep tool-output action buttons visible above streamed output.

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -286,12 +286,13 @@ html[data-theme="kilo-vscode"] [data-component="bash-output"] {
   overflow-y: auto;
   overflow-x: hidden;
   max-height: 240px;
+  scrollbar-gutter: stable;
 }
 
 [data-component="bash-output"] [data-slot="bash-section-actions"] {
   position: absolute;
   top: 4px;
-  right: 16px;
+  right: 20px;
   z-index: 1;
   display: flex;
   align-items: center;

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -291,10 +291,14 @@ html[data-theme="kilo-vscode"] [data-component="bash-output"] {
 [data-component="bash-output"] [data-slot="bash-section-actions"] {
   position: absolute;
   top: 4px;
-  right: 4px;
+  right: 16px;
+  z-index: 1;
   display: flex;
   align-items: center;
   gap: 2px;
+  padding: 2px;
+  border-radius: var(--radius-sm);
+  background: var(--surface-tool-output-base);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.15s ease;

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -286,7 +286,6 @@ html[data-theme="kilo-vscode"] [data-component="bash-output"] {
   overflow-y: auto;
   overflow-x: hidden;
   max-height: 240px;
-  scrollbar-gutter: stable;
 }
 
 [data-component="bash-output"] [data-slot="bash-section-actions"] {


### PR DESCRIPTION
Tool output action buttons can be covered by streamed output and the native scrollbar. This makes the copy and open controls hard to see and use while a command is running or when output is long.

Keep the code area full width so the scrollbar remains at the far right. Place the action group just to its left with a stable scrollbar gutter and an opaque background. The existing hover and focus behavior remains unchanged.

Before:

<img width="522" alt="Tool output action buttons overlap the scrollbar and output" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260819-tool-output-loading-before.png" />

After:

<img width="522" alt="Tool output action buttons remain clear to the left of the scrollbar" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260819-tool-output-loading-after-v2.png" />
