### PR TITLE
docs(vscode): document background agent status strip

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/platforms/vscode/index.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/vscode/index.md
@@ -35,6 +35,28 @@ Key features include:
 - **Sub-Agent Viewer** — Read-only panels for viewing child agent sessions
 - **Legacy Migration** — Automatic migration wizard for VSCode extension settings
 
+## Background agents
+
+When Kilo starts an agent in the background, a collapsible status strip appears in the chat header. The strip stays visible while the transcript scrolls, so you can check background work without searching the conversation. Click the strip to expand it and see each agent.
+
+Each agent shows one of these states:
+
+| State | Meaning |
+|---|---|
+| **Running** | The agent is still working. |
+| **Done** | The agent completed successfully. |
+| **Cancelled** | The agent was stopped before it completed. |
+| **Error** | The agent stopped because it encountered an error. |
+
+An agent can also show **Needs input** when it is waiting for a permission decision or an answer to a question. Open the agent row to inspect its read-only transcript and handle the request in the child-agent view. In the sidebar and Kilo tab, the transcript opens in a read-only editor tab. In Agent Manager, it opens in the right-hand inspector.
+
+Use these controls in the expanded strip:
+
+- **Stop** cancels a running agent and its child session.
+- **Dismiss** hides one finished agent from the strip. It does not delete the transcript or the agent record.
+- **Clear finished** hides all agents that are no longer running.
+- **Continue in background** appears when a foreground subagent is running. It detaches that work so the parent session can continue while the subagent runs in the background.
+
 ## Shared Settings
 
 Settings apply across extension surfaces, including the sidebar and Agent Manager. The standalone CLI uses the same `~/.config/kilo/kilo.jsonc` (global) and `./kilo.jsonc` (project) files when used directly.


### PR DESCRIPTION
Background-agent work can continue after its task card scrolls out of view, but the controls and lifecycle states were not documented for VS Code users.

Document the persistent chat-header status strip, Running/Done/Cancelled/Error and Needs input states, read-only transcript destinations, and the Stop, Dismiss, Clear finished, and Continue in background controls. Keep the content on the VS Code platform page instead of duplicating a full guide in Agent Manager.