### PR TITLE
docs(vscode): document subagent inspector tabs

### DIFF
--- a/packages/kilo-docs/pages/automate/agent-manager.md
+++ b/packages/kilo-docs/pages/automate/agent-manager.md
@@ -151,6 +151,8 @@ Imported work stays associated with its branch or worktree and can be continued 
 - Use session history to reopen local sessions or preview cloud sessions
 - Continue a cloud session locally from Agent Manager using the same extension sign-in and provider settings
 
+When a session delegates work to a subagent, open the child transcript from its task card or background-agent row. Agent Manager displays it in the read-only **Subagents** inspector. The inspector supports multiple child-session tabs and keeps them scoped to the selected project and parent session. For the difference between Agent Manager inspector tabs and the separate subagent editor tabs used by the sidebar, see [Inspecting delegated sessions in VS Code](/docs/customize/custom-subagents#inspecting-delegated-sessions-in-vs-code).
+
 ### Renaming Worktrees
 
 Double-click a worktree name to edit its label inline. You can also right-click the worktree and choose **Rename**. Press `Enter` or click outside the field to save, or press `Escape` to cancel.

--- a/packages/kilo-docs/pages/customize/custom-subagents.md
+++ b/packages/kilo-docs/pages/customize/custom-subagents.md
@@ -254,6 +254,14 @@ kilo agent list
 
 This displays each agent's name, mode, and permission configuration.
 
+## Inspecting delegated sessions in VS Code
+
+When a subagent is delegated from a session in the VS Code extension, open its transcript from the task card or background-agent row. In Agent Manager, the transcript opens in the **Subagents** inspector as a read-only tab. Use the inspector tab strip to switch between multiple child sessions, reorder tabs, or close tabs.
+
+Inspector tabs are scoped to the current project and parent session. When you switch worktrees or sessions, Agent Manager shows the tabs for that project and parent only, so child transcripts from another session are not mixed into the current view.
+
+This differs from the sidebar and Kilo editor subagent tabs. In those surfaces, **Open in Tab** opens the child transcript as a separate read-only VS Code editor tab. Agent Manager keeps the transcript inside its right-hand inspector alongside the session's other panels. In both surfaces, the child session is a delegated transcript, not a new prompt you can send messages to directly.
+
 ## Configuration Precedence
 
 Agent configurations are merged from multiple sources. Later sources override earlier ones:


### PR DESCRIPTION
Delegated child sessions use different viewing surfaces in the VS Code extension, and the distinction was not documented. This made it unclear how to inspect multiple child sessions in Agent Manager or why tabs change with the selected project and parent session.

Document the read-only Agent Manager Subagents inspector, its multiple-tab behavior and project/parent scoping, and the separate editor-tab behavior used from the sidebar and Kilo editor. Add a focused cross-link from the Agent Manager guide.