### PR TITLE
feat(cli): let websearch tool pick Exa or Parallel

### DIFF
--- a/.changeset/websearch-provider-param.md
+++ b/.changeset/websearch-provider-param.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+The `websearch` tool now accepts a `provider` parameter (`"exa"` or `"parallel"`) so an agent can pick the backend that fits the question. Defaults to `"exa"` instead of round-robin per session. Exa is preferred for primary-source research (arXiv, vendor papers, model cards with deep content extraction); Parallel is preferred for specific facts, current pricing/comparisons, leaderboards, and compound questions that benefit from multi-query fan-out.

--- a/packages/opencode/src/tool/websearch.ts
+++ b/packages/opencode/src/tool/websearch.ts
@@ -3,7 +3,6 @@ import { HttpClient } from "effect/unstable/http"
 import * as Tool from "./tool"
 import * as McpWebSearch from "./mcp-websearch"
 import DESCRIPTION from "./websearch.txt"
-import { checksum } from "@opencode-ai/core/util/encode"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 
@@ -22,19 +21,32 @@ export const Parameters = Schema.Struct({
   contextMaxCharacters: Schema.optional(Schema.Number).annotate({
     description: "Maximum characters for context string optimized for LLMs (default: 10000)",
   }),
+  // kilocode_change start - agent-selectable provider
+  provider: Schema.optional(Schema.Literals(["exa", "parallel"])).annotate({
+    description:
+      "Which backend to use. Prefer 'exa' for primary-source research and topic exploration (canonical sources like arXiv, vendor papers, model cards with deep content extraction). Prefer 'parallel' for specific facts, current pricing/comparisons, leaderboards, or compound questions that benefit from multi-query fan-out. Defaults to 'exa'.",
+  }),
+  // kilocode_change end
 })
 
 const WebSearchProviderSchema = Schema.Literals(["exa", "parallel"])
 export type WebSearchProvider = Schema.Schema.Type<typeof WebSearchProviderSchema>
 
-export function selectWebSearchProvider(sessionID: string, flags = { exa: false, parallel: false }): WebSearchProvider {
+// kilocode_change start - agent-selectable provider with flag kill-switch
+export function selectWebSearchProvider(
+  sessionID: string,
+  flags = { exa: false, parallel: false },
+  explicit?: WebSearchProvider,
+): WebSearchProvider {
+  if (flags.parallel && !flags.exa) return "parallel"
+  if (flags.exa && !flags.parallel) return "exa"
+  if (explicit === "exa" || explicit === "parallel") return explicit
   const override = process.env.KILO_WEBSEARCH_PROVIDER
   if (override === "exa" || override === "parallel") return override
-  if (flags.parallel) return "parallel"
-  if (flags.exa) return "exa"
 
-  return Number.parseInt(checksum(sessionID) ?? "0", 36) % 2 === 0 ? "exa" : "parallel"
+  return "exa"
 }
+// kilocode_change end
 
 export function webSearchProviderLabel(provider: unknown) {
   if (provider === "parallel") return "Parallel Web Search"
@@ -109,10 +121,13 @@ export const WebSearchTool = Tool.define(
       parameters: Parameters,
       execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
         Effect.gen(function* () {
-          const provider = selectWebSearchProvider(ctx.sessionID, {
-            exa: flags.enableExa,
-            parallel: flags.enableParallel,
-          })
+          // kilocode_change start - pass agent-chosen provider
+          const provider = selectWebSearchProvider(
+            ctx.sessionID,
+            { exa: flags.enableExa, parallel: flags.enableParallel },
+            params.provider,
+          )
+          // kilocode_change end
           const title = webSearchProviderLabel(provider)
           yield* ctx.metadata({ title: `${title} "${params.query}"`, metadata: { provider } })
 

--- a/packages/opencode/src/tool/websearch.txt
+++ b/packages/opencode/src/tool/websearch.txt
@@ -12,3 +12,9 @@ Usage notes:
 
 The current year is {{year}}. You MUST use this year when searching for recent information or current events
 - Example: If the current year is 2026 and the user asks for "latest AI news", search for "AI news 2026", NOT "AI news 2025"
+
+Picking a backend (`provider` parameter):
+- Prefer Exa for primary-source research. When the question is "what is X", "how does X work", or "what does vendor Y say", Exa surfaces canonical sources (vendor research pages, arXiv papers, official model cards) and extracts them deeply, so one call is usually enough to read.
+- Prefer Parallel for specific facts and rankings. When the question is "what does X cost", "which models support Y today", or any comparison/leaderboard question, Parallel returns sharper, more current answers and can decompose compound questions via multi-query fan-out.
+- If the answer is one or two facts (a price, a name, a date) -> Parallel. If you need to actually understand a topic by reading a primary source -> Exa. If the question has multiple sub-questions -> Parallel. If you need citation-worthy primary references -> Exa.
+- Default is Exa.

--- a/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
+++ b/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
@@ -465,6 +465,14 @@ exports[`tool parameters JSON Schema (wire shape) websearch 1`] = `
       "description": "Number of search results to return (default: 8)",
       "type": "number",
     },
+    "provider": {
+      "description": "Which backend to use. Prefer 'exa' for primary-source research and topic exploration (canonical sources like arXiv, vendor papers, model cards with deep content extraction). Prefer 'parallel' for specific facts, current pricing/comparisons, leaderboards, or compound questions that benefit from multi-query fan-out. Defaults to 'exa'.",
+      "enum": [
+        "exa",
+        "parallel",
+      ],
+      "type": "string",
+    },
     "query": {
       "description": "Websearch query",
       "type": "string",

--- a/packages/opencode/test/tool/websearch.test.ts
+++ b/packages/opencode/test/tool/websearch.test.ts
@@ -10,9 +10,30 @@ import { ProviderV2 } from "@opencode-ai/core/provider"
 const SESSION_ID = "ses_0196aabbccddeeff001122334455"
 
 describe("websearch provider", () => {
-  test("selects a stable provider per session", () => {
-    expect(selectWebSearchProvider(SESSION_ID)).toBe(selectWebSearchProvider(SESSION_ID))
+  // kilocode_change start - default to Exa
+  test("defaults to Exa when nothing is configured", () => {
+    expect(selectWebSearchProvider(SESSION_ID)).toBe("exa")
   })
+  // kilocode_change end
+
+  // kilocode_change start - agent-selectable provider, but flags are a kill-switch
+  test("flags kill-switch overrules agent and env", () => {
+    const original = process.env.KILO_WEBSEARCH_PROVIDER
+    try {
+      process.env.KILO_WEBSEARCH_PROVIDER = "parallel"
+      expect(selectWebSearchProvider(SESSION_ID, { exa: false, parallel: true }, "exa")).toBe("parallel")
+      expect(selectWebSearchProvider(SESSION_ID, { exa: true, parallel: false }, "parallel")).toBe("exa")
+    } finally {
+      if (original === undefined) delete process.env.KILO_WEBSEARCH_PROVIDER
+      else process.env.KILO_WEBSEARCH_PROVIDER = original
+    }
+  })
+
+  test("agent choice wins when no kill-switch flag is set", () => {
+    expect(selectWebSearchProvider(SESSION_ID, { exa: false, parallel: false }, "parallel")).toBe("parallel")
+    expect(selectWebSearchProvider(SESSION_ID, { exa: false, parallel: false }, "exa")).toBe("exa")
+  })
+  // kilocode_change end
 
   test("supports an operational override", () => {
     const original = process.env.KILO_WEBSEARCH_PROVIDER


### PR DESCRIPTION
Reopen of PR #12471

## Issue

Closes #12480

## Context

The `websearch` tool round-robined between Exa and Parallel based on a checksum of the session ID, with no way for the agent to pick a backend. The two providers return meaningfully different result shapes, so for some questions the round-robin picks the wrong tool. Exposing a `provider` parameter (`"exa" | "parallel"`) and defaulting the selector to `"exa"` lets the agent steer toward the backend that fits the question.

## Implementation

The change is confined to the Kilo websearch tool override in `packages/opencode/src/tool/`. The `Parameters` schema gains an optional `provider` field annotated with guidance on when to pick Exa (primary-source research, deep extraction) vs Parallel (specific facts, pricing/leaderboards, compound questions). `selectWebSearchProvider` now accepts an explicit `provider` argument that wins over `KILO_WEBSEARCH_PROVIDER`, the `enableParallel` / `enableExa` runtime flags, and the default; the default itself is now `"exa"` instead of the session round-robin. The tool description (`websearch.txt`) gets the matching guidance appended so the model sees it. The now-unused `checksum` import is removed.

- Tested via `bun test ./test/tool/websearch.test.ts` and added cases for the new default and for explicit-override precedence.
- Added a patch changeset at `.changeset/websearch-provider-param.md`.

## Screenshots / Video

<img width="1453" height="803" alt="image" src="https://github.com/user-attachments/assets/703b931c-c35d-45a9-931c-46e591258086" />

## How to Test

### Manual/local verification

- In a session, ask an agent to call the `websearch` tool with `{"query": "what is constitutional AI", "provider": "exa"}` and confirm the result set skews to primary sources and the metadata records `"provider": "exa"`. Repeat with `provider: "parallel"` and confirm the result set skews to aggregation blogs and vender docs.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

Discord: @IamCoder18