### PR TITLE
docs(agent-manager): document send-all review context

### DIFF
--- a/packages/kilo-docs/pages/automate/agent-manager-workflows.md
+++ b/packages/kilo-docs/pages/automate/agent-manager-workflows.md
@@ -38,7 +38,7 @@ Every productive worktree session follows the same rhythm:
 1. **Open a new worktree dialog** (`Cmd+N` / `Ctrl+N`), then describe the task.
 2. **Let the agent run.** Switch to another worktree, another session, or step away.
 3. **Verify manually.** Before you trust "all tests pass", run the app with the run script (`Cmd+E` / `Ctrl+E`) or open the worktree's terminal (`Cmd+/` / `Ctrl+/`) and run the tests yourself.
-4. **Review the diff** (`Cmd+D` / `Ctrl+D`). Drop inline comments, then **Send to chat** to feed them back to the agent.
+4. **Review the diff** (`Cmd+D` / `Ctrl+D`). Add inline comments, then send all collected comments to chat or the active Agent Manager terminal with **Send all to chat**. Use `Cmd+Enter` / `Ctrl+Enter` as a shortcut.
 5. **Iterate.** Re-run, re-review. Repeat until the diff is ready — not until the agent says it is done.
 6. **Ship it.** See [Merging worktree and parent branch](#merging-worktree-and-parent-branch).
 

--- a/packages/kilo-docs/pages/automate/agent-manager.md
+++ b/packages/kilo-docs/pages/automate/agent-manager.md
@@ -230,6 +230,12 @@ Press `Cmd+D` (macOS) / `Ctrl+D` (Windows/Linux) to toggle the diff panel. It sh
 - Markdown files include an eye/code toggle in the file header to switch between rendered Markdown and the raw diff
 - **Drag file headers into chat** — drag a file header from the diff panel into the chat input to insert an `@file` mention, giving the agent context about specific changed files
 
+### Sending review comments
+
+Add comments in the diff panel or in the rendered view of a Markdown document. Click **Send all to chat** to send the collected comments to chat. If an Agent Manager terminal is active, the comments are sent to that terminal instead. Press `Cmd+Enter` (macOS) or `Ctrl+Enter` (Windows/Linux) to use the same action from the review panel.
+
+After sending, the local comment collection is cleared. To discard collected comments without sending them, click **Clear all** in the chat input.
+
 ### Diff Scope
 
 A scope selector in the diff toolbar (both in the side panel and the full-screen review) chooses which changes the diff shows:


### PR DESCRIPTION
The Agent Manager documentation described sending individual diff comments to chat but did not explain the bulk review-context flow.

Document the **Send all to chat** action for comments collected from diffs and rendered Markdown documents, including routing to the active Agent Manager terminal, the `Cmd+Enter` / `Ctrl+Enter` shortcut, and clearing collected comments.