### PR TITLE
feat(tui): add last-commit diff view option

### DIFF
--- a/.changeset/last-commit-diff-viewer.md
+++ b/.changeset/last-commit-diff-viewer.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Add a "last commit" option to the diff viewer that shows changes from the most recent git commit (HEAD vs HEAD~1), independent of working tree state.

--- a/packages/opencode/src/kilocode/git-refs.ts
+++ b/packages/opencode/src/kilocode/git-refs.ts
@@ -1,0 +1,92 @@
+// kilocode_change - new file
+import { Effect } from "effect"
+import { Git } from "@/git"
+
+type DiffRefsOptions = {
+  readonly context?: number
+  readonly maxOutputBytes?: number
+}
+
+const kind = (code: string): Git.Kind => {
+  if (code === "??") return "added"
+  if (code.includes("U")) return "modified"
+  if (code.includes("A") && !code.includes("D")) return "added"
+  if (code.includes("D") && !code.includes("A")) return "deleted"
+  return "modified"
+}
+
+const nuls = (text: string) => text.split("\0").filter(Boolean)
+
+export const diffRefs = Effect.fn("KiloGit.diffRefs")(function* (
+  git: Git.Interface,
+  cwd: string,
+  from: string,
+  to: string,
+) {
+  const result = yield* git.run(
+    ["diff", "--no-ext-diff", "--no-renames", "--name-status", "-z", `${from}..${to}`, "--", "."],
+    { cwd },
+  )
+  if (result.exitCode !== 0) return []
+  const list = nuls(result.text())
+  return list.flatMap((code, idx) => {
+    if (idx % 2 !== 0) return []
+    const file = list[idx + 1]
+    if (!code || !file) return []
+    return [{ file, code, status: kind(code) } satisfies Git.Item]
+  })
+})
+
+export const statsRefs = Effect.fn("KiloGit.statsRefs")(function* (
+  git: Git.Interface,
+  cwd: string,
+  from: string,
+  to: string,
+) {
+  const result = yield* git.run(
+    ["diff", "--no-ext-diff", "--no-renames", "--numstat", "-z", `${from}..${to}`, "--", "."],
+    { cwd },
+  )
+  if (result.exitCode !== 0) return []
+  return nuls(result.text()).flatMap((item) => {
+    const a = item.indexOf("\t")
+    const b = item.indexOf("\t", a + 1)
+    if (a === -1 || b === -1) return []
+    const file = item.slice(b + 1)
+    if (!file) return []
+    const adds = item.slice(0, a)
+    const dels = item.slice(a + 1, b)
+    const additions = adds === "-" ? 0 : Number.parseInt(adds || "0", 10)
+    const deletions = dels === "-" ? 0 : Number.parseInt(dels || "0", 10)
+    return [
+      {
+        file,
+        additions: Number.isFinite(additions) ? additions : 0,
+        deletions: Number.isFinite(deletions) ? deletions : 0,
+      } satisfies Git.Stat,
+    ]
+  })
+})
+
+export const patchAllRefs = Effect.fn("KiloGit.patchAllRefs")(function* (
+  git: Git.Interface,
+  cwd: string,
+  from: string,
+  to: string,
+  options?: DiffRefsOptions,
+) {
+  const result = yield* git.run(
+    [
+      "diff",
+      "--patch",
+      "--no-ext-diff",
+      "--no-renames",
+      `--unified=${options?.context ?? 3}`,
+      `${from}..${to}`,
+      "--",
+      ".",
+    ],
+    { cwd, maxOutputBytes: options?.maxOutputBytes },
+  )
+  return { text: result.text(), truncated: result.truncated } satisfies Git.Patch
+})

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -247,25 +247,26 @@ const lastCommitDiff = Effect.fnUntraced(function* (
     { concurrency: 3 },
   )
 
-  const patches = splitGitPatch(batchResult).reduce((acc, patch, index) => {
+  const statMap = nums(stats)
+  const batchPatches = splitGitPatch(batchResult).reduce((acc, patch, index) => {
     const file = fileFromPatchChunk(patch) ?? list[index]?.file
     if (!file) return acc
     acc.set(file, (acc.get(file) ?? "") + patch)
     return acc
   }, new Map<string, string>())
-  const capped = batchResult.truncated
-  const statMap = nums(stats)
+  const batch = { patches: batchPatches, capped: false }
+  const ref = `${parent}..HEAD`
 
   const next: FileDiff[] = []
   let total = 0
+  let capped = false
   for (const item of list.toSorted((a, b) => a.file.localeCompare(b.file))) {
     const stat = statMap.get(item.file)
-    const patch = capped
-      ? emptyPatch(item.file)
-      : patches.get(item.file) ?? emptyPatch(item.file)
+    const patch = yield* patchForItem(git, cwd, ref, item, batch, capped, options)
     const result: { patch: string; capped: boolean } = capped
       ? { patch, capped: true }
       : totalPatch(item.file, patch, total)
+    capped = capped || result.capped
     if (!capped) {
       total += Buffer.byteLength(result.patch)
     }

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -4,6 +4,7 @@ import { formatPatch, structuredPatch } from "diff"
 import { InstanceState } from "@/effect/instance-state"
 import { Watcher } from "@opencode-ai/core/filesystem/watcher"
 import { Git } from "@/git"
+import { diffRefs, patchAllRefs, statsRefs } from "@/kilocode/git-refs" // kilocode_change
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { EventV2 } from "@opencode-ai/core/event"
 import { VcsEvent } from "@opencode-ai/schema/vcs-event"
@@ -222,6 +223,65 @@ const diffAgainstRef = Effect.fnUntraced(function* (
   )
 })
 
+// kilocode_change start - diff for the last commit (HEAD vs HEAD~1)
+const lastCommitDiff = Effect.fnUntraced(function* (
+  git: Git.Interface,
+  cwd: string,
+  options?: DiffOptions,
+) {
+  if (!(yield* git.hasHead(cwd))) return []
+  const result = yield* git.run(["rev-parse", "--verify", "HEAD~1"], { cwd })
+  if (result.exitCode !== 0) return []
+  const parent = result.text().trim()
+  if (!parent) return []
+
+  const [list, stats, batchResult] = yield* Effect.all(
+    [
+      diffRefs(git, cwd, parent, "HEAD"),
+      statsRefs(git, cwd, parent, "HEAD"),
+      patchAllRefs(git, cwd, parent, "HEAD", {
+        context: options?.context ?? PATCH_CONTEXT_LINES,
+        maxOutputBytes: MAX_TOTAL_PATCH_BYTES,
+      }),
+    ],
+    { concurrency: 3 },
+  )
+
+  const patches = splitGitPatch(batchResult).reduce((acc, patch, index) => {
+    const file = fileFromPatchChunk(patch) ?? list[index]?.file
+    if (!file) return acc
+    acc.set(file, (acc.get(file) ?? "") + patch)
+    return acc
+  }, new Map<string, string>())
+  const capped = batchResult.truncated
+  const statMap = nums(stats)
+
+  const next: FileDiff[] = []
+  let total = 0
+  for (const item of list.toSorted((a, b) => a.file.localeCompare(b.file))) {
+    const stat = statMap.get(item.file)
+    const patch = capped
+      ? emptyPatch(item.file)
+      : patches.get(item.file) ?? emptyPatch(item.file)
+    const result: { patch: string; capped: boolean } = capped
+      ? { patch, capped: true }
+      : totalPatch(item.file, patch, total)
+    if (!capped) {
+      total += Buffer.byteLength(result.patch)
+    }
+    next.push({
+      file: item.file,
+      patch: result.patch,
+      additions: stat?.additions ?? 0,
+      deletions: stat?.deletions ?? 0,
+      status: item.status,
+    })
+  }
+
+  return next
+})
+// kilocode_change end
+
 const track = Effect.fnUntraced(function* (
   git: Git.Interface,
   cwd: string,
@@ -232,7 +292,7 @@ const track = Effect.fnUntraced(function* (
   return yield* diffAgainstRef(git, cwd, ref, options)
 })
 
-export const Mode = Schema.Literals(["git", "branch"])
+export const Mode = Schema.Literals(["git", "branch", "last-commit"]) // kilocode_change
 export type Mode = Schema.Schema.Type<typeof Mode>
 
 export const Event = VcsEvent
@@ -377,6 +437,8 @@ const layer: Layer.Layer<Service, never, Git.Service | EventV2Bridge.Service> = 
         if (mode === "git") {
           return yield* track(git, ctx.directory, (yield* git.hasHead(ctx.directory)) ? "HEAD" : undefined, options)
         }
+
+        if (mode === "last-commit") return yield* lastCommitDiff(git, ctx.directory, options) // kilocode_change
 
         if (!value.root) return []
         if (value.current && value.current === value.root.name) return []

--- a/packages/opencode/test/project/vcs.test.ts
+++ b/packages/opencode/test/project/vcs.test.ts
@@ -332,4 +332,37 @@ describe("Vcs diff", () => {
       }),
     { git: true },
   )
+
+  // kilocode_change start
+  it.instance(
+    "diff('last-commit') returns changes from the most recent commit only",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        yield* write(path.join(test.directory, "stale.txt"), "old\n")
+        yield* git(test.directory, ["add", "."])
+        yield* git(test.directory, ["commit", "--no-gpg-sign", "-m", "first"])
+        yield* write(path.join(test.directory, "fresh.txt"), "new\n")
+        yield* write(path.join(test.directory, "stale.txt"), "changed\n")
+        yield* git(test.directory, ["add", "."])
+        yield* git(test.directory, ["commit", "--no-gpg-sign", "-m", "second"])
+        yield* write(path.join(test.directory, "uncommitted.txt"), "working\n")
+
+        const vcs = yield* init()
+        const diff = yield* vcs.diff("last-commit")
+
+        const files = diff.map((item) => item.file).sort()
+        expect(files).toEqual(["fresh.txt", "stale.txt"])
+        expect(diff.find((item) => item.file === "uncommitted.txt")).toBeUndefined()
+        const fresh = diff.find((item) => item.file === "fresh.txt")
+        expect(fresh?.patch).toContain("diff --git")
+        expect(fresh?.patch).toContain("+new")
+        const stale = diff.find((item) => item.file === "stale.txt")
+        expect(stale?.patch).toContain("diff --git")
+        expect(stale?.patch).toContain("-old")
+        expect(stale?.patch).toContain("+changed")
+      }),
+    { git: true },
+  )
+  // kilocode_change end
 })

