### PR TITLE
feat(vscode): use default mode for new worktrees

### DIFF
--- a/.changeset/worktree-default-mode.md
+++ b/.changeset/worktree-default-mode.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Inherit the Kilo default mode when creating a new worktree instead of always proposing the free tier. New worktrees now use the model from your Kilo account or organization defaults when no explicit model is configured.

--- a/packages/kilo-vscode/src/provider-actions.ts
+++ b/packages/kilo-vscode/src/provider-actions.ts
@@ -63,11 +63,21 @@ export async function fetchProviderData(client: KiloClient, dir: string) {
     .authStatus({ directory: dir }, { throwOnError: true })
     .then((r) => (r.data?.authenticated ? (r.data.type ?? null) : null))
     .catch(() => null)
+  // The config/providers endpoint overlays the Kilo API default model (the
+  // user's or organization's default mode) onto the kilo provider's default.
+  const defaultRequest =
+    typeof client.config?.providers === "function"
+      ? client.config
+          .providers({ directory: dir }, { throwOnError: true })
+          .then((r) => r.data?.default)
+          .catch(() => undefined)
+      : Promise.resolve(undefined)
 
-  const [{ data: response }, authMethods, kiloAuth] = await Promise.all([
+  const [{ data: response }, authMethods, kiloAuth, kiloDefault] = await Promise.all([
     client.provider.list({ directory: dir }, { throwOnError: true }),
     authRequest,
     kiloRequest,
+    defaultRequest,
   ])
   const authStates: Record<string, AuthState> = {}
   const storedKeys: Record<string, StoredProviderKey> = {}
@@ -90,7 +100,12 @@ export async function fetchProviderData(client: KiloClient, dir: string) {
   })
   delete authStates[KILO_PROVIDER_ID]
   if (kiloAuth) authStates[KILO_PROVIDER_ID] = kiloAuth
-  return { response: { ...response, all }, authMethods, authStates, storedKeys }
+  return {
+    response: { ...response, all, default: kiloDefault ?? response.default },
+    authMethods,
+    authStates,
+    storedKeys,
+  }
 }
 
 /**

--- a/packages/kilo-vscode/tests/unit/model-selection.test.ts
+++ b/packages/kilo-vscode/tests/unit/model-selection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { resolveModelSelection } from "../../webview-ui/src/context/model-selection"
+import { kiloDefault, resolveModelSelection } from "../../webview-ui/src/context/model-selection"
 import { KILO_AUTO, parseModelString } from "../../src/shared/provider-model"
 import type { Provider } from "../../webview-ui/src/types/messages"
 
@@ -102,5 +102,17 @@ describe("resolveModelSelection", () => {
       fallback: KILO_AUTO,
     })
     expect(result).toEqual({ providerID: "openai", modelID: "gpt-4.1" })
+  })
+})
+
+describe("kiloDefault", () => {
+  it("uses the kilo gateway default mode when present", () => {
+    const result = kiloDefault({ kilo: "kilo-auto/efficient" }, KILO_AUTO)
+    expect(result).toEqual({ providerID: "kilo", modelID: "kilo-auto/efficient" })
+  })
+
+  it("falls back to the provided fallback when the kilo default is missing", () => {
+    const result = kiloDefault({}, KILO_AUTO)
+    expect(result).toEqual(KILO_AUTO)
   })
 })

--- a/packages/kilo-vscode/tests/unit/provider-actions-save.test.ts
+++ b/packages/kilo-vscode/tests/unit/provider-actions-save.test.ts
@@ -557,6 +557,53 @@ describe("fetchProviderData", () => {
     })
     expect(result.response.all.every((item) => !("key" in (item as Record<string, unknown>)))).toBe(true)
   })
+
+  it("overlays the kilo default from config/providers onto the provider list default", async () => {
+    const client = {
+      provider: {
+        list: async () => ({
+          data: {
+            all: [{ id: "kilo", name: "Kilo Gateway", source: "custom", env: [], models: {} }],
+            connected: ["kilo"],
+            default: { kilo: "kilo-auto/frontier" },
+          },
+        }),
+        auth: async () => ({ data: {} }),
+      },
+      kilo: {
+        authStatus: async () => ({ data: { authenticated: true, type: "oauth" } }),
+      },
+      config: {
+        providers: async () => ({ data: { providers: [], default: { kilo: "kilo-auto/efficient" } } }),
+      },
+    } as unknown as Parameters<typeof fetchProviderData>[0]
+
+    const result = await fetchProviderData(client, "/tmp")
+
+    expect(result.response.default).toEqual({ kilo: "kilo-auto/efficient" })
+  })
+
+  it("keeps the provider list default when config/providers is unavailable", async () => {
+    const client = {
+      provider: {
+        list: async () => ({
+          data: {
+            all: [{ id: "kilo", name: "Kilo Gateway", source: "custom", env: [], models: {} }],
+            connected: ["kilo"],
+            default: { kilo: "kilo-auto/frontier" },
+          },
+        }),
+        auth: async () => ({ data: {} }),
+      },
+      kilo: {
+        authStatus: async () => ({ data: { authenticated: true, type: "oauth" } }),
+      },
+    } as unknown as Parameters<typeof fetchProviderData>[0]
+
+    const result = await fetchProviderData(client, "/tmp")
+
+    expect(result.response.default).toEqual({ kilo: "kilo-auto/frontier" })
+  })
 })
 
 describe("resolveStoredKey", () => {

--- a/packages/kilo-vscode/webview-ui/src/context/model-selection.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/model-selection.ts
@@ -1,4 +1,5 @@
 import type { ModelSelection, Provider } from "../types/messages"
+import { KILO_PROVIDER_ID } from "../../../src/shared/provider-model"
 import { isModelValid } from "./provider-utils"
 
 function validate(
@@ -40,4 +41,10 @@ export function resolveModelSelection(input: {
     input.fallback ??
     null
   )
+}
+
+/** Kilo gateway default mode from the backend provider defaults, falling back to `fallback`. */
+export function kiloDefault(defaults: Record<string, string>, fallback: ModelSelection): ModelSelection {
+  const modelID = defaults[KILO_PROVIDER_ID]
+  return modelID ? { providerID: KILO_PROVIDER_ID, modelID } : fallback
 }

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -73,7 +73,7 @@ import {
   type MessagePageState,
 } from "./session-utils"
 import { Identifier } from "../utils/id"
-import { resolveModelSelection } from "./model-selection"
+import { kiloDefault, resolveModelSelection } from "./model-selection"
 import { getAgentModel } from "./session-model-store"
 import { resolveMessagePrefs } from "./session-preferences"
 import { errorIDs, preserveSessionErrors, withoutResolvedSessionErrors } from "./session-errors"
@@ -595,7 +595,7 @@ export const SessionProvider: ParentComponent = (props) => {
       mode: getModeModel(agentName),
       global: getGlobalModel(),
       recent: store.recentModels,
-      fallback: KILO_AUTO,
+      fallback: kiloDefault(provider.defaults(), KILO_AUTO),
     })
   }
 
