### PR TITLE
fix(vscode): persist sidebar model picks from active sessions

### DIFF
--- a/.changeset/remember-sidebar-model-picks.md
+++ b/.changeset/remember-sidebar-model-picks.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Remember model selections made in the sidebar while a session is open.

--- a/packages/kilo-vscode/tests/fixtures/session-model-scope-components.tsx
+++ b/packages/kilo-vscode/tests/fixtures/session-model-scope-components.tsx
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict"
+import { Window } from "happy-dom"
+
+const window = new Window({ url: "http://localhost" })
+Object.assign(globalThis, {
+  window,
+  document: window.document,
+  navigator: window.navigator,
+  Node: window.Node,
+  Element: window.Element,
+  HTMLElement: window.HTMLElement,
+  HTMLButtonElement: window.HTMLButtonElement,
+  HTMLInputElement: window.HTMLInputElement,
+  SVGElement: window.SVGElement,
+  ShadowRoot: window.ShadowRoot,
+  customElements: window.customElements,
+  MutationObserver: window.MutationObserver,
+  ResizeObserver: window.ResizeObserver,
+  CustomEvent: window.CustomEvent,
+  Event: window.Event,
+  KeyboardEvent: window.KeyboardEvent,
+  MessageEvent: window.MessageEvent,
+  requestAnimationFrame: window.requestAnimationFrame.bind(window),
+  cancelAnimationFrame: window.cancelAnimationFrame.bind(window),
+  getComputedStyle: window.getComputedStyle.bind(window),
+})
+
+globalThis.acquireVsCodeApi = () => ({
+  postMessage: () => undefined,
+  getState: () => undefined,
+  setState: () => undefined,
+})
+
+const { render } = await import("solid-js/web")
+const { VSCodeProvider } = await import("../../webview-ui/src/context/vscode")
+const { LanguageContext } = await import("../../webview-ui/src/context/language")
+const { ProviderContext } = await import("../../webview-ui/src/context/provider")
+const { SessionContext } = await import("../../webview-ui/src/context/session")
+const { NotificationsContext } = await import("../../webview-ui/src/context/notifications")
+const { WorktreeModeProvider } = await import("../../webview-ui/src/context/worktree-mode")
+const { ModelSelector } = await import("../../webview-ui/src/components/shared/ModelSelector")
+const { KiloNotifications } = await import("../../webview-ui/src/components/chat/KiloNotifications")
+
+const model = { id: "new", name: "New", providerID: "kilo", providerName: "Kilo" }
+const selection = { providerID: "kilo", modelID: "new" }
+const provider = {
+  providers: () => ({ kilo: { id: "kilo", name: "Kilo", models: { new: model } } }),
+  connected: () => ["kilo"],
+  defaults: () => ({}),
+  defaultSelection: () => selection,
+  models: () => [model],
+  findModel: (value: typeof selection | null) =>
+    value?.providerID === selection.providerID && value.modelID === selection.modelID ? model : undefined,
+  authMethods: () => ({}),
+  authStates: () => ({}),
+  isModelValid: (value: typeof selection | null) =>
+    value?.providerID === selection.providerID && value.modelID === selection.modelID,
+}
+const language = {
+  locale: () => "en",
+  setLocale: () => undefined,
+  userOverride: () => "",
+  t: (key: string, params?: { model?: string }) => (params?.model ? `${key}:${params.model}` : key),
+}
+const notifications = {
+  notifications: () => [{ id: "notification", title: "Try a model", message: "Try it", suggestModelId: "new" }],
+  filteredNotifications: () => [{ id: "notification", title: "Try a model", message: "Try it", suggestModelId: "new" }],
+  dismiss: () => undefined,
+}
+
+type ModelCall = [string, string, string | undefined, string | undefined]
+
+function mount(inAgentManager: boolean, child: () => unknown) {
+  const calls: ModelCall[] = []
+  const session = {
+    selected: () => null,
+    selectModel: (...args: ModelCall) => calls.push(args),
+    modelUsageHistory: () => ({}),
+    favoriteModels: () => [],
+    recentModels: () => [],
+    toggleFavorite: () => undefined,
+    currentSessionID: () => "session-a",
+    draftSessionID: () => undefined,
+  }
+  const root = document.createElement("div")
+  document.body.append(root)
+  const content = () => (
+    <ProviderContext.Provider value={provider as never}>
+      <LanguageContext.Provider value={language as never}>
+        <SessionContext.Provider value={session as never}>
+          <NotificationsContext.Provider value={notifications as never}>{child()}</NotificationsContext.Provider>
+        </SessionContext.Provider>
+      </LanguageContext.Provider>
+    </ProviderContext.Provider>
+  )
+  const dispose = render(
+    () => (
+      <VSCodeProvider>
+        {inAgentManager ? <WorktreeModeProvider>{content()}</WorktreeModeProvider> : content()}
+      </VSCodeProvider>
+    ),
+    root,
+  )
+  return {
+    calls,
+    root,
+    dispose: () => {
+      dispose()
+      root.remove()
+    },
+  }
+}
+
+async function settle() {
+  await Promise.resolve()
+  await new Promise((resolve) => setTimeout(resolve, 25))
+}
+
+async function selectFromPicker(inAgentManager: boolean, expectedScope: "global" | "session") {
+  const mounted = mount(inAgentManager, () => <ModelSelector sessionID={() => "session-a"} portal={false} />)
+  const trigger = mounted.root.querySelector<HTMLButtonElement>("button")
+  assert.ok(trigger, "model selector trigger rendered")
+  trigger.click()
+  await settle()
+
+  const input = document.querySelector<HTMLInputElement>(".model-selector-search")
+  const body = document.querySelector<HTMLElement>(".model-selector-body")
+  assert.ok(input, "model selector search rendered")
+  assert.ok(body, "model selector body rendered")
+  input.value = "new"
+  input.dispatchEvent(new Event("input", { bubbles: true }))
+  await settle()
+  body.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }))
+  await settle()
+
+  assert.deepEqual(mounted.calls, [["kilo", "new", "session-a", expectedScope]])
+  mounted.dispose()
+}
+
+async function selectFromNotification(inAgentManager: boolean, expectedScope: "global" | "session") {
+  const mounted = mount(inAgentManager, () => <KiloNotifications sessionID={() => "session-a"} />)
+  await settle()
+
+  const action = mounted.root.querySelector<HTMLButtonElement>(".kilo-notifications-action-btn")
+  assert.ok(action, "notification model action rendered")
+  action.click()
+  await settle()
+
+  assert.deepEqual(mounted.calls, [["kilo", "new", "session-a", expectedScope]])
+  mounted.dispose()
+}
+
+await selectFromPicker(false, "global")
+await selectFromPicker(true, "session")
+await selectFromNotification(false, "global")
+await selectFromNotification(true, "session")

