### PR TITLE
fix(cli): normalize null tool-call content for OpenAI-compatible APIs

### DIFF
--- a/packages/opencode/src/kilocode/provider/cloud-auth.ts
+++ b/packages/opencode/src/kilocode/provider/cloud-auth.ts
@@ -1,4 +1,5 @@
 import type { Auth } from "@/auth"
+import { patchOpenAICompatibleOptions } from "./provider"
 
 function record(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value)
@@ -57,6 +58,7 @@ export function providerKey(providerID: string, auth: Auth.Info) {
 const VERTEX_CREDENTIALS = "kiloVertexCredentials"
 
 export function vertexOptions(providerID: string, npm: string, options: Record<string, unknown>) {
+  patchOpenAICompatibleOptions(npm, options)
   const getter = options[VERTEX_CREDENTIALS]
   delete options[VERTEX_CREDENTIALS]
   if (providerID !== "google-vertex" || npm.includes("@ai-sdk/openai-compatible")) return

--- a/packages/opencode/src/kilocode/provider/provider.ts
+++ b/packages/opencode/src/kilocode/provider/provider.ts
@@ -21,6 +21,33 @@ import type { Auth } from "@/auth"
 import type { Config } from "@/config/config"
 import { organization, token } from "./catalog"
 
+type RequestBody = Record<string, unknown>
+type RequestTransform = (body: RequestBody) => RequestBody
+
+const isRequestBody = (value: unknown): value is RequestBody =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const isRequestTransform = (value: unknown): value is RequestTransform => typeof value === "function"
+
+export function patchOpenAICompatibleOptions(npm: string, options: Record<string, unknown>) {
+  if (!npm.includes("@ai-sdk/openai-compatible")) return
+  const previous = isRequestTransform(options.transformRequestBody) ? options.transformRequestBody : undefined
+  options.transformRequestBody = (body: RequestBody) => {
+    const transformed = previous?.(body) ?? body
+    if (!Array.isArray(transformed.messages)) return transformed
+    return {
+      ...transformed,
+      messages: transformed.messages.map((message) => {
+        if (!isRequestBody(message)) return message
+        if (message.role !== "assistant") return message
+        if (message.content !== null) return message
+        if (!Array.isArray(message.tool_calls) || message.tool_calls.length === 0) return message
+        return { ...message, content: "" }
+      }),
+    }
+  }
+}
+
 /** Default timeout (ms) for provider HTTP requests (connection phase). */
 export const REQUEST_TIMEOUT_MS = 300_000 // 5 minutes
 

--- a/packages/opencode/test/kilocode/provider/cloud-auth.test.ts
+++ b/packages/opencode/test/kilocode/provider/cloud-auth.test.ts
@@ -78,4 +78,41 @@ describe("cloud provider auth", () => {
     vertexOptions("google-vertex", "@ai-sdk/google-vertex", options)
     expect(options).toEqual({ project: "test-project", googleAuthOptions: { credentials } })
   })
+
+  test("normalizes null content for OpenAI-compatible tool-only assistant messages", () => {
+    const options: Record<string, unknown> = {}
+    vertexOptions("custom", "@ai-sdk/openai-compatible", options)
+
+    const transform = options.transformRequestBody as (body: Record<string, unknown>) => Record<string, unknown>
+    expect(transform).toBeFunction()
+    expect(
+      transform({
+        messages: [
+          { role: "user", content: "hello" },
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: [{ id: "call-1", type: "function", function: { name: "test", arguments: "{}" } }],
+          },
+          { role: "assistant", content: null },
+        ],
+      }),
+    ).toEqual({
+      messages: [
+        { role: "user", content: "hello" },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [{ id: "call-1", type: "function", function: { name: "test", arguments: "{}" } }],
+        },
+        { role: "assistant", content: null },
+      ],
+    })
+  })
+
+  test("does not install the request transform for non OpenAI-compatible providers", () => {
+    const options: Record<string, unknown> = {}
+    vertexOptions("custom", "@ai-sdk/openai", options)
+    expect(options.transformRequestBody).toBeUndefined()
+  })
 })


### PR DESCRIPTION
Fixes #12330
Supersedes #12331.

## Summary

OpenAI-compatible backends currently disagree on the accepted representation of **tool-only assistant messages**.

KiloCode currently uses `@ai-sdk/openai-compatible` `2.0.48`, which serializes an assistant message containing tool calls but no text as:

```json
{
  "role": "assistant",
  "content": null,
  "tool_calls": [...]
}
```

Some compatible backends accept or require this nullable representation. Others reject `content: null` and require `content` to remain a string. The affected endpoint in #12330 is in the latter category.

This PR adds a narrowly scoped compatibility normalization for direct `@ai-sdk/openai-compatible` models:

```json
{
  "role": "assistant",
  "content": "",
  "tool_calls": [...]
}
```

Only `assistant + content:null + non-empty tool_calls` is changed. Other assistant messages, tool calls, tool results, request ordering, streaming behavior, model selection and non-OpenAI-compatible providers remain unchanged.

## Why this is not simply a Vercel AI SDK bug

