### PR TITLE
fix(cli): stop env-var skill docs from triggering shell prompts

### DIFF
--- a/.changeset/skill-shell-env-var-docs.md
+++ b/.changeset/skill-shell-env-var-docs.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Stop env-var documentation placeholders in skill markdown from triggering shell permission prompts.

--- a/packages/opencode/src/kilocode/skills/inject.ts
+++ b/packages/opencode/src/kilocode/skills/inject.ts
@@ -139,9 +139,9 @@ export namespace SkillInject {
     )
   }
 
-  // `!`RUST_LOG`` in prose documents an env var name, not a shell command to run.
+  // `!`RUST_LOG`` (and `!`_JAVA_OPTIONS``) in prose documents an env var name, not a shell command to run.
   function documentationShell(command: string) {
-    return /^[A-Z][A-Z0-9_]*$/.test(command.trim())
+    return /^_?[A-Z][A-Z0-9_]*$/.test(command.trim())
   }
 
   function isInert(index: number, command: string, inert: (index: number) => boolean) {

--- a/packages/opencode/src/kilocode/skills/inject.ts
+++ b/packages/opencode/src/kilocode/skills/inject.ts
@@ -41,7 +41,7 @@ export namespace SkillInject {
   export const render = Effect.fn("SkillInject.render")(function* (opts: Options) {
     // Fenced blocks and inline code spans (`` !`cmd` ``) are documentation, not live commands.
     const inert = ranges(opts.content)
-    const live = ConfigMarkdown.shell(opts.content).filter((m) => !inert(m.index))
+    const live = ConfigMarkdown.shell(opts.content).filter((m) => !isInert(m.index, m[1], inert))
     if (live.length === 0) return opts.content
 
     // Policy checks before the approval gate; `replace` only touches live placeholders.
@@ -135,8 +135,17 @@ export namespace SkillInject {
   // containing `!`cmd`` stays inert, and documentation examples stay literal text.
   function rewrite(content: string, inert: (index: number) => boolean, value: (command: string) => string) {
     return content.replace(ConfigMarkdown.SHELL_REGEX, (match, command: string, index: number) =>
-      inert(index) ? match : value(command),
+      isInert(index, command, inert) ? match : value(command),
     )
+  }
+
+  // `!`RUST_LOG`` in prose documents an env var name, not a shell command to run.
+  function documentationShell(command: string) {
+    return /^[A-Z][A-Z0-9_]*$/.test(command.trim())
+  }
+
+  function isInert(index: number, command: string, inert: (index: number) => boolean) {
+    return inert(index) || documentationShell(command)
   }
 
   // Fenced code block spans (``` or ~~~), sorted and non-overlapping by construction.

--- a/packages/opencode/test/kilocode/skills/inject.test.ts
+++ b/packages/opencode/test/kilocode/skills/inject.test.ts
@@ -339,6 +339,28 @@ describe("skill shell injection", () => {
     }),
   )
 
+  unix("does not treat env-var documentation placeholders as shell commands", () =>
+    Effect.gen(function* () {
+      // Regression for #12868: prose like `!`RUST_LOG`` documents an env var name and must
+      // not request bash permission or try to execute it.
+      yield* writeGlobalSkill(
+        "env-var-doc-shell",
+        "- Make log level configurable via env (!`RUST_LOG` or `EnvFilter`).",
+      )
+
+      const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+      const result = yield* loadSkill("env-var-doc-shell", (req) =>
+        Effect.sync(() => {
+          requests.push(req)
+        }),
+      )
+
+      expect(result.output).toContain("!`RUST_LOG`")
+      expect(result.output).not.toContain("[skill shell")
+      expect(requests.some((r) => r.permission === "bash")).toBe(false)
+    }),
+  )
+
   unix("does not let distant unrelated inline code spans merge into one inert range", () =>
     Effect.gen(function* () {
       // Code spans cannot cross a blank line. Stray double-backticks in an earlier paragraph
@@ -516,6 +538,20 @@ describe("SkillInject.render gating", () => {
     Effect.gen(function* () {
       const out = yield* Effect.promise(() => run({ trusted: true, disabled: false, content: "no commands here" }))
       expect(out).toBe("no commands here")
+    }),
+  )
+
+  it.effect("env-var documentation placeholders stay literal without asking", () =>
+    Effect.gen(function* () {
+      const out = yield* Effect.promise(() =>
+        run({
+          trusted: true,
+          disabled: false,
+          content: "- Make log level configurable via env (!`RUST_LOG` or `EnvFilter`).",
+        }),
+      )
+      expect(out).toContain("!`RUST_LOG`")
+      expect(out).not.toContain("[skill shell")
     }),
   )
 })


### PR DESCRIPTION
Fixes #12868

Treat SCREAMING_SNAKE_CASE (and optional leading underscore)  placeholders in skill prose as documentation-only, so they no longer request bash permission or attempt to execute env var names as shell commands.