### PR TITLE
fix(tui): order live transcript by message created time so wrapped ids stay visible

### DIFF
--- a/.changeset/tui-message-time-order.md
+++ b/.changeset/tui-message-time-order.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": patch
 ---
 
-Keep TUI session output visible after message IDs wrap, instead of hiding new turns until the session is reopened
+Fix TUI sessions where new turns stopped appearing until the session was reopened

--- a/.changeset/tui-message-time-order.md
+++ b/.changeset/tui-message-time-order.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep TUI session output visible after message IDs wrap, instead of hiding new turns until the session is reopened

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -38,6 +38,7 @@ import path from "path"
 import { useKV } from "./kv"
 import { handleSuggestionEvent } from "@/kilocode/suggestion/tui/sync" // kilocode_change
 import { appendTerminalOutput } from "@/kilocode/interactive-terminal/output" // kilocode_change
+import { at, recent, slot } from "../kilocode/message-order" // kilocode_change
 import { useToast } from "../ui/toast" // kilocode_change
 import { usePermission } from "./permission"
 
@@ -501,7 +502,7 @@ export const {
             setStore("message", event.properties.info.sessionID, [event.properties.info])
             break
           }
-          const result = search(messages, event.properties.info.id, (m) => m.id)
+          const result = slot(messages, event.properties.info) // kilocode_change - order by created time, ids wrap
           if (result.found) {
             setStore("message", event.properties.info.sessionID, result.index, reconcile(event.properties.info))
             break
@@ -537,7 +538,7 @@ export const {
         case "message.removed": {
           touchMessage(event.properties.sessionID, event.properties.messageID)
           const messages = store.message[event.properties.sessionID]
-          const result = search(messages, event.properties.messageID, (m) => m.id)
+          const result = at(messages, event.properties.messageID) // kilocode_change - list is time-ordered, not id-sorted
           if (result.found) {
             setStore(
               "message",
@@ -680,7 +681,7 @@ export const {
             setStore("message", info.sessionID, [info])
             break
           }
-          const match = search(messages, info.id, (item) => item.id)
+          const match = slot(messages, info) // kilocode_change - order by created time, ids wrap
           if (match.found) {
             setStore("message", info.sessionID, match.index, reconcile(info))
             break
@@ -710,7 +711,7 @@ export const {
           touchMessage(event.data.sessionID, event.data.messageID)
           const messages = store.message[event.data.sessionID]
           if (!messages) break
-          const match = search(messages, event.data.messageID, (item) => item.id)
+          const match = at(messages, event.data.messageID) // kilocode_change - list is time-ordered, not id-sorted
           if (!match.found) break
           setStore(
             "message",
@@ -1008,9 +1009,11 @@ export const {
                     (message) => tracker.messages.has(message.id) && !infos.some((item) => item.id === message.id),
                   ),
                 )
-                const removed = infos.slice(0, -100)
-                const visible = infos.slice(-100)
+                // kilocode_change start - window by created time so wrapped ids stay visible
+                const visible = recent(infos)
                 const visibleIDs = new Set(visible.map((message) => message.id))
+                const removed = infos.filter((message) => !visibleIDs.has(message.id))
+                // kilocode_change end
                 for (const message of messages.data ?? []) {
                   if (!visibleIDs.has(message.info.id)) {
                     delete draft.part[message.info.id]

--- a/packages/tui/src/kilocode/message-order.ts
+++ b/packages/tui/src/kilocode/message-order.ts
@@ -1,0 +1,22 @@
+type Stamped = { id: string; time: { created: number } }
+
+export function older(a: Stamped, b: Stamped) {
+  if (a.time.created !== b.time.created) return a.time.created - b.time.created
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+}
+
+export function at(list: readonly { id: string }[], id: string) {
+  const index = list.findIndex((item) => item.id === id)
+  return { found: index >= 0, index }
+}
+
+export function slot<T extends Stamped>(list: readonly T[], item: T) {
+  const hit = at(list, item.id)
+  if (hit.found) return hit
+  const index = list.findIndex((entry) => older(item, entry) < 0)
+  return { found: false, index: index < 0 ? list.length : index }
+}
+
+export function recent<T extends Stamped>(list: readonly T[], cap = 100) {
+  return list.toSorted(older).slice(-cap)
+}

--- a/packages/tui/test/kilocode/message-order-sync.test.tsx
+++ b/packages/tui/test/kilocode/message-order-sync.test.tsx
@@ -7,6 +7,7 @@ import { json, mount, wait } from "../cli/cmd/tui/sync-fixture"
 const sessionID = "ses_order"
 const partID = "prt_order"
 const directory = "/tmp/opencode/packages/tui"
+let seq = 0
 const session = {
   id: sessionID,
   title: "order",
@@ -26,27 +27,53 @@ const base = {
   cost: 0,
   tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
 }
+const old = { ...base, id: "msg_ff0cb2300001Z6YIo5V52u114f", time: { created: 1, completed: 2 } }
+const next = { ...base, id: "msg_019f1d3da001955TwEJ8qKEbj3", time: { created: 3 } }
 
 function wrap(payload: GlobalEvent["payload"]): GlobalEvent {
   return { directory, project: "proj_test", payload }
 }
 
-test("a later message with a lexicographically earlier id stays at the tail", async () => {
-  await using tmp = await tmpdir()
-  await Bun.write(`${tmp.path}/kv.json`, "{}")
-  const old = { ...base, id: "msg_ff0cb2300001Z6YIo5V52u114f", time: { created: 1, completed: 2 } }
-  const next = { ...base, id: "msg_019f1d3da001955TwEJ8qKEbj3", time: { created: 3 } }
-  const { app, emit, sync } = await mount((url) => {
+function sync1(id: string, info: (typeof base & { id: string; time: { created: number } }) | undefined): GlobalEvent {
+  return {
+    directory,
+    project: "proj_test",
+    payload: {
+      type: "sync",
+      syncEvent: {
+        id,
+        type: "message.updated.1",
+        seq: ++seq,
+        aggregateID: sessionID,
+        data: { sessionID, info },
+      },
+    },
+  } as GlobalEvent
+}
+
+function serve(infos: (typeof old)[]) {
+  return (url: URL) => {
     if (url.pathname === `/session/${sessionID}`) return json(session)
     if (url.pathname === `/session/${sessionID}/message`) {
-      return json([{ info: old, parts: [{ id: partID, sessionID, messageID: old.id, type: "text", text: "old" }] }])
+      return json(infos.map((info) => ({ info, parts: [] })))
     }
     if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`) return json([])
     return undefined
+  }
+}
+
+test("a later message with a lexicographically earlier id stays at the tail", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+  const { app, emit, sync } = await mount((url) => {
+    if (url.pathname === `/session/${sessionID}/message`) {
+      return json([{ info: old, parts: [{ id: partID, sessionID, messageID: old.id, type: "text", text: "old" }] }])
+    }
+    return serve([])(url)
   }, tmp.path)
   try {
     await sync.session.sync(sessionID)
-    await wait(() => sync.data.message[sessionID]?.some((item) => item.id === old.id) === true)
+    await wait(() => sync.data.message[sessionID]?.some((item) => item.id === old.id) ?? false)
     emit(
       wrap({
         id: "evt_next",
@@ -54,7 +81,54 @@ test("a later message with a lexicographically earlier id stays at the tail", as
         properties: { sessionID, info: next },
       }),
     )
-    await wait(() => sync.data.message[sessionID]?.some((item) => item.id === next.id) === true)
+    await wait(() => sync.data.message[sessionID]?.some((item) => item.id === next.id) ?? false)
+    const ids = (sync.data.message[sessionID] ?? []).map((item) => item.id)
+    expect(ids[0]).toBe(old.id)
+    expect(ids.at(-1)).toBe(next.id)
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("eviction at the window cap drops the oldest message, not the newest", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+  const infos = Array.from({ length: 100 }, (_, index) => ({
+    ...base,
+    id: `msg_ff0c${String(index).padStart(4, "0")}`,
+    time: { created: index + 1, completed: index + 2 },
+  }))
+  const { app, emit, sync } = await mount(serve(infos), tmp.path)
+  try {
+    await sync.session.sync(sessionID)
+    await wait(() => sync.data.message[sessionID]?.length === 100)
+    emit(
+      wrap({
+        id: "evt_next",
+        type: "message.updated",
+        properties: { sessionID, info: { ...next, time: { created: 200 } } },
+      }),
+    )
+    await wait(() => sync.data.message[sessionID]?.some((item) => item.id === next.id) ?? false)
+    const ids = (sync.data.message[sessionID] ?? []).map((item) => item.id)
+    expect(ids).toHaveLength(100)
+    expect(ids.at(-1)).toBe(next.id)
+    expect(ids).not.toContain(infos[0].id)
+    expect(ids[0]).toBe(infos[1].id)
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("the versioned sync channel also keeps a wrapped id at the tail", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+  const { app, emit, sync } = await mount(serve([old]), tmp.path)
+  try {
+    await sync.session.sync(sessionID)
+    await wait(() => sync.data.message[sessionID]?.some((item) => item.id === old.id) ?? false)
+    emit(sync1("evt_next_v1", next))
+    await wait(() => sync.data.message[sessionID]?.some((item) => item.id === next.id) ?? false)
     const ids = (sync.data.message[sessionID] ?? []).map((item) => item.id)
     expect(ids[0]).toBe(old.id)
     expect(ids.at(-1)).toBe(next.id)

--- a/packages/tui/test/kilocode/message-order-sync.test.tsx
+++ b/packages/tui/test/kilocode/message-order-sync.test.tsx
@@ -1,0 +1,64 @@
+/** @jsxImportSource @opentui/solid */
+import { expect, test } from "bun:test"
+import type { GlobalEvent } from "@kilocode/sdk/v2"
+import { tmpdir } from "../fixture/fixture"
+import { json, mount, wait } from "../cli/cmd/tui/sync-fixture"
+
+const sessionID = "ses_order"
+const partID = "prt_order"
+const directory = "/tmp/opencode/packages/tui"
+const session = {
+  id: sessionID,
+  title: "order",
+  time: { created: 0, updated: 0 },
+  version: "1.15.13",
+  directory,
+}
+const base = {
+  sessionID,
+  role: "assistant" as const,
+  agent: "build",
+  modelID: "model",
+  providerID: "test",
+  mode: "build",
+  parentID: "msg_user",
+  path: { cwd: directory, root: directory },
+  cost: 0,
+  tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+}
+
+function wrap(payload: GlobalEvent["payload"]): GlobalEvent {
+  return { directory, project: "proj_test", payload }
+}
+
+test("a later message with a lexicographically earlier id stays at the tail", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+  const old = { ...base, id: "msg_ff0cb2300001Z6YIo5V52u114f", time: { created: 1, completed: 2 } }
+  const next = { ...base, id: "msg_019f1d3da001955TwEJ8qKEbj3", time: { created: 3 } }
+  const { app, emit, sync } = await mount((url) => {
+    if (url.pathname === `/session/${sessionID}`) return json(session)
+    if (url.pathname === `/session/${sessionID}/message`) {
+      return json([{ info: old, parts: [{ id: partID, sessionID, messageID: old.id, type: "text", text: "old" }] }])
+    }
+    if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`) return json([])
+    return undefined
+  }, tmp.path)
+  try {
+    await sync.session.sync(sessionID)
+    await wait(() => sync.data.message[sessionID]?.some((item) => item.id === old.id) === true)
+    emit(
+      wrap({
+        id: "evt_next",
+        type: "message.updated",
+        properties: { sessionID, info: next },
+      }),
+    )
+    await wait(() => sync.data.message[sessionID]?.some((item) => item.id === next.id) === true)
+    const ids = (sync.data.message[sessionID] ?? []).map((item) => item.id)
+    expect(ids[0]).toBe(old.id)
+    expect(ids.at(-1)).toBe(next.id)
+  } finally {
+    app.renderer.destroy()
+  }
+})

--- a/packages/tui/test/kilocode/message-order.test.ts
+++ b/packages/tui/test/kilocode/message-order.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test"
+import { at, older, recent, slot } from "../../src/kilocode/message-order"
+
+const old = { id: "msg_ff0cb2300001Z6YIo5V52u114f", time: { created: 1 } }
+const next = { id: "msg_019f1d3da001955TwEJ8qKEbj3", time: { created: 2 } }
+
+test("a later message with an earlier id sorts after the older one", () => {
+  expect(older(old, next)).toBeLessThan(0)
+  expect(older(next, old)).toBeGreaterThan(0)
+})
+
+test("equal created times fall back to id order", () => {
+  const a = { id: "msg_a", time: { created: 1 } }
+  const b = { id: "msg_b", time: { created: 1 } }
+  expect(older(a, b)).toBeLessThan(0)
+  expect(older(a, a)).toBe(0)
+})
+
+test("a later message with an earlier id inserts at the tail", () => {
+  expect(slot([old], next)).toEqual({ found: false, index: 1 })
+})
+
+test("slot finds an existing message by id", () => {
+  expect(slot([old, next], next)).toEqual({ found: true, index: 1 })
+})
+
+test("the message window keeps newest by created time, not id", () => {
+  expect(recent([next, old], 1).map((item) => item.id)).toEqual([next.id])
+})
+
+test("lookup by id is linear so time-ordered lists still find removals", () => {
+  expect(at([old, next], next.id)).toEqual({ found: true, index: 1 })
+  expect(at([old, next], "msg_missing")).toEqual({ found: false, index: -1 })
+})


### PR DESCRIPTION
## What

The TUI live transcript hides new turns in long-running sessions whose message IDs crossed the 48-bit timestamp wrap on 2026-08-14. Persistence is fine — quitting and reopening shows the missing work — only the live store drops it.

For context I resumed a session from 2 weeks before and it got stuck without streaming anything and the only visible movement was the spinner. With the fix, the same session resumed correctly.

## Screenshots

### Before
> Old session resumed: Session stuck after I sent "Continue" 
<img width="824" height="319" alt="Screenshot 2026-08-20 at 12 33 49" src="https://github.com/user-attachments/assets/d64fc6e1-23dd-42b7-aaf1-03b90bccba4c" />

### After
> Old session resumed: Session streaming after I sent "Continue" 
<img width="400" height="913" alt="Screenshot 2026-08-20 at 12 33 19" src="https://github.com/user-attachments/assets/60e68b6e-7f81-4571-9230-22183a068790" />

## Why

`packages/opencode/src/id/id.ts` encodes `Date.now() * 0x1000 + counter` in 48 bits, wrapping roughly every 795 days. Wrap 25 ended 2026-08-14 13:19:55; new IDs restarted at `msg_000…`/`msg_019…`. The TUI sync store (`packages/tui/src/context/sync.tsx`) inserted messages by binary search on **id** and evicted `list[0]` as "oldest" when the 100-message window overflowed. After the wrap, a new `msg_019f…` sorts before an old `msg_ff0c…`, so every new turn inserted at index 0 and was immediately evicted. Hydration over HTTP orders by `time_created`, which is why reopening looked correct (observed in `ses_023cb4401ffe2R9oTrbp7nj9Hz`, 606 messages spanning the wrap).

This also closes a second latent bug: after hydration the list was time-ordered but binary-searched as if id-ordered, so a lookup could miss an element that was present — `message.updated` could insert a duplicate entry and `message.removed` could fail to remove one. The linear id lookup eliminates both.

## How

Ordering logic lives in a new kilo-owned helper, `packages/tui/src/kilocode/message-order.ts`, ordering by `time.created` with id as tiebreaker (matching the server's canonical `(time_created, id)` order):

- `older(a, b)` — comparator by created time, then id
- `slot(list, item)` — insert/update index by created time
- `at(list, id)` — linear id lookup (the list is no longer id-sorted)
- `recent(list, cap = 100)` — newest-by-created window

`sync.tsx` changes are limited to five marked call-site swaps: `message.updated` / `message.updated.1` insert via `slot`, `message.removed` / `message.removed.1` look up via `at`, and the hydrate window uses `recent` instead of `slice(-100)`.

Tests live in `packages/tui/test/kilocode/`: unit coverage for the helper plus sync-store tests asserting a later `msg_019f…` emitted after an older `msg_ff0c…` stays at the tail (on both the plain and versioned sync channels) and that eviction at the 100-message cap drops the oldest message, not the newest.

Known remaining limitation, out of scope here: a few upstream-owned render-layer sites in `packages/tui/src/routes/session/index.tsx` still compare message ids lexicographically as a proxy for chronology (queued styling, revert boundaries for undo/redo/copy). Those are pre-existing and unaffected by this change.