--- a/packages/opencode/test/project/vcs.test.ts
+++ b/packages/opencode/test/project/vcs.test.ts
@@ -364,5 +364,39 @@ describe("Vcs diff", () => {
       }),
     { git: true },
   )
+
+  it.instance(
+    "diff('last-commit') recovers patches when batch fetch is truncated",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        yield* write(path.join(test.directory, "seed.txt"), "seed\n")
+        yield* git(test.directory, ["add", "."])
+        yield* git(test.directory, ["commit", "--no-gpg-sign", "-m", "seed"])
+
+        // Large file pushes the unified batch patch over MAX_TOTAL_PATCH_BYTES
+        // (10MB), but each individual file diff stays well under it. Smaller
+        // commits must still produce real patches via per-file fallback.
+        const big = "x".repeat(11 * 1024 * 1024)
+        yield* write(path.join(test.directory, "big.bin"), big)
+        yield* write(path.join(test.directory, "small.txt"), "tiny change\n")
+        yield* git(test.directory, ["add", "."])
+        yield* git(test.directory, ["commit", "--no-gpg-sign", "-m", "mixed sizes"])
+
+        const vcs = yield* init()
+        const diff = yield* vcs.diff("last-commit")
+
+        const files = diff.map((item) => item.file).sort()
+        expect(files).toEqual(["big.bin", "small.txt"])
+
+        const small = diff.find((item) => item.file === "small.txt")
+        expect(small?.patch).toContain("diff --git")
+        expect(small?.patch).toContain("+tiny change")
+
+        const bigItem = diff.find((item) => item.file === "big.bin")
+        expect(bigItem?.patch).toBeDefined()
+      }),
+    { git: true, timeout: 60_000 },
+  )
   // kilocode_change end
 })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2743,7 +2743,7 @@ export class Vcs extends HeyApiClient {
     parameters: {
       directory?: string
       workspace?: string
-      mode: "git" | "branch"
+      mode: "git" | "branch" | "last-commit"
       context?: number
     },
     options?: Options<never, ThrowOnError>,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -11598,7 +11598,7 @@ export type VcsDiffData = {
   query: {
     directory?: string
     workspace?: string
-    mode: "git" | "branch"
+    mode: "git" | "branch" | "last-commit"
     context?: number
   }
   url: "/vcs/diff"

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -2789,7 +2789,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["git", "branch"]
+              "enum": ["git", "branch", "last-commit"]
             },
             "required": true
           },

