### PR TITLE
docs(agent-manager): clarify terminal context routing

### DIFF
--- a/packages/kilo-docs/pages/automate/agent-manager.md
+++ b/packages/kilo-docs/pages/automate/agent-manager.md
@@ -247,6 +247,8 @@ See [Agent Manager Workflows](/docs/automate/agent-manager-workflows#merging-wor
 
 Each session has a dedicated terminal rooted in the session's worktree directory. Press `Cmd+/` (macOS) / `Ctrl+/` (Windows/Linux) to focus the terminal for the active session. If the embedded terminal is already visible but the prompt has focus, the same shortcut focuses the terminal without hiding it. Press it again while the terminal has focus to hide the panel.
 
+When you use `@terminal` in an Agent Manager prompt, Kilo captures the focused terminal for the selected session or worktree. This includes embedded **Run** and **Setup** tabs. Terminal context is limited to 500 lines or 50,000 characters; longer output is truncated.
+
 ### Choosing the Terminal Destination
 
 The toolbar's terminal button is a split button: click it to open a terminal, or use its dropdown to choose where terminals open:

--- a/packages/kilo-docs/pages/automate/extending/shell-integration.md
+++ b/packages/kilo-docs/pages/automate/extending/shell-integration.md
@@ -42,13 +42,13 @@ The CLI automatically detects the appropriate shell for your platform using `She
 
 ## Agent Manager Terminals (VS Code Extension)
 
-When using the Kilo Code VS Code extension with the Agent Manager, each agent session gets its own dedicated VS Code terminal.
+When using the Kilo Code VS Code extension with the Agent Manager, each agent session gets its own terminal. Depending on the terminal destination, this is either a dedicated VS Code integrated terminal or an embedded terminal in the Agent Manager panel.
 
 ### Per-Session Terminals
 
-- Each session creates a terminal named **`Agent: {branch}`**, where `{branch}` is the git branch or worktree the session is working in
+- Each session creates a terminal named **`Agent: {branch}`**, where `{branch}` is the git branch or worktree the session is working in, when you use a VS Code integrated terminal
 - The terminal's working directory is automatically set to the session's worktree directory
-- Terminals are standard VS Code integrated terminals — you can interact with them directly
+- VS Code terminal destinations are standard integrated terminals. The Agent Manager panel destination uses embedded terminals in the Agent Manager layout.
 
 ### Keyboard Shortcuts
 
@@ -59,7 +59,7 @@ When using the Kilo Code VS Code extension with the Agent Manager, each agent se
 
 ### Terminal Context Menu Actions
 
-Right-click in an Agent Manager terminal to access these actions:
+Right-click in a VS Code integrated Agent Manager terminal to access these actions:
 
 - **Add Terminal Content to Context** — sends the terminal's visible output to the agent as context
 - **Fix This Command** — asks the agent to diagnose and fix the last failed command

--- a/packages/kilo-docs/pages/code-with-ai/agents/chat-interface.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/chat-interface.md
@@ -67,7 +67,7 @@ Open your terminal and run `kilo` to launch the interactive terminal interface (
 
 **Providing context:**
 
-The extension automatically passes context from your editor, including your open tabs and active file. You can type `@` in the chat input to get file and terminal autocomplete suggestions — use `@filename` to attach a file or `@terminal` to include your active terminal output. You can also mention file paths naturally in your message (e.g., "update src/utils.ts to add a helper function"). The agent can also discover files on its own using its built-in tools.
+The extension automatically passes context from your editor, including your open tabs and active file. You can type `@` in the chat input to get file and terminal autocomplete suggestions. Use `@filename` to attach a file. In the sidebar, `@terminal` includes the active VS Code terminal output. In Agent Manager, it includes the focused terminal for the selected session or worktree, including embedded **Run** and **Setup** tabs. You can also mention file paths naturally in your message (e.g., "update src/utils.ts to add a helper function"). The agent can also discover files on its own using its built-in tools.
 
 **Exporting local transcripts:**
 

--- a/packages/kilo-docs/pages/code-with-ai/agents/context-mentions.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/context-mentions.md
@@ -23,11 +23,13 @@ Type `@` in the chat input to get autocomplete suggestions. You can mention:
 | Mention | Description | Example |
 |---|---|---|
 | **File** | Attach a file's contents to your message | `@src/utils.ts` |
-| **Terminal** | Include your active VS Code terminal output | `@terminal` |
+| **Terminal** | In the sidebar, include the active VS Code terminal output. In Agent Manager, include the focused terminal for the selected session or worktree, including embedded **Run** and **Setup** tabs. | `@terminal` |
 | **Git Changes** | Attach uncommitted working-tree diffs and new files | `@git-changes` |
 | **Past chats** | Add a previous session's chat history as context | `@` → **Past chats** → pick a session |
 
 Selecting a suggestion inserts the mention and highlights it in the input. File contents, terminal output, and git changes are attached as context when you send the message.
+
+Terminal context is limited to 500 lines or 50,000 characters. Longer output is truncated. If no terminal content is available, Kilo reports that terminal content is unavailable instead of attaching an empty file.
 
 ### Referencing Past Chats
 


### PR DESCRIPTION
Terminal context documentation did not distinguish the sidebar terminal source from the Agent Manager terminal source. This made it unclear which output `@terminal` attaches when multiple sessions, worktrees, or embedded script terminals are active.

Document the active VS Code terminal behavior in the sidebar and the focused selected-session/worktree behavior in Agent Manager, including embedded Run and Setup tabs. Also align shell integration documentation with the available embedded terminal destination.