### PR TITLE
fix(vscode): persist sidebar model picks from active sessions

### DIFF
--- a/.changeset/remember-sidebar-model-picks.md
+++ b/.changeset/remember-sidebar-model-picks.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Remember model selections made in the sidebar while a session is open.

--- a/packages/kilo-vscode/tests/unit/session-model-selector.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-model-selector.test.ts
@@ -47,4 +47,23 @@ describe("model selector", () => {
     expect(models).toEqual([{ id: "session", selection: model }])
     expect(variants).toEqual([{ value: "high", session: "session" }])
   })
+
+  it("passes the requested selection scope to the state transition", () => {
+    const selected = { providerID: "kilo", modelID: "old" }
+    const scopes: Array<string | undefined> = []
+    const selector = createModelSelector({
+      current: () => "session",
+      agent: () => "code",
+      selected: () => selected,
+      variant: () => undefined,
+      apply: (_agent, _selection, _id, scope) => scopes.push(scope),
+      set: () => undefined,
+      carry: () => undefined,
+      hide: () => undefined,
+    })
+
+    selector.select("kilo", "new", "session", "global")
+
+    expect(scopes).toEqual(["global"])
+  })
 })

--- a/packages/kilo-vscode/tests/unit/session-model-store.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-model-store.test.ts
@@ -166,9 +166,17 @@ describe("per-mode model memory", () => {
     expect(getAgentModel(store, configured, "code", true)).toEqual(claude)
   })
 
