### PR TITLE
fix(cli): send max-step instruction as user message

### DIFF
--- a/.changeset/fix-max-steps-prefill.md
+++ b/.changeset/fix-max-steps-prefill.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent provider errors when agents reach their step limit by sending the final summary instruction as user input instead of an assistant prefill.

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -209,7 +209,7 @@ const layer = Layer.effect(
         system: [agent.info?.system, system.baseline]
           .filter((part): part is string => part !== undefined && part.length > 0)
           .map(SystemPart.make),
-        messages: [...toLLMMessages(context, model), ...(isLastStep ? [Message.assistant(MAX_STEPS_PROMPT)] : [])],
+        messages: [...toLLMMessages(context, model), ...(isLastStep ? [Message.user(MAX_STEPS_PROMPT)] : [])], // kilocode_change - avoid provider-incompatible assistant prefill
         tools: toolMaterialization?.definitions ?? [],
         toolChoice: isLastStep ? "none" : undefined,
       })

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -3022,7 +3022,7 @@ describe("SessionRunnerLLM", () => {
       expect(requests[1]?.toolChoice).toMatchObject({ type: "none" })
       expect(requests[1]?.tools).toEqual([])
       expect(requests[1]?.messages.at(-1)).toMatchObject({
-        role: "assistant",
+        role: "user", // kilocode_change - max-step instructions must not become assistant prefill
         content: [{ type: "text", text: expect.stringContaining("MAXIMUM STEPS REACHED") }],
       })
       expect(executions).toEqual(["done"])

--- a/packages/llm/src/protocols/anthropic-messages.ts
+++ b/packages/llm/src/protocols/anthropic-messages.ts
@@ -435,7 +435,10 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
         }
         return yield* ProviderShared.unsupportedContent("Anthropic Messages", "user", ["text", "media"])
       }
-      messages.push({ role: "user", content })
+      const previous = messages.at(-1) // kilocode_change
+      if (previous?.role === "user") // kilocode_change
+        messages[messages.length - 1] = { role: "user", content: [...previous.content, ...content] } // kilocode_change
+      else messages.push({ role: "user", content }) // kilocode_change
       continue
     }
 
@@ -482,7 +485,10 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
         cache_control: cacheControl(breakpoints, part.cache),
       })
     }
-    messages.push({ role: "user", content })
+    const previous = messages.at(-1) // kilocode_change
+    if (previous?.role === "user") // kilocode_change
+      messages[messages.length - 1] = { role: "user", content: [...previous.content, ...content] } // kilocode_change
+    else messages.push({ role: "user", content }) // kilocode_change
   }
 
   return messages

--- a/packages/llm/src/protocols/anthropic-messages.ts
+++ b/packages/llm/src/protocols/anthropic-messages.ts
@@ -415,10 +415,7 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
       }
       const part = yield* ProviderShared.wrappedSystemUpdate("Anthropic Messages", message)
       const block = { type: "text" as const, text: part.text, cache_control: cacheControl(breakpoints, part.cache) }
-      const previous = messages.at(-1)
-      if (previous?.role === "user")
-        messages[messages.length - 1] = { role: "user", content: [...previous.content, block] }
-      else messages.push({ role: "user", content: [block] })
+      ProviderShared.appendUserMessage(messages, { role: "user", content: [block] }) // kilocode_change
       continue
     }
 
@@ -435,10 +432,7 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
         }
         return yield* ProviderShared.unsupportedContent("Anthropic Messages", "user", ["text", "media"])
       }
-      const previous = messages.at(-1) // kilocode_change
-      if (previous?.role === "user") // kilocode_change
-        messages[messages.length - 1] = { role: "user", content: [...previous.content, ...content] } // kilocode_change
-      else messages.push({ role: "user", content }) // kilocode_change
+      ProviderShared.appendUserMessage(messages, { role: "user", content }) // kilocode_change
       continue
     }
 
@@ -485,10 +479,7 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
         cache_control: cacheControl(breakpoints, part.cache),
       })
     }
