### PR TITLE
fix(vscode): bootstrap dependencies in worktrees

### DIFF
--- a/.changeset/worktree-dependencies.md
+++ b/.changeset/worktree-dependencies.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Bootstrap missing locked workspace dependencies before building the extension from an Agent Manager worktree.

--- a/packages/kilo-vscode/script/launch.ts
+++ b/packages/kilo-vscode/script/launch.ts
@@ -240,6 +240,7 @@ async function compile() {
     return
   }
 
+  await ensureDependencies()
   console.log("[launch] Building extension...")
   await $`bun run build:launch`.cwd(root).env(cleanEnv(process.env))
   console.log("[launch] Build complete")
@@ -252,6 +253,26 @@ function cleanEnv(input: NodeJS.ProcessEnv) {
     if (value !== undefined) env[key] = value.trim()
   }
   return env
+}
+
+async function ensureDependencies() {
+  const required = [
+    { name: "esbuild", dir: root },
+    { name: "@opencode-ai/core/npm", dir: join(repo, "packages", "opencode") },
+    { name: "@hey-api/openapi-ts", dir: join(repo, "packages", "sdk", "js") },
+  ]
+  const ready = required.every((item) => {
+    try {
+      Bun.resolveSync(item.name, item.dir)
+      return true
+    } catch {
+      return false
+    }
+  })
+  if (ready) return
+
+  console.log("[launch] Worktree dependencies are missing, installing...")
+  await $`bun install --frozen-lockfile`.cwd(repo).env(cleanEnv(process.env))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fresh Agent Manager worktrees do not contain ignored node_modules or generated build artifacts. Running the extension launcher in one of these worktrees therefore fails when Bun cannot resolve workspace packages such as @opencode-ai/core, even though the source checkout is valid.

The launcher now checks the required extension bundler, CLI core, and SDK generator modules before building. If any are missing, it runs one locked root workspace install with bun install --frozen-lockfile. Existing launches with valid dependencies continue without an install.

This keeps dependency provisioning at the launcher boundary, where it covers direct launch commands and Agent Manager run scripts without changing CLI or SDK build behavior.