### PR TITLE
fix(ui): expand answered questions in chat

### DIFF
--- a/.changeset/answered-questions-expanded.md
+++ b/.changeset/answered-questions-expanded.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep answered questions expanded in chat history and improve their text wrapping.

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -525,7 +525,34 @@ html[data-theme="kilo-vscode"] [data-component="todos"] {
 }
 
 [data-component="question-answers"] {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
   padding: 8px;
+  font-family: var(--font-family-sans);
+  font-size: var(--kilo-font-size-13);
+  line-height: var(--line-height-large);
+
+  [data-slot="question-answer-item"] {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  [data-slot="question-text"],
+  [data-slot="answer-text"] {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  [data-slot="question-text"] {
+    color: var(--text-weak);
+  }
+
+  [data-slot="answer-text"] {
+    color: var(--text-strong);
+  }
 }
 
 @keyframes reasoning-card-down {

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -3171,7 +3171,7 @@ ToolRegistry.register({
     return (
       <BasicTool
         {...props}
-        defaultOpen={false}
+        defaultOpen={completed() && !dismissed()}
         icon="bubble-5"
         trigger={
           <ToolTriggerRow

--- a/packages/kilo-ui/src/stories/message-part.stories.tsx
+++ b/packages/kilo-ui/src/stories/message-part.stories.tsx
@@ -617,7 +617,7 @@ export const ToolHintErrors: Story = {
   ),
 }
 
-// --- Question tool: answered (collapsed) ---
+// --- Question tool: answered (expanded by default) ---
 
 export const QuestionAnswered: Story = {
   name: "QuestionAnswered",
@@ -628,10 +628,10 @@ export const QuestionAnswered: Story = {
   ),
 }
 
-// --- Question tool: answered (expanded) ---
+// --- Question tool: answered (manually collapsed) ---
 
-export const QuestionAnsweredExpanded: Story = {
-  name: "QuestionAnswered (expanded)",
+export const QuestionAnsweredCollapsed: Story = {
+  name: "QuestionAnswered (manually collapsed)",
   render: () => (
     <AllProviders data={mockDataQuestionAnswered}>
       <AssistantParts messages={[mockAssistantMessage]} />


### PR DESCRIPTION
Completed question prompts currently render as collapsed tool rows, which hides the question and answer pair until the user opens each row. This makes recent conversation history harder to scan and is especially costly in narrow chat panes.

Answered question cards now open by default while dismissed cards keep their compact default. The answer list uses the Kilo sans font tokens, readable line height, and wrapping so long questions and answers stay within the chat width. The Storybook coverage now includes the default expanded state and the manual collapse state.

Before:
<img width="536" alt="Answered question collapsed in chat" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260824-chat-answered-question-before.png" />

After:
<img width="536" alt="Answered question expanded in chat" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260824-chat-answered-question-after.png" />