### PR TITLE
fix(attachments): limit image session payloads

### DIFF
--- a/.changeset/quiet-images-fit.md
+++ b/.changeset/quiet-images-fit.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Reduce large image attachments before sending them to model providers and prevent oversized image payloads from breaking Session requests.

--- a/packages/core/src/image.ts
+++ b/packages/core/src/image.ts
@@ -81,9 +81,11 @@ const layer = Layer.effect(
       const normalize = yield* loadAdapter
       return yield* normalize(resource, content, {
         autoResize: image.auto_resize ?? true,
-        maxWidth: image.max_width ?? 2_000,
-        maxHeight: image.max_height ?? 2_000,
-        maxBase64Bytes: image.max_base64_bytes ?? 5 * 1024 * 1024,
+        // kilocode_change start - keep prompt images below common provider limits
+        maxWidth: image.max_width ?? 1_600,
+        maxHeight: image.max_height ?? 1_600,
+        maxBase64Bytes: image.max_base64_bytes ?? 1.5 * 1024 * 1024,
+        // kilocode_change end
       })
     })
     return Service.of({ normalize })

--- a/packages/core/src/image/photon.ts
+++ b/packages/core/src/image/photon.ts
@@ -7,7 +7,7 @@ import { FileSystem } from "../filesystem"
 import { DecodeError, PixelLimitError, ResizerUnavailableError, SizeError } from "../image" // kilocode_change
 import { allowed, dimensions, MAX_DIMENSION, MAX_PIXELS } from "../kilocode/image-size" // kilocode_change
 
-const JPEG_QUALITIES = [80, 85, 70, 55, 40]
+const JPEG_QUALITIES = [85, 80, 70, 55, 40] // kilocode_change - prefer higher quality before reducing it
 
 export const make = Effect.gen(function* () {
   ;(globalThis as typeof globalThis & { __OPENCODE_PHOTON_WASM_PATH?: string }).__OPENCODE_PHOTON_WASM_PATH =

--- a/packages/core/src/kilocode/session/media.ts
+++ b/packages/core/src/kilocode/session/media.ts
@@ -1,0 +1,68 @@
+// kilocode_change - new file
+import { Effect } from "effect"
+import { Image } from "../../image"
+import type { SessionMessage } from "../../session/message"
+
+export const MAX_BYTES = 3 * 1024 * 1024
+
+function data(uri: string) {
+  const index = uri.indexOf(";base64,")
+  if (!uri.startsWith("data:") || index === -1) return undefined
+  return uri.slice(index + ";base64,".length)
+}
+
+export const normalize = Effect.fn("SessionMedia.normalize")(function* (messages: readonly SessionMessage.Message[]) {
+  const image = yield* Image.Service
+  return yield* Effect.forEach(messages, (message) => {
+    if (message.type !== "user" || message.files === undefined) return Effect.succeed(message)
+    return Effect.forEach(message.files, (file) => {
+      if (!file.mime.startsWith("image/")) return Effect.succeed(file)
+      const content = data(file.uri)
+      if (content === undefined) return Effect.succeed(file)
+      return image
+        .normalize(file.uri, {
+          uri: file.uri,
+          name: file.name,
+          content,
+          encoding: "base64",
+          mime: file.mime,
+        })
+        .pipe(
+          Effect.map((result) => ({
+            ...file,
+            mime: result.mime,
+            uri: `data:${result.mime};base64,${result.content}`,
+          })),
+          Effect.orDie,
+        )
+    }).pipe(Effect.map((files) => ({ ...message, files })))
+  })
+})
+
+function media(parent: unknown, key: string) {
+  if (!parent || typeof parent !== "object" || !("type" in parent)) return false
+  if (String(parent.type) === "image") return key === "image"
+  if (!("mediaType" in parent) || typeof parent.mediaType !== "string") return false
+  return (
+    (String(parent.type) === "file" || String(parent.type) === "media") &&
+    parent.mediaType.startsWith("image/") &&
+    (key === "data" || key === "url")
+  )
+}
+
+function size(value: unknown) {
+  if (value instanceof Uint8Array) return Math.ceil(value.byteLength / 3) * 4
+  if (typeof value !== "string") return 0
+  const index = value.indexOf(",")
+  const encoded = index !== -1 && value.slice(0, index).includes(";base64,") ? value.slice(index + 1) : value
+  return Buffer.byteLength(encoded, "utf8")
+}
+
+export function encodedBytes(value: unknown): number {
+  if (Array.isArray(value)) return value.reduce((total, item) => total + encodedBytes(item), 0)
+  if (!value || typeof value !== "object") return 0
+  return Object.entries(value).reduce(
+    (total, [key, item]) => total + (media(value, key) ? size(item) : encodedBytes(item)),
+    0,
+  )
+}

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -37,6 +37,8 @@ import { createLLMEventPublisher } from "./publish-llm-event"
 import { toLLMMessages } from "./to-llm-message"
 import { MAX_STEPS_PROMPT } from "./max-steps"
 import { Snapshot } from "../../snapshot"
+import { Image } from "../../image" // kilocode_change
+import { MAX_BYTES, encodedBytes, normalize as normalizeMedia } from "../../kilocode/session/media" // kilocode_change
 import { makeLocationNode } from "../../effect/app-node"
 import { llmClient } from "../../effect/app-node-platform"
 
@@ -105,6 +107,7 @@ const layer = Layer.effect(
     const referenceGuidance = yield* ReferenceGuidance.Service
     const config = yield* Config.Service
     const snapshots = yield* Snapshot.Service
+    const image = yield* Image.Service // kilocode_change
     const db = (yield* Database.Service).db
     const compaction = SessionCompaction.make({ events, llm, config: yield* config.entries() })
     const getSession = Effect.fn("SessionRunner.getSession")(function* (sessionID: SessionSchema.ID) {
@@ -199,17 +202,28 @@ const layer = Layer.effect(
         initialized ?? (yield* SessionContextEpoch.prepare(db, events, loadSystemContext(agent), session.id, location))
       const model = yield* models.resolve(session)
       const entries = yield* SessionHistory.entriesForRunner(db, session.id, system.baselineSeq)
-      const context = entries.map((entry) => entry.message)
+      // kilocode_change start - normalize V2 prompt media before provider lowering
+      const context = yield* normalizeMedia(entries.map((entry) => entry.message)).pipe(
+        Effect.provideService(Image.Service, image),
+      )
+      // kilocode_change end
       const isLastStep = agent.info?.steps !== undefined && currentStep >= agent.info.steps
       const toolMaterialization = isLastStep ? undefined : yield* tools.materialize(agent.info?.permissions)
       const promptCacheKey = /^ses_[0-9a-f]{64}$/.test(session.id) ? session.id.slice(4) : session.id
+      // kilocode_change start - reject a provider request with an oversized media payload
+      const messages = [...toLLMMessages(context, model), ...(isLastStep ? [Message.assistant(MAX_STEPS_PROMPT)] : [])]
+      if (encodedBytes(messages) > MAX_BYTES)
+        return yield* Effect.die(
+          new Error("Image attachments exceed the 3 MiB request limit. Remove an image or send the images separately."),
+        )
+      // kilocode_change end
       const request = LLM.request({
         model,
         providerOptions: { openai: { promptCacheKey } },
         system: [agent.info?.system, system.baseline]
           .filter((part): part is string => part !== undefined && part.length > 0)
           .map(SystemPart.make),
-        messages: [...toLLMMessages(context, model), ...(isLastStep ? [Message.assistant(MAX_STEPS_PROMPT)] : [])],
+        messages, // kilocode_change
         tools: toolMaterialization?.definitions ?? [],
         toolChoice: isLastStep ? "none" : undefined,
       })
@@ -428,6 +442,7 @@ export const node = makeLocationNode({
     ReferenceGuidance.node,
     Config.node,
     Snapshot.node,
+    Image.node, // kilocode_change
     Database.node,
   ],
 })

--- a/packages/core/src/v1/config/attachment.ts
+++ b/packages/core/src/v1/config/attachment.ts
@@ -8,13 +8,13 @@ export const Image = Schema.Struct({
     description: "Resize images before sending them to the model when they exceed configured limits (default: true)",
   }),
   max_width: Schema.optional(PositiveInt).annotate({
-    description: "Maximum image width before resizing or rejecting the attachment (default: 2000)",
+    description: "Maximum image width before resizing or rejecting the attachment (default: 1600)", // kilocode_change
   }),
   max_height: Schema.optional(PositiveInt).annotate({
-    description: "Maximum image height before resizing or rejecting the attachment (default: 2000)",
+    description: "Maximum image height before resizing or rejecting the attachment (default: 1600)", // kilocode_change
   }),
   max_base64_bytes: Schema.optional(PositiveInt).annotate({
-    description: "Maximum base64 payload bytes for an image attachment (default: 5242880)",
+    description: "Maximum base64 payload bytes for an image attachment (default: 1572864)", // kilocode_change
   }),
 }).annotate({ identifier: "ImageAttachmentConfig" })
 export type Image = Schema.Schema.Type<typeof Image>

--- a/packages/core/test/tool-read.test.ts
+++ b/packages/core/test/tool-read.test.ts
@@ -390,7 +390,7 @@ describe("ReadTool", () => {
       })
 
       expect(result.type).toBe("error")
-      if (result.type === "error") expect(result.value).toContain("exceeding configured limits 4x2000")
+      if (result.type === "error") expect(result.value).toContain("exceeding configured limits 4x1600") // kilocode_change
     }),
   )
 