--- a/packages/tui/src/feature-plugins/system/diff-viewer.tsx
+++ b/packages/tui/src/feature-plugins/system/diff-viewer.tsx
@@ -43,7 +43,7 @@ const VCS_DIFF_CONTEXT_LINES = 12
 const KV_SHOW_FILE_TREE = "diff_viewer_show_file_tree"
 const KV_SINGLE_PATCH = "diff_viewer_single_patch"
 const KV_VIEW = "diff_viewer_view"
-type DiffMode = "git" | "branch" | "last-turn"
+type DiffMode = "git" | "branch" | "last-turn" | "last-commit" // kilocode_change
 type DiffViewerFocus = "patches" | "files"
 type DiffView = "split" | "unified"
 type SelectedHunk = { readonly fileIndex: number; readonly hunkIndex: number; readonly scrollTop: number }
@@ -84,6 +84,7 @@ function storedView(value: unknown): DiffView | undefined {
 
 function diffSourceLabel(mode: DiffMode) {
   if (mode === "last-turn") return "last turn"
+  if (mode === "last-commit") return "last commit" // kilocode_change
   if (mode === "branch") return "main branch"
   return "working tree"
 }
@@ -703,6 +704,13 @@ function DiffViewer(props: { api: TuiPluginApi }) {
         value: "last-turn" as const,
         description: "Show changes from the last assistant turn",
       },
+      // kilocode_change start
+      {
+        title: "Last commit",
+        value: "last-commit" as const,
+        description: "Show changes introduced by the most recent git commit",
+      },
+      // kilocode_change end
     ]
   })
 
