### PR TITLE
fix(cli): avoid Windows PTY termination verification

### DIFF
--- a/.changeset/fix-windows-pty-termination.md
+++ b/.changeset/fix-windows-pty-termination.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix PTY cleanup on Windows when POSIX process-tree inspection is unavailable.

--- a/packages/core/src/kilocode/pty/termination.ts
+++ b/packages/core/src/kilocode/pty/termination.ts
@@ -153,7 +153,7 @@ export async function terminate(proc: Process, input: Runtime = runtime): Promis
       })
       if ((!killed || input.alive(proc.pid)) && !state.exited) direct(proc)
       if (!state.exited) await input.sleep(GRACE_MS)
-      await verify(proc, state.exited, input)
+      if (!state.exited && input.alive(proc.pid)) throw new Error(`PTY process tree is still alive: ${proc.pid}`)
       return
     }
 

--- a/packages/core/test/kilocode/pty-termination.test.ts
+++ b/packages/core/test/kilocode/pty-termination.test.ts
@@ -18,6 +18,8 @@ function runtime(
     taskkillLeavesAlive?: boolean
     signal?: "throw"
     tree?: Array<{ pid: number; parent: number }>
+    treeError?: boolean
+    treeCalls?: { count: number }
   } = {},
 ) {
   const tasks: Array<{
@@ -36,7 +38,11 @@ function runtime(
       if (result && !input.taskkillLeavesAlive) alive = false
       return result
     },
-    tree: async () => input.tree ?? [],
+    tree: async () => {
+      if (input.treeCalls) input.treeCalls.count++
+      if (input.treeError) throw new Error("process tree unavailable")
+      return input.tree ?? []
+    },
     alive: () => alive,
     signal: (pid, signal) => {
       signals.push({ pid, signal })
@@ -81,6 +87,18 @@ describe("pty process-tree termination", () => {
 
     expect(item.calls).toEqual([undefined])
     expect(input.sleeps).toEqual([200])
+  })
+
+  test("continues when Windows process-tree inspection is unavailable", async () => {
+    const treeCalls = { count: 0 }
+    const input = runtime("win32", { treeError: true, treeCalls })
+    const item = fake(42)
+
+    await KiloPtyTermination.terminate(item.proc, input.value)
+
+    expect(item.calls).toEqual([])
+    expect(input.sleeps).toEqual([200])
+    expect(treeCalls.count).toBe(0)
   })
 
   test("signals POSIX process groups before escalating", async () => {


### PR DESCRIPTION
Windows PTY cleanup used the POSIX process-tree verifier after taskkill /t completed. Standard Windows installations do not provide ps, so removing a running PTY could fail even after the process tree was terminated. The failed cleanup also left Agent Manager terminal cleanup and subsequent PTY creation in a bad state.

Keep the durable PTY registry and process-tree termination behavior, but use the Windows-native root-process liveness check after taskkill /f /t. POSIX platforms retain the existing process-tree verification. Add regression coverage for the Windows branch and ship the fix as a CLI patch release.

The Windows unit-test matrix must pass, including the core PTY termination and durability tests, before merge.