### PR TITLE
docs(agent-manager): document document inspector

### DIFF
--- a/packages/kilo-docs/pages/automate/agent-manager.md
+++ b/packages/kilo-docs/pages/automate/agent-manager.md
@@ -230,21 +230,6 @@ Press `Cmd+D` (macOS) / `Ctrl+D` (Windows/Linux) to toggle the diff panel. It sh
 - Markdown files include an eye/code toggle in the file header to switch between rendered Markdown and the raw diff
 - **Drag file headers into chat** — drag a file header from the diff panel into the chat input to insert an `@file` mention, giving the agent context about specific changed files
 
-## Documents inspector
-
-The Documents inspector previews files referenced from Agent Manager chat and review surfaces without leaving the panel. Open a file reference to add it as a document tab, then use the tab strip to switch, reorder, or close open documents. The inspector keeps one tab per file in the active project and worktree context.
-
-- Markdown files (`.md`, `.mdx`, and `.markdown`) open in rendered view by default. Use the preview/source toggle to switch between rendered Markdown and syntax-highlighted source.
-- Text files show a syntax-highlighted preview. Supported images (PNG, JPEG, GIF, WebP, and SVG) show as inline image previews.
-- Use **Open file** to open the document in the native VS Code editor. The original line and column are preserved when available. Files that are not handled by the inspector, such as source-file references, open in the native editor instead.
-- Unsupported, binary, missing, out-of-scope, or oversized files show an error fallback in the inspector. Text previews are limited to 2 MB and image previews to 5 MB; open the file in VS Code to inspect larger or unsupported content.
-
-### Inline document review
-
-In a rendered Markdown preview, use the line gutter or line number to add a comment at that line. Draft comments can be edited or deleted, sent individually to the active session, or sent together with **Send all to chat**. Comments are attached to the document path and line, and remain isolated to the active project and worktree context.
-
-The project and worktree context owns document tabs, loaded content, and comments. The session ID attached to an opened file selects the session's worktree for reading and native-editor navigation. Sessions that share one worktree also share its document inspector state; switching project or worktree changes the visible context without mixing tabs or comments across worktrees.
-
 ### Diff Scope
 
 A scope selector in the diff toolbar (both in the side panel and the full-screen review) chooses which changes the diff shows:
@@ -257,6 +242,21 @@ A scope selector in the diff toolbar (both in the side panel and the full-screen
 The Branch scope also has a base-branch picker next to it for overriding the comparison branch. **Apply to local** works only on the Branch scope — switch back to Branch to apply.
 
 See [Agent Manager Workflows](/docs/automate/agent-manager-workflows#merging-worktree-and-parent-branch) for the full integration story, including when to apply locally vs. merge directly vs. open a pull request.
+
+## Documents inspector
+
+The Documents inspector previews Markdown file references from Agent Manager chat without leaving the panel. Open a file reference to add it as a document tab, then use the tab strip to switch, reorder, or close open documents. The inspector keeps one tab per file in the active project and worktree context.
+
+- Markdown files (`.md`, `.mdx`, and `.markdown`) open in rendered view by default. Use the preview/source toggle to switch between rendered Markdown and syntax-highlighted source.
+- The document renderer also supports syntax-highlighted text and inline PNG, JPEG, GIF, WebP, and SVG previews when a document payload is available. Normal Agent Manager file-opening actions route non-Markdown source references to the native VS Code editor.
+- Use **Open file** to open the document in the native VS Code editor. The original line and column are preserved when available.
+- Unsupported, binary, missing, out-of-scope, or oversized files show an error fallback in the inspector. Text previews are limited to 2 MB and image previews to 5 MB; open the file in VS Code to inspect larger or unsupported content.
+
+### Inline document review
+
+In a rendered Markdown preview, use the comment control in the line gutter to add a comment at that line. Clicking a line number opens that location in the native editor. Draft comments can be edited or deleted, sent individually to the active session, or sent together with **Send all to chat**. Comments are attached to the document path and line, and remain isolated to the active project and worktree context.
+
+The project and worktree context owns document tabs, loaded content, and comments. The session ID attached to an opened file selects the session's worktree for reading and native-editor navigation. Sessions that share one worktree also share its document inspector state; switching project or worktree changes the visible context without mixing tabs or comments across worktrees.
 
 ## Terminals
 

--- a/packages/kilo-docs/pages/automate/agent-manager.md
+++ b/packages/kilo-docs/pages/automate/agent-manager.md
@@ -230,6 +230,21 @@ Press `Cmd+D` (macOS) / `Ctrl+D` (Windows/Linux) to toggle the diff panel. It sh
 - Markdown files include an eye/code toggle in the file header to switch between rendered Markdown and the raw diff
 - **Drag file headers into chat** — drag a file header from the diff panel into the chat input to insert an `@file` mention, giving the agent context about specific changed files
 
+## Documents inspector
+
+The Documents inspector previews files referenced from Agent Manager chat and review surfaces without leaving the panel. Open a file reference to add it as a document tab, then use the tab strip to switch, reorder, or close open documents. The inspector keeps one tab per file in the active project and worktree context.
+
+- Markdown files (`.md`, `.mdx`, and `.markdown`) open in rendered view by default. Use the preview/source toggle to switch between rendered Markdown and syntax-highlighted source.
+- Text files show a syntax-highlighted preview. Supported images (PNG, JPEG, GIF, WebP, and SVG) show as inline image previews.
+- Use **Open file** to open the document in the native VS Code editor. The original line and column are preserved when available. Files that are not handled by the inspector, such as source-file references, open in the native editor instead.
+- Unsupported, binary, missing, out-of-scope, or oversized files show an error fallback in the inspector. Text previews are limited to 2 MB and image previews to 5 MB; open the file in VS Code to inspect larger or unsupported content.
+
+### Inline document review
+
+In a rendered Markdown preview, use the line gutter or line number to add a comment at that line. Draft comments can be edited or deleted, sent individually to the active session, or sent together with **Send all to chat**. Comments are attached to the document path and line, and remain isolated to the active project and worktree context.
+
+The project and worktree context owns document tabs, loaded content, and comments. The session ID attached to an opened file selects the session's worktree for reading and native-editor navigation. Sessions that share one worktree also share its document inspector state; switching project or worktree changes the visible context without mixing tabs or comments across worktrees.
+
 ### Diff Scope
 
 A scope selector in the diff toolbar (both in the side panel and the full-screen review) chooses which changes the diff shows:


### PR DESCRIPTION
The Agent Manager reference did not describe the Documents inspector or its inline Markdown review workflow. This left document tabs, preview limits, native-editor fallbacks, and context boundaries undocumented.

Add a focused reference section covering document tabs, rendered and source Markdown, text and image previews, native-editor opening, unsupported and oversized fallbacks, line comments, and project/worktree/session scoping.