-  it("applyModel in a session writes only to sessionOverrides", () => {
+  it("global session picks update per-mode memory and the active session", () => {
     const store = emptyStore()
-    const result = applyModel(store, "code", claude, "session-a")
+    const result = applyModel(store, "code", claude, "session-a", "global")
+
+    expect(result.sessionOverrides["session-a"]).toEqual(claude)
+    expect(result.modelSelections["code"]).toEqual(claude)
+  })
+
+  it("session-scoped picks do not update per-mode memory", () => {
+    const store = emptyStore()
+    const result = applyModel(store, "code", claude, "session-a", "session")
 
     expect(result.sessionOverrides["session-a"]).toEqual(claude)
     expect(result.modelSelections["code"]).toBeUndefined()

--- a/packages/kilo-vscode/webview-ui/src/components/chat/KiloNotifications.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/KiloNotifications.tsx
@@ -4,6 +4,7 @@ import { useVSCode } from "../../context/vscode"
 import { useSession } from "../../context/session"
 import { useProvider } from "../../context/provider"
 import { useLanguage } from "../../context/language"
+import { useWorktreeMode } from "../../context/worktree-mode"
 import { KILO_PROVIDER_ID } from "../../../../src/shared/provider-model"
 import { TelemetryEventName } from "../../../../src/services/telemetry/types"
 import { stripSubProviderPrefix } from "../shared/model-selector-utils"
@@ -14,6 +15,7 @@ export const KiloNotifications: Component<{ sessionID?: Accessor<string | undefi
   const session = useSession()
   const provider = useProvider()
   const language = useLanguage()
+  const worktree = useWorktreeMode()
   const [index, setIndex] = createSignal(0)
   const sessionID = () => props.sessionID?.() ?? session.currentSessionID() ?? session.draftSessionID()
 
@@ -78,7 +80,7 @@ export const KiloNotifications: Component<{ sessionID?: Accessor<string | undefi
   const handleTryModel = () => {
     const suggestion = suggestedModel()
     if (!suggestion) return
-    session.selectModel(suggestion.providerID, suggestion.modelID, sessionID())
+    session.selectModel(suggestion.providerID, suggestion.modelID, sessionID(), worktree ? "session" : "global")
     vscode.postMessage({
       type: "telemetry",
       event: TelemetryEventName.NOTIFICATION_CLICKED,

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -30,6 +30,7 @@ import { useProvider } from "../../context/provider"
 import type { EnrichedModel } from "../../context/provider"
 import { useSession, SessionContext } from "../../context/session"
 import { useLanguage } from "../../context/language"
+import { useWorktreeMode } from "../../context/worktree-mode"
 import { useVSCode } from "../../context/vscode"
 import type { ModelSelection } from "../../types/messages"
 import { isEnterKeyCommitNotIme } from "../../utils/ime-enter"
@@ -1149,13 +1150,14 @@ interface ModelSelectorProps {
 
 export const ModelSelector: Component<ModelSelectorProps> = (props) => {
   const session = useSession()
+  const worktree = useWorktreeMode()
   const id = () => props.sessionID?.()
 
   return (
     <ModelSelectorBase
       value={session.selected(id())}
       onSelect={(providerID, modelID) => {
-        session.selectModel(providerID, modelID, id())
+        session.selectModel(providerID, modelID, id(), worktree ? "session" : "global")
       }}
       onPick={() => {
         requestAnimationFrame(() => window.dispatchEvent(new CustomEvent("focusPrompt", { detail: { restore: true } })))

--- a/packages/kilo-vscode/webview-ui/src/context/session-model-selector.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-model-selector.ts
@@ -1,24 +1,25 @@
 import type { ModelSelection } from "../types/messages"
+import type { ModelSelectionScope } from "./session-model-store"
 
 type Deps = {
   current: () => string | undefined
   agent: (session?: string) => string
   selected: (session?: string) => ModelSelection | null
   variant: (session?: string) => string | undefined
-  apply: (agent: string, selection: ModelSelection, session?: string) => void
+  apply: (agent: string, selection: ModelSelection, session?: string, scope?: ModelSelectionScope) => void
   set: (session: string, selection: ModelSelection) => void
   carry: (selection: ModelSelection, value: string | undefined, agent: string, session?: string) => void
   hide: (session: string) => void
 }
 
 export function createModelSelector(deps: Deps) {
-  const select = (providerID: string, modelID: string, sessionID?: string) => {
+  const select = (providerID: string, modelID: string, sessionID?: string, scope?: ModelSelectionScope) => {
     const session = sessionID ?? deps.current()
     const agent = deps.agent(session)
     const current = deps.selected(session)
     const value = current ? deps.variant(session) : undefined
     const selection = { providerID, modelID }
-    deps.apply(agent, selection, session)
+    deps.apply(agent, selection, session, scope)
     deps.carry(selection, value, agent, session)
     if (session) deps.hide(session)
   }

--- a/packages/kilo-vscode/webview-ui/src/context/session-model-store.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-model-store.ts
@@ -18,6 +18,8 @@ export interface ModelStore {
   recentModels: ModelSelection[]
 }
 
+export type ModelSelectionScope = "global" | "session"
+
 export interface ResolveEnv {
   providers: Record<string, Provider>
   connected: string[]
@@ -98,18 +100,19 @@ export interface ApplyResult {
  * Apply a user-initiated model selection.
  *
  * Session-scoped selections write only to the per-session override.
- * No-session selections write to the global modelSelections map so sidebar
- * default picks still mirror CLI TUI's model.json behavior.
+ * Global selections also update the per-session override when a session is
+ * active, so the sidebar reflects the pick immediately while the last-used
+ * per-mode value remains durable.
  */
 export function applyModel(
   store: ModelStore,
   agentName: string,
   selection: ModelSelection,
   sessionID: string | undefined,
+  scope: ModelSelectionScope = sessionID ? "session" : "global",
 ): ApplyResult {
-  const modelSelections = sessionID
-    ? { ...store.modelSelections }
-    : { ...store.modelSelections, [agentName]: selection }
+  const modelSelections =
+    scope === "global" ? { ...store.modelSelections, [agentName]: selection } : { ...store.modelSelections }
   const sessionOverrides = { ...store.sessionOverrides }
 
   if (sessionID) {

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -73,7 +73,7 @@ import {
 } from "./session-utils"
 import { Identifier } from "../utils/id"
 import { resolveModelSelection } from "./model-selection"
-import { getAgentModel } from "./session-model-store"
+import { getAgentModel, type ModelSelectionScope } from "./session-model-store"
 import { resolveMessagePrefs } from "./session-preferences"
 import { errorIDs, preserveSessionErrors, withoutResolvedSessionErrors } from "./session-errors"
 import { PartStash } from "./part-stash"
@@ -191,7 +191,7 @@ interface SessionContextValue {
   configModel: (sessionID?: string) => ModelSelection | null
   modelForAgent: (agent: string) => ModelSelection | null
   configModelForAgent: (agent: string) => ModelSelection | null
-  selectModel: (providerID: string, modelID: string, sessionID?: string) => void
+  selectModel: (providerID: string, modelID: string, sessionID?: string, scope?: ModelSelectionScope) => void
   hasModelOverride: (sessionID?: string) => boolean
   clearModelOverride: (sessionID?: string) => void
 
@@ -635,23 +635,25 @@ export const SessionProvider: ParentComponent = (props) => {
     vscode.postMessage({ type: "recordModelUsage", providerID, modelID })
   }
 
-  function applyModel(agentName: string, selection: ModelSelection, sessionID?: string) {
+  function applyModel(
+    agentName: string,
+    selection: ModelSelection,
+    sessionID?: string,
+    scope: ModelSelectionScope = sessionID ? "session" : "global",
+  ) {
     pushRecent(selection)
-    if (sessionID) {
-      setStore("sessionOverrides", sessionID, selection)
-      return
+    if (scope === "global") {
+      // Remember ordinary sidebar picks per mode, even when a session is open.
+      setUserSetAgents((prev) => ({ ...prev, [agentName]: true }))
+      setStore("modelSelections", agentName, selection)
+      vscode.postMessage({
+        type: "persistModelSelection",
+        agent: agentName,
+        providerID: selection.providerID,
+        modelID: selection.modelID,
+      })
     }
-    // Always remember the per-mode model choice so switching modes restores
-    // the last-used model (mirrors CLI TUI's model.json behavior).
-    setUserSetAgents((prev) => ({ ...prev, [agentName]: true }))
-    setStore("modelSelections", agentName, selection)
-    // Persist to model.json via the extension host
-    vscode.postMessage({
-      type: "persistModelSelection",
-      agent: agentName,
-      providerID: selection.providerID,
-      modelID: selection.modelID,
-    })
+    if (sessionID) setStore("sessionOverrides", sessionID, selection)
   }
 
   const variants = createSessionVariants({


### PR DESCRIPTION
## Issue

Related to #13254

## Context

Choosing a model from the sidebar while a chat session was already active updated only the in-memory session override. The durable per-mode last selection stayed stale, so starting a new task or changing roles could restore an older model.

## Implementation

The model selection transition now accepts an explicit scope. Sidebar selections update both the active session override and the per-mode selection used by subsequent sessions. The session manager keeps its existing session-only behavior. The model picker and notification action pass the appropriate scope, with unit coverage for both transitions.

## Screenshots / Video

Not applicable; this changes state persistence only.

## How to Test

### Manual/local verification

- `bun test tests/unit/session-model-store.test.ts tests/unit/session-model-selector.test.ts` (21 passed)
- `bun run typecheck`
- `bun run lint`
- `bun run bundle`
- `bun run knip`
- `bun run compile-tests`
- The pre-push repository typecheck completed successfully for 29 packages plus the JetBrains package.
- The equivalent marker check run directly in Git Bash completed with no findings.

### Reviewer test steps

1. Open a sidebar chat with an existing session.
2. Choose a different model, send a prompt, and create a new task.
3. Confirm the chosen model remains selected for the new task.
4. Open two session-manager sessions, choose different models, and confirm each session keeps its own choice.

### Blocked checks and substitute verification

- Full `bun run test:unit` was not usable in this Windows checkout: unrelated existing tests fail on path normalization, line endings, and temporary-directory permissions, and the run later stalled. The affected model tests pass in isolation.
- `bun run check-kilocode-change` uses Unix shell syntax that Bun's Windows script runner does not parse; the equivalent command was run under Git Bash and produced no findings.

## Checklist

- [x] Issue linked above
- [x] Tests and verification described
- [x] No visual changes
- [x] Changeset added
- [x] Diff reviewed