--- a/packages/kilo-vscode/tests/unit/session-model-scope-components.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-model-scope-components.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test"
+import { unlinkSync } from "node:fs"
+import path from "node:path"
+import { build } from "esbuild"
+import { solidPlugin } from "esbuild-plugin-solid"
+
+const ROOT = path.resolve(import.meta.dir, "../..")
+const WEBVIEW = path.join(ROOT, "webview-ui")
+const FIXTURE = path.join(ROOT, "tests/fixtures/session-model-scope-components.tsx")
+
+describe("model selection surfaces", () => {
+  it("persists sidebar picks globally and keeps Agent Manager picks session-scoped", async () => {
+    const solid = path.dirname(Bun.resolveSync("solid-js/package.json", WEBVIEW))
+    const aliases: Record<string, string> = {
+      "solid-js": path.join(solid, "dist/solid.js"),
+      "solid-js/web": path.join(solid, "web/dist/web.js"),
+      "solid-js/store": path.join(solid, "store/dist/store.js"),
+    }
+    const dedupe = {
+      name: "solid-dedupe",
+      setup(ctx: Parameters<NonNullable<Parameters<typeof build>[0]["plugins"]>[number]["setup"]>[0]) {
+        ctx.onResolve({ filter: /^solid-js(\/web|\/store)?$/ }, (args) => ({ path: aliases[args.path] }))
+        ctx.onResolve({ filter: /markdown-shiki\.worker\.ts\?worker&url$/ }, () => ({
+          path: "markdown-shiki-worker-url",
+          namespace: "kilo-worker-url",
+        }))
+        ctx.onLoad({ filter: /.*/, namespace: "kilo-worker-url" }, () => ({
+          contents: "export default undefined",
+          loader: "js",
+        }))
+      },
+    }
+    const result = await build({
+      entryPoints: [FIXTURE],
+      bundle: true,
+      conditions: ["browser"],
+      external: ["happy-dom"],
+      format: "esm",
+      logLevel: "silent",
+      platform: "node",
+      plugins: [dedupe, solidPlugin()],
+      target: "es2022",
+      write: false,
+    })
+    const file = path.join(ROOT, `.session-model-scope-components-${crypto.randomUUID()}.mjs`)
+    try {
+      await Bun.write(file, result.outputFiles[0]!.contents)
+      const child = Bun.spawnSync(["bun", file], { cwd: WEBVIEW, stdout: "pipe", stderr: "pipe" })
+      const output = child.stdout.toString() + child.stderr.toString()
+      expect(child.exitCode, output).toBe(0)
+    } finally {
+      unlinkSync(file)
+    }
+  })
+})

