### PR TITLE
feat(agent-manager): add PR link copy button

### DIFF
--- a/.changeset/copy-pr-link.md
+++ b/.changeset/copy-pr-link.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add a button to copy pull request links from the Agent Manager PR panel.

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -194,6 +194,7 @@ export const dict = {
   "agentManager.review.metaComment": "تعليق المستخدم",
   "agentManager.review.metaAuthor": "المؤلف",
   "agentManager.pr.comment.title": "التعليقات",
+  "agentManager.pr.copyLink": "نسخ رابط PR",
   "agentManager.pr.comment.unresolvedCount": "{{count}} غير محلولة",
   "agentManager.pr.comment.resolvedGroup": "تم الحل ({{count}})",
   "agentManager.pr.comment.sendAll": "إرسال {{count}} غير محلولة إلى الوكيل",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -197,6 +197,7 @@ export const dict = {
   "agentManager.review.metaComment": "Comentário do usuário",
   "agentManager.review.metaAuthor": "Autor",
   "agentManager.pr.comment.title": "Comentários",
+  "agentManager.pr.copyLink": "Copiar link do PR",
   "agentManager.pr.comment.unresolvedCount": "{{count}} não resolvidos",
   "agentManager.pr.comment.resolvedGroup": "Resolvidos ({{count}})",
   "agentManager.pr.comment.sendAll": "Enviar {{count}} não resolvidos para o agente",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -197,6 +197,7 @@ export const dict = {
   "agentManager.review.metaComment": "Komentar korisnika",
   "agentManager.review.metaAuthor": "Autor",
   "agentManager.pr.comment.title": "Komentari",
+  "agentManager.pr.copyLink": "Kopiraj PR vezu",
   "agentManager.pr.comment.unresolvedCount": "{{count}} neriješenih",
   "agentManager.pr.comment.resolvedGroup": "Riješeno ({{count}})",
   "agentManager.pr.comment.sendAll": "Pošalji {{count}} neriješenih agentu",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -198,6 +198,7 @@ export const dict = {
   "agentManager.review.metaComment": "Brugerkommentar",
   "agentManager.review.metaAuthor": "Forfatter",
   "agentManager.pr.comment.title": "Kommentarer",
+  "agentManager.pr.copyLink": "Kopiér PR-link",
   "agentManager.pr.comment.unresolvedCount": "{{count}} uløste",
   "agentManager.pr.comment.resolvedGroup": "Løste ({{count}})",
   "agentManager.pr.comment.sendAll": "Send {{count}} uløste til agenten",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -199,6 +199,7 @@ export const dict = {
   "agentManager.review.metaComment": "Benutzerkommentar",
   "agentManager.review.metaAuthor": "Autor",
   "agentManager.pr.comment.title": "Kommentare",
+  "agentManager.pr.copyLink": "PR-Link kopieren",
   "agentManager.pr.comment.unresolvedCount": "{{count}} ungelöst",
   "agentManager.pr.comment.resolvedGroup": "Gelöst ({{count}})",
   "agentManager.pr.comment.sendAll": "{{count}} ungelöste an Agent senden",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -200,6 +200,7 @@ export const dict = {
   "agentManager.review.metaComment": "User comment",
   "agentManager.review.metaAuthor": "Author",
   "agentManager.pr.comment.title": "Comments",
+  "agentManager.pr.copyLink": "Copy PR link",
   "agentManager.pr.comment.unresolvedCount": "{{count}} unresolved",
   "agentManager.pr.comment.resolvedGroup": "Resolved ({{count}})",
   "agentManager.pr.comment.sendAll": "Send {{count}} unresolved to agent",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -198,6 +198,7 @@ export const dict = {
   "agentManager.review.metaComment": "Comentario del usuario",
   "agentManager.review.metaAuthor": "Autor",
   "agentManager.pr.comment.title": "Comentarios",
+  "agentManager.pr.copyLink": "Copiar enlace del PR",
   "agentManager.pr.comment.unresolvedCount": "{{count}} sin resolver",
   "agentManager.pr.comment.resolvedGroup": "Resueltos ({{count}})",
   "agentManager.pr.comment.sendAll": "Enviar {{count}} sin resolver al agente",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
@@ -201,6 +201,7 @@ export const dict = {
   "agentManager.review.metaComment": "نظر کاربر",
   "agentManager.review.metaAuthor": "نویسنده",
   "agentManager.pr.comment.title": "نظرات",
+  "agentManager.pr.copyLink": "کپی پیوند PR",
   "agentManager.pr.comment.unresolvedCount": "{{count}} حل‌نشده",
   "agentManager.pr.comment.resolvedGroup": "حل‌شده ({{count}})",
   "agentManager.pr.comment.sendAll": "ارسال {{count}} مورد حل‌نشده به عامل",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -199,6 +199,7 @@ export const dict = {
   "agentManager.review.metaComment": "Commentaire de l'utilisateur",
   "agentManager.review.metaAuthor": "Auteur",
   "agentManager.pr.comment.title": "Commentaires",
+  "agentManager.pr.copyLink": "Copier le lien du PR",
   "agentManager.pr.comment.unresolvedCount": "{{count}} non résolus",
   "agentManager.pr.comment.resolvedGroup": "Résolus ({{count}})",
   "agentManager.pr.comment.sendAll": "Envoyer {{count}} non résolus à l’agent",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
@@ -204,6 +204,7 @@ export const dict = {
   "agentManager.review.metaComment": "Commento utente",
   "agentManager.review.metaAuthor": "Autore",
   "agentManager.pr.comment.title": "Commenti",
+  "agentManager.pr.copyLink": "Copia link PR",
   "agentManager.pr.comment.unresolvedCount": "{{count}} non risolti",
   "agentManager.pr.comment.resolvedGroup": "Risolti ({{count}})",
   "agentManager.pr.comment.sendAll": "Invia {{count}} non risolti all'agente",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -198,6 +198,7 @@ export const dict = {
   "agentManager.review.metaComment": "ユーザーコメント",
   "agentManager.review.metaAuthor": "作成者",
   "agentManager.pr.comment.title": "コメント",
+  "agentManager.pr.copyLink": "PRリンクをコピー",
   "agentManager.pr.comment.unresolvedCount": "{{count}} 件未解決",
   "agentManager.pr.comment.resolvedGroup": "解決済み ({{count}})",
   "agentManager.pr.comment.sendAll": "{{count}} 件の未解決コメントをエージェントに送信",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -196,6 +196,7 @@ export const dict = {
   "agentManager.review.metaComment": "사용자 코멘트",
   "agentManager.review.metaAuthor": "작성자",
   "agentManager.pr.comment.title": "댓글",
+  "agentManager.pr.copyLink": "PR 링크 복사",
   "agentManager.pr.comment.unresolvedCount": "{{count}}개 미해결",
   "agentManager.pr.comment.resolvedGroup": "해결됨 ({{count}})",
   "agentManager.pr.comment.sendAll": "{{count}}개 미해결 댓글을 에이전트로 보내기",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
@@ -203,6 +203,7 @@ export const dict = {
   "agentManager.review.metaComment": "Gebruikersopmerking",
   "agentManager.review.metaAuthor": "Auteur",
   "agentManager.pr.comment.title": "Opmerkingen",
+  "agentManager.pr.copyLink": "PR-link kopiëren",
   "agentManager.pr.comment.unresolvedCount": "{{count}} onopgelost",
   "agentManager.pr.comment.resolvedGroup": "Opgelost ({{count}})",
   "agentManager.pr.comment.sendAll": "{{count}} onopgeloste opmerkingen naar agent sturen",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -195,6 +195,7 @@ export const dict = {
   "agentManager.review.metaComment": "Brukerkommentar",
   "agentManager.review.metaAuthor": "Forfatter",
   "agentManager.pr.comment.title": "Kommentarer",
+  "agentManager.pr.copyLink": "Kopier PR-lenke",
   "agentManager.pr.comment.unresolvedCount": "{{count}} uløste",
   "agentManager.pr.comment.resolvedGroup": "Løste ({{count}})",
   "agentManager.pr.comment.sendAll": "Send {{count}} uløste til agenten",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -197,6 +197,7 @@ export const dict = {
   "agentManager.review.metaComment": "Komentarz użytkownika",
   "agentManager.review.metaAuthor": "Autor",
   "agentManager.pr.comment.title": "Komentarze",
+  "agentManager.pr.copyLink": "Kopiuj link do PR",
   "agentManager.pr.comment.unresolvedCount": "{{count}} nierozwiązanych",
   "agentManager.pr.comment.resolvedGroup": "Rozwiązane ({{count}})",
   "agentManager.pr.comment.sendAll": "Wyślij {{count}} nierozwiązanych do agenta",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -198,6 +198,7 @@ export const dict = {
   "agentManager.review.metaComment": "Комментарий пользователя",
   "agentManager.review.metaAuthor": "Автор",
   "agentManager.pr.comment.title": "Комментарии",
+  "agentManager.pr.copyLink": "Копировать ссылку на PR",
   "agentManager.pr.comment.unresolvedCount": "{{count}} нерешённых",
   "agentManager.pr.comment.resolvedGroup": "Решённые ({{count}})",
   "agentManager.pr.comment.sendAll": "Отправить {{count}} нерешённых агенту",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -192,6 +192,7 @@ export const dict = {
   "agentManager.review.metaComment": "ความคิดเห็นของผู้ใช้",
   "agentManager.review.metaAuthor": "ผู้เขียน",
   "agentManager.pr.comment.title": "ความคิดเห็น",
+  "agentManager.pr.copyLink": "คัดลอกลิงก์ PR",
   "agentManager.pr.comment.unresolvedCount": "ยังไม่แก้ไข {{count}} รายการ",
   "agentManager.pr.comment.resolvedGroup": "แก้ไขแล้ว ({{count}})",
   "agentManager.pr.comment.sendAll": "ส่งความคิดเห็นที่ยังไม่แก้ไข {{count}} รายการไปยังเอเจนต์",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
@@ -205,6 +205,7 @@ export const dict = {
   "agentManager.review.metaComment": "Kullanıcı yorumu",
   "agentManager.review.metaAuthor": "Yazar",
   "agentManager.pr.comment.title": "Yorumlar",
+  "agentManager.pr.copyLink": "PR bağlantısını kopyala",
   "agentManager.pr.comment.unresolvedCount": "{{count}} çözülmemiş",
   "agentManager.pr.comment.resolvedGroup": "Çözüldü ({{count}})",
   "agentManager.pr.comment.sendAll": "{{count}} çözülmemiş yorumu ajana gönder",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
@@ -206,6 +206,7 @@ export const dict = {
   "agentManager.review.metaComment": "Коментар користувача",
   "agentManager.review.metaAuthor": "Автор",
   "agentManager.pr.comment.title": "Коментарі",
+  "agentManager.pr.copyLink": "Копіювати посилання на PR",
   "agentManager.pr.comment.unresolvedCount": "{{count}} невирішених",
   "agentManager.pr.comment.resolvedGroup": "Вирішено ({{count}})",
   "agentManager.pr.comment.sendAll": "Надіслати {{count}} невирішених агенту",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -190,6 +190,7 @@ export const dict = {
   "agentManager.review.metaComment": "用户评论",
   "agentManager.review.metaAuthor": "作者",
   "agentManager.pr.comment.title": "评论",
+  "agentManager.pr.copyLink": "复制 PR 链接",
   "agentManager.pr.comment.unresolvedCount": "{{count}} 个未解决",
   "agentManager.pr.comment.resolvedGroup": "已解决 ({{count}})",
   "agentManager.pr.comment.sendAll": "将 {{count}} 个未解决评论发送给代理",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -190,6 +190,7 @@ export const dict = {
   "agentManager.review.metaComment": "使用者評論",
   "agentManager.review.metaAuthor": "作者",
   "agentManager.pr.comment.title": "留言",
+  "agentManager.pr.copyLink": "複製 PR 連結",
   "agentManager.pr.comment.unresolvedCount": "{{count}} 個未解決",
   "agentManager.pr.comment.resolvedGroup": "已解決 ({{count}})",
   "agentManager.pr.comment.sendAll": "將 {{count}} 個未解決留言傳送給代理",

--- a/packages/kilo-vscode/webview-ui/agent-manager/pr/CopyButton.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/pr/CopyButton.tsx
@@ -1,11 +1,13 @@
 /** @jsxImportSource solid-js */
 import { createSignal } from "solid-js"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
+import { useVSCode } from "../../src/context/vscode"
 
 export function CopyButton(props: { text: string; label?: string; class?: string }) {
+  const vscode = useVSCode()
   const [copied, setCopied] = createSignal(false)
   const copy = () => {
-    navigator.clipboard.writeText(props.text)
+    vscode.postMessage({ type: "agentManager.copyToClipboard", text: props.text })
     setCopied(true)
     setTimeout(() => setCopied(false), 1500)
   }

--- a/packages/kilo-vscode/webview-ui/agent-manager/pr/PRPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/pr/PRPanel.tsx
@@ -4,6 +4,7 @@ import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import type { WorktreeState } from "../../src/types/messages"
 import type { PRStatus } from "../../src/types/messages"
+import { useLanguage } from "../../src/context/language"
 import { PRBadge } from "./PRBadge"
 import { PROverview } from "./PROverview"
 import { PRReviewers } from "./PRReviewers"
@@ -12,6 +13,7 @@ import { PRChecks } from "./PRChecks"
 import { PRComments } from "./PRComments"
 import { commentScroll, setCommentScroll } from "./pr-comment-state"
 import { PRSummary } from "./PRSummary"
+import { CopyButton } from "./CopyButton"
 import "./pr-panel.css"
 
 interface PRPanelProps {
@@ -27,6 +29,7 @@ interface PRPanelProps {
 }
 
 export const PRPanel: Component<PRPanelProps> = (props) => {
+  const { t } = useLanguage()
   let commentsRef: HTMLDivElement | undefined
   let bodyRef: HTMLDivElement | undefined
   let capture: number | undefined
@@ -117,6 +120,9 @@ export const PRPanel: Component<PRPanelProps> = (props) => {
           <span class="am-pr-panel-number">#{props.pr.number}</span>
         </div>
         <div class="am-pr-panel-actions am-pr-row">
+          <Tooltip value={t("agentManager.pr.copyLink")} placement="bottom">
+            <CopyButton text={props.pr.url} label={t("agentManager.pr.copyLink")} />
+          </Tooltip>
           <Tooltip value="Open in browser" placement="bottom">
             <IconButton
               icon="link"

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -822,6 +822,11 @@ export interface OpenWorktreeRequest {
   worktreeId: string
 }
 
+export interface AgentManagerCopyToClipboardRequest {
+  type: "agentManager.copyToClipboard"
+  text: string
+}
+
 // Copy text to the system clipboard via the extension host
 export interface CopyToClipboardRequest {
   type: "copyToClipboard"
@@ -1591,6 +1596,7 @@ export type WebviewMessage =
   | ShowLocalTerminalRequest
   | ShowWorktreeTerminalRequest
   | OpenWorktreeRequest
+  | AgentManagerCopyToClipboardRequest
   | CopyToClipboardRequest
   | ShowExistingLocalTerminalRequest
   | AgentManagerOpenFileRequest


### PR DESCRIPTION
The Agent Manager PR panel currently provides actions to open a pull request in the browser and close the panel, but it does not provide a quick way to share the PR URL.

Add a copy action beside the existing PR header controls. It reuses the standard copy icon, routes clipboard writes through the Agent Manager extension-host bridge, and shows the existing check-state feedback after a successful click. The action label is localized in every Agent Manager locale.

Before:

<img width="700" alt="Agent Manager PR panel before the copy button" src="https://marius-kilocode.github.io/pr-assets/20260824-agent-manager-pr-copy-link-before.png" />

After:

<img width="700" alt="Agent Manager PR panel with the copy button" src="https://marius-kilocode.github.io/pr-assets/20260824-agent-manager-pr-copy-link-after.png" />