### PR TITLE
fix(cli): clarify background Task orchestration

### DIFF
--- a/.changeset/clear-background-task-waiting.md
+++ b/.changeset/clear-background-task-waiting.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Clarify when to use foreground subagents and wait for required background results before the final answer.

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -33,8 +33,7 @@ export interface TaskPromptOps {
 const id = "task"
 const BACKGROUND_DESCRIPTION = [
   "Background mode: background=true launches the subagent asynchronously and returns immediately.",
-  "Foreground is the default; use it when you need the result before continuing.",
-  "Use background only for independent work that can run while you continue elsewhere.",
+  "Use foreground when you need the result before proceeding; otherwise use background for non-overlapping work, but do not give the final answer until all required background results have arrived.", // kilocode_change
   "You will be notified automatically when it finishes.",
 ].join(" ")
 const BACKGROUND_STARTED = [


### PR DESCRIPTION
Background Task execution already returns immediately and automatically retriggers the parent when a result arrives. The issue was ambiguous guidance that did not clearly distinguish work that can run independently from work whose result is needed before the parent proceeds.

This change makes the Task guidance generic:

- Use foreground when the next step depends on the result.
- Use background only while useful non-overlapping work remains.
- Do not give the final answer until all required background results have arrived.

The change intentionally does not alter the Task lifecycle, notification payloads, runtime finish behavior, or add a tracking registry. The investigation and public-harness comparison are documented in #13360.