### PR TITLE
docs(kilo-docs): mark KiloClaw end of life

### DIFF
--- a/packages/kilo-docs/markdoc/partials/kiloclaw-eol.md
+++ b/packages/kilo-docs/markdoc/partials/kiloclaw-eol.md
@@ -1,0 +1,3 @@
+{% callout type="warning" title="KiloClaw is end of life" %}
+KiloClaw is no longer available to new users, and support for the product is ending. This documentation is kept for reference by existing users and is no longer maintained.
+{% /callout %}

--- a/packages/kilo-docs/pages/ai-providers/openai-chatgpt-plus-pro.md
+++ b/packages/kilo-docs/pages/ai-providers/openai-chatgpt-plus-pro.md
@@ -16,7 +16,7 @@ If you already pay for ChatGPT Plus or Pro, you can use that subscription to run
 - **Multiple AI modes:** Switch between Code, Plan, Debug, and Ask modes for different tasks.
 
 {% callout type="note" %}
-Your ChatGPT subscription works with Kilo Code's core functionality (VS Code extension and CLI), but does **not** include cloud features such as Cloud Agents, Kilo Deploy, or KiloClaw. To use GPT models in those features, use the [Kilo Gateway](/docs/gateway).
+Your ChatGPT subscription works with Kilo Code's core functionality (VS Code extension and CLI), but does **not** include cloud features such as Cloud Agents or Kilo Deploy. To use GPT models in those features, use the [Kilo Gateway](/docs/gateway).
 {% /callout %}
 
 ## Setup
@@ -62,7 +62,7 @@ Then set your default model to one of the OpenAI Codex models available in Kilo 
 
 - **Codex catalog models only.** This provider only exposes the models listed in Kilo Code's Codex model catalog. It does not give access to every model available through the OpenAI API.
 - **OAuth tokens can't be exported with settings.** Tokens are stored in VS Code SecretStorage, which isn't included in Kilo Code's settings export.
-- **Cloud features not included.** Cloud Agents, Kilo Deploy, and KiloClaw require the [Kilo Gateway](/docs/gateway).
+- **Cloud features not included.** Cloud Agents and Kilo Deploy require the [Kilo Gateway](/docs/gateway).
 
 ## FAQ
 
@@ -78,5 +78,5 @@ Usage counts against your ChatGPT subscription limits — there are no separate 
 **Can I still switch to other AI providers?**
 Yes. Use OpenAI when it fits and switch to Claude, Gemini, or any local model at any time.
 
-**Can I use my ChatGPT subscription in KiloClaw?**
-No. For KiloClaw and other cloud features, use GPT models through the [Kilo Gateway](/docs/gateway), which gives access to 500+ models including the latest GPT releases.
+**Can I use my ChatGPT subscription in Kilo's cloud features?**
+No. For Cloud Agents, Kilo Deploy, and other cloud features, use GPT models through the [Kilo Gateway](/docs/gateway), which gives access to 500+ models including the latest GPT releases.