--- a/packages/kilo-vscode/tests/unit/session-model-selector.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-model-selector.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { createModelSelector } from "../../webview-ui/src/context/session-model-selector"
+import { createModelSelector, modelSelectionScope } from "../../webview-ui/src/context/session-model-selector"
 
 describe("model selector", () => {
   it("carries the active session variant for the selected model", () => {
@@ -46,5 +46,29 @@ describe("model selector", () => {
     const model = { providerID: "kilo", modelID: "new" }
     expect(models).toEqual([{ id: "session", selection: model }])
     expect(variants).toEqual([{ value: "high", session: "session" }])
+  })
+
+  it("passes the requested selection scope to the state transition", () => {
+    const selected = { providerID: "kilo", modelID: "old" }
+    const scopes: Array<string | undefined> = []
+    const selector = createModelSelector({
+      current: () => "session",
+      agent: () => "code",
+      selected: () => selected,
+      variant: () => undefined,
+      apply: (_agent, _selection, _id, scope) => scopes.push(scope),
+      set: () => undefined,
+      carry: () => undefined,
+      hide: () => undefined,
+    })
+
+    selector.select("kilo", "new", "session", "global")
+
+    expect(scopes).toEqual(["global"])
+  })
+
+  it("keeps Agent Manager selections session-scoped and sidebar selections global", () => {
+    expect(modelSelectionScope(true)).toBe("session")
+    expect(modelSelectionScope(false)).toBe("global")
   })
 })

--- a/packages/kilo-vscode/tests/unit/session-model-store.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-model-store.test.ts
@@ -166,12 +166,26 @@ describe("per-mode model memory", () => {
     expect(getAgentModel(store, configured, "code", true)).toEqual(claude)
   })
 
-  it("applyModel in a session writes only to sessionOverrides", () => {
+  it("global session picks update per-mode memory and the active session", () => {
     const store = emptyStore()
-    const result = applyModel(store, "code", claude, "session-a")
+    const result = applyModel(store, "code", claude, "session-a", "global")
+
+    expect(result.sessionOverrides["session-a"]).toEqual(claude)
+    expect(result.modelSelections["code"]).toEqual(claude)
+    expect(result.persistModelSelection).toEqual({
+      agent: "code",
+      providerID: "anthropic",
+      modelID: "claude-sonnet-4",
+    })
+  })
+
+  it("session-scoped picks do not update per-mode memory", () => {
+    const store = emptyStore()
+    const result = applyModel(store, "code", claude, "session-a", "session")
 
     expect(result.sessionOverrides["session-a"]).toEqual(claude)
     expect(result.modelSelections["code"]).toBeUndefined()
+    expect(result.persistModelSelection).toBeUndefined()
   })
 
   it("switching modes falls back to default after session override is cleared", () => {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/KiloNotifications.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/KiloNotifications.tsx
@@ -2,8 +2,10 @@ import { Component, Show, createEffect, createMemo, createSignal, type Accessor 
 import { useNotifications } from "../../context/notifications"
 import { useVSCode } from "../../context/vscode"
 import { useSession } from "../../context/session"
+import { modelSelectionScope } from "../../context/session-model-selector"
 import { useProvider } from "../../context/provider"
 import { useLanguage } from "../../context/language"
+import { useWorktreeMode } from "../../context/worktree-mode"
 import { KILO_PROVIDER_ID } from "../../../../src/shared/provider-model"
 import { TelemetryEventName } from "../../../../src/services/telemetry/types"
 import { stripSubProviderPrefix } from "../shared/model-selector-utils"
@@ -14,6 +16,7 @@ export const KiloNotifications: Component<{ sessionID?: Accessor<string | undefi
   const session = useSession()
   const provider = useProvider()
   const language = useLanguage()
+  const worktree = useWorktreeMode()
   const [index, setIndex] = createSignal(0)
   const sessionID = () => props.sessionID?.() ?? session.currentSessionID() ?? session.draftSessionID()
 
@@ -78,7 +81,7 @@ export const KiloNotifications: Component<{ sessionID?: Accessor<string | undefi
   const handleTryModel = () => {
     const suggestion = suggestedModel()
     if (!suggestion) return
-    session.selectModel(suggestion.providerID, suggestion.modelID, sessionID())
+    session.selectModel(suggestion.providerID, suggestion.modelID, sessionID(), modelSelectionScope(!!worktree))
     vscode.postMessage({
       type: "telemetry",
       event: TelemetryEventName.NOTIFICATION_CLICKED,

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -29,7 +29,9 @@ import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useProvider } from "../../context/provider"
 import type { EnrichedModel } from "../../context/provider"
 import { useSession, SessionContext } from "../../context/session"
+import { modelSelectionScope } from "../../context/session-model-selector"
 import { useLanguage } from "../../context/language"
+import { useWorktreeMode } from "../../context/worktree-mode"
 import { useVSCode } from "../../context/vscode"
 import type { ModelSelection } from "../../types/messages"
 import { isEnterKeyCommitNotIme } from "../../utils/ime-enter"
@@ -1145,17 +1147,20 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
 
 interface ModelSelectorProps {
   sessionID?: Accessor<string | undefined>
+  portal?: boolean
 }
 
 export const ModelSelector: Component<ModelSelectorProps> = (props) => {
   const session = useSession()
+  const worktree = useWorktreeMode()
   const id = () => props.sessionID?.()
 
   return (
     <ModelSelectorBase
       value={session.selected(id())}
+      portal={props.portal}
       onSelect={(providerID, modelID) => {
-        session.selectModel(providerID, modelID, id())
+        session.selectModel(providerID, modelID, id(), modelSelectionScope(!!worktree))
       }}
       onPick={() => {
         requestAnimationFrame(() => window.dispatchEvent(new CustomEvent("focusPrompt", { detail: { restore: true } })))

--- a/packages/kilo-vscode/webview-ui/src/context/session-model-selector.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-model-selector.ts
@@ -1,24 +1,29 @@
 import type { ModelSelection } from "../types/messages"
+import type { ModelSelectionScope } from "./session-model-store"
 
 type Deps = {
   current: () => string | undefined
   agent: (session?: string) => string
   selected: (session?: string) => ModelSelection | null
   variant: (session?: string) => string | undefined
-  apply: (agent: string, selection: ModelSelection, session?: string) => void
+  apply: (agent: string, selection: ModelSelection, session?: string, scope?: ModelSelectionScope) => void
   set: (session: string, selection: ModelSelection) => void
   carry: (selection: ModelSelection, value: string | undefined, agent: string, session?: string) => void
   hide: (session: string) => void
 }
 
+export function modelSelectionScope(inAgentManager: boolean): ModelSelectionScope {
+  return inAgentManager ? "session" : "global"
+}
+
 export function createModelSelector(deps: Deps) {
-  const select = (providerID: string, modelID: string, sessionID?: string) => {
+  const select = (providerID: string, modelID: string, sessionID?: string, scope?: ModelSelectionScope) => {
     const session = sessionID ?? deps.current()
     const agent = deps.agent(session)
     const current = deps.selected(session)
     const value = current ? deps.variant(session) : undefined
     const selection = { providerID, modelID }
-    deps.apply(agent, selection, session)
+    deps.apply(agent, selection, session, scope)
     deps.carry(selection, value, agent, session)
     if (session) deps.hide(session)
   }

--- a/packages/kilo-vscode/webview-ui/src/context/session-model-store.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-model-store.ts
@@ -18,6 +18,8 @@ export interface ModelStore {
   recentModels: ModelSelection[]
 }
 
+export type ModelSelectionScope = "global" | "session"
+
 export interface ResolveEnv {
   providers: Record<string, Provider>
   connected: string[]
@@ -92,29 +94,38 @@ export function getAgentModel(
 export interface ApplyResult {
   modelSelections: Record<string, ModelSelection | null>
   sessionOverrides: Record<string, ModelSelection>
+  persistModelSelection?: {
+    agent: string
+    providerID: string
+    modelID: string
+  }
 }
 
 /**
  * Apply a user-initiated model selection.
  *
  * Session-scoped selections write only to the per-session override.
- * No-session selections write to the global modelSelections map so sidebar
- * default picks still mirror CLI TUI's model.json behavior.
+ * Global selections also update the per-session override when a session is
+ * active, so the sidebar reflects the pick immediately while the last-used
+ * per-mode value remains durable.
  */
 export function applyModel(
   store: ModelStore,
   agentName: string,
   selection: ModelSelection,
   sessionID: string | undefined,
+  scope: ModelSelectionScope = sessionID ? "session" : "global",
 ): ApplyResult {
-  const modelSelections = sessionID
-    ? { ...store.modelSelections }
-    : { ...store.modelSelections, [agentName]: selection }
+  const modelSelections =
+    scope === "global" ? { ...store.modelSelections, [agentName]: selection } : { ...store.modelSelections }
   const sessionOverrides = { ...store.sessionOverrides }
 
   if (sessionID) {
     sessionOverrides[sessionID] = selection
   }
 
-  return { modelSelections, sessionOverrides }
+  const persistModelSelection =
+    scope === "global" ? { agent: agentName, providerID: selection.providerID, modelID: selection.modelID } : undefined
+
+  return { modelSelections, sessionOverrides, persistModelSelection }
 }

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -73,7 +73,7 @@ import {
 } from "./session-utils"
 import { Identifier } from "../utils/id"
 import { resolveModelSelection } from "./model-selection"
-import { getAgentModel } from "./session-model-store"
+import { applyModel as applyModelSelection, getAgentModel, type ModelSelectionScope } from "./session-model-store"
 import { resolveMessagePrefs } from "./session-preferences"
 import { errorIDs, preserveSessionErrors, withoutResolvedSessionErrors } from "./session-errors"
 import { PartStash } from "./part-stash"
@@ -191,7 +191,7 @@ interface SessionContextValue {
   configModel: (sessionID?: string) => ModelSelection | null
   modelForAgent: (agent: string) => ModelSelection | null
   configModelForAgent: (agent: string) => ModelSelection | null
-  selectModel: (providerID: string, modelID: string, sessionID?: string) => void
+  selectModel: (providerID: string, modelID: string, sessionID?: string, scope?: ModelSelectionScope) => void
   hasModelOverride: (sessionID?: string) => boolean
   clearModelOverride: (sessionID?: string) => void
 
@@ -635,23 +635,20 @@ export const SessionProvider: ParentComponent = (props) => {
     vscode.postMessage({ type: "recordModelUsage", providerID, modelID })
   }
 
-  function applyModel(agentName: string, selection: ModelSelection, sessionID?: string) {
+  function applyModel(
+    agentName: string,
+    selection: ModelSelection,
+    sessionID?: string,
+    scope: ModelSelectionScope = sessionID ? "session" : "global",
+  ) {
     pushRecent(selection)
-    if (sessionID) {
-      setStore("sessionOverrides", sessionID, selection)
-      return
-    }
-    // Always remember the per-mode model choice so switching modes restores
-    // the last-used model (mirrors CLI TUI's model.json behavior).
-    setUserSetAgents((prev) => ({ ...prev, [agentName]: true }))
-    setStore("modelSelections", agentName, selection)
-    // Persist to model.json via the extension host
-    vscode.postMessage({
-      type: "persistModelSelection",
-      agent: agentName,
-      providerID: selection.providerID,
-      modelID: selection.modelID,
-    })
+    const result = applyModelSelection(store, agentName, selection, sessionID, scope)
+    setStore("modelSelections", reconcile(result.modelSelections))
+    setStore("sessionOverrides", reconcile(result.sessionOverrides))
+    const persistence = result.persistModelSelection
+    if (!persistence) return
+    setUserSetAgents((prev) => ({ ...prev, [persistence.agent]: true }))
+    vscode.postMessage({ type: "persistModelSelection", ...persistence })
   }
 
   const variants = createSessionVariants({


### PR DESCRIPTION
## Issue

Fixes #13283

Related to #13254

## Context

Selecting a model from the sidebar while a chat session was active updated only the session override. The durable per-mode selection remained stale, so a new task or a later role change could restore an older model.

## Implementation

Sidebar model selections now use global scope even when a session is active, while Agent Manager selections remain session-scoped. `SessionProvider` delegates the state transition and persistence decision to the tested `session-model-store.ts` implementation instead of maintaining a second copy of that logic. Component coverage exercises the actual model picker and notification action in both sidebar and Agent Manager contexts.

## Screenshots / Video

Not applicable; this changes model state persistence and has no visual effect.

## How to Test

### Manual/local verification

Executed in this checkout:

- `bun test tests/unit/session-model-store.test.ts tests/unit/session-model-selector.test.ts tests/unit/session-model-scope-components.test.ts` — 23 passed, 0 failed.
- `bun run typecheck` — passed.
- `bun run lint` — passed.
- `bun run bundle` — passed.
- `bun run knip` — passed.
- `bun run compile-tests` — passed.
- The normal pre-push hook passed typechecking for 29 packages and the JetBrains package.
- The equivalent `kilocode_change` marker command completed in Git Bash with no findings.

### Reviewer test steps

1. Open a sidebar chat with an existing session.
2. Select a different model, then create a new task.
3. Confirm the selected model remains the per-mode selection for the new task.
4. Open two Agent Manager sessions and choose a different model in each.
5. Confirm each Agent Manager session keeps its own model without changing the other session.

### Blocked checks and substitute verification

- `bun run check-kilocode-change` does not parse its leading shell `!` through Bun's Windows script runner. The exact marker pipeline was executed directly in Git Bash and returned no findings.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.