### PR TITLE
fix(vscode): expose skills in worktree prompt

### DIFF
--- a/.changeset/worktree-relative-skills.md
+++ b/.changeset/worktree-relative-skills.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Make project skills available as slash commands while composing a new Agent Manager worktree.

--- a/packages/kilo-vscode/tests/unit/agent-manager-new-worktree-project.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-new-worktree-project.test.ts
@@ -40,6 +40,12 @@ describe("Agent Manager New Worktree project targeting", () => {
     expect(css).toContain('[data-component="dialog"]:has(.am-nv-project-inline [data-component="popover-content"])')
   })
 
+  it("keeps project skills available in the worktree prompt", () => {
+    expect(dialog).toContain("WORKTREE_PROMPT_COMMAND_SOURCES")
+    expect(dialog).toContain('new Set<NonNullable<SlashCommandInfo["source"]>>(["skill"])')
+    expect(dialog).toContain("WORKTREE_PROMPT_COMMAND_SOURCES,\n  )")
+  })
+
   it("keeps project activation separate from accordion expansion", () => {
     const header = readFileSync(join(root, "webview-ui", "agent-manager", "SidebarSectionHeader.tsx"), "utf8")
     const projects = readFileSync(join(root, "webview-ui", "agent-manager", "ProjectsSection.tsx"), "utf8")

--- a/packages/kilo-vscode/tests/unit/use-slash-command.test.ts
+++ b/packages/kilo-vscode/tests/unit/use-slash-command.test.ts
@@ -10,6 +10,7 @@ function setup(
     exclude?: () => Set<string>
     include?: Set<string>
     extra?: SlashCommandEntry[]
+    includeSources?: Set<"command" | "mcp" | "skill">
   } = {},
 ) {
   const sent: WebviewMessage[] = []
@@ -29,6 +30,7 @@ function setup(
       options.include,
       undefined,
       options.extra,
+      options.includeSources,
     ),
   }))
   const fire = (message: ExtensionMessage) => {
@@ -127,6 +129,25 @@ describe("useSlashCommand sandbox action", () => {
 
     ctx.slash.onInput("/models", 7)
     expect(ctx.slash.results().map((command) => command.name)).toEqual(["models"])
+    ctx.dispose()
+  })
+
+  it("keeps skill commands available when the worktree menu restricts built-ins", () => {
+    const ctx = setup(() => {}, {
+      include: new Set(["models", "agents", "variant", "sandbox"]),
+      includeSources: new Set(["skill"]),
+    })
+
+    ctx.fire({
+      type: "commandsLoaded",
+      commands: [
+        { name: "project-skill", description: "A relative-path project skill", source: "skill", hints: [] },
+        { name: "project-command", description: "A regular project command", source: "command", hints: [] },
+      ],
+    })
+
+    ctx.slash.onInput("/project", 8)
+    expect(ctx.slash.results().map((command) => command.name)).toEqual(["project-skill"])
     ctx.dispose()
   })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -10,6 +10,7 @@ import type {
   BranchInfo,
   EnhancePromptResultMessage,
   EnhancePromptErrorMessage,
+  SlashCommandInfo,
 } from "../src/types/messages"
 import { Dialog } from "@kilocode/kilo-ui/dialog"
 import { showToast } from "@kilocode/kilo-ui/toast"
@@ -56,6 +57,7 @@ import { createDialogModels } from "./new-worktree-models"
 type VersionCount = 1 | 2 | 3 | 4
 const VERSION_OPTIONS: VersionCount[] = [1, 2, 3, 4]
 const WORKTREE_PROMPT_COMMANDS = new Set(["models", "agents", "variant", "sandbox", "project"])
+const WORKTREE_PROMPT_COMMAND_SOURCES = new Set<NonNullable<SlashCommandInfo["source"]>>(["skill"])
 const WORKTREE_PROMPT_SCOPE = "agent-manager-worktree-prompt"
 
 type DialogTab = "new" | "import"
@@ -364,6 +366,7 @@ export const NewWorktreeDialog: Component<{
         action: () => setProjectOpen(true),
       },
     ],
+    WORKTREE_PROMPT_COMMAND_SOURCES,
   )
   const onFocusPrompt = () => restorePrompt()
   window.addEventListener("focusPrompt", onFocusPrompt)

--- a/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
@@ -59,6 +59,7 @@ export function useSlashCommand(
   include?: Set<string> | Accessor<Set<string>>,
   scope?: string,
   extra?: SlashCommandEntry[],
+  includeSources?: ReadonlySet<NonNullable<SlashCommandInfo["source"]>>,
 ): SlashCommand {
   const [server, setServer] = createSignal<SlashCommandInfo[]>([])
   const [query, setQuery] = createSignal<string | null>(null)
@@ -225,10 +226,13 @@ export function useSlashCommand(
     return include
   }
 
+  const includedBySource = (command: SlashCommandEntry) =>
+    command.source !== undefined && includeSources?.has(command.source)
+
   const client = () => {
     const set = excluded()
     const only = included()
-    return all.filter((c) => !set?.has(c.name) && (!only || only.has(c.name)))
+    return all.filter((c) => !set?.has(c.name) && (!only || only.has(c.name) || includedBySource(c)))
   }
 
   const commands = (): SlashCommandEntry[] => {
@@ -236,7 +240,9 @@ export function useSlashCommand(
     const names = new Set(list.map((c) => c.name))
     const set = excluded()
     const only = included()
-    const filtered = server().filter((c) => !names.has(c.name) && !set?.has(c.name) && (!only || only.has(c.name)))
+    const filtered = server().filter(
+      (c) => !names.has(c.name) && !set?.has(c.name) && (!only || only.has(c.name) || includedBySource(c)),
+    )
     return [...list, ...filtered]
   }
 


### PR DESCRIPTION
## Summary

- let the Agent Manager worktree prompt include slash commands backed by discovered skills
- keep the existing name whitelist for built-in configuration actions and continue hiding regular project commands
- add hook-level and dialog call-site regressions

## Why

Project skills configured through relative `skills.paths` are already exposed by the CLI as commands with `source: "skill"`, but the worktree dialog's name-only whitelist filtered them out before a worktree session existed. The selected skill command is later executed inside the newly created worktree session, so allowing only skill-sourced entries makes relative-path skills selectable without broadening the dialog to arbitrary commands.

Fixes #13281

## Testing

- `bun test tests/unit/use-slash-command.test.ts tests/unit/agent-manager-new-worktree-project.test.ts` (30 passed)
- `prettier@3.6.2 --write` on the changed files
- confirmed the regression test failed before the fix (expected `project-skill`, received no result) and passed after it