--- a/packages/kilo-docs/pages/ai-providers/xai.md
+++ b/packages/kilo-docs/pages/ai-providers/xai.md
@@ -28,7 +28,7 @@ If you have an active [SuperGrok or X Premium subscription](https://x.ai/grok), 
 - **Automatic token refresh:** Kilo Code refreshes your access token in the background so long-running sessions stay authenticated.
 
 {% callout type="note" %}
-SuperGrok and X Premium subscription access works with Kilo Code's core functionality (VS Code extension and CLI). For cloud features such as Cloud Agents or KiloClaw, use the [Kilo Gateway](/docs/gateway) — the Gateway supports xAI via [BYOK](/docs/getting-started/byok) with an API key (OAuth and subscription-based access are not supported through the Gateway).
+SuperGrok and X Premium subscription access works with Kilo Code's core functionality (VS Code extension and CLI). For cloud features such as Cloud Agents, use the [Kilo Gateway](/docs/gateway) — the Gateway supports xAI via [BYOK](/docs/getting-started/byok) with an API key (OAuth and subscription-based access are not supported through the Gateway).
 {% /callout %}
 
 ### Setup with SuperGrok / X Premium

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cloud-agent.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cloud-agent.md
@@ -159,11 +159,8 @@ Triggers allow you to initiate cloud agent sessions automatically, either via HT
 Triggers are currently in beta and subject to change.
 {% /callout %}
 
-Webhook triggers and scheduled triggers use the same trigger concepts across Cloud
-Agent and KiloClaw, but target different agents. Use Cloud Agent triggers when an
-HTTP event or schedule should start a Cloud Agent session against a repository.
-Use KiloClaw triggers when the event should deliver a chat message to a KiloClaw
-instance.
+Use Cloud Agent triggers when an HTTP event or schedule should start a Cloud Agent
+session against a repository.
 
 ### Accessing Triggers
 

--- a/packages/kilo-docs/pages/code-with-ai/platforms/mobile.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/mobile.md
@@ -5,7 +5,7 @@ description: "Using Kilo Code on iOS and Android"
 
 # Mobile Apps
 
-Use Kilo Code from your phone to keep coding sessions moving while you are away from your desk. The mobile app connects to Cloud Agents, KiloClaw, and remote sessions from your local CLI or editor extensions.
+Use Kilo Code from your phone to keep coding sessions moving while you are away from your desk. The mobile app connects to Cloud Agents and remote sessions from your local CLI or editor extensions.
 
 {% callout type="info" title="Android app available now" %}
 Install Kilo Code for Android from [Google Play](https://play.google.com/store/apps/details?id=com.kilocode.kiloapp).
@@ -16,10 +16,8 @@ Install Kilo Code for Android from [Google Play](https://play.google.com/store/a
 The mobile app lets you:
 
 - View and manage Kilo Code sessions, including remote CLI and extension sessions running on your local machine.
-- Chat with KiloClaw from your phone.
 - Spawn Cloud Agents and code directly from the app.
 - Monitor and view all non-remote sessions in one place.
-- Create, onboard, and manage KiloClaw instances.
 - Send follow-up messages while a session is still running — they are queued and processed in order.
 - Run slash commands (like `/compact`) on connected remote CLI sessions, and start a new session in the same workspace with `/new`. The new session inherits the current session's mode and model. Older CLI versions that do not support remote commands prompt you to upgrade.
 - Clear the visible transcript of a remote CLI session with `/clear`. Clearing is client-side only, so it works on any CLI version; server history is kept and may reappear when you re-enter the session.
@@ -38,16 +36,14 @@ You can review or change your decision at any time in **Settings**. Declining op
 For Kilo Pass pricing, billing, and account management details, use the [Kilo Pass pricing page](https://kilo.ai/pricing/kilo-pass).
 
 {% imageGallery columns="3" width="220px" %}
-{% image src="/docs/img/mobile-apps/home.webp" alt="Kilo Code mobile home screen showing KiloClaw and active agent sessions" caption="Start coding tasks, open KiloClaw, and resume active sessions from the mobile home screen." /%}
+{% image src="/docs/img/mobile-apps/home.webp" alt="Kilo Code mobile home screen showing active agent sessions" caption="Start coding tasks and resume active sessions from the mobile home screen." /%}
 
 {% image src="/docs/img/mobile-apps/new-session.webp" alt="Kilo Code mobile new session screen with coding mode selector" caption="Create a new Cloud Agent session and choose the right mode for the task." /%}
 
 {% image src="/docs/img/mobile-apps/session-chat.webp" alt="Kilo Code mobile session chat with an active coding task" caption="Review progress and continue coding conversations from the mobile app." /%}
 {% /imageGallery %}
 
-{% imageGallery columns="2" width="220px" %}
-{% image src="/docs/img/mobile-apps/kiloclaw-chat.webp" alt="KiloClaw chat in the Kilo Code mobile app" caption="Chat with KiloClaw on mobile." /%}
-
+{% imageGallery columns="1" width="220px" %}
 {% image src="/docs/img/mobile-apps/session-filters.webp" alt="Kilo Code mobile session filter panel for Cloud Extension CLI Slack and other platforms" caption="Filter sessions by platform and project, including Cloud, Extension, CLI, Slack, and other sessions." /%}
 {% /imageGallery %}
 

--- a/packages/kilo-docs/pages/contributing/architecture/index.md
+++ b/packages/kilo-docs/pages/contributing/architecture/index.md
@@ -223,4 +223,3 @@ After system-boundary pages, continue with Development Patterns for implementati
 - [Development Patterns](/docs/contributing/architecture/development-patterns) - code-ownership decisions and contributor workflow
 - [Development Environment](/docs/contributing/development-environment) - setup guide
 - [Ecosystem](/docs/contributing/ecosystem) - related projects and integrations
-- [KiloClaw Overview](/docs/kiloclaw/overview) - customer-facing KiloClaw docs

--- a/packages/kilo-docs/pages/index.tsx
+++ b/packages/kilo-docs/pages/index.tsx
@@ -66,25 +66,6 @@ const terminalContent = {
       <span className="terminal-prompt">$</span> kilo rules list
     </>
   ),
-  kiloclaw: (
-    <>
-      <span className="terminal-comment"># Chat with your KiloClaw agent from the CLI</span>
-      {"\n"}
-      <span className="terminal-prompt">$</span> kilo /claw
-      {"\n"}
-      {"\n"}
-      <span className="terminal-comment"># Or connect via chat platforms</span>
-      {"\n"}
-      <span className="terminal-comment"># Telegram, Discord, Slack — no self-hosting required</span>
-      {"\n"}
-      {"\n"}
-      <span className="terminal-comment"># Trigger your agent via webhook</span>
-      {"\n"}
-      <span className="terminal-prompt">$</span> curl -X POST https://your-instance.kiloclaw.ai/webhook \{"\n"}
-      -H "Content-Type: application/json" \{"\n"}
-      {`  -d '{"event":"deploy","repo":"my-app"}'`}
-    </>
-  ),
 }
 
 // Category card data based on the information architecture
@@ -118,24 +99,6 @@ const categories = [
       { title: "The Chat Interface", href: "/code-with-ai" },
       { title: "Using Modes", href: "/code-with-ai" },
       { title: "Custom Rules", href: "/code-with-ai" },
-    ],
-  },
-  {
-    title: "KiloClaw",
-    description:
-      "Hosted OpenClaw agents — deploy, manage, and integrate AI agents with chat platforms, dev tools, and triggers without self-hosting.",
-    href: "/kiloclaw/overview",
-    icon: (
-      <svg className="category-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-        <path d="M12 2L2 7l10 5 10-5-10-5z" strokeLinecap="round" strokeLinejoin="round" />
-        <path d="M2 17l10 5 10-5" strokeLinecap="round" strokeLinejoin="round" />
-        <path d="M2 12l10 5 10-5" strokeLinecap="round" strokeLinejoin="round" />
-      </svg>
-    ),
-    links: [
-      { title: "Overview", href: "/kiloclaw/overview" },
-      { title: "Chat Platforms", href: "/kiloclaw/chat-platforms" },
-      { title: "Development Tools", href: "/kiloclaw/development-tools" },
     ],
   },
   {
@@ -230,9 +193,7 @@ const categories = [
 ]
 
 export default function HomePage() {
-  const [activeTab, setActiveTab] = useState<"installation" | "firstTask" | "customRules" | "gateway" | "kiloclaw">(
-    "installation",
-  )
+  const [activeTab, setActiveTab] = useState<"installation" | "firstTask" | "customRules" | "gateway">("installation")
 
   return (
     <div className="homepage">
@@ -247,15 +208,15 @@ export default function HomePage() {
         <div className="hero-content">
           <h1 className="hero-title">Kilo Documentation</h1>
           <p className="hero-subtitle">
-            Explore guides and examples for the Kilo platform — from coding agents and AI-powered development to hosted
-            agentic infrastructure with KiloClaw.
+            Explore guides and examples for the Kilo platform — from coding agents and AI-powered development to
+            automation and hosted agentic infrastructure.
           </p>
           <div className="hero-buttons">
             <Link href="/getting-started" className="btn btn-primary">
               Get started with Kilo Code →
             </Link>
-            <Link href="/kiloclaw/overview" className="btn btn-secondary">
-              Explore KiloClaw
+            <Link href="/gateway" className="btn btn-secondary">
+              Explore Kilo Gateway
             </Link>
           </div>
         </div>
@@ -273,20 +234,6 @@ export default function HomePage() {
               </Link>
               <Link href="/getting-started" className="quick-link">
                 Your First Task
-              </Link>
-            </div>
-          </div>
-          <div className="quick-section">
-            <h3 className="quick-title">KILOCLAW</h3>
-            <div className="quick-links">
-              <Link href="/kiloclaw/overview" className="quick-link">
-                Overview
-              </Link>
-              <Link href="/kiloclaw/chat-platforms" className="quick-link">
-                Chat Platforms
-              </Link>
-              <Link href="/kiloclaw/development-tools" className="quick-link">
-                Development Tools
               </Link>
             </div>
           </div>
@@ -348,7 +295,7 @@ export default function HomePage() {
       <section className="terminal-section">
         <div className="terminal-intro">
           <h2 className="section-title">Try it out</h2>
-          <p className="terminal-description">Get started quickly with Kilo Code, KiloClaw, and Kilo Gateway</p>
+          <p className="terminal-description">Get started quickly with Kilo Code and Kilo Gateway</p>
         </div>
         <div className="terminal-container">
           <div className="terminal-tabs">
@@ -369,12 +316,6 @@ export default function HomePage() {
               onClick={() => setActiveTab("customRules")}
             >
               Custom Rules
-            </button>
-            <button
-              className={`terminal-tab ${activeTab === "kiloclaw" ? "active" : ""}`}
-              onClick={() => setActiveTab("kiloclaw")}
-            >
-              KiloClaw
             </button>
             <button
               className={`terminal-tab ${activeTab === "gateway" ? "active" : ""}`}

--- a/packages/kilo-docs/pages/kiloclaw/chat-platforms/discord.md
+++ b/packages/kilo-docs/pages/kiloclaw/chat-platforms/discord.md
@@ -5,6 +5,8 @@ description: "Use KiloClaw with Discord: setup, DM access control, and channel c
 
 # Discord
 
+{% partial file="kiloclaw-eol.md" /%}
+
 This page covers everything you need to use KiloClaw with Discord: connecting your bot, controlling who can DM it, and adding it to specific channels.
 
 ## Connecting KiloClaw to Discord

--- a/packages/kilo-docs/pages/kiloclaw/chat-platforms/index.md
+++ b/packages/kilo-docs/pages/kiloclaw/chat-platforms/index.md
@@ -5,6 +5,8 @@ description: "Use Kilo Chat or connect your KiloClaw agent to Telegram, Discord,
 
 # Chat Platforms
 
+{% partial file="kiloclaw-eol.md" /%}
+
 KiloClaw includes Kilo Chat as its first-party channel and also supports connecting your AI agent to messaging platforms so it can receive instructions and send responses directly in your chat apps. You can configure third-party channels from the **Settings** tab on your [KiloClaw dashboard](/docs/kiloclaw/dashboard#channels), or from the OpenClaw Control UI after accessing your instance.
 
 ## Kilo Chat

--- a/packages/kilo-docs/pages/kiloclaw/chat-platforms/slack.md
+++ b/packages/kilo-docs/pages/kiloclaw/chat-platforms/slack.md
@@ -5,6 +5,8 @@ description: "Using KiloClaw with Slack"
 
 # Slack
 
+{% partial file="kiloclaw-eol.md" /%}
+
 This page covers everything you need to use KiloClaw with Slack: connecting your bot, controlling who can DM it, and adding it to channels.
 
 ## Connecting KiloClaw to Slack

--- a/packages/kilo-docs/pages/kiloclaw/chat-platforms/telegram.md
+++ b/packages/kilo-docs/pages/kiloclaw/chat-platforms/telegram.md
@@ -5,6 +5,8 @@ description: "Use KiloClaw with Telegram: setup, DM access control, and group ch
 
 # Telegram
 
+{% partial file="kiloclaw-eol.md" /%}
+
 This page covers everything you need to use KiloClaw with Telegram: connecting your bot and adding it to group chats.
 
 ## Connecting KiloClaw to Telegram

--- a/packages/kilo-docs/pages/kiloclaw/control-ui/changing-models.md
+++ b/packages/kilo-docs/pages/kiloclaw/control-ui/changing-models.md
@@ -5,6 +5,8 @@ description: "Browse and switch models from the Control UI chat"
 
 # Changing Models
 
+{% partial file="kiloclaw-eol.md" /%}
+
 The Control UI Chat tab doubles as a command line for model management. KiloClaw exposes 335+ models through the `kilocode` provider and you can browse and switch between them without leaving the chat.
 
 | Command | Description |

--- a/packages/kilo-docs/pages/kiloclaw/control-ui/exec-approvals.md
+++ b/packages/kilo-docs/pages/kiloclaw/control-ui/exec-approvals.md
@@ -5,6 +5,8 @@ description: "Control which commands your KiloClaw agent can run on the host mac
 
 # Exec Approvals
 
+{% partial file="kiloclaw-eol.md" /%}
+
 Exec approvals are the safety interlock that controls which commands your agent can run on the host machine (gateway or node). By default, **all host exec requests are denied** — you must explicitly allowlist the commands you want your agent to run independently. This prevents accidental execution of destructive commands.
 
 {% callout type="warning" %}

--- a/packages/kilo-docs/pages/kiloclaw/control-ui/overview.md
+++ b/packages/kilo-docs/pages/kiloclaw/control-ui/overview.md
@@ -5,6 +5,8 @@ description: "Browser-based dashboard for managing your OpenClaw instance"
 
 # OpenClaw Control UI
 
+{% partial file="kiloclaw-eol.md" /%}
+
 The Control UI is a browser-based dashboard (built with Vite + Lit) served by the OpenClaw Gateway on the same port as the gateway itself (default: `http://localhost:18789/`). It connects via WebSocket and gives you real-time control over your agent, channels, sessions, and system configuration. For KiloClaw users, see [Accessing the Control UI](/docs/kiloclaw/dashboard#accessing-the-control-ui) to get started.
 
 ## Features

--- a/packages/kilo-docs/pages/kiloclaw/control-ui/version-pinning.md
+++ b/packages/kilo-docs/pages/kiloclaw/control-ui/version-pinning.md
@@ -5,6 +5,8 @@ description: "Pin your KiloClaw instance to a specific OpenClaw version and vari
 
 # Version Pinning
 
+{% partial file="kiloclaw-eol.md" /%}
+
 Version pinning lets you lock your KiloClaw instance to a specific OpenClaw version and variant. This gives you control over when your instance upgrades — it stays on the pinned version until you explicitly change it.
 
 ## When to Use Version Pinning

--- a/packages/kilo-docs/pages/kiloclaw/dashboard.md
+++ b/packages/kilo-docs/pages/kiloclaw/dashboard.md
@@ -5,6 +5,8 @@ description: "Managing your KiloClaw instance from the dashboard"
 
 # KiloClaw Dashboard
 
+{% partial file="kiloclaw-eol.md" /%}
+
 This page covers everything you can do from the KiloClaw dashboard. For getting started, see [KiloClaw Overview](/docs/kiloclaw/overview).
 
 {% image src="/docs/img/kiloclaw/dashboard.png" alt="Connect account screen" width="800" caption="The KiloClaw Dashboard" /%}

--- a/packages/kilo-docs/pages/kiloclaw/development-tools/composio.md
+++ b/packages/kilo-docs/pages/kiloclaw/development-tools/composio.md
@@ -5,6 +5,8 @@ description: "Connect Composio to your KiloClaw agent to access hundreds of tool
 
 # Composio Integration
 
+{% partial file="kiloclaw-eol.md" /%}
+
 Connect Composio to your KiloClaw agent to instantly unlock access to 250+ tool integrations — from Salesforce and HubSpot to Notion, Jira, and beyond. Composio is a platform that handles the authentication and connection details for each service, so your agent can use them without you having to set up each one individually.
 
 {% callout type="info" title="Tip" %}

--- a/packages/kilo-docs/pages/kiloclaw/development-tools/github.md
+++ b/packages/kilo-docs/pages/kiloclaw/development-tools/github.md
@@ -5,6 +5,8 @@ description: "Connect a GitHub account to your KiloClaw agent for repository acc
 
 # GitHub Integration
 
+{% partial file="kiloclaw-eol.md" /%}
+
 Connect a GitHub account to your KiloClaw agent so it can clone repositories, push commits, open pull requests, and leave code reviews — all autonomously.
 
 {% callout type="warning" title="Security" %}

--- a/packages/kilo-docs/pages/kiloclaw/development-tools/google.md
+++ b/packages/kilo-docs/pages/kiloclaw/development-tools/google.md
@@ -5,6 +5,8 @@ description: "Connect a dedicated Google account to KiloClaw for access to Gmail
 
 # Google Workspace Integration
 
+{% partial file="kiloclaw-eol.md" /%}
+
 Connect a dedicated Google account to KiloClaw so it can interact with Google Workspace services — Gmail, Calendar, Drive, Docs, Sheets, Slides, Tasks, People, Forms, Chat, Classroom, and Apps Script.
 
 {% callout type="warning" title="Use a dedicated Google account" %}

--- a/packages/kilo-docs/pages/kiloclaw/development-tools/index.md
+++ b/packages/kilo-docs/pages/kiloclaw/development-tools/index.md
@@ -5,6 +5,8 @@ description: "Manage integrations and settings for your KiloClaw agent"
 
 # Integrations
 
+{% partial file="kiloclaw-eol.md" /%}
+
 Configure integrations and settings for your KiloClaw agent. Connect third-party services to give your agent access to repositories, issue trackers, calendars, documents, and hundreds of other tools — all without manual intervention.
 
 ## Available Integrations

--- a/packages/kilo-docs/pages/kiloclaw/development-tools/linear.md
+++ b/packages/kilo-docs/pages/kiloclaw/development-tools/linear.md
@@ -5,6 +5,8 @@ description: "Connect Linear to your KiloClaw agent to create and manage issues 
 
 # Linear Integration
 
+{% partial file="kiloclaw-eol.md" /%}
+
 Connect Linear to your KiloClaw agent so it can create issues, update their status, read project backlogs, and track work — all automatically. Linear is a project management tool popular with software teams for planning and tracking features, bugs, and tasks.
 
 {% callout type="warning" title="Keep your API key private" %}

--- a/packages/kilo-docs/pages/kiloclaw/end-to-end.md
+++ b/packages/kilo-docs/pages/kiloclaw/end-to-end.md
@@ -5,6 +5,8 @@ description: "Start-to-finish guide for configuring your KiloClaw instance"
 
 # Setup walkthrough
 
+{% partial file="kiloclaw-eol.md" /%}
+
 This guide walks you through a full KiloClaw setup — from creating accounts to scheduling your first automated workflow. Plan for about 60 minutes.
 
 ## Planning your setup

--- a/packages/kilo-docs/pages/kiloclaw/faq/general.md
+++ b/packages/kilo-docs/pages/kiloclaw/faq/general.md
@@ -5,6 +5,8 @@ description: "Frequently asked questions about KiloClaw"
 
 # FAQ
 
+{% partial file="kiloclaw-eol.md" /%}
+
 ## How can I change my model?
 
 You can change the model in two ways:

--- a/packages/kilo-docs/pages/kiloclaw/faq/pricing.md
+++ b/packages/kilo-docs/pages/kiloclaw/faq/pricing.md
@@ -5,6 +5,8 @@ description: "Pricing details for KiloClaw instances and model inference"
 
 # Pricing
 
+{% partial file="kiloclaw-eol.md" /%}
+
 KiloClaw uses Kilo Gateway credits by default — if you route requests through BYOK, model usage is billed directly by your provider instead.
 
 ## Instance Hosting

--- a/packages/kilo-docs/pages/kiloclaw/overview.md
+++ b/packages/kilo-docs/pages/kiloclaw/overview.md
@@ -5,6 +5,8 @@ description: "One-click deployment of your Kilo-hosted AI agent with OpenClaw"
 
 # KiloClaw 🦀
 
+{% partial file="kiloclaw-eol.md" /%}
+
 KiloClaw is Kilo's hosted [OpenClaw](https://openclaw.ai) service — a one-click deployment that gives you a personal or organization-scoped AI agent without the complexity of self-hosting. OpenClaw is a 24/7, open source AI agent that connects to Kilo Chat and optional chat platforms like Telegram, Discord, and Slack so it can take real actions automatically, not just chat.
 
 KiloClaw is powered by Kilo Code. The API key is platform-managed, so you never need to bring your own.

--- a/packages/kilo-docs/pages/kiloclaw/pre-installed-software.md
+++ b/packages/kilo-docs/pages/kiloclaw/pre-installed-software.md
@@ -5,6 +5,8 @@ description: "Default system utilities, languages, and CLI tools included in the
 
 # Pre-installed Software
 
+{% partial file="kiloclaw-eol.md" /%}
+
 Every KiloClaw instance ships with a curated set of system utilities, language runtimes, package managers, and CLI tools. This page documents everything that comes pre-installed in the KiloClaw Docker image so you know what's available out of the box. Where a specific version is listed it reflects the pin in the Dockerfile as of March 2026. Entries marked **unpinned** install the latest available version at image build time and may differ between releases.
 
 ## Base Image

--- a/packages/kilo-docs/pages/kiloclaw/tools/1password.md
+++ b/packages/kilo-docs/pages/kiloclaw/tools/1password.md
@@ -5,6 +5,8 @@ description: "Connect your KiloClaw agent to 1Password to securely manage creden
 
 # 1Password Integration Guide
 
+{% partial file="kiloclaw-eol.md" /%}
+
 Connect your KiloClaw agent to 1Password to securely manage credentials. This allows your agent to fetch API keys or passwords without ever seeing them in plain text.
 
 ## Step 1: Create a Dedicated Vault

--- a/packages/kilo-docs/pages/kiloclaw/tools/agentcard.md
+++ b/packages/kilo-docs/pages/kiloclaw/tools/agentcard.md
@@ -5,6 +5,8 @@ description: "Enable your KiloClaw agents to perform financial transactions with
 
 # AgentCard Integration
 
+{% partial file="kiloclaw-eol.md" /%}
+
 Enable your KiloClaw agents to perform financial transactions by creating and managing virtual debit cards. This integration allows for automated purchasing and expense management within set limits.
 
 ## AgentCard Setup

--- a/packages/kilo-docs/pages/kiloclaw/tools/brave-search.md
+++ b/packages/kilo-docs/pages/kiloclaw/tools/brave-search.md
@@ -5,6 +5,8 @@ description: "Equip your KiloClaw agent with real-time web browsing via the Brav
 
 # Brave Search Integration
 
+{% partial file="kiloclaw-eol.md" /%}
+
 Equip your KiloClaw agent with real-time web browsing capabilities by integrating the Brave Search API. This allows the agent to fetch up-to-date information, perform market research, and verify facts beyond its training data.
 
 ## How to Generate a Brave Search API Key

--- a/packages/kilo-docs/pages/kiloclaw/tools/index.md
+++ b/packages/kilo-docs/pages/kiloclaw/tools/index.md
@@ -5,6 +5,8 @@ description: "Third-party tool integrations for your KiloClaw agent"
 
 # Tools
 
+{% partial file="kiloclaw-eol.md" /%}
+
 KiloClaw supports integrations with third-party tools that extend your agent's capabilities — from secure credential management to web search and financial transactions.
 
 ## Available Integrations

--- a/packages/kilo-docs/pages/kiloclaw/tools/other-tools.md
+++ b/packages/kilo-docs/pages/kiloclaw/tools/other-tools.md
@@ -5,6 +5,8 @@ description: "Configure your KiloClaw agent to use third-party tools and service
 
 # Setting Up Other Services
 
+{% partial file="kiloclaw-eol.md" /%}
+
 While KiloClaw comes with a set of [pre-configured tool integrations](/docs/kiloclaw/tools), your agent isn't limited to just those. KiloClaw can be configured to use virtually any third-party integration as a tool — as long as it has a CLI or an API, you can teach your agent to work with it.
 
 We have seen this pattern work well with outside services like ZenDesk, Todoist, GitLab, and more.

--- a/packages/kilo-docs/pages/kiloclaw/triggers/index.md
+++ b/packages/kilo-docs/pages/kiloclaw/triggers/index.md
@@ -5,6 +5,8 @@ description: "Automate your KiloClaw agent with webhooks and scheduled triggers"
 
 # Triggers
 
+{% partial file="kiloclaw-eol.md" /%}
+
 Triggers let external events and schedules drive your KiloClaw agent automatically. Instead of typing every instruction yourself, triggers deliver messages to your agent on your behalf. This lets it react to real-world events or run tasks on a schedule without polling.
 
 All triggers are managed from the **Settings** page in the KiloClaw section of the sidebar.

--- a/packages/kilo-docs/pages/kiloclaw/triggers/scheduled.md
+++ b/packages/kilo-docs/pages/kiloclaw/triggers/scheduled.md
@@ -5,6 +5,8 @@ description: "Run tasks on a schedule using cron expressions"
 
 # Scheduled Triggers
 
+{% partial file="kiloclaw-eol.md" /%}
+
 Scheduled triggers let your KiloClaw agent run tasks automatically on a recurring schedule. Instead of waiting for an external event, a scheduled trigger fires at the times you define using cron expressions. When it fires, the prompt template is rendered and delivered as a chat message to your KiloClaw instance, just like a webhook.
 
 Scheduled triggers are one trigger mode shared by KiloClaw and Cloud Agent. In

--- a/packages/kilo-docs/pages/kiloclaw/triggers/webhooks.md
+++ b/packages/kilo-docs/pages/kiloclaw/triggers/webhooks.md
@@ -5,6 +5,8 @@ description: "Trigger your KiloClaw agent from external events using webhooks"
 
 # Webhooks
 
+{% partial file="kiloclaw-eol.md" /%}
+
 KiloClaw supports inbound webhooks so external events can trigger your agent automatically. Form submissions, alerts, calendar updates, ecommerce orders, IoT sensor data; anything that can send an HTTP request can kick off a conversation with your agent. When a webhook fires, the payload is rendered through a prompt template and delivered as a chat message to your KiloClaw instance. The agent processes and responds as if you typed it yourself.
 
 Webhook triggers are one trigger mode shared by KiloClaw and Cloud Agent. In

--- a/packages/kilo-docs/pages/kiloclaw/troubleshooting/architecture.md
+++ b/packages/kilo-docs/pages/kiloclaw/troubleshooting/architecture.md
@@ -5,6 +5,8 @@ description: "How KiloClaw instances are structured"
 
 # Architecture Notes
 
+{% partial file="kiloclaw-eol.md" /%}
+
 For advanced users — how KiloClaw instances are structured:
 
 - **Dedicated machine** — Each user gets their own machine and persistent volume. There is no shared infrastructure between users.

--- a/packages/kilo-docs/pages/kiloclaw/troubleshooting/common-questions.md
+++ b/packages/kilo-docs/pages/kiloclaw/troubleshooting/common-questions.md
@@ -5,6 +5,8 @@ description: "Answers to common KiloClaw troubleshooting questions"
 
 # Common Questions
 
+{% partial file="kiloclaw-eol.md" /%}
+
 ## OpenClaw Doctor
 
 OpenClaw Doctor is the recommended first step when something isn't working. It runs diagnostics on your instance and automatically fixes common configuration issues.

--- a/packages/kilo-docs/pages/kiloclaw/troubleshooting/faq.md
+++ b/packages/kilo-docs/pages/kiloclaw/troubleshooting/faq.md
@@ -5,6 +5,8 @@ description: "Frequently asked questions about KiloClaw"
 
 # FAQ
 
+{% partial file="kiloclaw-eol.md" /%}
+
 ## How can I change my model?
 
 You can change the model in two ways:

--- a/packages/kilo-docs/pages/kiloclaw/troubleshooting/gateway-process.md
+++ b/packages/kilo-docs/pages/kiloclaw/troubleshooting/gateway-process.md
@@ -5,6 +5,8 @@ description: "Understanding KiloClaw gateway process states"
 
 # Gateway Process States
 
+{% partial file="kiloclaw-eol.md" /%}
+
 The Gateway Process tab shows the current state of the OpenClaw process inside your machine:
 
 - **Running** — The process is up and handling requests


### PR DESCRIPTION
## What

Marks KiloClaw as end of life across the docs site and stops pointing users at it.

- Every page under `pages/kiloclaw/` now renders an EOL warning callout stating that KiloClaw is closed to new users and that support is ending.
- The docs homepage no longer promotes KiloClaw: the category card, hero CTA, quick-links column, and "Try it out" terminal tab are gone.
- Other product pages no longer reference KiloClaw — the mobile app capability list and screenshots, the Cloud Agent triggers comparison, and the ChatGPT and xAI cloud-feature notes.

## Why

Signups are closed and we're ending support, so KiloClaw shouldn't appear in promotional surfaces or in stories about other products. The section stays reachable from the top-level nav so existing users can still read the docs, which is why the banner is on every page rather than only the overview.

## Notes for reviewers

The banner lives in one Markdoc partial, `markdoc/partials/kiloclaw-eol.md`, included from all 31 pages — edit that file to change the wording everywhere. It deliberately carries no shutdown date; add one when it's decided.

`pages/contributing/architecture/` keeps its KiloClaw entries. Those are contributor-facing tables and diagrams describing code that still exists (`services/kiloclaw*` in the cloud repo, `webview-ui/kiloclaw/` in this one), not promotion. Removing them would make the architecture docs disagree with the codebase and drop a documented security boundary. They should go when the code does.

Still reading as if the product is live, left for a follow-up: `kiloclaw/overview.md` tells readers to sign up and walks through creating an instance, and `kiloclaw/faq/pricing.md` reads as an active price list.

No changeset: docs-only, nothing user-facing to release.