@@ -989,7 +997,7 @@ function DiffViewerHelpDialog() {
     {
       shortcut: useCommandShortcut("diff.switch_source"),
       action: "Switch source",
-      description: "Choose working tree, main branch, or last-turn changes",
+      description: "Choose working tree, main branch, last-turn, or last-commit changes", // kilocode_change
     },
     {
       shortcut: useCommandShortcut("diff.toggle_view"),


### PR DESCRIPTION
## Issue

Fixes #13258

## Context

The TUI diff viewer offers three sources: working tree, main branch, and last assistant turn. There was no way to inspect only the changes introduced by the most recent git commit (HEAD vs HEAD~1) without mixing in working tree noise. This adds a new "Last commit" entry to the Switch source dialog that drives a new `last-commit` mode on the existing `Vcs.diff` route.

## Implementation

A new `last-commit` mode on `Vcs.diff` that resolves `HEAD~1` via `git rev-parse` and returns the diff between the two refs. The ref-to-ref helpers (`diffRefs`, `statsRefs`, `patchAllRefs`) live in a Kilo-only module (`packages/opencode/src/kilocode/git-refs.ts`) so the shared `Git.Interface` is not widened. The result is built directly to `FileDiff[]` instead of going through the shared `files()` helper, so a missing batched patch can never fall through to the working-tree-vs-`/dev/null` untracked diff path. The TUI diff viewer adds the new mode to its `DiffMode` type, Switch source dialog, header label, and help dialog. SDK and OpenAPI spec are regenerated.

## How to Test

### Manual/local verification

Manually tested end-to-end in the TUI (`bun dev`) against a git repo with multiple commits and uncommitted working tree changes. Confirmed the "Last commit" option appears in the Switch source dialog, shows only the files changed in the most recent commit with correct patch content, and excludes uncommitted working tree edits.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.