### PR TITLE
fix(vscode): limit Agent Manager document viewer to Markdown plans

### DIFF
--- a/.changeset/rendered-document-inspector.md
+++ b/.changeset/rendered-document-inspector.md
@@ -2,4 +2,4 @@
 "kilo-code": minor
 ---
 
-Add an Agent Manager document inspector that previews Markdown and text files, with inline Markdown review comments that can be sent to the agent.
+Add an Agent Manager document inspector that previews Markdown files with inline review comments that can be sent to the agent, while source files open in the VS Code editor.

--- a/packages/kilo-vscode/tests/unit/agent-manager-documents.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-documents.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
-import { createDocumentComments, createDocuments } from "../../webview-ui/documents/state"
+import {
+  createDocumentComments,
+  createDocuments,
+  handleDocumentOpen,
+  isMarkdownPath,
+} from "../../webview-ui/documents/state"
 import type { AgentManagerDocumentMessage } from "../../webview-ui/src/types/messages"
 
 describe("Agent Manager document state", () => {
@@ -68,5 +73,36 @@ describe("Agent Manager document state", () => {
       expect(comments.comments()).toEqual([])
       dispose()
     })
+  })
+
+  it("keeps Markdown in the document inspector and opens source files in VS Code", () => {
+    expect(isMarkdownPath(".kilo/plans/feature.md")).toBe(true)
+    expect(isMarkdownPath("docs/architecture.MDX")).toBe(true)
+    expect(isMarkdownPath("src/index.ts")).toBe(false)
+
+    const opened: unknown[] = []
+    const native: unknown[] = []
+    const markdown = new CustomEvent("kilo:open-file", {
+      cancelable: true,
+      detail: { filePath: ".kilo/plans/feature.md", sessionID: "wt-a", line: 4, column: 2 },
+    })
+    handleDocumentOpen(markdown, (...args) => {
+      opened.push(args)
+      return true
+    })
+    expect(markdown.defaultPrevented).toBe(true)
+    expect(opened).toEqual([[".kilo/plans/feature.md", "wt-a", 4, 2]])
+
+    const source = new CustomEvent("kilo:open-file", {
+      cancelable: true,
+      detail: { filePath: "src/index.ts", sessionID: "wt-a", line: 8, column: 3 },
+    })
+    handleDocumentOpen(
+      source,
+      () => false,
+      (...args) => native.push(args),
+    )
+    expect(source.defaultPrevented).toBe(true)
+    expect(native).toEqual([["src/index.ts", 8, 3, "wt-a"]])
   })
 })

--- a/packages/kilo-vscode/tests/unit/agent-manager-documents.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-documents.test.ts
@@ -104,5 +104,16 @@ describe("Agent Manager document state", () => {
     )
     expect(source.defaultPrevented).toBe(true)
     expect(native).toEqual([["src/index.ts", 8, 3, "wt-a"]])
+
+    const missing = new CustomEvent("kilo:open-file", {
+      cancelable: true,
+      detail: { filePath: "src/missing.ts" },
+    })
+    handleDocumentOpen(
+      missing,
+      () => false,
+      () => false,
+    )
+    expect(missing.defaultPrevented).toBe(false)
   })
 })

--- a/packages/kilo-vscode/webview-ui/diff-viewer/MarkdownAnnotationLayer.tsx
+++ b/packages/kilo-vscode/webview-ui/diff-viewer/MarkdownAnnotationLayer.tsx
@@ -183,7 +183,7 @@ export const MarkdownAnnotationLayer: Component<MarkdownAnnotationLayerProps> = 
       layer.appendChild(row)
     }
 