@@ -429,7 +429,7 @@ describe("ReadTool", () => {
       if (media?.type !== "file") return
       const resized = photon.PhotonImage.new_from_byteslice(Buffer.from(media.uri.split(",")[1] ?? "", "base64"))
       expect(resized.get_width()).toBeLessThanOrEqual(4)
-      expect(resized.get_height()).toBeLessThanOrEqual(2_000)
+      expect(resized.get_height()).toBeLessThanOrEqual(1_600) // kilocode_change
       resized.free()
     }),
   )

--- a/packages/kilo-vscode/tests/unit/image-attachments-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/image-attachments-utils.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from "bun:test"
 import {
   ACCEPTED_IMAGE_TYPES,
+  getBase64ByteLength,
+  getImageDimensions,
   isAcceptedImageType,
   isDragLeavingComponent,
+  isStaticImageType,
 } from "../../webview-ui/src/hooks/image-attachments-utils"
 
 describe("ACCEPTED_IMAGE_TYPES", () => {
@@ -35,6 +38,38 @@ describe("isAcceptedImageType", () => {
   it("returns false for image types not in the accepted list", () => {
     expect(isAcceptedImageType("image/svg+xml")).toBe(false)
     expect(isAcceptedImageType("image/bmp")).toBe(false)
+  })
+})
+
+describe("isStaticImageType", () => {
+  it("returns true for canvas-safe static formats", () => {
+    expect(isStaticImageType("image/png")).toBe(true)
+    expect(isStaticImageType("image/jpeg")).toBe(true)
+    expect(isStaticImageType("image/webp")).toBe(true)
+  })
+
+  it("returns false for animated GIFs", () => {
+    expect(isStaticImageType("image/gif")).toBe(false)
+  })
+})
+
+describe("getImageDimensions", () => {
+  it("preserves aspect ratio while limiting the longest side", () => {
+    expect(getImageDimensions(3840, 2160)).toEqual({ width: 1600, height: 900 })
+    expect(getImageDimensions(1000, 2000)).toEqual({ width: 800, height: 1600 })
+  })
+
+  it("does not enlarge images already within the limit", () => {
+    expect(getImageDimensions(800, 600)).toEqual({ width: 800, height: 600 })
+  })
+})
+
+describe("getBase64ByteLength", () => {
+  it("returns the encoded payload length", () => {
+    expect(getBase64ByteLength(0)).toBe(0)
+    expect(getBase64ByteLength(1)).toBe(4)
+    expect(getBase64ByteLength(3)).toBe(4)
+    expect(getBase64ByteLength(4)).toBe(8)
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/src/hooks/image-attachments-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/image-attachments-utils.ts
@@ -1,8 +1,33 @@
 export const ACCEPTED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"]
+export const STATIC_IMAGE_TYPES = ["image/png", "image/jpeg", "image/webp"]
+export const IMAGE_MAX_SIDE = 1600
+export const IMAGE_MAX_BASE64_BYTES = 1.5 * 1024 * 1024
 
 /** Returns true if the given MIME type is an accepted image type. */
 export function isAcceptedImageType(mimeType: string): boolean {
   return ACCEPTED_IMAGE_TYPES.includes(mimeType)
+}
+
+/** Returns true for static image formats that can be safely drawn to a canvas. */
+export function isStaticImageType(mimeType: string): boolean {
+  return STATIC_IMAGE_TYPES.includes(mimeType)
+}
+
+/** Returns dimensions scaled down to fit within the maximum side length. */
+export function getImageDimensions(width: number, height: number, maxSide = IMAGE_MAX_SIDE) {
+  if (width <= maxSide && height <= maxSide) return { width, height }
+
+  const scale = Math.min(maxSide / width, maxSide / height)
+  return {
+    width: Math.max(1, Math.min(maxSide, Math.round(width * scale))),
+    height: Math.max(1, Math.min(maxSide, Math.round(height * scale))),
+  }
+}
+
+/** Returns the base64 payload length produced by encoding the given byte count. */
+export function getBase64ByteLength(bytes: number): number {
+  if (!Number.isFinite(bytes) || bytes <= 0) return 0
+  return Math.ceil(bytes / 3) * 4
 }
 
 /**

--- a/packages/kilo-vscode/webview-ui/src/hooks/useImageAttachments.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useImageAttachments.ts
@@ -1,5 +1,13 @@
 import { createSignal } from "solid-js"
-import { ACCEPTED_IMAGE_TYPES, isAcceptedImageType, isDragLeavingComponent } from "./image-attachments-utils"
+import {
+  ACCEPTED_IMAGE_TYPES,
+  getBase64ByteLength,
+  getImageDimensions,
+  IMAGE_MAX_BASE64_BYTES,
+  isAcceptedImageType,
+  isDragLeavingComponent,
+  isStaticImageType,
+} from "./image-attachments-utils"
 import { extractDropPaths, KILO_FILE_PATH_MIME } from "../utils/path-mentions"
 
 export interface ImageAttachment {
@@ -11,6 +19,123 @@ export interface ImageAttachment {
 
 /** Callback for handling text/URI file path drops. */
 export type FilePathDropHandler = (paths: string[]) => void
+
+const JPEG_QUALITIES = [0.85, 0.8, 0.7, 0.55, 0.4]
+
+interface ImageSource {
+  blob: Blob
+  mime: string
+}
+
+interface EncodedImage {
+  blob: Blob
+  mime: string
+}
+
+function toBlob(canvas: HTMLCanvasElement, mime: string, quality?: number): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error("Image encoding failed"))
+          return
+        }
+        resolve(blob)
+      },
+      mime,
+      quality,
+    )
+  })
+}
+
+function isOpaque(ctx: CanvasRenderingContext2D): boolean {
+  const pixels = ctx.getImageData(0, 0, ctx.canvas.width, ctx.canvas.height).data
+  for (let i = 3; i < pixels.length; i += 4) {
+    if (pixels[i] !== 255) return false
+  }
+  return true
+}
+
+async function normalizeImage(file: File): Promise<ImageSource> {
+  if (!isStaticImageType(file.type)) return { blob: file, mime: file.type }
+  if (typeof createImageBitmap !== "function" || typeof document === "undefined") {
+    return { blob: file, mime: file.type }
+  }
+
+  const bitmap = await createImageBitmap(file)
+  let canvas: HTMLCanvasElement | undefined
+  try {
+    const size = getImageDimensions(bitmap.width, bitmap.height)
+    if (
+      size.width === bitmap.width &&
+      size.height === bitmap.height &&
+      getBase64ByteLength(file.size) <= IMAGE_MAX_BASE64_BYTES
+    ) {
+      return { blob: file, mime: file.type }
+    }
+
+    const node = document.createElement("canvas")
+    canvas = node
+    if (typeof node.toBlob !== "function") return { blob: file, mime: file.type }
+
+    const draw = (next: { width: number; height: number }) => {
+      node.width = next.width
+      node.height = next.height
+      const ctx = node.getContext("2d")
+      if (!ctx) throw new Error("Canvas context unavailable")
+      ctx.imageSmoothingEnabled = true
+      ctx.imageSmoothingQuality = "high"
+      ctx.drawImage(bitmap, 0, 0, next.width, next.height)
+      return ctx
+    }
+
+    const encode = async (next: { width: number; height: number }, mime: string, qualities: (number | undefined)[]) => {
+      draw(next)
+      let last: EncodedImage | undefined
+      for (const quality of qualities) {
+        const blob = await toBlob(node, mime, quality)
+        last = { blob, mime: blob.type || mime }
+        if (getBase64ByteLength(blob.size) <= IMAGE_MAX_BASE64_BYTES) return last
+      }
+      return last
+    }
+
+    const shrink = async (mime: string, qualities: (number | undefined)[]) => {
+      let next = size
+      for (let attempt = 0; attempt < 8; attempt++) {
+        const image = await encode(next, mime, qualities)
+        if (image && getBase64ByteLength(image.blob.size) <= IMAGE_MAX_BASE64_BYTES) return image
+        const bytes = image ? getBase64ByteLength(image.blob.size) : IMAGE_MAX_BASE64_BYTES
+        const scale = Math.min(0.9, Math.max(0.5, Math.sqrt(IMAGE_MAX_BASE64_BYTES / bytes) * 0.9))
+        const smaller = getImageDimensions(
+          Math.max(1, Math.floor(next.width * scale)),
+          Math.max(1, Math.floor(next.height * scale)),
+        )
+        if (smaller.width === next.width && smaller.height === next.height) return undefined
+        next = smaller
+      }
+      return undefined
+    }
+
+    const primary = await encode(size, file.type, file.type === "image/png" ? [undefined] : JPEG_QUALITIES)
+    if (primary && getBase64ByteLength(primary.blob.size) <= IMAGE_MAX_BASE64_BYTES) return primary
+
+    if (file.type !== "image/jpeg" && isOpaque(draw(size))) {
+      const jpeg = await shrink("image/jpeg", JPEG_QUALITIES)
+      if (jpeg) return jpeg
+    }
+
+    const resized = await shrink(file.type, file.type === "image/png" ? [undefined] : JPEG_QUALITIES)
+    if (resized) return resized
+    return { blob: file, mime: file.type }
+  } finally {
+    bitmap.close()
+    if (canvas) {
+      canvas.width = 0
+      canvas.height = 0
+    }
+  }
+}
 
 export function useImageAttachments() {
   const [images, setImages] = createSignal<ImageAttachment[]>([])
@@ -24,17 +149,22 @@ export function useImageAttachments() {
 
   const add = (file: File) => {
     if (!isAcceptedImageType(file.type)) return
-    const reader = new FileReader()
-    reader.onload = () => {
-      const attachment: ImageAttachment = {
-        id: crypto.randomUUID(),
-        filename: file.name || "image",
-        mime: file.type,
-        dataUrl: reader.result as string,
-      }
-      setImages((prev) => [...prev, attachment])
-    }
-    reader.readAsDataURL(file)
+    void normalizeImage(file)
+      .catch(() => ({ blob: file, mime: file.type }))
+      .then((source) => {
+        const reader = new FileReader()
+        reader.onload = () => {
+          if (typeof reader.result !== "string") return
+          const attachment: ImageAttachment = {
+            id: crypto.randomUUID(),
+            filename: file.name || "image",
+            mime: source.mime,
+            dataUrl: reader.result,
+          }
+          setImages((prev) => [...prev, attachment])
+        }
+        reader.readAsDataURL(source.blob)
+      })
   }
 
   const remove = (id: string) => {

--- a/packages/llm/src/provider-error.ts
+++ b/packages/llm/src/provider-error.ts
@@ -3,7 +3,6 @@ import { LLMError, ProviderErrorEvent } from "./schema"
 
 const patterns = [
   /prompt is too long/i,
-  /request_too_large/i,
   /input is too long for requested model/i,
   /exceeds the context window/i,
   /exceeds (?:the )?(?:model'?s )?maximum context length(?: of [\d,]+ tokens?|\s*\([\d,]+\))/i,
@@ -20,7 +19,6 @@ const patterns = [
   /context window exceeds limit/i,
   /exceeded model token limit/i,
   /context[_ ]length[_ ]exceeded/i,
-  /request entity too large/i,
   /context length is only \d+ tokens/i,
   /input length.*exceeds.*context length/i,
   /prompt too long; exceeded (?:max )?context length/i,
@@ -42,7 +40,7 @@ const exclusions = [
 
 export const isContextOverflow = (message: string) =>
   !exclusions.some((pattern) => pattern.test(message)) &&
-  (patterns.some((pattern) => pattern.test(message)) || /^4(00|13)\s*(status code)?\s*\(no body\)/i.test(message))
+  (patterns.some((pattern) => pattern.test(message)) || /^400\s*(status code)?\s*\(no body\)/i.test(message)) // kilocode_change - 413 is a payload limit, not a context signal
 
 export const isContextOverflowFailure = (failure: unknown) =>
   failure instanceof LLMError

--- a/packages/opencode/src/image/image.ts
+++ b/packages/opencode/src/image/image.ts
@@ -6,65 +6,14 @@ import photonWasm from "@silvia-odwyer/photon-node/photon_rs_bg.wasm" with { typ
 import { Context, Effect, Layer, Schema } from "effect"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { allowed, dimensions as safeDimensions } from "@opencode-ai/core/kilocode/image-size" // kilocode_change
 
-export const MAX_BASE64_BYTES = 5 * 1024 * 1024 // kilocode_change - share user file pre-read limit
-const MAX_WIDTH = 2000
-const MAX_HEIGHT = 2000
+export const MAX_BASE64_BYTES = 1.5 * 1024 * 1024 // kilocode_change - share user file pre-read limit
+const MAX_WIDTH = 1600
+const MAX_HEIGHT = 1600
 const AUTO_RESIZE = true
-const JPEG_QUALITIES = [80, 85, 70, 55, 40]
+const JPEG_QUALITIES = [85, 80, 70, 55, 40]
 // kilocode_change start - preserve valid in-limit images when Photon is unavailable
-function dimensions(mime: string, data: Buffer) {
-  if (
-    mime === "image/png" &&
-    data.length >= 24 &&
-    data.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) &&
-    data.subarray(12, 16).toString("ascii") === "IHDR"
-  )
-    return { width: data.readUInt32BE(16), height: data.readUInt32BE(20) }
-
-  if (mime === "image/gif" && data.length >= 10) {
-    const head = data.subarray(0, 6).toString("ascii")
-    if (head === "GIF87a" || head === "GIF89a") return { width: data.readUInt16LE(6), height: data.readUInt16LE(8) }
-  }
-
-  if ((mime === "image/jpeg" || mime === "image/jpg") && data.length >= 4 && data.readUInt16BE(0) === 0xffd8) {
-    for (let offset = 2; offset + 8 < data.length; ) {
-      if (data[offset] !== 0xff) {
-        offset++
-        continue
-      }
-      const marker = data[offset + 1]
-      if (marker === 0xd9 || marker === 0xda) break
-      const length = data.readUInt16BE(offset + 2)
-      if (length < 2 || offset + length + 2 > data.length) break
-      if ([0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf].includes(marker))
-        return { width: data.readUInt16BE(offset + 7), height: data.readUInt16BE(offset + 5) }
-      offset += length + 2
-    }
-  }
-
-  if (
-    mime === "image/webp" &&
-    data.length >= 30 &&
-    data.subarray(0, 4).toString("ascii") === "RIFF" &&
-    data.subarray(8, 12).toString("ascii") === "WEBP"
-  ) {
-    const chunk = data.subarray(12, 16).toString("ascii")
-    if (chunk === "VP8X")
-      return {
-        width: 1 + data.readUIntLE(24, 3),
-        height: 1 + data.readUIntLE(27, 3),
-      }
-    if (chunk === "VP8L" && data[20] === 0x2f)
-      return {
-        width: 1 + data[21] + ((data[22] & 0x3f) << 8),
-        height: 1 + (data[22] >> 6) + (data[23] << 2) + ((data[24] & 0x0f) << 10),
-      }
-    if (chunk === "VP8 " && data[23] === 0x9d && data[24] === 0x01 && data[25] === 0x2a)
-      return { width: data.readUInt16LE(26) & 0x3fff, height: data.readUInt16LE(28) & 0x3fff }
-  }
-}
-
 export function fallback(
   input: MessageV2.FilePart,
   base64: string,
@@ -82,8 +31,25 @@ export function fallback(
     })
   const data = Buffer.from(base64, "base64")
   const canonical = data.toString("base64").replace(/=+$/, "") === base64.replace(/=+$/, "")
-  const size = canonical ? dimensions(input.mime, data) : undefined
+  const size = canonical
+    ? (() => {
+        try {
+          return safeDimensions(data)
+        } catch {
+          return undefined
+        }
+      })()
+    : undefined
   if (!base64 || !size) return new DecodeError()
+  if (!allowed(size))
+    return new SizeError({
+      bytes,
+      max: max.bytes,
+      width: size.width,
+      height: size.height,
+      max_width: max.width,
+      max_height: max.height,
+    })
   if (size.width > max.width || size.height > max.height)
     return new SizeError({
       bytes,
@@ -180,6 +146,20 @@ const layer = Layer.effect(
         }),
       )
       if (!photon) return input
+
+      const header = yield* Effect.try({
+        try: () => safeDimensions(Buffer.from(base64, "base64")),
+        catch: () => new DecodeError(),
+      })
+      if (!allowed(header))
+        return yield* new SizeError({
+          bytes,
+          max: info.maxBase64Bytes,
+          width: header.width,
+          height: header.height,
+          max_width: info.maxWidth,
+          max_height: info.maxHeight,
+        })
 
       const decoded = yield* Effect.try({
         try: () => photon.PhotonImage.new_from_byteslice(Buffer.from(base64, "base64")),

--- a/packages/opencode/src/kilocode/session/media.ts
+++ b/packages/opencode/src/kilocode/session/media.ts
@@ -1,0 +1,36 @@
+// kilocode_change - new file
+import type { ModelMessage } from "ai"
+
+export const MAX_BYTES = 3 * 1024 * 1024
+
+function media(parent: unknown, key: string) {
+  if (!parent || typeof parent !== "object" || !("type" in parent)) return false
+  if (String(parent.type) === "image") return key === "image"
+  if (!("mediaType" in parent) || typeof parent.mediaType !== "string") return false
+  return (
+    (String(parent.type) === "file" || String(parent.type) === "media") &&
+    parent.mediaType.startsWith("image/") &&
+    (key === "data" || key === "url")
+  )
+}
+
+function size(value: unknown) {
+  if (value instanceof Uint8Array) return Math.ceil(value.byteLength / 3) * 4
+  if (typeof value !== "string") return 0
+  const index = value.indexOf(",")
+  const encoded = index !== -1 && value.slice(0, index).includes(";base64,") ? value.slice(index + 1) : value
+  return Buffer.byteLength(encoded, "utf8")
+}
+
+export function encodedBytes(value: unknown): number {
+  if (Array.isArray(value)) return value.reduce((total, item) => total + encodedBytes(item), 0)
+  if (!value || typeof value !== "object") return 0
+  return Object.entries(value).reduce(
+    (total, [key, item]) => total + (media(value, key) ? size(item) : encodedBytes(item)),
+    0,
+  )
+}
+
+export function within(messages: ModelMessage[]) {
+  return encodedBytes(messages) <= MAX_BYTES
+}

--- a/packages/opencode/src/kilocode/session/overflow.ts
+++ b/packages/opencode/src/kilocode/session/overflow.ts
@@ -3,11 +3,14 @@ import type { Provider } from "@/provider/provider"
 import type { MessageV2 } from "@/session/message-v2"
 import { Token } from "@/util/token"
 import type { ModelMessage } from "ai"
+import { dimensions } from "@opencode-ai/core/kilocode/image-size" // kilocode_change
 
 // Token.estimate undercounts provider tokenizers, especially for code and JSON payloads.
 const FACTOR = 1.3
 const MEDIA = "[encoded media]"
 const MEDIA_TOKENS = Token.estimate(MEDIA)
+const IMAGE_TILE = 512
+const IMAGE_TILE_TOKENS = 256
 
 type Payload = {
   messages: ModelMessage[]
@@ -45,6 +48,7 @@ export namespace KiloSessionOverflow {
 
   export function measure(input: Payload) {
     let extra = 0
+    let vision = 0
     const normalized = JSON.stringify(input.messages, function (this: unknown, key, value: unknown) {
       if (!["data", "url", "image"].includes(key)) return value
       if (!this || typeof this !== "object" || !("type" in this)) return value
@@ -54,6 +58,7 @@ export namespace KiloSessionOverflow {
           ? Math.ceil(value.byteLength / 4)
           : Token.estimate(typeof value === "string" ? value : (JSON.stringify(value) ?? ""))
       extra += Math.max(0, tokens - MEDIA_TOKENS)
+      vision += Math.max(0, image(this, value) - MEDIA_TOKENS)
       return MEDIA
     })
     const messages = Token.estimate(normalized)
@@ -68,9 +73,34 @@ export namespace KiloSessionOverflow {
       ),
     )
     return {
-      normalized: Math.ceil((messages + tools) * FACTOR),
-      raw: Math.ceil((raw + tools) * FACTOR),
+      normalized: Math.ceil((messages + tools + vision) * FACTOR),
+      raw: Math.ceil((raw + tools + vision) * FACTOR),
       continuation: continued(input.messages),
+    }
+  }
+
+  function image(parent: unknown, value: unknown) {
+    if (!parent || typeof parent !== "object" || !("type" in parent)) return 0
+    const type = String(parent.type)
+    if (type !== "image" && type !== "file" && type !== "media") return 0
+    if (
+      type !== "image" &&
+      (!("mediaType" in parent) || typeof parent.mediaType !== "string" || !parent.mediaType.startsWith("image/"))
+    )
+      return 0
+    const encoded = typeof value === "string" && value.includes(",") ? value.slice(value.indexOf(",") + 1) : value
+    const bytes =
+      typeof encoded === "string"
+        ? Buffer.from(encoded, "base64")
+        : encoded instanceof Uint8Array
+          ? Buffer.from(encoded)
+          : undefined
+    if (!bytes) return 0
+    try {
+      const size = dimensions(bytes)
+      return Math.ceil(size.width / IMAGE_TILE) * Math.ceil(size.height / IMAGE_TILE) * IMAGE_TILE_TOKENS
+    } catch {
+      return 0
     }
   }
 

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -189,13 +189,27 @@ export type ParsedAPICallError =
 export function parseAPICallError(input: { providerID: ProviderV2.ID; error: APICallError }): ParsedAPICallError {
   const m = message(input.providerID, input.error)
   const body = json(input.error.responseBody)
-  if (isContextOverflow(m) || input.error.statusCode === 413 || body?.error?.code === "context_length_exceeded") {
+  // kilocode_change start - distinguish request payload failures from context overflow
+  const payload = input.error.statusCode === 413 || /request entity too large|function_payload_too_large/i.test(m)
+  if (payload && body?.error?.code !== "context_length_exceeded") {
+    return {
+      type: "api_error",
+      message: "Provider request payload is too large. Reduce or remove image attachments and try again.",
+      statusCode: input.error.statusCode,
+      isRetryable: false,
+      responseBody: input.error.responseBody,
+    }
+  }
+  // kilocode_change end
+  // kilocode_change start - preserve explicit context overflow classification
+  if (isContextOverflow(m) || body?.error?.code === "context_length_exceeded") {
     return {
       type: "context_overflow",
       message: m,
       responseBody: input.error.responseBody,
     }
   }
+  // kilocode_change end
 
   const metadata = input.error.url ? { url: input.error.url } : undefined
   return {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -89,6 +89,7 @@ import { SessionTools } from "./tools"
 import { LLMEvent } from "@opencode-ai/llm"
 import { RepositoryCache } from "@opencode-ai/core/repository-cache" // kilocode_change
 import { SessionResume } from "@/kilocode/session-resume" // kilocode_change
+import { MAX_BYTES as MAX_MEDIA_BYTES, encodedBytes as encodedMediaBytes } from "@/kilocode/session/media" // kilocode_change
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -138,14 +139,10 @@ function isOrphanedInterruptedTool(part: SessionV1.ToolPart) {
 
 export interface Interface {
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
-  readonly prompt: (
-    input: PromptInput,
-  ) => Effect.Effect<SessionV1.WithParts, Image.Error>
+  readonly prompt: (input: PromptInput) => Effect.Effect<SessionV1.WithParts, Image.Error> // kilocode_change
   readonly loop: (input: LoopInput) => Effect.Effect<SessionV1.WithParts>
   readonly shell: (input: ShellInput) => Effect.Effect<SessionV1.WithParts, Session.BusyError>
-  readonly command: (
-    input: CommandInput,
-  ) => Effect.Effect<SessionV1.WithParts, Image.Error | Error>
+  readonly command: (input: CommandInput) => Effect.Effect<SessionV1.WithParts, Image.Error | Error> // kilocode_change
   readonly resolvePromptParts: (template: string) => Effect.Effect<PromptInput["parts"]>
 }
 
@@ -979,14 +976,18 @@ export const layer = Layer.effect(
                     synthetic: true,
                     text: `[Binary MCP resource attached: ${filename ?? uri} (${mime})]`,
                   })
-                  pieces.push({
+                  // kilocode_change start - normalize MCP images before persistence
+                  const file: MessageV2.FilePart = {
+                    id: PartID.ascending(),
                     messageID: info.id,
                     sessionID: input.sessionID,
                     type: "file",
                     mime,
                     filename,
                     url: `data:${mime};base64,${c.blob}`,
-                  })
+                  }
+                  pieces.push(file.mime.startsWith("image/") ? yield* image.normalize(file).pipe(Effect.orDie) : file)
+                  // kilocode_change end
                 }
               }
             } else {
@@ -1733,6 +1734,29 @@ export const layer = Layer.effect(
           let modelMsgs = yield* MessageV2.toModelMessagesEffect(msgs, model).pipe(
             Effect.provideService(Database.Service, database),
           )
+          let mediaBytes = encodedMediaBytes(modelMsgs)
+          // kilocode_change start - strip historical media before rejecting an oversized current turn
+          if (mediaBytes > MAX_MEDIA_BYTES) {
+            msgs = KiloSessionPrompt.stripHistoricalMedia(msgs)
+            modelMsgs = yield* MessageV2.toModelMessagesEffect(msgs, model).pipe(
+              Effect.provideService(Database.Service, database),
+            )
+            mediaBytes = encodedMediaBytes(modelMsgs)
+          }
+          // kilocode_change end
+          // kilocode_change start - reject an over-budget current-turn media request
+          if (mediaBytes > MAX_MEDIA_BYTES) {
+            handle.message.error = new MessageV2.APIError({
+              message: `Image attachments exceed the ${Math.round(MAX_MEDIA_BYTES / (1024 * 1024))} MiB request limit. Remove an image or send the images in separate messages.`,
+              isRetryable: false,
+            }).toObject()
+            handle.message.finish = "error"
+            yield* sessions.updateMessage(handle.message)
+            yield* events.publish(Session.Event.Error, { sessionID, error: handle.message.error })
+            closeReasons.set(sessionID, "error")
+            return "break" as const
+          }
+          // kilocode_change end
           const size = Buffer.byteLength(JSON.stringify(modelMsgs))
           if (size > REQUEST_PRUNE_BYTES) {
             yield* compaction.prune({ sessionID, reason: "payload-limit" })
@@ -2518,7 +2542,10 @@ export const PromptInput = Schema.Struct({
 // `parts` type from the exported Schema input types so callers see a proper
 // tagged union.
 type PartInputUnion =
-  MessageV2.TextPartInput | MessageV2.FilePartInput | MessageV2.AgentPartInput | MessageV2.SubtaskPartInput
+  | MessageV2.TextPartInput
+  | MessageV2.FilePartInput
+  | MessageV2.AgentPartInput
+  | MessageV2.SubtaskPartInput
 export type PromptInput = Omit<Schema.Schema.Type<typeof PromptInput>, "parts" | "editorContext"> & {
   parts: PartInputUnion[]
   editorContext?: MessageV2.EditorContext

--- a/packages/opencode/test/kilocode/session-media.test.ts
+++ b/packages/opencode/test/kilocode/session-media.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test"
+import { encodedBytes, MAX_BYTES, within } from "@/kilocode/session/media"
+import type { ModelMessage } from "ai"
+
+describe("Kilo session media budget", () => {
+  test("counts encoded image data across all messages", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          { type: "file", mediaType: "image/png", data: "a".repeat(1_000_000) },
+          { type: "file", mediaType: "text/plain", data: "b".repeat(5_000_000) },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "image", image: "c".repeat(1_000_000) }],
+      },
+    ] satisfies ModelMessage[]
+
+    expect(encodedBytes(messages)).toBe(2_000_000)
+    expect(within(messages)).toBe(true)
+  })
+
+  test("rejects aggregate media above the request budget", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [{ type: "image", image: "a".repeat(MAX_BYTES) }],
+      },
+    ] satisfies ModelMessage[]
+
+    expect(encodedBytes(messages)).toBe(MAX_BYTES)
+    expect(within(messages)).toBe(true)
+    expect(
+      within([
+        {
+          role: "user",
+          content: [{ type: "image", image: "a".repeat(MAX_BYTES + 1) }],
+        },
+      ] satisfies ModelMessage[]),
+    ).toBe(false)
+  })
+})

--- a/packages/opencode/test/kilocode/session-overflow.test.ts
+++ b/packages/opencode/test/kilocode/session-overflow.test.ts
@@ -375,7 +375,6 @@ describe("Kilo preflight compaction", () => {
     expect(usage.normalized).toBeLessThan(100)
     expect(usage.raw).toBeGreaterThan(100_000)
   })
-
   test("still compacts oversized text when the request includes media", () => {
     const conf = cfg({ threshold_percent: 75 })
     const mdl = model({ context: 200_000, output: 32_000 })

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1524,7 +1524,10 @@ describe("session.message-v2.fromError", () => {
         isRetryable: false,
       })
       const result = MessageV2.fromError(error, { providerID })
-      expect(SessionV1.ContextOverflowError.isInstance(result)).toBe(true)
+      // kilocode_change start - 413 without context text is a payload error
+      expect(SessionV1.ContextOverflowError.isInstance(result)).toBe(message !== "413 status code (no body)")
+      if (message === "413 status code (no body)") expect(SessionV1.APIError.isInstance(result)).toBe(true)
+      // kilocode_change end
     })
   })
 
@@ -1547,6 +1550,27 @@ describe("session.message-v2.fromError", () => {
     const result = MessageV2.fromError(error, { providerID })
     expect(SessionV1.ContextOverflowError.isInstance(result)).toBe(true)
   })
+
+  // kilocode_change start - distinguish request payload errors from context overflow
+  test("reports request payload errors separately from context overflow", () => {
+    const result = MessageV2.fromError(
+      new APICallError({
+        message: "Request Entity Too Large",
+        url: "https://example.com",
+        requestBodyValues: {},
+        statusCode: 413,
+        responseHeaders: { "content-type": "text/plain" },
+        responseBody: "FUNCTION_PAYLOAD_TOO_LARGE",
+        isRetryable: false,
+      }),
+      { providerID },
+    )
+
+    expect(SessionV1.ContextOverflowError.isInstance(result)).toBe(false)
+    expect(SessionV1.APIError.isInstance(result)).toBe(true)
+    if (SessionV1.APIError.isInstance(result)) expect(result.data.message).toContain("payload")
+  })
+  // kilocode_change end
 
   test("does not classify 429 no body as context overflow", () => {
     const result = MessageV2.fromError(

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -759,7 +759,7 @@ it.instance("loop stops provider overflow instead of auto-compacting when disabl
     const sessions = yield* Session.Service
     const chat = yield* sessions.create({ title: "Pinned" })
 
-    yield* llm.error(413, { error: { message: "request entity too large" } })
+    yield* llm.error(413, { error: { code: "context_length_exceeded" } })
     yield* prompt.prompt({
       sessionID: chat.id,
       agent: "build",
@@ -1836,77 +1836,79 @@ it.instance(
   10_000,
 )
 
-it.instance("prompt submitted during an active run is included in the next LLM input", () =>
-  Effect.gen(function* () {
-    const { llm } = yield* useServerConfig(providerCfg)
-    const gate = yield* Deferred.make<void>()
-    const prompt = yield* SessionPrompt.Service
-    const sessions = yield* Session.Service
-    const chat = yield* sessions.create({ title: "Pinned" })
+it.instance(
+  "prompt submitted during an active run is included in the next LLM input",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig(providerCfg)
+      const gate = yield* Deferred.make<void>()
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Pinned" })
 
-    yield* llm.hold("first", deferredAsPromise(gate))
-    yield* llm.text("second")
+      yield* llm.hold("first", deferredAsPromise(gate))
+      yield* llm.text("second")
 
-    const a = yield* prompt
-      .prompt({
-        sessionID: chat.id,
-        agent: "build",
-        model: ref,
-        parts: [{ type: "text", text: "first" }],
-      })
-      .pipe(Effect.forkChild)
+      const a = yield* prompt
+        .prompt({
+          sessionID: chat.id,
+          agent: "build",
+          model: ref,
+          parts: [{ type: "text", text: "first" }],
+        })
+        .pipe(Effect.forkChild)
 
-    yield* llm.wait(1)
-    yield* waitForBusy(chat.id)
+      yield* llm.wait(1)
+      yield* waitForBusy(chat.id)
 
-    const id = MessageID.ascending()
-    const b = yield* prompt
-      .prompt({
-        sessionID: chat.id,
-        messageID: id,
-        agent: "build",
-        model: ref,
-        parts: [{ type: "text", text: "second" }],
-      })
-      .pipe(Effect.forkChild)
+      const id = MessageID.ascending()
+      const b = yield* prompt
+        .prompt({
+          sessionID: chat.id,
+          messageID: id,
+          agent: "build",
+          model: ref,
+          parts: [{ type: "text", text: "second" }],
+        })
+        .pipe(Effect.forkChild)
 
-    yield* pollWithTimeout(
-      sessions
-        .messages({ sessionID: chat.id })
-        .pipe(
-          Effect.map((msgs) =>
-            msgs.some((msg) => msg.info.role === "user" && msg.info.id === id) ? true : undefined,
+      yield* pollWithTimeout(
+        sessions
+          .messages({ sessionID: chat.id })
+          .pipe(
+            Effect.map((msgs) =>
+              msgs.some((msg) => msg.info.role === "user" && msg.info.id === id) ? true : undefined,
+            ),
           ),
-        ),
-      "timed out waiting for second prompt to save",
-    )
+        "timed out waiting for second prompt to save",
+      )
 
-    yield* Deferred.succeed(gate, void 0)
+      yield* Deferred.succeed(gate, void 0)
 
-    const [ea, eb] = yield* Effect.all([Fiber.await(a), Fiber.await(b)])
-    expect(Exit.isSuccess(ea)).toBe(true)
-    expect(Exit.isSuccess(eb)).toBe(true)
-    expect(yield* llm.calls).toBe(2)
+      const [ea, eb] = yield* Effect.all([Fiber.await(a), Fiber.await(b)])
+      expect(Exit.isSuccess(ea)).toBe(true)
+      expect(Exit.isSuccess(eb)).toBe(true)
+      expect(yield* llm.calls).toBe(2)
 
-    const msgs = yield* sessions.messages({ sessionID: chat.id })
-    const assistants = msgs.filter((msg) => msg.info.role === "assistant")
-    expect(assistants).toHaveLength(2)
-    const last = assistants.at(-1)
-    if (!last || last.info.role !== "assistant") throw new Error("expected second assistant")
-    expect(last.info.parentID).toBe(id)
-    expect(last.parts.some((part) => part.type === "text" && part.text === "second")).toBe(true)
+      const msgs = yield* sessions.messages({ sessionID: chat.id })
+      const assistants = msgs.filter((msg) => msg.info.role === "assistant")
+      expect(assistants).toHaveLength(2)
+      const last = assistants.at(-1)
+      if (!last || last.info.role !== "assistant") throw new Error("expected second assistant")
+      expect(last.info.parentID).toBe(id)
+      expect(last.parts.some((part) => part.type === "text" && part.text === "second")).toBe(true)
 
-    const inputs = yield* llm.inputs
-    expect(inputs).toHaveLength(2)
-    const messages = inputs.at(-1)?.messages
-    if (!Array.isArray(messages)) throw new Error("expected LLM messages")
-    // kilocode_change start - Kilo appends environment details to queued user prompts
-    expect(messages.at(-1)).toMatchObject({
-      role: "user",
-      content: expect.arrayContaining([{ type: "text", text: "second" }]),
-    })
-    // kilocode_change end
-  }),
+      const inputs = yield* llm.inputs
+      expect(inputs).toHaveLength(2)
+      const messages = inputs.at(-1)?.messages
+      if (!Array.isArray(messages)) throw new Error("expected LLM messages")
+      // kilocode_change start - Kilo appends environment details to queued user prompts
+      expect(messages.at(-1)).toMatchObject({
+        role: "user",
+        content: expect.arrayContaining([{ type: "text", text: "second" }]),
+      })
+      // kilocode_change end
+    }),
   10_000,
 )
 

--- a/specs/image-attachment-normalization-plan.md
+++ b/specs/image-attachment-normalization-plan.md
@@ -1,0 +1,496 @@
+# Image Attachment Normalization Plan
+
+## Problem
+
+Large screenshots can fail a Session request even though the V1 backend already normalizes most prompt images. The current behavior has several gaps:
+
+- VS Code sends the original image as a base64 data URL before backend normalization.
+- The V1 default allows one normalized image to contain up to 5 MiB of base64 data and to be up to 2,000 x 2,000 pixels.
+- The request pruning threshold is 1.25 MB, but pruning keeps media from the current user turn.
+- Context estimation replaces encoded media with a placeholder and cannot estimate provider-specific image token use.
+- V2 prompt attachments and MCP resource images do not consistently use the normalizer.
+- Limits apply to each image. There is no total media budget for one model request.
+- HTTP 413 responses can be classified as context overflow even when the request body is too large.
+
+The result is an inconsistent system. A pasted 4K screenshot normally gets smaller before it reaches the model, but it can still exceed a gateway payload limit or consume more model context than local preflight predicts.
+
+## Goals
+
+- Normalize every model-visible image at a backend boundary before persistence or provider use.
+- Keep each image small enough for common model and gateway limits.
+- Limit the total encoded media in one provider request.
+- Estimate image context use without counting base64 bytes as text tokens.
+- Return a clear attachment error before a provider request when media cannot fit.
+- Reduce VS Code webview memory and transport costs for pasted screenshots.
+- Keep original files unchanged outside Session storage.
+- Preserve delivery-only `send_file` behavior.
+
+## Non-Goals
+
+- Do not add OCR or replace image input with extracted text.
+- Do not make one exact image-token formula work for every provider.
+- Do not remove images from the durable transcript after successful admission.
+- Do not recompress PDFs or other binary attachments in this work.
+- Do not make client-side normalization a security or correctness boundary.
+- Do not change delivery-only `send_file` attachments.
+
+## Proposed Policy
+
+Use one backend policy for every model-visible image.
+
+| Policy | Proposed default |
+|---|---:|
+| Maximum width | 1,600 px |
+| Maximum height | 1,600 px |
+| Maximum encoded bytes per image | 1.5 MiB |
+| Maximum encoded media per request | 3 MiB |
+| Known payload-limit reserve | 512 KiB |
+| Automatic resize | Enabled |
+| Preferred output | PNG when it fits, otherwise JPEG |
+| JPEG quality sequence | 85, 80, 70, 55, 40 |
+
+The encoded byte limits apply to the base64 payload, without the data URL prefix. The aggregate media limit includes base64 payloads for current and historical images that remain in the final model request.
+
+For a provider with a known request-body limit, calculate the effective media budget as the smaller of:
+
+```text
+configured aggregate media limit
+known provider body limit - measured non-media request bytes - safety reserve
+```
+
+For a provider without a known body limit, use the configured aggregate media limit. Do not assume that every provider has a 4 MiB limit.
+
+Keep the backend settings configurable through the existing attachment image configuration. Add an aggregate media setting only if one does not already exist. A user can raise the defaults for a provider that supports larger images, but the request still must pass provider-specific hard limits.
+
+## Design Rules
+
+1. The backend is the source of truth.
+2. Normalize before durable persistence when the image enters as user input.
+3. Normalize before tool-result persistence when a tool creates model-visible media.
+4. Validate dimensions before native image decoding.
+5. Apply an aggregate budget to the final model-visible request.
+6. Remove historical media before reducing or rejecting media from the current user turn.
+7. Never silently remove a current-turn attachment.
+8. Return typed, actionable errors without including image data.
+9. Keep Kilo-specific request-budget behavior in Kilo-owned paths where possible.
+10. Keep changes to upstream-owned OpenCode files small and mark them with `kilocode_change` comments.
+
+## Target Flow
+
+```text
+Client image
+  -> client preflight resize when available
+  -> backend MIME and base64 validation
+  -> header-based dimension and pixel safety check
+  -> per-image resize and recompression
+  -> current-turn aggregate media normalization
+  -> durable Session persistence
+  -> historical media pruning
+  -> final request media budget check
+  -> image context estimate
+  -> provider adapter
+```
+
+Client normalization reduces transport and memory use. The backend repeats validation and normalization because other clients can bypass VS Code.
+
+## Phase 1: Consolidate Backend Image Policy
+
+### Work
+
+- Define one internal policy shape for maximum dimensions, per-image encoded bytes, aggregate encoded bytes, auto-resize, and output qualities.
+- Keep the existing configuration keys for `auto_resize`, `max_width`, `max_height`, and `max_base64_bytes`.
+- Add an aggregate media setting with a 3 MiB default if the current schema has no equivalent.
+- Change the default dimensions from 2,000 x 2,000 to 1,600 x 1,600.
+- Change the default per-image base64 limit from 5 MiB to 1.5 MiB.
+- Make the JPEG quality sequence monotonic: 85, 80, 70, 55, 40.
+- Return normalization metadata with the result: original dimensions, final dimensions, original encoded bytes, final encoded bytes, and final MIME type.
+- Keep metadata out of the persisted public file-part schema unless later request processing needs it.
+- Reuse the Core header parser before Photon decoding in the V1 path, or add an equivalent safe parser in a Kilo-owned module.
+- Reject zero dimensions, dimensions over 16,384 pixels per side, and images over 25,000,000 pixels before Photon allocation.
+
+### Main Code Areas
+
+| Area | Expected files |
+|---|---|
+| V1 normalization | `packages/opencode/src/image/image.ts` |
+| V1 attachment config | `packages/core/src/v1/config/attachment.ts` |
+| V2 normalization | `packages/core/src/image.ts`, `packages/core/src/image/photon.ts` |
+| V2 attachment config | `packages/core/src/config/attachments.ts` |
+| Safe dimension parsing | `packages/core/src/kilocode/image-size.ts` or a shared Kilo-owned equivalent |
+
+### Acceptance Criteria
+
+- A 3,840 x 2,160 screenshot becomes no larger than 1,600 x 900.
+- A normalized image contains no more than 1.5 MiB of base64 data.
+- An in-limit image stays byte-for-byte unchanged.
+- A malformed or unsafe image fails before native decode.
+- A transparent PNG stays PNG when it fits the budget.
+- A PNG that does not fit can become JPEG with the returned MIME and data URL kept consistent.
+- Normalization errors report limits and measured metadata, but not base64 content.
+
+## Phase 2: Cover Every Model-Visible Ingress Path
+
+### Work
+
+- Keep V1 data URL prompt attachments on the existing normalization path.
+- Change V1 local file attachment handling so a large but safe source image can reach the normalizer instead of being truncated before resize.
+- Use a bounded raw-ingest limit, then perform header validation and normalization.
+- Wire V2 prompt attachment materialization through the Core image normalizer before it is lowered to an LLM media part.
+- Normalize MCP resource images before persistence and provider use.
+- Confirm that remote image attachments enter the same normalizer after fetch materialization.
+- Keep normal image-producing tool results on the normalization path.
+- Keep `send_file` exempt because it is delivery-only and removed from future model context.
+- Reject or normalize unsupported client image formats before the provider adapter. Do not let client-specific MIME support create provider-specific failures.
+
+### Main Code Areas
+
+| Ingress | Expected files |
+|---|---|
+| V1 user prompt | `packages/opencode/src/session/prompt.ts` |
+| V1 tool result | `packages/opencode/src/session/processor.ts` |
+| V2 prompt admission | `packages/core/src/session/input.ts` |
+| V2 model lowering | `packages/core/src/session/runner/to-llm-message.ts` |
+| MCP resources | `packages/opencode/src/session/prompt.ts`, `packages/opencode/src/session/tools.ts` |
+| Remote attachments | `packages/opencode/src/kilocode/remote-attachments.ts` |
+| Delivery-only exemption | `packages/opencode/src/kilocode/tool/send-file.ts`, `packages/opencode/src/session/message-v2.ts` |
+
+### Acceptance Criteria
+
+- The same source image produces the same normalized limits through V1 data URL, V1 file URL, V2 prompt, MCP resource, and remote attachment paths.
+- Tool-generated model-visible images use the same limits.
+- An image source up to the bounded raw-ingest limit can be resized instead of being rejected only because its original encoding exceeds 1.5 MiB.
+- `send_file` delivers the original allowed bytes and does not appear in later model context.
+- No model-visible image bypasses MIME, dimension, pixel-count, and encoded-size validation.
+
+## Phase 3: Add an Aggregate Request Media Budget
+
+### Work
+
+- Add a Kilo-owned media-budget helper near Session request assembly.
+- Measure base64 payload bytes for every model-visible image after historical pruning.
+- Apply the 3 MiB aggregate budget before the provider call.
+- Use a lower dynamic budget when the provider has a known request-body limit.
+- Remove historical image and PDF media first, using the existing placeholder behavior.
+- If current-turn images still exceed the budget, progressively normalize the largest image first.
+- Stop when every image respects its per-image limit and the request respects its aggregate limit.
+- Return a typed attachment-budget error if the current turn cannot fit at the minimum supported size and quality.
+- Do not send an over-budget request with only a warning log.
+- Apply the same check after provider transforms if the transform can materially change inline media representation.
+
+### Budget Algorithm
+
+```text
+collect model-visible image parts
+-> remove media already eligible for historical stripping
+-> calculate effective aggregate budget
+-> if total is within budget, continue
+-> sort current-turn images by encoded bytes, largest first
+-> reduce the largest image one candidate step
+-> repeat until within budget or no image can be reduced
+-> fail admission or request preparation with AttachmentBudgetError
+```
+
+The first implementation should optimize for predictable limits, not perfect quality allocation. It must preserve attachment order and aspect ratio.
+
+### Main Code Areas
+
+| Area | Expected files |
+|---|---|
+| Kilo media policy | New file under `packages/opencode/src/kilocode/session/` |
+| Request assembly | `packages/opencode/src/session/prompt.ts` |
+| Historical stripping | `packages/opencode/src/kilocode/session/prompt.ts` |
+| V2 request assembly | V2 Session runner request preparation under `packages/core/src/session/runner/` |
+| Provider capability data | `packages/opencode/src/provider/provider.ts` |
+
+### Acceptance Criteria
+
+- One image cannot exceed 1.5 MiB with default settings.
+- All images in one unknown-provider request cannot exceed 3 MiB with default settings.
+- Known provider body limits reduce the effective media budget.
+- Several images are reduced predictably instead of causing a provider 413 response.
+- A current-turn image is never silently replaced with placeholder text.
+- The user receives a clear error when the current attachments cannot fit.
+
+## Phase 4: Add Image-Aware Context Estimation
+
+### Work
+
+- Continue to exclude base64 bytes from text-token estimation.
+- Parse normalized image dimensions from data URL headers without fully decoding pixels.
+- Add a conservative provider-neutral estimate based on image dimensions and tiles.
+- Add provider-specific estimation only where the provider publishes a stable formula.
+- Count the estimate in preflight compaction and output-token reservation.
+- Keep raw encoded bytes as a separate payload metric.
+- Prefer the larger of the provider-reported prior-turn usage and the local estimate, as the current logic does.
+- Record the estimate separately from actual provider usage so diagnostics do not present estimates as billed tokens.
+
+### Initial Estimator Contract
+
+```ts
+type ImageEstimate = {
+  width: number
+  height: number
+  tokens: number
+  encodedBytes: number
+  method: "provider" | "conservative"
+}
+```
+
+The exact type can follow repository conventions. The contract must keep context tokens and payload bytes separate.
+
+### Main Code Areas
+
+| Area | Expected files |
+|---|---|
+| Current estimator | `packages/opencode/src/kilocode/session/overflow.ts` |
+| Output cap | `packages/opencode/src/kilocode/session/llm.ts` |
+| Model limits | `packages/opencode/src/provider/provider.ts` |
+| V2 compaction estimate | V2 Session runner compaction and request-budget code |
+
+### Acceptance Criteria
+
+- Increasing image dimensions increases estimated context use even when encoded byte size stays similar.
+- Base64 characters are not counted as ordinary text tokens.
+- A large image can reduce reserved output tokens or trigger preflight compaction.
+- Provider-reported actual usage supersedes a lower local estimate on later turns.
+- Logs and diagnostics identify whether an image-token value is estimated or reported.
+
+## Phase 5: Separate Payload and Context Failures
+
+### Work
+
+- Add a distinct payload-too-large classification.
+- Classify HTTP 413 as payload-too-large unless the provider response explicitly identifies context length.
+- Keep explicit `context_length_exceeded` and known token-window messages classified as context overflow.
+- Retry payload failures only when request reduction is safe and no side effects have occurred.
+- On a payload retry, strip eligible historical media and old tool output, then reapply the aggregate media budget.
+- Do not start normal context compaction only because the HTTP body is too large.
+- Surface attachment-specific guidance when current media caused the failure.
+
+### Main Code Areas
+
+| Area | Expected files |
+|---|---|
+| Provider error classification | `packages/opencode/src/provider/error.ts` |
+| Session recovery | `packages/opencode/src/session/processor.ts` |
+| Payload recovery | `packages/opencode/src/kilocode/session/compaction-payload-recovery.ts` |
+| Session error schema | Session message and server error schemas used by clients |
+
+### Acceptance Criteria
+
+- A plain provider 413 is reported as payload-too-large.
+- A provider response with `context_length_exceeded` is reported as context overflow.
+- Payload recovery does not create an unnecessary context summary.
+- A repeated payload failure ends with a clear error and does not loop.
+- The UI can distinguish attachment-size failures from context-window failures.
+
+## Phase 6: Add VS Code Client Preflight Normalization
+
+### Work
+
+- Normalize pasted and native-dropped images before `FileReader.readAsDataURL` stores the attachment.
+- Decode with `createImageBitmap` where supported.
+- Resize on a canvas while preserving aspect ratio.
+- Keep PNG when it fits. Use JPEG for oversized opaque screenshots.
+- Avoid converting animated GIF input in the client. Let the backend apply the authoritative policy.
+- Cap the client result at the same 1,600-pixel dimensions and 1.5 MiB encoded target.
+- Apply a total 3 MiB client-side attachment target for immediate feedback.
+- Show progress while a large image is processed.
+- Show a clear error when decoding or normalization fails.
+- Revoke object URLs and release decoded image resources after use.
+- Do not persist the original full-size data URL in draft or Agent Manager webview state.
+
+### Main Code Areas
+
+| Area | Expected files |
+|---|---|
+| Attachment hook | `packages/kilo-vscode/webview-ui/src/hooks/useImageAttachments.ts` |
+| Attachment utilities | `packages/kilo-vscode/webview-ui/src/hooks/image-attachments-utils.ts` |
+| Prompt feedback | `packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx` |
+| Agent Manager | `packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx` |
+
+### Acceptance Criteria
+
+- Pasting a 4K screenshot does not put the original 4K base64 data URL in webview state.
+- The attachment preview remains clear enough to read normal UI text.
+- The resulting client attachment respects the target dimensions and byte size.
+- Sending the same image through a client without preflight still produces a valid backend-normalized image.
+- Multiple attachments that exceed the client aggregate target produce immediate feedback.
+- Animated GIF behavior does not regress because of client canvas conversion.
+
+## Phase 7: Other Clients
+
+### Work
+
+- Add the same optional preflight optimization to JetBrains clipboard images.
+- Apply the existing JetBrains file-size limit after clipboard PNG encoding, not only to file attachments.
+- Consider CLI preflight only if measurements show that local base64 conversion is a material cost.
+- Keep backend normalization mandatory for JetBrains, CLI, ACP, remote Sessions, and future clients.
+- Align accepted image MIME types with the provider protocol boundary.
+
+### Acceptance Criteria
+
+- JetBrains clipboard images cannot bypass all encoded-size checks.
+- CLI and ACP images receive the same backend policy without client changes.
+- Client MIME support does not exceed formats that the backend can normalize and providers can accept.
+
+## Phase 8: Observability and User Feedback
+
+### Work
+
+- Add structured debug logging for normalization outcomes.
+- Record only MIME type, dimensions, byte counts, ingress path, provider ID, and normalization result.
+- Never log data URLs, base64 data, filenames that may contain sensitive text, or image contents.
+- Add counters for resized images, converted formats, rejected images, aggregate-budget failures, provider payload failures, and provider context failures with images.
+- Show the final dimensions and approximate attachment size in UI error details where useful.
+- Use one user-facing message for a local attachment-budget failure and a different message for a provider context-window failure.
+
+### Suggested User Messages
+
+```text
+This image could not be attached because it is too large after resizing. Use a smaller crop or attach fewer images.
+```
+
+```text
+These attachments exceed the request media limit. Remove an image or send the images in separate messages.
+```
+
+```text
+The model context is full. Compact the Session or start a new Session before sending this image.
+```
+
+## Test Plan
+
+### Unit Tests
+
+- Preserve an in-limit PNG without re-encoding.
+- Resize a 3,840 x 2,160 PNG to no more than 1,600 x 900.
+- Resize a 2,160 x 3,840 portrait screenshot to no more than 900 x 1,600.
+- Convert a large PNG to JPEG when PNG cannot fit.
+- Keep MIME type and data URL prefix consistent after conversion.
+- Reduce JPEG quality in monotonic order.
+- Reject invalid base64 and mismatched MIME data.
+- Reject zero, excessive, and unsafe dimensions before Photon decode.
+- Fit two or more images within the aggregate budget.
+- Fail with a typed error when aggregate normalization cannot fit.
+- Estimate more context tokens for larger dimensions.
+- Keep encoded bytes separate from estimated context tokens.
+- Distinguish plain 413 payload errors from explicit context overflow.
+
+### Integration Tests
+
+- Send a 4K VS Code data URL through the Session HTTP API and inspect the persisted normalized part.
+- Send the same image by local file URL and confirm equivalent limits.
+- Admit a V2 image prompt and confirm normalization before LLM lowering.
+- Attach an MCP resource image and confirm it cannot bypass normalization.
+- Return a large image from `read` and confirm tool-result normalization.
+- Use `send_file` and confirm the original allowed bytes are delivered but omitted from model replay.
+- Send several current-turn images and confirm the final request stays within the aggregate budget.
+- Include historical images and confirm they are stripped before current-turn images are reduced.
+- Simulate provider payload and context errors and confirm different recovery paths.
+
+### VS Code Tests
+
+- Paste and drop a 4K PNG.
+- Paste a large JPEG.
+- Paste several images over the aggregate target.
+- Paste an animated GIF.
+- Restore a prompt draft and confirm only normalized image data is stored.
+- Create an Agent Manager worktree with an attached screenshot.
+- Confirm backend rejection is shown as an attachment error.
+
+### Performance Checks
+
+- Measure webview memory before and after pasting one 4K screenshot.
+- Measure webview-to-extension message bytes before and after client normalization.
+- Measure normalization latency for 4K PNG and JPEG samples.
+- Measure backend peak memory during Photon decode.
+- Confirm header validation rejects unsafe images before native allocation.
+
+## Validation Commands
+
+Run the smallest relevant checks after each phase.
+
+```sh
+# V1 CLI and Session changes
+cd packages/opencode
+bun run typecheck
+bun test ./test/image/image.test.ts
+bun test ./test/session/prompt.test.ts
+bun test ./test/kilocode/session-overflow.test.ts
+
+# V2 Core changes
+cd packages/core
+bun run typecheck
+bun test
+
+# VS Code changes
+cd packages/kilo-vscode
+bun run typecheck
+bun run lint
+bun run test:unit
+bun run knip
+bun run check-kilocode-change
+
+# Shared OpenCode changes
+cd ../..
+bun run script/check-opencode-annotations.ts --worktree
+bun run script/check-opencode-promise-facades.ts
+```
+
+Adjust targeted test paths to the final file names. Do not run the root `bun test` command.
+
+## Rollout
+
+1. Add backend coverage and tests without changing defaults.
+2. Add aggregate measurement in log-only mode to collect request-size and image-count distributions.
+3. Enable the lower per-image defaults and aggregate enforcement.
+4. Add payload/context error separation.
+5. Add image-aware context estimation.
+6. Add VS Code preflight normalization.
+7. Add JetBrains preflight normalization.
+8. Remove temporary rollout logs after the policy is stable.
+
+Use one concise changeset for the user-visible behavior. The release note should state that Kilo automatically reduces large screenshots and prevents image attachments from exceeding model request limits.
+
+## Compatibility and Migration
+
+- Existing persisted Session images remain unchanged.
+- Request-time aggregate checks apply when old images are replayed to a model.
+- Existing user configuration overrides continue to work.
+- Lower defaults affect only images normalized after the change.
+- If an aggregate config key is added to public config, update all generated schemas and the cloud config schema required by repository policy.
+- Client-side normalized attachments remain ordinary file parts and need no protocol version change.
+- A new typed error may require SDK regeneration if it changes a server endpoint schema.
+
+## Security and Privacy
+
+- Validate dimensions before Photon or another native decoder allocates image memory.
+- Bound raw fetch and local file ingestion separately from encoded output size.
+- Do not trust MIME declarations without checking decoded image headers.
+- Do not log image content or complete data URLs.
+- Do not upload images to a third-party compression service.
+- Keep all normalization local to the client or Kilo backend.
+
+## Open Decisions
+
+Resolve these decisions with measurements during Phase 1 and Phase 2:
+
+- Whether 1.5 MiB per image provides enough text clarity for dense screenshots.
+- Whether the unknown-provider aggregate default should be 2 MiB or 3 MiB.
+- Whether transparent images that cannot fit as PNG should use a fixed background before JPEG conversion.
+- Whether provider-specific image-token formulas are stable enough to maintain.
+- Whether aggregate normalization should happen only at admission or also before every provider request.
+- Whether V1 and V2 can share one normalization service without increasing upstream merge conflicts.
+
+## Definition of Done
+
+- Every model-visible image ingress path uses the backend policy.
+- Default normalized images are at most 1,600 x 1,600 and 1.5 MiB encoded.
+- Final requests enforce an aggregate media budget.
+- Image dimensions contribute to context estimation.
+- Payload-too-large and context-overflow failures are distinct.
+- VS Code reduces large pasted screenshots before storing or transmitting them.
+- Unit, integration, and VS Code tests cover 4K screenshots and multiple images.
+- Relevant typecheck, lint, unit, guard, and manual extension checks pass.
+- A changeset documents the user-visible behavior.


### PR DESCRIPTION
Large pasted screenshots can exceed provider payload or context limits even after the existing image normalization path. The failure is especially visible for 4K screenshots and for sessions with multiple or historical image attachments.

This change applies one conservative image policy across the backend and V2 runner, normalizes MCP image resources, enforces a 3 MiB aggregate media budget after historical media pruning, and distinguishes payload-too-large errors from context-window errors. VS Code also resizes static pasted images before base64 encoding to reduce webview memory and transport overhead. Animated GIFs and delivery-only `send_file` attachments keep their existing behavior.

The change includes focused coverage for image limits, aggregate media accounting, provider error classification, V2 normalization, and VS Code attachment helpers.