### PR TITLE
fix(cli): skip sandboxed command approval prompts and fix TUI git escalation hang

### DIFF
--- a/.changeset/tui-sandbox-escalation.md
+++ b/.changeset/tui-sandbox-escalation.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Skip the redundant bash/external-directory approval prompt for commands that run inside the enabled sandbox — the sandbox already confines them, so only mutating Git commands that escape the sandbox still ask for confirmation. The interactive TUI no longer hangs when such a Git confirmation is needed while auto-approve is on.

--- a/.changeset/tui-sandbox-escalation.md
+++ b/.changeset/tui-sandbox-escalation.md
@@ -2,4 +2,4 @@
 "@kilocode/cli": patch
 ---
 
-Skip the redundant bash/external-directory approval prompt for commands that run inside the enabled sandbox — the sandbox already confines them, so only mutating Git commands that escape the sandbox still ask for confirmation. The interactive TUI no longer hangs when such a Git confirmation is needed while auto-approve is on.
+Skip the redundant bash/external-directory approval prompt for commands that run inside the enabled sandbox — the sandbox already confines them, so they auto-approve like an allow rule while deny rules and plan-mode hard rules still apply. Only mutating Git commands that escape the sandbox still ask for a one-shot confirmation. The interactive TUI no longer hangs when such a Git confirmation is needed while auto-approve is on.

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -214,6 +214,10 @@ const layer = Layer.effect(
       // kilocode_change end
 
       const forceAsk = request.metadata?.["skillShell"] === true || request.metadata?.["sandboxEscalation"] === true // kilocode_change
+      // kilocode_change start - a sandboxed command is already confined to writable paths, so an "ask"
+      // outcome auto-approves like an allow rule — but deny rules and hard vetoes above still terminate.
+      const sandboxed = request.metadata?.["sandboxed"] === true
+      // kilocode_change end
       for (const pattern of request.patterns) {
         const rule = resolve(request.permission, pattern, ruleset, approved, local) // kilocode_change — include session-scoped rules
         yield* Effect.logInfo("evaluated", { permission: request.permission, pattern, action: rule })
@@ -232,8 +236,9 @@ const layer = Layer.effect(
           continue
         }
         // kilocode_change end
-        // kilocode_change start - override "allow" to "ask" for protected config paths
-        if (rule.action === "allow" && (!isProtected || trusted)) {
+        // kilocode_change start - override "allow" to "ask" for protected config paths; sandboxed
+        // requests treat an "ask" outcome as allowed (no prompt) while still honoring deny above.
+        if ((rule.action === "allow" || sandboxed) && (!isProtected || trusted)) {
           approvedRule = rule // remember the winning rule so callers can explain the auto-approval
           continue
         }

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -289,6 +289,7 @@ const ask = Effect.fn("ShellTool.ask")(function* (
   command: string,
   metadata: ReturnType<typeof heredocs>, // kilocode_change
   description?: string, // kilocode_change
+  sandboxed = false, // kilocode_change - sandboxed commands skip the prompt but keep deny evaluation
 ) {
   // kilocode_change
   if (scan.dirs.size > 0) {
@@ -308,6 +309,7 @@ const ask = Effect.fn("ShellTool.ask")(function* (
         directories,
         patterns: globs,
         ...(scan.access === "read" ? { access: "read" as const } : {}),
+        ...(sandboxed ? { sandboxed: true } : {}), // kilocode_change
         ...metadata,
       },
       // kilocode_change end
@@ -319,7 +321,12 @@ const ask = Effect.fn("ShellTool.ask")(function* (
     permission: ShellID.ToolID,
     patterns: Array.from(scan.patterns),
     always: Array.from(scan.always),
-    metadata: { command: normalizeUrls(command), ...(description ? { description } : {}), ...metadata }, // kilocode_change
+    metadata: {
+      command: normalizeUrls(command),
+      ...(description ? { description } : {}),
+      ...(sandboxed ? { sandboxed: true } : {}), // kilocode_change
+      ...metadata,
+    }, // kilocode_change
   })
 })
 
@@ -432,12 +439,12 @@ export const ShellPermission = Effect.gen(function* () {
           scan.dirs.add(input.cwd)
           scan.access = "unknown"
         }
-        // kilocode_change start - a sandboxed command is confined to writable paths, so the normal
-        // bash/external-directory approval is redundant (the sandbox already constrains the command,
-        // like an allow rule); only git mutations that escape the sandbox need the confirmation below.
-        if (!input.escalate) {
-          yield* ask(ctx, scan, input.command, metadata, input.description) // kilocode_change
-        }
+        // kilocode_change start - a sandboxed command is confined to writable paths, so its
+        // bash/external-directory check auto-approves instead of prompting (Permission.ask treats
+        // the sandboxed flag like an allow rule); deny rules and plan-mode hard rules still veto,
+        // and git mutations additionally ask the one-shot sandbox escalation below because they
+        // escape the sandbox.
+        yield* ask(ctx, scan, input.command, metadata, input.description, input.escalate) // kilocode_change
         // kilocode_change end
         const gitMutation = commands(tree.rootNode).some((node) => mutatesGit(node.text))
         if (input.escalate && gitMutation) {

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -432,7 +432,13 @@ export const ShellPermission = Effect.gen(function* () {
           scan.dirs.add(input.cwd)
           scan.access = "unknown"
         }
-        yield* ask(ctx, scan, input.command, metadata, input.description) // kilocode_change
+        // kilocode_change start - a sandboxed command is confined to writable paths, so the normal
+        // bash/external-directory approval is redundant (the sandbox already constrains the command,
+        // like an allow rule); only git mutations that escape the sandbox need the confirmation below.
+        if (!input.escalate) {
+          yield* ask(ctx, scan, input.command, metadata, input.description) // kilocode_change
+        }
+        // kilocode_change end
         const gitMutation = commands(tree.rootNode).some((node) => mutatesGit(node.text))
         if (input.escalate && gitMutation) {
           yield* ctx.ask({

--- a/packages/opencode/test/kilocode/permission/sandboxed-auto-approve.test.ts
+++ b/packages/opencode/test/kilocode/permission/sandboxed-auto-approve.test.ts
@@ -1,0 +1,150 @@
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { expect } from "bun:test"
+import { Cause, Effect, Exit, Fiber, Layer } from "effect"
+import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
+import { Permission } from "@/permission"
+import { testEffect } from "../../lib/effect"
+import { SessionID } from "@/session/schema"
+import * as Config from "@/config/config"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+
+// A sandboxed shell command is already confined to the writable paths, so its
+// bash/external-directory ask auto-approves like an allow rule — no prompt.
+// Deny rules and plan-mode hard vetoes must still terminate the command.
+
+const env = Layer.mergeAll(
+  AppNodeBuilder.build(Permission.node),
+  AppNodeBuilder.build(Config.node),
+  AppNodeBuilder.build(CrossSpawnSpawner.node),
+)
+const it = testEffect(env)
+
+const ask = (input: Parameters<Permission.Interface["ask"]>[0]) =>
+  Effect.gen(function* () {
+    return yield* (yield* Permission.Service).ask(input)
+  })
+
+const list = () =>
+  Effect.gen(function* () {
+    return yield* (yield* Permission.Service).list()
+  })
+
+const waitForPending = (count: number) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* Effect.gen(function* () {
+      while (true) {
+        const pending = yield* permission.list()
+        if (pending.length === count) return pending
+        yield* Effect.sleep("10 millis")
+      }
+    }).pipe(Effect.timeoutOrElse({ duration: "1 second", orElse: () => Effect.fail(new Error("timed out")) }))
+  })
+
+const fail = <A, E, R>(self: Effect.Effect<A, E, R>) =>
+  Effect.gen(function* () {
+    const exit = yield* self.pipe(Effect.exit)
+    if (Exit.isFailure(exit)) return Cause.squash(exit.cause)
+    throw new Error("expected permission effect to fail")
+  })
+
+it.instance(
+  "sandboxed - an ask outcome auto-approves without queuing a prompt",
+  () =>
+    Effect.gen(function* () {
+      const outcome = yield* ask({
+        sessionID: SessionID.make("session_test"),
+        permission: "bash",
+        patterns: ["npm run build"],
+        metadata: { sandboxed: true },
+        always: [],
+        ruleset: [],
+      })
+      expect(outcome.manual).toBe(false)
+      expect(yield* list()).toHaveLength(0)
+    }),
+  { git: true },
+)
+
+it.instance(
+  "sandboxed - a deny rule still terminates the command",
+  () =>
+    Effect.gen(function* () {
+      const err = yield* fail(
+        ask({
+          sessionID: SessionID.make("session_test"),
+          permission: "bash",
+          patterns: ["rm -rf node_modules"],
+          metadata: { sandboxed: true },
+          always: [],
+          ruleset: [{ permission: "bash", pattern: "rm -rf *", action: "deny" }],
+        }),
+      )
+
+      expect(err).toBeInstanceOf(PermissionV1.DeniedError)
+      expect(yield* list()).toHaveLength(0)
+    }),
+  { git: true },
+)
+
+it.instance(
+  "sandboxed - a plan-mode hard veto still terminates the command",
+  () =>
+    Effect.gen(function* () {
+      const err = yield* fail(
+        ask({
+          sessionID: SessionID.make("session_test"),
+          permission: "bash",
+          patterns: ["rm -rf node_modules"],
+          metadata: { sandboxed: true },
+          always: [],
+          ruleset: [{ permission: "bash", pattern: "*", action: "allow" }],
+          hardRuleset: [{ permission: "bash", pattern: "*", action: "deny" }],
+        }),
+      )
+
+      expect(err).toBeInstanceOf(PermissionV1.DeniedError)
+      expect(yield* list()).toHaveLength(0)
+    }),
+  { git: true },
+)
+
+it.instance(
+  "sandboxed - an explicit allow rule is honored and still reports the rule",
+  () =>
+    Effect.gen(function* () {
+      const outcome = yield* ask({
+        sessionID: SessionID.make("session_test"),
+        permission: "bash",
+        patterns: ["git status"],
+        metadata: { sandboxed: true },
+        always: [],
+        ruleset: [{ permission: "bash", pattern: "git *", action: "allow" }],
+      })
+      expect(outcome.manual).toBe(false)
+      expect(outcome.rule?.action).toBe("allow")
+      expect(yield* list()).toHaveLength(0)
+    }),
+  { git: true },
+)
+
+it.instance(
+  "without the sandboxed flag an ask outcome still prompts",
+  () =>
+    Effect.gen(function* () {
+      const fiber = yield* ask({
+        sessionID: SessionID.make("session_test"),
+        permission: "bash",
+        patterns: ["npm run build"],
+        metadata: {},
+        always: [],
+        ruleset: [],
+      }).pipe(Effect.forkScoped)
+
+      const [pending] = yield* waitForPending(1)
+      yield* (yield* Permission.Service).reply({ requestID: pending.id, reply: "once" })
+      expect((yield* Fiber.join(fiber)).manual).toBe(true)
+      expect(yield* list()).toHaveLength(0)
+    }),
+  { git: true },
+)

--- a/packages/opencode/test/kilocode/tool/shell-unparsed.test.ts
+++ b/packages/opencode/test/kilocode/tool/shell-unparsed.test.ts
@@ -84,11 +84,17 @@ afterEach(async () => {
 })
 
 describe("shell permission scanner fails closed on unparsed commands", () => {
-  test("asks separately before mutating Git when the session sandbox is enabled", async () => {
+  test("sandboxed commands skip the bash approval; mutating Git asks only for the sandbox escalation", async () => {
     await using tmp = await tmpdir({ git: true })
     const requests = await scan(tmp.path, "git add . && git commit -m test", "bash", true)
-    expect(requests.map((request) => request.permission)).toEqual(["bash", "sandbox_escalation"])
-    expect(requests[1]?.metadata?.sandboxEscalation).toBe(true)
+    expect(requests.map((request) => request.permission)).toEqual(["sandbox_escalation"])
+    expect(requests[0]?.metadata?.sandboxEscalation).toBe(true)
+  })
+
+  test("sandboxed non-git and read-only git commands run without any approval prompt", async () => {
+    await using tmp = await tmpdir({ git: true })
+    expect(await scan(tmp.path, "npm run build", "bash", true)).toEqual([])
+    expect(await scan(tmp.path, "git status", "bash", true)).toEqual([])
   })
 
   test("pwsh: bare '--' git commands now produce a denied pattern", async () => {

--- a/packages/opencode/test/kilocode/tool/shell-unparsed.test.ts
+++ b/packages/opencode/test/kilocode/tool/shell-unparsed.test.ts
@@ -84,17 +84,21 @@ afterEach(async () => {
 })
 
 describe("shell permission scanner fails closed on unparsed commands", () => {
-  test("sandboxed commands skip the bash approval; mutating Git asks only for the sandbox escalation", async () => {
+  test("sandboxed commands still emit the bash check, flagged so the server auto-approves without a prompt", async () => {
     await using tmp = await tmpdir({ git: true })
-    const requests = await scan(tmp.path, "git add . && git commit -m test", "bash", true)
-    expect(requests.map((request) => request.permission)).toEqual(["sandbox_escalation"])
-    expect(requests[0]?.metadata?.sandboxEscalation).toBe(true)
+    for (const command of ["npm run build", "git status"]) {
+      const requests = await scan(tmp.path, command, "bash", true)
+      expect(requests.map((request) => request.permission)).toEqual(["bash"])
+      expect(requests[0]?.metadata?.sandboxed).toBe(true)
+    }
   })
 
-  test("sandboxed non-git and read-only git commands run without any approval prompt", async () => {
+  test("sandboxed mutating Git asks only for the sandbox escalation, bash check flagged sandboxed", async () => {
     await using tmp = await tmpdir({ git: true })
-    expect(await scan(tmp.path, "npm run build", "bash", true)).toEqual([])
-    expect(await scan(tmp.path, "git status", "bash", true)).toEqual([])
+    const requests = await scan(tmp.path, "git add . && git commit -m test", "bash", true)
+    expect(requests.map((request) => request.permission)).toEqual(["bash", "sandbox_escalation"])
+    expect(requests[0]?.metadata?.sandboxed).toBe(true)
+    expect(requests[1]?.metadata?.sandboxEscalation).toBe(true)
   })
 
   test("pwsh: bare '--' git commands now produce a denied pattern", async () => {

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -256,7 +256,11 @@ export const {
 
         case "permission.asked": {
           const request = event.properties
-          if (permission.mode === "auto") {
+          // kilocode_change start - sandbox escalation and skill-shell batches require an interactive
+          // human decision; the server refuses non-interactive approvals, so render them even in auto
+          // mode instead of replying "once" and leaving the request pending (command hangs forever).
+          const sensitive = request.metadata?.["sandboxEscalation"] === true || request.metadata?.["skillShell"] === true
+          if (permission.mode === "auto" && !sensitive) {
             void sdk.client.permission.reply({
               requestID: request.id,
               reply: "once",
@@ -265,6 +269,7 @@ export const {
             })
             break
           }
+          // kilocode_change end
           const requests = store.permission[request.sessionID]
           if (!requests) {
             setStore("permission", request.sessionID, [request])


### PR DESCRIPTION
## Issue

No linked issue — reported through the sandbox approval UX: with the sandbox enabled the command approval UI still appeared, and occasionally got stuck without dismissing.

## Context

When the sandbox is enabled, the shell tool still fired the normal `bash`/`external_directory` approval ask for every command, even though the sandbox already confines the command to the writable paths — equivalent to an already-allowed pattern, so no prompt should appear. Only mutating Git commands that escape the sandbox (`.git` is read-only inside the sandbox) need the separate one-shot `sandbox_escalation` confirmation.

The sandboxed command must still run through the permission system: deny rules and plan-mode hard rules are evaluated inside `Permission.ask`, so skipping the check entirely would silently bypass them. Instead the `bash`/`external_directory` ask stays, tagged with a `sandboxed` flag that auto-approves an "ask" outcome — like an allow rule — while deny and hard vetoes keep terminating the command.

Separately, the interactive TUI's auto-approve mode auto-replied `"once"` to `sandbox_escalation` (and `skillShell`) requests. The server refuses non-interactive approvals for those, so the reply was silently dropped and the request stayed pending forever: the command hung and the approval UI never dismissed.

## Implementation

- `packages/opencode/src/tool/shell.ts`: the shell permission check now runs for sandboxed commands too (`input.escalate`), tagging the `bash`/`external_directory` requests with a `sandboxed` metadata flag instead of skipping them; the one-shot `sandbox_escalation` ask remains for mutating Git commands that escape the sandbox.
- `packages/opencode/src/permission/index.ts`: `Permission.ask` treats a `sandboxed` request's "ask" outcome as auto-approved (the sandbox already confines the command), while deny rules and plan-mode hard vetoes still terminate it.
- `packages/tui/src/context/sync.tsx`: in auto-approve mode, stop auto-replying `"once"` to `sandboxEscalation`/`skillShell` requests; render them for a human decision instead (matching VS Code's auto-approve, which already skips `sandboxEscalation`).
- Tests: `shell-unparsed.test.ts` asserts the `sandboxed` flag on the emitted `bash` request plus the `sandbox_escalation` ask for git mutations; new `sandboxed-auto-approve.test.ts` covers `Permission.ask` auto-approval while deny/hard rules still block.

## Screenshots / Video

N/A — no changes to the approval UI rendering itself.

## How to Test

### Manual/local verification

- `bun test ./test/kilocode/tool/shell-unparsed.test.ts ./test/kilocode/permission/sandboxed-auto-approve.test.ts` from `packages/opencode/` — 16 pass.
- `bun test ./test/kilocode/sandbox/` from `packages/opencode/` — 78 pass / 17 skip (macOS-only) / 0 fail.
- `bun run typecheck` from `packages/opencode/` — clean (exit 0).

### Reviewer test steps

1. Enable the sandbox (Linux/macOS with a working Bubblewrap/Seatbelt backend).
2. Ask the agent to run a read-only or non-Git command (`git status`, `npm run build`) — no approval prompt should appear, but a matching deny rule (`"rm -rf *": "deny"`) must still block the command.
3. Ask the agent to run a mutating Git command (`git commit`) — the one-shot "Allow Git operation outside the sandbox?" prompt appears, and the command runs unsandboxed only after approval.
4. With TUI auto-approve on, repeat step 3 — the prompt renders instead of the session hanging.

### Blocked checks and substitute verification

- `bun turbo typecheck` from the repo root could not complete locally: this sandbox has pre-existing missing-dependency resolution errors in `packages/tui` (`solid-js`, `@opencode-ai/schema/permission`, etc.). `packages/opencode` typechecks clean, and the `sync.tsx` error count is unchanged by this PR (104 before and after).
- The sandbox integration suite needs a Bubblewrap binary. On this machine bwrap lives under a pixi prefix rather than `/usr/bin`, so it is run with `KILO_BWRAP_PATH=/home/trim21/.pixi/bin/bwrap bun test ./test/kilocode/sandbox/`.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