-    observer?.observe(root, { childList: true, subtree: true })
+    observer?.observe(pane, { childList: true, subtree: true })
   }
 
   createEffect(() => {

--- a/packages/kilo-vscode/webview-ui/diff-viewer/MarkdownAnnotationLayer.tsx
+++ b/packages/kilo-vscode/webview-ui/diff-viewer/MarkdownAnnotationLayer.tsx
@@ -199,14 +199,14 @@ export const MarkdownAnnotationLayer: Component<MarkdownAnnotationLayerProps> = 
   })
 
   createEffect(() => {
-    const root = props.root()
-    if (!root) return
+    const pane = props.pane()
+    if (!pane) return
     observer?.disconnect()
     observer = new MutationObserver((mutations) => {
       if (mutations.every(isAnnotationMutation)) return
       schedule()
     })
-    observer.observe(root, { childList: true, subtree: true })
+    observer.observe(pane, { childList: true, subtree: true })
   })
 
   onCleanup(() => {

--- a/packages/kilo-vscode/webview-ui/documents/state.ts
+++ b/packages/kilo-vscode/webview-ui/documents/state.ts
@@ -175,8 +175,11 @@ export function createDocumentInspector(
     openPanel()
     return true
   }
+  const openFile = (file: string, line?: number, column?: number, sessionId = context()) => {
+    if (sessionId) vscode.postMessage({ type: "agentManager.openFile", sessionId, filePath: file, line, column })
+  }
   onMount(() => {
-    const handler = (event: Event) => handleDocumentOpen(event, open)
+    const handler = (event: Event) => handleDocumentOpen(event, open, openFile)
     const message = vscode.onMessage((item) => {
       if (item.type === "document.result" || item.type === "agentManager.document") documents.onMessage(item)
     })
@@ -191,10 +194,6 @@ export function createDocumentInspector(
   // Tabs are keyed per worktree, so this hides itself on a worktree with none,
   // and stays visible while the panel is open so it can still be toggled shut.
   const available = () => documents.tabs().length > 0 || isOpen()
-  const openFile = (file: string, line?: number, column?: number) => {
-    const sessionId = context()
-    if (sessionId) vscode.postMessage({ type: "agentManager.openFile", sessionId, filePath: file, line, column })
-  }
   const toggle = () => (isOpen() ? closePanel() : open())
   return { documents, comments, open, openFile, toggle, available, isOpen, scope }
 }
@@ -202,6 +201,7 @@ export function createDocumentInspector(
 export function handleDocumentOpen(
   event: Event,
   open: (file: string, sessionId?: string, line?: number, column?: number) => boolean,
+  openFile?: (file: string, line?: number, column?: number, sessionId?: string) => void,
 ): void {
   const detail = (event as CustomEvent<{ filePath?: unknown; sessionID?: unknown; line?: unknown; column?: unknown }>)
     .detail
@@ -210,5 +210,11 @@ export function handleDocumentOpen(
   const sessionId = typeof detail.sessionID === "string" ? detail.sessionID : undefined
   const line = typeof detail.line === "number" ? detail.line : undefined
   const column = typeof detail.column === "number" ? detail.column : undefined
+  if (!isMarkdownPath(file)) {
+    if (!openFile) return
+    openFile(file, line, column, sessionId)
+    event.preventDefault()
+    return
+  }
   if (open(file, sessionId, line, column)) event.preventDefault()
 }

--- a/packages/kilo-vscode/webview-ui/documents/state.ts
+++ b/packages/kilo-vscode/webview-ui/documents/state.ts
@@ -176,7 +176,9 @@ export function createDocumentInspector(
     return true
   }
   const openFile = (file: string, line?: number, column?: number, sessionId = context()) => {
-    if (sessionId) vscode.postMessage({ type: "agentManager.openFile", sessionId, filePath: file, line, column })
+    if (!sessionId) return false
+    vscode.postMessage({ type: "agentManager.openFile", sessionId, filePath: file, line, column })
+    return true
   }
   onMount(() => {
     const handler = (event: Event) => handleDocumentOpen(event, open, openFile)
@@ -201,7 +203,7 @@ export function createDocumentInspector(
 export function handleDocumentOpen(
   event: Event,
   open: (file: string, sessionId?: string, line?: number, column?: number) => boolean,
-  openFile?: (file: string, line?: number, column?: number, sessionId?: string) => void,
+  openFile?: (file: string, line?: number, column?: number, sessionId?: string) => boolean,
 ): void {
   const detail = (event as CustomEvent<{ filePath?: unknown; sessionID?: unknown; line?: unknown; column?: unknown }>)
     .detail
@@ -212,7 +214,7 @@ export function handleDocumentOpen(
   const column = typeof detail.column === "number" ? detail.column : undefined
   if (!isMarkdownPath(file)) {
     if (!openFile) return
-    openFile(file, line, column, sessionId)
+    if (!openFile(file, line, column, sessionId)) return
     event.preventDefault()
     return
   }


### PR DESCRIPTION
Opening a large source file from the Agent Manager document viewer rendered the entire file inside the webview. A 20,977-line, 409 KB generated TypeScript file created about 194,000 DOM nodes and 194,000 layout objects, caused a 2,010 ms main-thread task, and took about 4 seconds to settle. The existing Pierre source renderer only enables line virtualization above 500 KB, so this file remained on the full-render path despite its line count.

The document inspector exists primarily for reading and commenting on Markdown plans. Source files do not need that inline review surface because the user is already in VS Code, which provides a mature native editor and large-file rendering. The document-open routing now keeps Markdown, MDX, and .markdown files in the inline Agent Manager inspector, while opening other files through the existing worktree-aware VS Code editor path with line and column navigation. This avoids duplicating an editor or adding a second virtualization framework.

The change also fixes a Markdown annotation initialization race. The annotation layer now observes the stable Markdown pane while asynchronous Markdown content mounts, so plan comment gutters are populated reliably. Existing plan comments, draft comments, and send-to-agent behavior remain unchanged.

The identical large-file profile after the change created 1 DOM node and 42 layout objects, had no long tasks, and measured about 89 ms of task duration. A representative 555-line plan rendered inline with 215 commentable anchors, and a gutter click opened a working comment draft.

This keeps the inline viewer focused on the document type that benefits from comments and delegates source editing to the editor already hosting Agent Manager.