-    const previous = messages.at(-1) // kilocode_change
-    if (previous?.role === "user") // kilocode_change
-      messages[messages.length - 1] = { role: "user", content: [...previous.content, ...content] } // kilocode_change
-    else messages.push({ role: "user", content }) // kilocode_change
+    ProviderShared.appendUserMessage(messages, { role: "user", content }) // kilocode_change
   }
 
   return messages

--- a/packages/llm/src/protocols/anthropic-messages.ts
+++ b/packages/llm/src/protocols/anthropic-messages.ts
@@ -415,7 +415,7 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
       }
       const part = yield* ProviderShared.wrappedSystemUpdate("Anthropic Messages", message)
       const block = { type: "text" as const, text: part.text, cache_control: cacheControl(breakpoints, part.cache) }
-      ProviderShared.appendUserMessage(messages, { role: "user", content: [block] }) // kilocode_change
+      ProviderShared.appendUserMessage(messages, { role: "user", content: [block] }, "content") // kilocode_change
       continue
     }
 
@@ -432,7 +432,7 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
         }
         return yield* ProviderShared.unsupportedContent("Anthropic Messages", "user", ["text", "media"])
       }
-      ProviderShared.appendUserMessage(messages, { role: "user", content }) // kilocode_change
+      ProviderShared.appendUserMessage(messages, { role: "user", content }, "content") // kilocode_change
       continue
     }
 
@@ -479,7 +479,7 @@ const lowerMessages = Effect.fn("AnthropicMessages.lowerMessages")(function* (
         cache_control: cacheControl(breakpoints, part.cache),
       })
     }
-    ProviderShared.appendUserMessage(messages, { role: "user", content }) // kilocode_change
+    ProviderShared.appendUserMessage(messages, { role: "user", content }, "content") // kilocode_change
   }
 
   return messages

--- a/packages/llm/src/protocols/bedrock-converse.ts
+++ b/packages/llm/src/protocols/bedrock-converse.ts
@@ -330,7 +330,10 @@ const lowerMessages = Effect.fn("BedrockConverse.lowerMessages")(function* (
           continue
         }
       }
-      messages.push({ role: "user", content })
+      const previous = messages.at(-1) // kilocode_change
+      if (previous?.role === "user") // kilocode_change
+        messages[messages.length - 1] = { role: "user", content: [...previous.content, ...content] } // kilocode_change
+      else messages.push({ role: "user", content }) // kilocode_change
       continue
     }
 
@@ -372,7 +375,10 @@ const lowerMessages = Effect.fn("BedrockConverse.lowerMessages")(function* (
       const cachePoint = BedrockCache.block(breakpoints, part.cache)
       if (cachePoint) content.push(cachePoint)
     }
-    messages.push({ role: "user", content })
+    const previous = messages.at(-1) // kilocode_change
+    if (previous?.role === "user") // kilocode_change
+      messages[messages.length - 1] = { role: "user", content: [...previous.content, ...content] } // kilocode_change
+    else messages.push({ role: "user", content }) // kilocode_change
   }
 
   return messages

