### PR TITLE
docs: document worktree session history

### DIFF
--- a/packages/kilo-docs/pages/automate/agent-manager.md
+++ b/packages/kilo-docs/pages/automate/agent-manager.md
@@ -149,6 +149,7 @@ Imported work stays associated with its branch or worktree and can be continued 
 - Create a worktree session to start a new agent in an isolated branch
 - Press `Cmd+T` (macOS) / `Ctrl+T` (Windows/Linux) to start another session in the selected worktree
 - Use session history to reopen local sessions or preview cloud sessions
+- When a worktree is selected, open session history to use the **Worktree** source, which is selected by default and lists only sessions assigned to that worktree. Opening a worktree session returns to its owning worktree.
 - Continue a cloud session locally from Agent Manager using the same extension sign-in and provider settings
 
 ### Renaming Worktrees

--- a/packages/kilo-docs/pages/code-with-ai/agents/session-history.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/session-history.md
@@ -17,7 +17,7 @@ Different search surfaces cover different content and scopes:
 
 | Method | Searches | Scope |
 |---|---|---|
-| [VS Code History](#search-session-history-in-vs-code) | Session titles | Sessions loaded in the selected Local or Cloud history view |
+| [VS Code History](#search-session-history-in-vs-code) | Session titles | Sessions loaded in the selected Local, Cloud, or Worktree history view |
 | [JetBrains History](#search-session-history-in-jetbrains) | Session titles | Sessions loaded in the selected Local or Cloud history view |
 | [CLI Past chats](#reference-a-past-chat-in-the-cli-tui) | Session titles | Current workspace |
 | [`kilo session list --search`](#filter-session-titles) | Session titles | Current workspace, or every local workspace with `--all` |
@@ -42,6 +42,8 @@ History and CLI list searches do **not** search message content. To find a strin
 5. Select a result to reopen it.
 
 Local history actions also let you rename, export, or delete a session. Cloud history can be filtered to **Only this repository**.
+
+In Agent Manager, select a worktree before opening **History**. The **Worktree** source is selected by default and lists only sessions assigned to that worktree. When you open a worktree session, Agent Manager returns to its owning worktree. Select **Local** or **Cloud** to view another source.
 
 The History search is a fuzzy title search over the sessions currently loaded into the view. It does not search prompts or agent replies.
 


### PR DESCRIPTION
Session history documentation did not describe the Agent Manager worktree-specific source. This update documents that selecting a worktree defaults History to Worktree, limits results to sessions assigned to that worktree, and returns to the owning worktree when a managed session opens. The Agent Manager reference mirrors this behavior.