@@ -782,7 +782,7 @@ export const SessionProvider: ParentComponent = (props) => {
         connected: provider.connected(),
         getModeModel,
         getGlobalModel,
-        fallback: KILO_AUTO,
+        fallback: kiloDefault(provider.defaults(), KILO_AUTO),
       },
       agentName,
       userSetAgents()[agentName] === true,


### PR DESCRIPTION
Closes #13311

## What

New worktrees now inherit the Kilo default mode instead of always proposing `kilo-auto/free`. When a worktree is created without an explicit model, it uses the model from the user's Kilo account or organization defaults (e.g. `kilo-auto/efficient`).

## Why

The Agent Manager worktree dialog resolved its initial model through the sidebar's model-resolution chain, whose final fallback is the hardcoded `KILO_AUTO` (`kilo-auto/free`). Users on paid/organization plans don't have access to that tier, so the first worktree prompt failed with `Model not found: kilo/kilo-auto/free` even though their account default was `kilo-auto/efficient`.

The CLI already resolves the correct default: the `config/providers` endpoint overlays the Kilo API default model (`fetchDefaultModel`, from `/api/defaults` or `/api/organizations/{org}/defaults`) onto the kilo provider's `default` map. The extension was fetching `provider/list` (which lacks that overlay) and discarding the richer source.

## Changes

- `fetchProviderData` now also fetches `config/providers` and uses its `default` map (Kilo API overlay) for the provider defaults sent to the webview, falling back to the `provider/list` default when unavailable.
- The webview model-resolution fallback now uses the kilo gateway default from `provider.defaults()` instead of the hardcoded `KILO_AUTO`, via a new pure helper `kiloDefault` in `model-selection.ts`.

## Testing

- `bun run test:unit` — 4121 pass, 0 fail
- `bun test tests/unit/model-selection.test.ts tests/unit/provider-actions-save.test.ts` — 37 pass (added `kiloDefault` and `fetchProviderData` overlay coverage)
- `bun run lint`, `bun run typecheck`, `bun run format:check`, `bun run knip` — all pass