--- a/packages/llm/src/protocols/bedrock-converse.ts
+++ b/packages/llm/src/protocols/bedrock-converse.ts
@@ -309,10 +309,7 @@ const lowerMessages = Effect.fn("BedrockConverse.lowerMessages")(function* (
     if (message.role === "system") {
       const part = yield* ProviderShared.wrappedSystemUpdate("Bedrock Converse", message)
       const content = textWithCache(breakpoints, part.text, part.cache)
-      const previous = messages.at(-1)
-      if (previous?.role === "user")
-        messages[messages.length - 1] = { role: "user", content: [...previous.content, ...content] }
-      else messages.push({ role: "user", content })
+      ProviderShared.appendUserMessage(messages, { role: "user", content }) // kilocode_change
       continue
     }
 
@@ -330,10 +327,7 @@ const lowerMessages = Effect.fn("BedrockConverse.lowerMessages")(function* (
           continue
         }
       }
-      const previous = messages.at(-1) // kilocode_change
-      if (previous?.role === "user") // kilocode_change
-        messages[messages.length - 1] = { role: "user", content: [...previous.content, ...content] } // kilocode_change
-      else messages.push({ role: "user", content }) // kilocode_change
+      ProviderShared.appendUserMessage(messages, { role: "user", content }) // kilocode_change
       continue
     }
 
@@ -375,10 +369,7 @@ const lowerMessages = Effect.fn("BedrockConverse.lowerMessages")(function* (
       const cachePoint = BedrockCache.block(breakpoints, part.cache)
       if (cachePoint) content.push(cachePoint)
     }
-    const previous = messages.at(-1) // kilocode_change
-    if (previous?.role === "user") // kilocode_change
-      messages[messages.length - 1] = { role: "user", content: [...previous.content, ...content] } // kilocode_change
-    else messages.push({ role: "user", content }) // kilocode_change
+    ProviderShared.appendUserMessage(messages, { role: "user", content }) // kilocode_change
   }
 
   return messages

--- a/packages/llm/src/protocols/bedrock-converse.ts
+++ b/packages/llm/src/protocols/bedrock-converse.ts
@@ -309,7 +309,7 @@ const lowerMessages = Effect.fn("BedrockConverse.lowerMessages")(function* (
     if (message.role === "system") {
       const part = yield* ProviderShared.wrappedSystemUpdate("Bedrock Converse", message)
       const content = textWithCache(breakpoints, part.text, part.cache)
-      ProviderShared.appendUserMessage(messages, { role: "user", content }) // kilocode_change
+      ProviderShared.appendUserMessage(messages, { role: "user", content }, "content") // kilocode_change
       continue
     }
 
@@ -327,7 +327,7 @@ const lowerMessages = Effect.fn("BedrockConverse.lowerMessages")(function* (
           continue
         }
       }
-      ProviderShared.appendUserMessage(messages, { role: "user", content }) // kilocode_change
+      ProviderShared.appendUserMessage(messages, { role: "user", content }, "content") // kilocode_change
       continue
     }
 
@@ -369,7 +369,7 @@ const lowerMessages = Effect.fn("BedrockConverse.lowerMessages")(function* (
       const cachePoint = BedrockCache.block(breakpoints, part.cache)
       if (cachePoint) content.push(cachePoint)
     }
-    ProviderShared.appendUserMessage(messages, { role: "user", content }) // kilocode_change
+    ProviderShared.appendUserMessage(messages, { role: "user", content }, "content") // kilocode_change
   }
 
   return messages

--- a/packages/llm/src/protocols/gemini.ts
+++ b/packages/llm/src/protocols/gemini.ts
@@ -208,7 +208,7 @@ const lowerMessages = Effect.fn("Gemini.lowerMessages")(function* (request: LLMR
   for (const message of request.messages) {
     if (message.role === "system") {
       const part = yield* ProviderShared.wrappedSystemUpdate("Gemini", message)
-      ProviderShared.appendUserMessage(contents, { role: "user", parts: [{ text: part.text }] }) // kilocode_change
+      ProviderShared.appendUserMessage(contents, { role: "user", parts: [{ text: part.text }] }, "parts") // kilocode_change
       continue
     }
 
@@ -219,7 +219,7 @@ const lowerMessages = Effect.fn("Gemini.lowerMessages")(function* (request: LLMR
           return yield* ProviderShared.unsupportedContent("Gemini", "user", ["text", "media"])
         parts.push(yield* lowerUserPart(part))
       }
-      ProviderShared.appendUserMessage(contents, { role: "user", parts }) // kilocode_change
+      ProviderShared.appendUserMessage(contents, { role: "user", parts }, "parts") // kilocode_change
       continue
     }
 
@@ -278,7 +278,7 @@ const lowerMessages = Effect.fn("Gemini.lowerMessages")(function* (request: LLMR
         parts.push({ inlineData: { mimeType: media.mime, data: media.base64 } })
       }
     }
-    ProviderShared.appendUserMessage(contents, { role: "user", parts }) // kilocode_change
+    ProviderShared.appendUserMessage(contents, { role: "user", parts }, "parts") // kilocode_change
   }
 
   return contents

--- a/packages/llm/src/protocols/gemini.ts
+++ b/packages/llm/src/protocols/gemini.ts
@@ -222,7 +222,10 @@ const lowerMessages = Effect.fn("Gemini.lowerMessages")(function* (request: LLMR
           return yield* ProviderShared.unsupportedContent("Gemini", "user", ["text", "media"])
         parts.push(yield* lowerUserPart(part))
       }
-      contents.push({ role: "user", parts })
+      const previous = contents.at(-1) // kilocode_change
+      if (previous?.role === "user") // kilocode_change
+        contents[contents.length - 1] = { role: "user", parts: [...previous.parts, ...parts] } // kilocode_change
+      else contents.push({ role: "user", parts }) // kilocode_change
       continue
     }
 
@@ -281,7 +284,10 @@ const lowerMessages = Effect.fn("Gemini.lowerMessages")(function* (request: LLMR
         parts.push({ inlineData: { mimeType: media.mime, data: media.base64 } })
       }
     }
-    contents.push({ role: "user", parts })
+    const previous = contents.at(-1) // kilocode_change
+    if (previous?.role === "user") // kilocode_change
+      contents[contents.length - 1] = { role: "user", parts: [...previous.parts, ...parts] } // kilocode_change
+    else contents.push({ role: "user", parts }) // kilocode_change
   }
 
   return contents

--- a/packages/llm/src/protocols/gemini.ts
+++ b/packages/llm/src/protocols/gemini.ts
@@ -208,10 +208,7 @@ const lowerMessages = Effect.fn("Gemini.lowerMessages")(function* (request: LLMR
   for (const message of request.messages) {
     if (message.role === "system") {
       const part = yield* ProviderShared.wrappedSystemUpdate("Gemini", message)
-      const previous = contents.at(-1)
-      if (previous?.role === "user")
-        contents[contents.length - 1] = { role: "user", parts: [...previous.parts, { text: part.text }] }
-      else contents.push({ role: "user", parts: [{ text: part.text }] })
+      ProviderShared.appendUserMessage(contents, { role: "user", parts: [{ text: part.text }] }) // kilocode_change
       continue
     }
 
@@ -222,10 +219,7 @@ const lowerMessages = Effect.fn("Gemini.lowerMessages")(function* (request: LLMR
           return yield* ProviderShared.unsupportedContent("Gemini", "user", ["text", "media"])
         parts.push(yield* lowerUserPart(part))
       }
-      const previous = contents.at(-1) // kilocode_change
-      if (previous?.role === "user") // kilocode_change
-        contents[contents.length - 1] = { role: "user", parts: [...previous.parts, ...parts] } // kilocode_change
-      else contents.push({ role: "user", parts }) // kilocode_change
+      ProviderShared.appendUserMessage(contents, { role: "user", parts }) // kilocode_change
       continue
     }
 
@@ -284,10 +278,7 @@ const lowerMessages = Effect.fn("Gemini.lowerMessages")(function* (request: LLMR
         parts.push({ inlineData: { mimeType: media.mime, data: media.base64 } })
       }
     }
-    const previous = contents.at(-1) // kilocode_change
-    if (previous?.role === "user") // kilocode_change
-      contents[contents.length - 1] = { role: "user", parts: [...previous.parts, ...parts] } // kilocode_change
-    else contents.push({ role: "user", parts }) // kilocode_change
+    ProviderShared.appendUserMessage(contents, { role: "user", parts }) // kilocode_change
   }
 
   return contents

--- a/packages/llm/src/protocols/shared.ts
+++ b/packages/llm/src/protocols/shared.ts
@@ -108,6 +108,30 @@ export const parseJson = (route: string, input: string, message: string) =>
  */
 export const joinText = (parts: ReadonlyArray<{ readonly text: string }>) => parts.map((part) => part.text).join("\n")
 
+// kilocode_change start - preserve provider role alternation when tool results lower to user messages
+type UserMessage =
+  | { readonly role: "user"; readonly content: ReadonlyArray<unknown> }
+  | { readonly role: "user"; readonly parts: ReadonlyArray<unknown> }
+
+export const appendUserMessage = <Message extends { readonly role: string }, User extends Message & UserMessage>(
+  messages: Message[],
+  message: User,
+) => {
+  const previous = messages.at(-1)
+  if (previous?.role !== "user") {
+    messages.push(message)
+    return
+  }
+  if ("content" in message) {
+    const content = (previous as { readonly content: ReadonlyArray<unknown> }).content
+    messages[messages.length - 1] = { ...message, content: [...content, ...message.content] }
+    return
+  }
+  const parts = (previous as { readonly parts: ReadonlyArray<unknown> }).parts
+  messages[messages.length - 1] = { ...message, parts: [...parts, ...message.parts] }
+}
+// kilocode_change end
+
 const escapeSystemUpdateText = (text: string) =>
   text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
 

--- a/packages/llm/src/protocols/shared.ts
+++ b/packages/llm/src/protocols/shared.ts
@@ -109,26 +109,21 @@ export const parseJson = (route: string, input: string, message: string) =>
 export const joinText = (parts: ReadonlyArray<{ readonly text: string }>) => parts.map((part) => part.text).join("\n")
 
 // kilocode_change start - preserve provider role alternation when tool results lower to user messages
-type UserMessage =
-  | { readonly role: "user"; readonly content: ReadonlyArray<unknown> }
-  | { readonly role: "user"; readonly parts: ReadonlyArray<unknown> }
-
-export const appendUserMessage = <Message extends { readonly role: string }, User extends Message & UserMessage>(
+export const appendUserMessage = <
+  const Key extends "content" | "parts",
+  Part,
+  Message extends { readonly role: string } & Record<Key, ReadonlyArray<Part>>,
+>(
   messages: Message[],
-  message: User,
+  message: Message,
+  key: Key,
 ) => {
   const previous = messages.at(-1)
   if (previous?.role !== "user") {
     messages.push(message)
     return
   }
-  if ("content" in message) {
-    const content = (previous as { readonly content: ReadonlyArray<unknown> }).content
-    messages[messages.length - 1] = { ...message, content: [...content, ...message.content] }
-    return
-  }
-  const parts = (previous as { readonly parts: ReadonlyArray<unknown> }).parts
-  messages[messages.length - 1] = { ...message, parts: [...parts, ...message.parts] }
+  messages[messages.length - 1] = { ...message, [key]: [...previous[key], ...message[key]] } as Message
 }
 // kilocode_change end
 

--- a/packages/llm/test/provider/anthropic-messages.test.ts
+++ b/packages/llm/test/provider/anthropic-messages.test.ts
@@ -197,6 +197,7 @@ describe("Anthropic Messages route", () => {
             Message.user("What is the weather?"),
             Message.assistant([ToolCallPart.make({ id: "call_1", name: "lookup", input: { query: "weather" } })]),
             Message.tool({ id: "call_1", name: "lookup", result: { forecast: "sunny" } }),
+            Message.user("Summarize the result."), // kilocode_change - preserve Anthropic role alternation
           ],
           cache: "none",
         }),
@@ -210,7 +211,15 @@ describe("Anthropic Messages route", () => {
             role: "assistant",
             content: [{ type: "tool_use", id: "call_1", name: "lookup", input: { query: "weather" } }],
           },
-          { role: "user", content: [{ type: "tool_result", tool_use_id: "call_1", content: '{"forecast":"sunny"}' }] },
+          // kilocode_change start - adjacent user content is coalesced with tool results
+          {
+            role: "user",
+            content: [
+              { type: "tool_result", tool_use_id: "call_1", content: '{"forecast":"sunny"}' },
+              { type: "text", text: "Summarize the result." },
+            ],
+          },
+          // kilocode_change end
         ],
         stream: true,
         max_tokens: 4096,

--- a/packages/llm/test/provider/bedrock-converse.test.ts
+++ b/packages/llm/test/provider/bedrock-converse.test.ts
@@ -164,6 +164,7 @@ describe("Bedrock Converse route", () => {
             Message.user("What is the weather?"),
             Message.assistant([ToolCallPart.make({ id: "tool_1", name: "lookup", input: { query: "weather" } })]),
             Message.tool({ id: "tool_1", name: "lookup", result: { forecast: "sunny" } }),
+            Message.user("Summarize the result."), // kilocode_change - preserve Bedrock role alternation
           ],
           cache: "none",
         }),
@@ -186,6 +187,7 @@ describe("Bedrock Converse route", () => {
                   status: "success",
                 },
               },
+              { text: "Summarize the result." }, // kilocode_change - coalesce adjacent user content
             ],
           },
         ],

--- a/packages/llm/test/provider/gemini.test.ts
+++ b/packages/llm/test/provider/gemini.test.ts
@@ -73,6 +73,7 @@ describe("Gemini route", () => {
             ]),
             Message.assistant([ToolCallPart.make({ id: "call_1", name: "lookup", input: { query: "weather" } })]),
             Message.tool({ id: "call_1", name: "lookup", result: { forecast: "sunny" } }),
+            Message.user("Summarize the result."), // kilocode_change - preserve Gemini role alternation
           ],
         }),
       )
