### PR TITLE
docs(agent-manager): add multi-project guide

### DIFF
--- a/packages/kilo-docs/lib/nav/automate.ts
+++ b/packages/kilo-docs/lib/nav/automate.ts
@@ -19,6 +19,7 @@ export const AutomateNav: NavSection[] = [
         children: "Agent Manager",
         subLinks: [
           { href: "/automate/agent-manager-workflows", children: "Workflows" },
+          { href: "/automate/agent-manager-projects", children: "Multi-project" },
         ],
       },
     ],

--- a/packages/kilo-docs/pages/automate/agent-manager-projects.md
+++ b/packages/kilo-docs/pages/automate/agent-manager-projects.md
@@ -1,0 +1,36 @@
+---
+title: "Multi-project Agent Manager"
+description: "Manage Agent Manager sessions across multiple Git repositories"
+---
+
+# Multi-project Agent Manager
+
+Multi-project Agent Manager lets you manage sessions and worktrees from multiple Git repositories in one Agent Manager panel. The feature is experimental and disabled by default. When it is disabled, Agent Manager keeps its existing single-project behavior.
+
+## Enable multi-project mode
+
+1. Open [Kilo Code Settings](/docs/getting-started/settings#experimental-features).
+2. Open the **Experimental** tab.
+3. Enable **Multi-Project Agent Manager**.
+
+The setting is also available as `kilo-code.new.experimental.multiProject`. It is an application-scoped VS Code setting and defaults to `false`.
+
+## Add Git repositories
+
+The repository in your current VS Code workspace is always the **default project**. You cannot remove it from Agent Manager.
+
+To add another repository:
+
+1. Open Agent Manager.
+2. Select **Add Project**.
+3. Choose a folder inside a Git repository.
+
+Agent Manager registers the repository root and makes it available immediately. Adding a project does not require a separate Agent Manager trust step. VS Code workspace trust still controls whether setup and run scripts can execute.
+
+## Persistence and project scope
+
+- Added repositories remain in the project list across VS Code restarts.
+- The default project is derived from the current workspace. It is not an added project in the persistent registry.
+- Each repository has its own worktrees, sessions, sections, selection, and Agent Manager state. Repository state is stored in that repository's `.kilo/agent-manager.json` and `.kilo/worktrees/` paths.
+- Switching projects keeps their state separate, so sessions and worktrees are not mixed between repositories.
+- Removing an added project only removes it from Agent Manager. It does not delete the repository, its branches, or its project state.


### PR DESCRIPTION
Multi-project Agent Manager is available behind an experimental VS Code setting, but the user-facing documentation did not explain how to enable it or manage repositories.

Add a focused guide covering the `kilo-code.new.experimental.multiProject` setting, the workspace default project, adding Git repositories, persistence, project-scoped state, and the removal of the separate Agent Manager trust step. Add the guide to Agent Manager navigation.