KiloCode previously used `@ai-sdk/openai-compatible` `2.0.41`. It was upgraded to `2.0.48` in KiloCode commit [`d8457d28`](https://github.com/Kilo-Org/kilocode/commit/d8457d28ad1c640269d4ef327fd6bc0484bdc11e) via PR #11117:

```diff
- "@ai-sdk/openai-compatible": "2.0.41",
+ "@ai-sdk/openai-compatible": "2.0.48",
```

The changed serialization upstream was intentional, not accidental. Vercel AI SDK commit [`bfb756d8`](https://github.com/vercel/ai/commit/bfb756d839d435e3fd0afa22135c59d4587c79f2) changed tool-only assistant content from `""` to `null` to address the opposite compatibility problem: backends such as Bedrock rejecting empty text blocks. See also [`vercel/ai#13466`](https://github.com/vercel/ai/issues/13466).

So there is no single representation that is universally accepted across implementations calling themselves OpenAI-compatible:

- some reject `content: ""`;
- some reject `content: null`;
- clients therefore need provider/backend compatibility handling at the adapter boundary when interoperability matters.

## Cross-client evidence

This is not unique to KiloCode. Other coding clients already carry compatibility behavior around the same class of OpenAI-compatible differences.

### OpenCode

Current OpenCode still pins `@ai-sdk/openai-compatible` to `2.0.41`, which predates the `content: null` behavior that exposed #12330:

[`packages/opencode/package.json`](https://github.com/anomalyco/opencode/blob/dev/packages/opencode/package.json)

I could not find evidence that OpenCode deliberately pins `2.0.41` specifically because of this issue, so this PR does **not** make that claim. The version difference simply explains why the same endpoint can work with current OpenCode while failing with affected KiloCode versions.

### Pi

Pi implements its own OpenAI-completions compatibility layer instead of assuming every compatible backend has identical validation behavior.

Relevant implementation permalink:

[`packages/ai/src/api/openai-completions.ts` @ `b7bb00b9`](https://github.com/earendil-works/pi/blob/b7bb00b936dbe21b8e160b3e89efdec361846699/packages/ai/src/api/openai-completions.ts)

Provider compatibility types, including `requiresAssistantAfterToolResult`:

[`packages/ai/src/types.ts` @ `b7bb00b9`](https://github.com/earendil-works/pi/blob/b7bb00b936dbe21b8e160b3e89efdec361846699/packages/ai/src/types.ts)

Pi normally allows nullable content for tool-only assistant messages, but its compatibility layer can substitute string content for providers requiring it. The important architectural point is that Pi treats these differences as provider-adapter compatibility concerns.

### Continue

Continue is even more explicit. Its OpenAI message converter deliberately normalizes empty assistant content to a single space before attaching tool calls:

[`core/llm/openaiTypeConverters.ts` @ `5522c6f4`](https://github.com/continuedev/continue/blob/5522c6f44ca0ac3528b37244818fbfa39b5af470/core/llm/openaiTypeConverters.ts)

The code contains this compatibility logic:

```ts
content:
  typeof message.content === "string"
    ? message.content || " " // LM Studio (and other providers) don't accept empty content
    : ...

if (message.toolCalls) {
  msg.tool_calls = message.toolCalls.map(...)
}
```

Continue therefore already handles this class of strict OpenAI-compatible backend behavior on the client side.

## Why the fix belongs here

The best long-term outcome is for backends advertising OpenAI compatibility to accept `content: null` for tool-only assistant messages where the schema allows it. However, KiloCode has to interoperate with a broad set of third-party and private compatible endpoints whose validation rules differ in practice.

For that reason this PR intentionally does **not** change KiloCode's internal conversation representation and does **not** modify tool-call logic globally. The normalization is applied only at the OpenAI-compatible provider boundary.

The helper also composes with any existing `transformRequestBody`, preserving previous provider-specific request transformations.

## Implementation

The compatibility helper lives in Kilo-owned provider code and is enabled only when the selected SDK package contains `@ai-sdk/openai-compatible`.

It applies the following predicate:

```text
role === "assistant"
AND content === null
AND tool_calls is a non-empty array
```

Only then is `content` replaced with `""`.

The current provider resolver already invokes the Kilo `vertexOptions(providerID, npm, options)` hook before SDK creation for every model. The normalization is attached through that existing Kilo-owned compatibility hook, avoiding another invasive change to the large shared provider resolver.

## Regression coverage

The targeted tests verify that:

- `assistant + content:null + tool_calls` becomes `content:""`;
- `tool_calls` are preserved unchanged;
- assistant messages without tool calls are not modified;
- tool messages are not modified;
- a pre-existing request-body transform is preserved;
- non-`@ai-sdk/openai-compatible` providers are untouched.

## PR history

This PR is a clean replacement for #12331. The original PR contained the initial implementation and investigation, but its branch became stale and could not be reopened after being recreated/force-updated.

#13260 has therefore been rebuilt on current `main` and intentionally squashed to **one commit** with a minimal current-tree diff.

The detailed original discussion and investigation remain available in #12331.