@@ -91,6 +92,7 @@ describe("Gemini route", () => {
             role: "user",
             parts: [
               { functionResponse: { name: "lookup", response: { name: "lookup", content: '{"forecast":"sunny"}' } } },
+              { text: "Summarize the result." }, // kilocode_change - coalesce adjacent user content
             ],
           },
         ],

--- a/packages/llm/test/provider/gemini.test.ts
+++ b/packages/llm/test/provider/gemini.test.ts
@@ -172,14 +172,16 @@ describe("Gemini route", () => {
         }),
       )
       expect(prepared.body.contents).toEqual([
-        { role: "user", parts: [{ inlineData: { mimeType: "image/png", data: "AAEC" } }] },
+        // kilocode_change start - adjacent user-compatible content is coalesced
         {
           role: "user",
           parts: [
+            { inlineData: { mimeType: "image/png", data: "AAEC" } },
             { functionResponse: { name: "read", response: { name: "read", content: "" } } },
             { inlineData: { mimeType: "image/jpeg", data: "/9j/" } },
           ],
         },
+        // kilocode_change end
       ])
     }),
   )

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1772,7 +1772,7 @@ export const layer = Layer.effect(
             system,
             messages: [
               ...modelMsgs,
-              ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS_PROMPT }] : []),
+              ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS_PROMPT }] : []), // kilocode_change - avoid provider-incompatible assistant prefill
             ],
             tools,
             model,

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -577,9 +577,7 @@ it.instance(
       if (!Array.isArray(messages)) throw new Error("expected LLM messages")
       expect(messages.at(-1)).toMatchObject({
         role: "user",
-        content: expect.arrayContaining([
-          { type: "text", text: expect.stringContaining("MAXIMUM STEPS REACHED") },
-        ]),
+        content: expect.stringContaining("MAXIMUM STEPS REACHED"),
       })
     }),
   30_000,

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -550,6 +550,42 @@ it.instance("loop calls LLM and returns assistant message", () =>
   }),
 )
 
