### PR TITLE
fix(vscode): prevent invalid PR check durations

### DIFF
--- a/.changeset/fix-pr-check-duration.md
+++ b/.changeset/fix-pr-check-duration.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent invalid GitHub check timestamps from displaying incorrect PR durations.

--- a/packages/kilo-vscode/src/agent-manager/pr/am-pr-utils.ts
+++ b/packages/kilo-vscode/src/agent-manager/pr/am-pr-utils.ts
@@ -57,7 +57,10 @@ export function checkStatus(state: string): CheckStatus {
 
 export function formatCheckDuration(startedAt?: string, completedAt?: string): string | undefined {
   if (!startedAt || !completedAt) return undefined
-  const secs = Math.round((new Date(completedAt).getTime() - new Date(startedAt).getTime()) / 1000)
+  const start = new Date(startedAt).getTime()
+  const end = new Date(completedAt).getTime()
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return undefined
+  const secs = Math.round((end - start) / 1000)
   return secs < 60 ? `${secs}s` : `${Math.floor(secs / 60)}m ${secs % 60}s`
 }
 

--- a/packages/kilo-vscode/tests/unit/am-pr-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/am-pr-utils.test.ts
@@ -195,6 +195,15 @@ describe("formatCheckDuration", () => {
     expect(formatCheckDuration("2024-01-01T00:00:00Z", undefined)).toBeUndefined()
   })
 
+  it("returns undefined for invalid timestamps", () => {
+    expect(formatCheckDuration("not a date", "2024-01-01T00:01:00Z")).toBeUndefined()
+    expect(formatCheckDuration("2024-01-01T00:00:00Z", "not a date")).toBeUndefined()
+  })
+
+  it("returns undefined when completedAt is before startedAt", () => {
+    expect(formatCheckDuration("2024-01-01T00:01:00Z", "2024-01-01T00:00:00Z")).toBeUndefined()
+  })
+
   it("formats sub-minute durations in seconds", () => {
     expect(formatCheckDuration("2024-01-01T00:00:00Z", "2024-01-01T00:00:45Z")).toBe("45s")
   })


### PR DESCRIPTION
GitHub can return malformed or inconsistent timestamps for checks that are still running. The PR view previously formatted those values directly, allowing invalid dates and negative elapsed times to appear as bogus durations such as a large negative number. Validate both timestamps and require completion to be no earlier than start; invalid durations are omitted while the check status remains visible as Running. Add focused regression coverage and a patch changeset.