### PR TITLE
fix(agent-manager): preserve new worktree base branch

### DIFF
--- a/.changeset/fix-worktree-base-branch.md
+++ b/.changeset/fix-worktree-base-branch.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Use the displayed current branch as the base when creating a worktree from the New Worktree dialog.

--- a/packages/kilo-vscode/tests/unit/new-worktree-dialog-sandbox.test.ts
+++ b/packages/kilo-vscode/tests/unit/new-worktree-dialog-sandbox.test.ts
@@ -27,3 +27,11 @@ describe("NewWorktreeDialog sandbox toggle", () => {
     expect(src).not.toContain("visible as isSandboxVisible")
   })
 })
+
+describe("NewWorktreeDialog base branch", () => {
+  it("sends the displayed default base branch when advanced options stay closed", () => {
+    expect(src).toContain("const effectiveBaseBranch = () => baseBranch() ?? defaultBranch()")
+    expect(src).toContain("baseBranch: effectiveBaseBranch(),")
+    expect(src).not.toContain("baseBranch: advanced ? (baseBranch() ?? undefined) : undefined")
+  })
+})

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -475,7 +475,7 @@ export const NewWorktreeDialog: Component<{
       modelID: sel?.modelID,
       agent: selectedAgent,
       variant: isCompare ? undefined : effectiveVariant(),
-      baseBranch: advanced ? (baseBranch() ?? undefined) : undefined,
+      baseBranch: effectiveBaseBranch(),
       branchName: customBranch,
       modelAllocations: allocations,
       sandbox: sandboxVisible() ? sandboxOverride() : undefined,


### PR DESCRIPTION
The New Worktree dialog can display the current checkout branch while omitting it from the creation request. The backend then selects the repository default branch, usually main, which makes the dialog misleading and can create worktrees from the wrong commit. Always pass the effective branch shown by the dialog as the worktree base, while preserving explicit Advanced options selections. Add regression coverage and a patch changeset.