+// kilocode_change start - guard provider-compatible max-step request shape
+it.instance(
+  "loop sends max steps instruction as a user message",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig((url) => ({
+        ...providerCfg(url),
+        agent: { build: { steps: 1 } },
+      }))
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Pinned" })
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "finish at the limit" }],
+      })
+      yield* llm.text("summary")
+
+      yield* prompt.loop({ sessionID: chat.id })
+
+      const inputs = yield* llm.inputs
+      const messages = inputs.at(-1)?.messages
+      if (!Array.isArray(messages)) throw new Error("expected LLM messages")
+      expect(messages.at(-1)).toMatchObject({
+        role: "user",
+        content: expect.arrayContaining([
+          { type: "text", text: expect.stringContaining("MAXIMUM STEPS REACHED") },
+        ]),
+      })
+    }),
+  30_000,
+)
+// kilocode_change end
+
 noLLMServer.instance(
   "new prompt dismisses a pending question",
   () =>


### PR DESCRIPTION
## What changed

Send the final max-step summary instruction as a synthetic user message in both session runtimes instead of appending it as assistant output. Add request-shape regression coverage for both paths.

## Why

An assistant message at the end of a request is interpreted as response prefill. Providers that do not support assistant prefill, including Anthropic models with thinking enabled, reject the final step instead of letting the agent summarize its work. A user message correctly represents the instruction and keeps the request compatible across providers.