### PR TITLE
fix(cli): sanitize Codex cache controls for GPT-5.6+

### DIFF
--- a/.changeset/fix-codex-cache-controls.md
+++ b/.changeset/fix-codex-cache-controls.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent GPT-5.6 ChatGPT subscription subagents from failing on unsupported prompt cache settings.

--- a/packages/opencode/src/kilocode/plugin/openai/codex.ts
+++ b/packages/opencode/src/kilocode/plugin/openai/codex.ts
@@ -1,0 +1,25 @@
+export function sanitize(body: RequestInit["body"]) {
+  if (typeof body !== "string") return body
+
+  try {
+    const parsed = JSON.parse(body) as unknown
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return body
+
+    const payload = parsed as Record<string, unknown>
+    if (typeof payload.model !== "string") return body
+
+    const match = payload.model.match(/^gpt-(\d+)\.(\d+)/)
+    if (!match) return body
+
+    const major = Number(match[1])
+    const minor = Number(match[2])
+    if (major < 5 || (major === 5 && minor < 6)) return body
+    if (!("prompt_cache_retention" in payload) && !("prompt_cache_options" in payload)) return body
+
+    delete payload.prompt_cache_retention
+    delete payload.prompt_cache_options
+    return JSON.stringify(payload)
+  } catch {
+    return body
+  }
+}

--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -7,6 +7,7 @@ import os from "os"
 import { setTimeout as sleep } from "node:timers/promises"
 import { createServer } from "http"
 import { refreshCodexAuth } from "@/kilocode/provider/codex-refresh" // kilocode_change
+import { sanitize } from "@/kilocode/plugin/openai/codex" // kilocode_change
 import { OpenAIWebSocketPool } from "./ws-pool"
 
 const log = Log.create({ service: "plugin.codex" }) // kilocode_change
@@ -529,7 +530,12 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
 
             const requestInit = {
               ...init,
-              body: init?.body,
+              // kilocode_change start
+              body:
+                parsed.pathname.includes("/v1/responses") || parsed.pathname.includes("/chat/completions")
+                  ? sanitize(init?.body)
+                  : init?.body,
+              // kilocode_change end
               headers,
             }
             if (websocketFetch && parsed.pathname.endsWith("/responses")) return websocketFetch(url, requestInit)

--- a/packages/opencode/test/kilocode/plugin/openai/codex-cache.test.ts
+++ b/packages/opencode/test/kilocode/plugin/openai/codex-cache.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test"
+import { CodexAuthPlugin } from "@/plugin/openai/codex"
+
+describe("Codex OAuth cache controls", () => {
+  test("removes unsupported GPT-5.6+ cache fields from forwarded requests", async () => {
+    const bodies: string[] = []
+    using server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        bodies.push(await request.text())
+        return new Response("{}", { status: 200 })
+      },
+    })
+    const hooks = await CodexAuthPlugin({} as never, {
+      codexApiEndpoint: new URL("/backend-api/codex/responses", server.url).toString(),
+    })
+    const loaded = await hooks.auth!.loader!(
+      async () =>
+        ({
+          type: "oauth",
+          refresh: "refresh",
+          access: "access",
+          expires: Date.now() + 60_000,
+        }) as never,
+      {} as never,
+    )
+    const send = (body: RequestInit["body"]) =>
+      loaded.fetch!("https://api.openai.com/v1/responses", {
+        method: "POST",
+        body,
+      })
+
+    await send(
+      JSON.stringify({
+        model: "gpt-5.6-luna",
+        prompt_cache_retention: "24h",
+        prompt_cache_options: { mode: "explicit", ttl: "30m" },
+        prompt_cache_key: "session-1",
+        input: "hello",
+      }),
+    )
+    await send(
+      JSON.stringify({
+        model: "gpt-5.6-sol-fast",
+        prompt_cache_retention: "in_memory",
+        input: "hello",
+      }),
+    )
+    await send(
+      JSON.stringify({
+        model: "gpt-5.5",
+        prompt_cache_retention: "24h",
+        prompt_cache_options: { ttl: "1h" },
+        input: "hello",
+      }),
+    )
+    const unchanged = '{\n  "model": "gpt-5.6-terra",\n  "input": "hello"\n}'
+    await send(unchanged)
+    await send("{not-json")
+    await send(new URLSearchParams({ model: "gpt-5.6-luna", prompt_cache_retention: "24h" }))
+
+    expect(JSON.parse(bodies[0]!)).toEqual({
+      model: "gpt-5.6-luna",
+      prompt_cache_key: "session-1",
+      input: "hello",
+    })
+    expect(JSON.parse(bodies[1]!)).toEqual({
+      model: "gpt-5.6-sol-fast",
+      input: "hello",
+    })
+    expect(JSON.parse(bodies[2]!)).toEqual({
+      model: "gpt-5.5",
+      prompt_cache_retention: "24h",
+      prompt_cache_options: { ttl: "1h" },
+      input: "hello",
+    })
+    expect(bodies[3]).toBe(unchanged)
+    expect(bodies[4]).toBe("{not-json")
+    expect(bodies[5]).toBe("model=gpt-5.6-luna&prompt_cache_retention=24h")
+  })
+})


### PR DESCRIPTION
## Issue

Fixes #13220

## Context

ChatGPT subscription requests for GPT-5.6 variants can include prompt cache fields that the Codex backend rejects, causing Task/subagent calls to fail with HTTP 400.

## Implementation

At the Codex OAuth forwarding boundary, remove `prompt_cache_retention` and `prompt_cache_options` from GPT-5.6+ JSON request bodies. Older models, clean or malformed JSON, and non-string bodies remain unchanged; `prompt_cache_key` is preserved.

## Screenshots / Video

N/A - runtime request handling only.

## How to Test

### Manual/local verification

- Agent-executed: `bun test test/kilocode/plugin/openai/codex-cache.test.ts test/plugin/codex.test.ts` (20 passed)
- Agent-executed: `bun run typecheck`
- Agent-executed: `bun run script/check-opencode-annotations.ts --worktree`
- Pre-push: 29 non-JetBrains package typechecks passed

### Reviewer test steps

1. Forward a GPT-5.6 OAuth Responses request containing `prompt_cache_retention` and `prompt_cache_options`.
2. Confirm the Codex endpoint receives neither unsupported field while retaining `prompt_cache_key`.
3. Confirm GPT-5.5 and non-JSON/non-string bodies remain unchanged.

### Blocked checks and substitute verification

- `@kilocode/kilo-jetbrains` typecheck could not start because Gradle 9.4.1 requires JVM 17+ and this machine only has JVM 15. The change does not touch JetBrains sources; the CLI unit tests, package typecheck, repository annotation check, and all 29 non-JetBrains pre-push typechecks passed.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [ ] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch
