### PR TITLE
feat(cli): add `kilo auth token` for scripting

### DIFF
--- a/.changeset/kilo-auth-token.md
+++ b/.changeset/kilo-auth-token.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Add `kilo auth token [provider]` to print a configured provider's credential to stdout for scripting. Defaults to the `kilo` provider; supports `api`, `oauth`, and `wellknown` credential types. `--help` lists every configured provider.

--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -18,6 +18,7 @@ import { errorMessage } from "@/util/error"
 import { text } from "node:stream/consumers"
 import { Effect, Option } from "effect"
 import { remove as removeAuth } from "@/kilocode/auth/remove" // kilocode_change
+import { TokenCommand } from "@/kilocode/cli/cmd/auth-token" // kilocode_change
 
 type PluginAuth = NonNullable<Hooks["auth"]>
 
@@ -244,7 +245,14 @@ export const ProvidersCommand = cmd({
   // kilocode_change end
   describe: "manage AI providers and credentials",
   builder: (yargs) =>
-    yargs.command(ProvidersListCommand).command(ProvidersLoginCommand).command(ProvidersLogoutCommand).demandCommand(),
+    // kilocode_change start - TokenCommand prints the active provider token to stdout for scripting
+    yargs
+      .command(ProvidersListCommand)
+      .command(ProvidersLoginCommand)
+      .command(ProvidersLogoutCommand)
+      .command(TokenCommand)
+      .demandCommand(),
+  // kilocode_change end
   async handler() {},
 })
 

--- a/packages/opencode/src/kilocode/cli/cmd/auth-token.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/auth-token.ts
@@ -1,0 +1,90 @@
+import { Effect, Option } from "effect"
+import fs from "fs"
+import path from "path"
+import type { Argv } from "yargs"
+import { Auth } from "@/auth"
+import { Global } from "@opencode-ai/core/global"
+import { CliError, effectCmd } from "@/cli/effect-cmd"
+
+const DEFAULT_PROVIDER = "kilo"
+export const AUTH_FILE = path.join(Global.Path.data, "auth.json")
+
+export const tokenFor = (info: Auth.Info): Option.Option<string> => {
+  switch (info.type) {
+    case "oauth":
+      return Option.some(info.access)
+    case "api":
+      return Option.some(info.key)
+    case "wellknown":
+      return Option.some(info.token)
+  }
+}
+
+export const resolveProvider = (input: string | undefined, known: readonly string[]): string => {
+  if (!input) return DEFAULT_PROVIDER
+  const lower = input.toLowerCase()
+  return known.find((id) => id.toLowerCase() === lower) ?? input
+}
+
+export const listConfiguredProviders = (): string[] => {
+  const raw = process.env.KILO_AUTH_CONTENT
+  if (raw) {
+    try {
+      return Object.keys(JSON.parse(raw) as Record<string, unknown>)
+    } catch {
+      // Mirrors `Auth.all`: a malformed `KILO_AUTH_CONTENT` falls through to reading auth.json.
+    }
+  }
+  try {
+    return Object.keys(JSON.parse(fs.readFileSync(AUTH_FILE, "utf8")) as Record<string, unknown>)
+  } catch {
+    return []
+  }
+}
+
+export interface RunInput {
+  provider?: string
+  all: Record<string, Auth.Info>
+  write: (chunk: string) => void
+}
+
+export const run = Effect.fn("KiloAuthToken.run")(function* (input: RunInput) {
+  const provider = resolveProvider(input.provider, Object.keys(input.all))
+  const info = input.all[provider]
+
+  if (!info) {
+    const known = Object.keys(input.all)
+    const hint = known.length
+      ? ` Configured providers: ${known.join(", ")}.`
+      : " Run `kilo auth login` to authenticate."
+    return yield* Effect.fail(new CliError({ message: `Not authenticated with "${provider}".${hint}` }))
+  }
+
+  const token = tokenFor(info)
+  if (Option.isNone(token)) {
+    return yield* Effect.fail(new CliError({ message: `No token available for "${provider}".` }))
+  }
+  input.write(token.value + "\n")
+})
+
+export const TokenCommand = effectCmd({
+  command: "token [provider]",
+  describe: "print the authentication token for a configured provider (default: kilo)",
+  // Reads only the global auth file; no project instance needed.
+  instance: false,
+  builder: (yargs: Argv) => {
+    const configured = listConfiguredProviders()
+    const positional = configured.length
+      ? `provider id to print the token for (default: kilo; configured: ${configured.join(", ")})`
+      : "provider id to print the token for (default: kilo; no providers configured — run `kilo auth login`)"
+    const epilog = configured.length
+      ? `Configured providers:\n  ${configured.join("\n  ")}`
+      : "No providers configured. Run `kilo auth login` to authenticate."
+    return yargs.positional("provider", { describe: positional, type: "string" }).epilog(epilog)
+  },
+  handler: Effect.fn("Cli.providers.token")(function* (args) {
+    const auth = yield* Auth.Service
+    const all = yield* Effect.orDie(auth.all())
+    yield* run({ provider: args.provider, all, write: (chunk) => process.stdout.write(chunk) })
+  }),
+})

--- a/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
+++ b/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
@@ -161,6 +161,8 @@ Commands:
   kilo providers list               list providers and credentials                 [aliases: ls]
   kilo providers login [url]        log in to a provider
   kilo providers logout [provider]  log out from a configured provider
+  kilo providers token [provider]   print the authentication token for a configured provider
+                                    (default: kilo)
 
 Options:
   -h, --help        show help                                                              [boolean]
@@ -553,6 +555,26 @@ Options:
       --print-logs  print logs to stderr                                                   [boolean]
       --log-level   log level                   [string] [choices: "DEBUG", "INFO", "WARN", "ERROR"]
       --pure        run without external plugins                                           [boolean]
+"
+`;
+
+exports[`Kilo CLI help-text snapshots every documented command emits stable help text: kilo providers token --help 1`] = `
+"kilo providers token [provider]
+
+print the authentication token for a configured provider (default: kilo)
+
+Positionals:
+  provider  provider id to print the token for (default: kilo; no providers configured — run \`kilo
+            auth login\`)                                                                    [string]
+
+Options:
+  -h, --help        show help                                                              [boolean]
+  -v, --version     show version number                                                    [boolean]
+      --print-logs  print logs to stderr                                                   [boolean]
+      --log-level   log level                   [string] [choices: "DEBUG", "INFO", "WARN", "ERROR"]
+      --pure        run without external plugins                                           [boolean]
+
+No providers configured. Run \`kilo auth login\` to authenticate.
 "
 `;
 

--- a/packages/opencode/test/cli/help/help-snapshots.test.ts
+++ b/packages/opencode/test/cli/help/help-snapshots.test.ts
@@ -90,6 +90,7 @@ const SUBCOMMANDS = [
   ["providers", "list"],
   ["providers", "login"],
   ["providers", "logout"],
+  ["providers", "token"], // kilocode_change - kilo auth token subcommand
   ["agent", "create"],
   ["agent", "list"],
   ["session", "list"],

--- a/packages/opencode/test/kilocode/cli/auth-token.test.ts
+++ b/packages/opencode/test/kilocode/cli/auth-token.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import fs from "fs"
+import path from "path"
+import { Cause, Effect, Exit, Option } from "effect"
+import { CliError } from "../../../src/cli/effect-cmd"
+import {
+  AUTH_FILE,
+  listConfiguredProviders,
+  resolveProvider,
+  run,
+  tokenFor,
+} from "../../../src/kilocode/cli/cmd/auth-token"
+
+const apiKey = { type: "api", key: "kilo-key" } as const
+const oauth = { type: "oauth", refresh: "r", access: "oauth-access", expires: 0 } as const
+const wellknown = { type: "wellknown", key: "k", token: "wk-token" } as const
+
+const runPromise = <A, E>(eff: Effect.Effect<A, E>) => Effect.runPromiseExit(eff)
+
+describe("auth token: tokenFor", () => {
+  test("returns the api key for api credentials", () => {
+    expect(Option.getOrUndefined(tokenFor(apiKey))).toBe("kilo-key")
+  })
+
+  test("returns the access token for oauth credentials", () => {
+    expect(Option.getOrUndefined(tokenFor(oauth))).toBe("oauth-access")
+  })
+
+  test("returns the token for wellknown credentials", () => {
+    expect(Option.getOrUndefined(tokenFor(wellknown))).toBe("wk-token")
+  })
+})
+
+describe("auth token: resolveProvider", () => {
+  const known = ["kilo", "openai", "anthropic"]
+
+  test("defaults to kilo when no provider is given", () => {
+    expect(resolveProvider(undefined, known)).toBe("kilo")
+  })
+
+  test("returns the requested provider when it matches a known id exactly", () => {
+    expect(resolveProvider("openai", known)).toBe("openai")
+  })
+
+  test("matches the provider id case-insensitively", () => {
+    expect(resolveProvider("Anthropic", known)).toBe("anthropic")
+  })
+
+  test("passes the input through when no known provider matches", () => {
+    expect(resolveProvider("custom", known)).toBe("custom")
+  })
+})
+
+describe("auth token: run", () => {
+  test("prints the kilo api key when no provider is given", async () => {
+    const writes: string[] = []
+    const exit = await runPromise(
+      run({ all: { kilo: apiKey, openai: { type: "api", key: "openai-key" } }, write: (c) => writes.push(c) }),
+    )
+    expect(Exit.isSuccess(exit)).toBe(true)
+    expect(writes.join("")).toBe("kilo-key\n")
+  })
+
+  test("prints the requested provider's token", async () => {
+    const writes: string[] = []
+    const exit = await runPromise(
+      run({
+        provider: "openai",
+        all: { kilo: apiKey, openai: { type: "api", key: "openai-key" } },
+        write: (c) => writes.push(c),
+      }),
+    )
+    expect(Exit.isSuccess(exit)).toBe(true)
+    expect(writes.join("")).toBe("openai-key\n")
+  })
+
+  test("matches the provider id case-insensitively", async () => {
+    const writes: string[] = []
+    const exit = await runPromise(run({ provider: "KILO", all: { kilo: apiKey }, write: (c) => writes.push(c) }))
+    expect(Exit.isSuccess(exit)).toBe(true)
+    expect(writes.join("")).toBe("kilo-key\n")
+  })
+
+  test("fails when the requested provider has no credentials", async () => {
+    const writes: string[] = []
+    const exit = await runPromise(run({ provider: "custom", all: { kilo: apiKey }, write: (c) => writes.push(c) }))
+    if (!Exit.isFailure(exit)) throw new Error("expected failure")
+    const err = Cause.squash(exit.cause)
+    expect(err).toBeInstanceOf(CliError)
+    expect((err as CliError).message).toContain('Not authenticated with "custom"')
+    expect((err as CliError).message).toContain("kilo")
+    expect(writes).toEqual([])
+  })
+
+  test("fails when there are no credentials at all", async () => {
+    const exit = await runPromise(run({ all: {}, write: () => {} }))
+    if (!Exit.isFailure(exit)) throw new Error("expected failure")
+    const err = Cause.squash(exit.cause)
+    expect(err).toBeInstanceOf(CliError)
+    expect((err as CliError).message).toContain("kilo auth login")
+  })
+
+  test("writes the access token for oauth credentials", async () => {
+    const writes: string[] = []
+    const exit = await runPromise(run({ all: { kilo: oauth }, write: (c) => writes.push(c) }))
+    expect(Exit.isSuccess(exit)).toBe(true)
+    expect(writes.join("")).toBe("oauth-access\n")
+  })
+})
+
+describe("auth token: listConfiguredProviders", () => {
+  const originalEnv = process.env.KILO_AUTH_CONTENT
+  let backup: string | undefined
+
+  const dir = path.dirname(AUTH_FILE)
+
+  beforeEach(() => {
+    backup =
+      fs.existsSync(AUTH_FILE) && fs.statSync(AUTH_FILE).isFile() ? fs.readFileSync(AUTH_FILE, "utf8") : undefined
+    delete process.env.KILO_AUTH_CONTENT
+  })
+
+  afterEach(() => {
+    try {
+      fs.rmSync(AUTH_FILE, { recursive: true, force: true })
+    } catch {}
+    if (backup !== undefined) fs.writeFileSync(AUTH_FILE, backup)
+    if (originalEnv === undefined) delete process.env.KILO_AUTH_CONTENT
+    else process.env.KILO_AUTH_CONTENT = originalEnv
+  })
+
+  test("returns the configured provider keys from auth.json", () => {
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(AUTH_FILE, JSON.stringify({ kilo: apiKey, "opencode-go": apiKey, minimax: oauth }))
+    expect(listConfiguredProviders().sort()).toEqual(["kilo", "minimax", "opencode-go"])
+  })
+
+  test("returns an empty list when auth.json is missing", () => {
+    try {
+      fs.unlinkSync(AUTH_FILE)
+    } catch {}
+    expect(listConfiguredProviders()).toEqual([])
+  })
+
+  test("returns an empty list when auth.json is malformed", () => {
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(AUTH_FILE, "not json")
+    expect(listConfiguredProviders()).toEqual([])
+  })
+
+  test("prefers KILO_AUTH_CONTENT when set", () => {
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(AUTH_FILE, JSON.stringify({ kilo: apiKey }))
+    process.env.KILO_AUTH_CONTENT = JSON.stringify({ "opencode-go": apiKey })
+    expect(listConfiguredProviders()).toEqual(["opencode-go"])
+  })
+
+  test("falls back to auth.json when KILO_AUTH_CONTENT is malformed", () => {
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(AUTH_FILE, JSON.stringify({ kilo: apiKey, "opencode-go": apiKey }))
+    process.env.KILO_AUTH_CONTENT = "not json"
+    expect(listConfiguredProviders().sort()).toEqual(["kilo", "opencode-go"])
+  })
+})


### PR DESCRIPTION
Reopen of PR #12451

## Issue

Closes #12450

## Context

The `kilo auth` command family had `list`, `login`, and `logout`, but no way to actually retrieve a stored credential for use in scripts, CI, or other tools. This adds `kilo auth token [provider]`, modeled on `gh auth token`: it prints the configured credential to stdout with no decoration, defaults to the `kilo` provider, and accepts an alternate provider id as a positional.

The implementation is intentionally small and isolated so the shared `ProvidersCommand` stays close to upstream opencode. The new command lives entirely under `packages/opencode/src/kilocode/cli/cmd/auth-token.ts` and is wired into the existing `kilo auth` builder.

The `--help` output is dynamic: it reads `auth.json` (or `KILO_AUTH_CONTENT`, matching the runtime `Auth.all` fallback) at builder time and surfaces every configured provider in both the positional describe and an epilog block. Users no longer have to guess provider ids like `opencode-go` vs. `opencode-zen`.

## Implementation

New Kilo-owned module at `packages/opencode/src/kilocode/cli/cmd/auth-token.ts` exports the `TokenCommand` (a yargs `effectCmd` with `instance: false`) plus small helpers: `tokenFor` picks the right field per credential type, `resolveProvider` does case-insensitive lookup against configured ids, `listConfiguredProviders` reads `auth.json` (or `KILO_AUTH_CONTENT`) for the `--help` output, and `run` is the pure Effect the handler delegates to. Wiring is a one-line import and a single `.command(TokenCommand)` on the existing `ProvidersCommand.builder` in shared `providers.ts`, both behind `kilocode_change` markers per the fork-merge minimization rules. Tests in `packages/opencode/test/kilocode/cli/auth-token.test.ts` cover all helpers, the full `run` handler (success, missing-provider, empty-config, oauth), and `listConfiguredProviders` (file, env override, missing, malformed). Changeset added as a `patch` bump for `@kilocode/cli`.

## Screenshots / Video

<img width="1016" height="532" alt="WindowsTerminal_u2PLdniaaz" src="https://github.com/user-attachments/assets/8f22fcd3-75a0-4892-aaf1-b78e78262da5" />
<img width="1920" height="267" alt="WindowsTerminal_8vu3switMf" src="https://github.com/user-attachments/assets/cf9f9966-3281-45b2-95bc-6151c2924720" />

## How to Test

### Manual/local verification

1. Run `kilo auth token` 
2. Run `kilo auth token [provider-id]`
3. Check `kilo auth token --help`

### Reviewer test steps

1. Run `kilo auth token` 
2. Run `kilo auth token [provider-id]`
3. Check `kilo auth token --help`

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

Discord: @IamCoder18 