### PR TITLE
fix(vscode): promote parallel subagents independently

### DIFF
--- a/.changeset/individual-background-subagent-promotion.md
+++ b/.changeset/individual-background-subagent-promotion.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Allow each foreground subagent to continue in the background independently, including when several subagents run in parallel.

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -163,6 +163,7 @@ export interface MessagePartProps {
   working?: boolean
   feedback?: MessageFeedbackControls
   throughput?: JSX.Element
+  readonly?: boolean
 }
 
 export type PartComponent = Component<MessagePartProps>
@@ -1044,6 +1045,7 @@ export function Part(props: MessagePartProps) {
         working={props.working}
         feedback={props.feedback}
         throughput={props.throughput}
+        readonly={props.readonly}
       />
     </Show>
   )
@@ -1068,6 +1070,7 @@ export interface ToolProps {
   locked?: boolean
   animate?: boolean
   reveal?: boolean
+  readonly?: boolean
 }
 
 export type ToolComponent = Component<ToolProps>
@@ -1267,6 +1270,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
                     forceOpen={props.forceOpen}
                     animate
                     reveal={props.animate}
+                    readonly={props.readonly}
                   />
                 )
               }
@@ -1344,6 +1348,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
                 forceOpenFile={props.forceOpenFile}
                 animate
                 reveal={props.animate}
+                readonly={props.readonly}
               />
             </ToolApprovalProvider>
           </Match>

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1043,7 +1043,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           modelUsage: (msg) => handleModelUsageMessage(msg, this.extensionContext, (value) => this.postMessage(value)),
           backgroundJobs: (sessionID, requestID) => this.fetchAndSendBackgroundJobs(sessionID, requestID),
           cancelBackgroundJob: (jobID, sessionID, requestID) => this.cancelBackgroundJob(jobID, sessionID, requestID),
-          backgroundSubagents: (sessionID) => this.backgroundSubagents(sessionID),
+          promoteBackgroundJob: (jobID, sessionID) => this.promoteBackgroundJob(jobID, sessionID),
         })
       ) {
         return
@@ -2937,16 +2937,16 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
   }
 
-  private async backgroundSubagents(sessionID: string): Promise<void> {
+  private async promoteBackgroundJob(jobID: string, sessionID: string): Promise<void> {
     const client = this.client
     if (!client || this.connectionState !== "connected") return
     try {
-      await client.experimental.session.background(
-        { sessionID, directory: this.getWorkspaceDirectory(sessionID) },
+      await client.kilocode.backgroundJob.promote(
+        { jobID, directory: this.getWorkspaceDirectory(sessionID) },
         { throwOnError: true },
       )
     } catch (error) {
-      console.error("[Kilo New] KiloProvider: Failed to background subagents:", error)
+      console.error("[Kilo New] KiloProvider: Failed to promote background job:", error)
     }
   }
 

--- a/packages/kilo-vscode/src/kilo-provider/early-message.ts
+++ b/packages/kilo-vscode/src/kilo-provider/early-message.ts
@@ -23,7 +23,7 @@ type Ctx = {
   modelUsage: (message: ModelUsageMessage) => Promise<void>
   backgroundJobs: (sessionID: string, requestID: string) => Promise<void>
   cancelBackgroundJob: (jobID: string, sessionID: string, requestID: string) => Promise<void>
-  backgroundSubagents: (sessionID: string) => Promise<void>
+  promoteBackgroundJob: (jobID: string, sessionID: string) => Promise<void>
 }
 
 async function routeBackgroundMessage(
@@ -46,8 +46,10 @@ async function routeBackgroundMessage(
     }
     return true
   }
-  if (message.type === "backgroundSubagents") {
-    if (typeof message.sessionID === "string") await ctx.backgroundSubagents(message.sessionID)
+  if (message.type === "promoteBackgroundJob") {
+    if (typeof message.jobID === "string" && typeof message.sessionID === "string") {
+      await ctx.promoteBackgroundJob(message.jobID, message.sessionID)
+    }
     return true
   }
   return undefined

--- a/packages/kilo-vscode/tests/unit/background-agents.test.ts
+++ b/packages/kilo-vscode/tests/unit/background-agents.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "bun:test"
 import {
   backgroundAgents,
   backgroundJobAgents,
-  foregroundAgent,
   showBackgroundAgent,
 } from "../../webview-ui/src/components/chat/background-agents"
 import type {
@@ -261,14 +260,5 @@ describe("backgroundAgents", () => {
 
     expect(showBackgroundAgent(agent, hidden)).toBe(true)
     expect(showBackgroundAgent({ ...agent, status: "completed" }, hidden)).toBe(false)
-  })
-
-  it("finds a running foreground child that can be promoted", () => {
-    const tools = [
-      taskPart({ id: "part_background", child: "child_background", background: true }),
-      taskPart({ id: "part_foreground", child: "child_foreground", background: false }),
-    ]
-
-    expect(foregroundAgent(tools, { child_background: busy, child_foreground: busy })).toBe("child_foreground")
   })
 })

--- a/packages/kilo-vscode/tests/unit/background-agents.test.ts
+++ b/packages/kilo-vscode/tests/unit/background-agents.test.ts
@@ -4,6 +4,7 @@ import {
   backgroundJobAgents,
   showBackgroundAgent,
 } from "../../webview-ui/src/components/chat/background-agents"
+import { childForeground, showChildPromotion } from "../../webview-ui/src/components/chat/task-tool-state"
 import type {
   BackgroundJobInfo,
   PermissionRequest,
@@ -71,6 +72,22 @@ describe("backgroundAgents", () => {
 
   it("ignores foreground subagents", () => {
     expect(backgroundAgents([taskPart({ child: "ses_child" })], { ses_child: busy })).toEqual([])
+  })
+
+  it("identifies each parallel foreground child independently", () => {
+    const status = { ses_a: busy, ses_b: busy }
+
+    expect(childForeground("ses_a", {}, {}, status)).toBe(true)
+    expect(childForeground("ses_b", {}, {}, status)).toBe(true)
+    expect(childForeground("ses_a", { background: true }, {}, status)).toBe(false)
+    expect(childForeground("ses_b", {}, { background: true }, status)).toBe(false)
+    expect(childForeground("ses_a", {}, {}, { ses_a: idle })).toBe(false)
+    expect(childForeground("ses_a", {}, {}, { ses_a: { type: "retry", attempt: 1, message: "retry", next: 1 } })).toBe(
+      true,
+    )
+    expect(childForeground(undefined, {}, {}, status)).toBe(false)
+    expect(showChildPromotion("ses_a", {}, {}, status, false)).toBe(true)
+    expect(showChildPromotion("ses_a", {}, {}, status, true)).toBe(false)
   })
 
   it("ignores agents whose session is no longer working", () => {

--- a/packages/kilo-vscode/tests/unit/early-message.test.ts
+++ b/packages/kilo-vscode/tests/unit/early-message.test.ts
@@ -76,4 +76,16 @@ describe("routeEarlyMessage background jobs", () => {
     ).toBe(true)
     expect(calls).toEqual([["ses_child", "ses_parent", "request-2"]])
   })
+
+  it("forwards promotion for one child through its owning parent session", async () => {
+    const calls: unknown[] = []
+    const ctx = {
+      promoteBackgroundJob: async (jobID: string, sessionID: string) => calls.push([jobID, sessionID]),
+    } as Ctx
+
+    expect(
+      await routeEarlyMessage({ type: "promoteBackgroundJob", jobID: "ses_child_a", sessionID: "ses_parent" }, ctx),
+    ).toBe(true)
+    expect(calls).toEqual([["ses_child_a", "ses_parent"]])
+  })
 })

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -114,6 +114,7 @@ interface AssistantMessageProps {
   forceOpenFile?: string
   /** Part behind the currently hovered/focused task-timeline bar, if any. */
   highlight?: () => TimelineHighlight | undefined
+  readonly?: boolean
 }
 
 type ToolStateProps = {
@@ -339,6 +340,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
                                       reasoningAutoCollapse={display.reasoningAutoCollapse()}
                                       feedback={props.feedback}
                                       throughput={throughputEl()}
+                                      readonly={props.readonly}
                                       animate={
                                         part.type === "tool" &&
                                         ((part as unknown as ToolPart).state?.status === "pending" ||

--- a/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
@@ -19,13 +19,7 @@ import { useLanguage } from "../../context/language"
 import { useSession } from "../../context/session"
 import { useVSCode } from "../../context/vscode"
 import { useWorktreeMode } from "../../context/worktree-mode"
-import {
-  backgroundAgents,
-  backgroundJobAgents,
-  foregroundAgent,
-  showBackgroundAgent,
-  type BackgroundAgent,
-} from "./background-agents"
+import { backgroundAgents, backgroundJobAgents, showBackgroundAgent, type BackgroundAgent } from "./background-agents"
 import { openSubagent } from "./open-subagent"
 
 export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
@@ -96,15 +90,9 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
   })
 
   const visible = createMemo(() => agents().filter((agent) => showBackgroundAgent(agent, hidden())))
-  const foreground = createMemo(() => {
-    const id = session.currentSessionID()
-    return id ? foregroundAgent(session.getSessionToolParts(id), session.allStatusMap()) : undefined
-  })
-
   const summary = createMemo(() => {
     const running = visible().filter((agent) => agent.status === "running").length
     const total = visible().length
-    if (total === 0 && foreground()) return language.t("task.backgroundAgents.foreground")
     if (total === 1 && running === 1) return language.t("task.backgroundAgents.running.one")
     if (running === total) return language.t("task.backgroundAgents.running.many", { count: String(total) })
     return language.t("task.backgroundAgents.summary", { running: String(running), total: String(total) })
@@ -142,11 +130,6 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
     vscode.postMessage({ type: "cancelBackgroundJob", jobID: agent.jobID, sessionID: id, requestID: pending })
   }
 
-  const background = () => {
-    const id = session.currentSessionID()
-    if (id) vscode.postMessage({ type: "backgroundSubagents", sessionID: id })
-  }
-
   const hideFinished = () =>
     setHidden(
       new Set(
@@ -157,7 +140,7 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
     )
 
   return (
-    <Show when={visible().length > 0 || (!props.readonly && foreground())}>
+    <Show when={visible().length > 0}>
       <div data-component="task-header-agents">
         <div data-slot="task-header-agents-toolbar">
           <Show when={visible().length > 0}>
@@ -192,16 +175,6 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
                 data-open={open() ? "" : undefined}
               />
             </button>
-          </Show>
-          <Show when={!props.readonly && foreground()}>
-            <Button
-              variant="ghost"
-              size="small"
-              aria-label={language.t("task.backgroundAgents.continueInBackground")}
-              onClick={background}
-            >
-              {language.t("task.backgroundAgents.continueInBackground")}
-            </Button>
           </Show>
           <Show when={!props.readonly && visible().some((agent) => agent.status !== "running")}>
             <Button

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -1332,6 +1332,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
                         activeSearch={activeKey() === row.key}
                         activeSearchPartID={activeKey() === row.key ? activeMatch()?.partId : undefined}
                         activeSearchPartFile={activeKey() === row.key ? activeMatch()?.partFile : undefined}
+                        readonly={props.readonly}
                       />
                     )}
                   </Virtualizer>
@@ -1345,6 +1346,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
                       activeSearch={activeKey() === key}
                       activeSearchPartID={activeKey() === key ? activeMatch()?.partId : undefined}
                       activeSearchPartFile={activeKey() === key ? activeMatch()?.partFile : undefined}
+                      readonly={props.readonly}
                     />
                   )}
                 </For>
@@ -1360,6 +1362,7 @@ export const MessageList: Component<MessageListProps> = (props) => {
                   activeSearch={activeKey() === row.key}
                   activeSearchPartID={activeKey() === row.key ? activeMatch()?.partId : undefined}
                   activeSearchPartFile={activeKey() === row.key ? activeMatch()?.partFile : undefined}
+                  readonly={props.readonly}
                 />
               )}
             </For>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
@@ -21,7 +21,7 @@ import { useVSCode } from "../../context/vscode"
 import { useWorktreeMode } from "../../context/worktree-mode"
 import { childID } from "../../context/session-utils"
 import { openSubagent } from "./open-subagent"
-import { taskResult, taskRunning, taskVisible } from "./task-tool-state"
+import { showChildPromotion, taskResult, taskRunning, taskVisible } from "./task-tool-state"
 
 const TaskToolRenderer: Component<ToolProps> = (props) => {
   const i18n = useI18n()
@@ -38,15 +38,15 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
       state: { metadata: props.metadata as { sessionId?: string } },
     })
 
-  const childForeground = createMemo(() => {
-    const id = childSessionId()
-    if (!id) return false
-    const part = props.partMetadata as { background?: boolean } | undefined
-    const state = props.metadata as { background?: boolean } | undefined
-    if (part?.background === true || state?.background === true) return false
-    const status = session.allStatusMap()[id]
-    return status?.type === "busy" || status?.type === "retry"
-  })
+  const promotable = createMemo(() =>
+    showChildPromotion(
+      childSessionId(),
+      props.partMetadata as Record<string, unknown> | undefined,
+      props.metadata as Record<string, unknown> | undefined,
+      session.allStatusMap(),
+      props.readonly,
+    ),
+  )
 
   const running = createMemo(() => taskRunning(props.status))
   // BasicTool's forceOpen effect only fires onOpenChange on a false->true
@@ -167,7 +167,7 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
         </Show>
       </div>
       <Show when={childSessionId()}>
-        <Show when={childForeground()}>
+        <Show when={promotable()}>
           <IconButton
             icon="play"
             size="small"

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
@@ -13,6 +13,7 @@ import { BasicTool, initialOpen } from "@kilocode/kilo-ui/basic-tool"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Markdown } from "@kilocode/kilo-ui/markdown"
+import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { useLanguage } from "../../context/language"
 import { useI18n } from "@kilocode/kilo-ui/context/i18n"
 import { createAutoScroll } from "@kilocode/kilo-ui/hooks"
@@ -168,13 +169,15 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
       </div>
       <Show when={childSessionId()}>
         <Show when={promotable()}>
-          <IconButton
-            icon="play"
-            size="small"
-            variant="ghost"
-            aria-label={language.t("task.backgroundAgents.continueInBackground")}
-            onClick={background}
-          />
+          <Tooltip value={language.t("task.backgroundAgents.continueInBackground")} placement="top">
+            <IconButton
+              icon="arrow-down-to-line"
+              size="small"
+              variant="ghost"
+              aria-label={language.t("task.backgroundAgents.continueInBackground")}
+              onClick={background}
+            />
+          </Tooltip>
         </Show>
         <IconButton
           icon="square-arrow-top-right"

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TaskToolExpanded.tsx
@@ -38,6 +38,16 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
       state: { metadata: props.metadata as { sessionId?: string } },
     })
 
+  const childForeground = createMemo(() => {
+    const id = childSessionId()
+    if (!id) return false
+    const part = props.partMetadata as { background?: boolean } | undefined
+    const state = props.metadata as { background?: boolean } | undefined
+    if (part?.background === true || state?.background === true) return false
+    const status = session.allStatusMap()[id]
+    return status?.type === "busy" || status?.type === "retry"
+  })
+
   const running = createMemo(() => taskRunning(props.status))
   // BasicTool's forceOpen effect only fires onOpenChange on a false->true
   // transition — a virtualized remount that starts with forceOpen already
@@ -134,6 +144,13 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
     })
   }
 
+  const background = (e: MouseEvent) => {
+    e.stopPropagation()
+    const id = session.currentSessionID()
+    const child = childSessionId()
+    if (id && child) vscode.postMessage({ type: "promoteBackgroundJob", jobID: child, sessionID: id })
+  }
+
   const trigger = () => (
     <div data-slot="basic-tool-tool-info-structured">
       <div data-slot="basic-tool-tool-info-main">
@@ -150,6 +167,15 @@ const TaskToolRenderer: Component<ToolProps> = (props) => {
         </Show>
       </div>
       <Show when={childSessionId()}>
+        <Show when={childForeground()}>
+          <IconButton
+            icon="play"
+            size="small"
+            variant="ghost"
+            aria-label={language.t("task.backgroundAgents.continueInBackground")}
+            onClick={background}
+          />
+        </Show>
         <IconButton
           icon="square-arrow-top-right"
           size="small"

--- a/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptRow.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/TranscriptRow.tsx
@@ -26,6 +26,7 @@ interface TranscriptRowViewProps {
   activeSearchPartID?: string
   /** For a multi-file apply_patch match, the specific file within that part. */
   activeSearchPartFile?: string
+  readonly?: boolean
 }
 
 export const TranscriptRowView: Component<TranscriptRowViewProps> = (props) => {
@@ -92,6 +93,7 @@ export const TranscriptRowView: Component<TranscriptRowViewProps> = (props) => {
               forceOpenPartID={props.activeSearchPartID}
               forceOpenFile={props.activeSearchPartFile}
               highlight={props.highlight}
+              readonly={props.readonly}
               feedback={{
                 enabled: feedback.telemetryEnabled(),
                 rating: feedback.getRating(row().message.id),

--- a/packages/kilo-vscode/webview-ui/src/components/chat/background-agents.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/background-agents.ts
@@ -108,18 +108,3 @@ export function backgroundJobAgents(
       }
     })
 }
-
-export function foregroundAgent(tools: ToolPart[], status: Record<string, SessionStatusInfo>): string | undefined {
-  const latest = new Map<string, ToolPart>()
-  for (const part of tools) {
-    if (part.tool !== "task") continue
-    const id = text(meta(part, "sessionId"))
-    if (id) latest.set(id, part)
-  }
-  for (const part of latest.values()) {
-    const id = text(meta(part, "sessionId"))
-    if (!id || meta(part, "background") === true || !working(status[id])) continue
-    return id
-  }
-  return undefined
-}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/task-tool-state.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/task-tool-state.ts
@@ -1,5 +1,28 @@
+import type { SessionStatusInfo } from "../../types/messages"
+
 export function taskRunning(status: string | undefined) {
   return status === "pending" || status === "running"
+}
+
+export function childForeground(
+  id: string | undefined,
+  part: Record<string, unknown> | undefined,
+  state: Record<string, unknown> | undefined,
+  status: Record<string, SessionStatusInfo>,
+) {
+  if (!id) return false
+  if (part?.background === true || state?.background === true) return false
+  return status[id]?.type === "busy" || status[id]?.type === "retry"
+}
+
+export function showChildPromotion(
+  id: string | undefined,
+  part: Record<string, unknown> | undefined,
+  state: Record<string, unknown> | undefined,
+  status: Record<string, SessionStatusInfo>,
+  readonly: boolean | undefined,
+) {
+  return !readonly && childForeground(id, part, state, status)
 }
 
 export function taskVisible(open: boolean | undefined, id: string | undefined) {

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1221,7 +1221,6 @@ export const dict = {
   "task.backgroundAgents.open": "فتح الوكيل الخلفي",
   "task.backgroundAgents.cancel": "إيقاف",
   "task.backgroundAgents.continueInBackground": "متابعة في الخلفية",
-  "task.backgroundAgents.foreground": "الوكيل الأمامي قيد التشغيل",
   "task.backgroundAgents.waiting": "وكيل خلفي يحتاج إلى إدخالك",
   "task.backgroundAgents.needsInput": "الإدخال مطلوب",
   "task.backgroundAgents.dismiss": "تجاهل",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1264,7 +1264,6 @@ export const dict = {
   "task.backgroundAgents.open": "Abrir agente em segundo plano",
   "task.backgroundAgents.cancel": "Parar",
   "task.backgroundAgents.continueInBackground": "Continuar em segundo plano",
-  "task.backgroundAgents.foreground": "O agente em primeiro plano está em execução",
   "task.backgroundAgents.waiting": "Um agente em segundo plano precisa da sua entrada",
   "task.backgroundAgents.needsInput": "Entrada necessária",
   "task.backgroundAgents.dismiss": "Dispensar",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1255,7 +1255,6 @@ export const dict = {
   "task.backgroundAgents.open": "Otvori agenta u pozadini",
   "task.backgroundAgents.cancel": "Zaustavi",
   "task.backgroundAgents.continueInBackground": "Nastavi u pozadini",
-  "task.backgroundAgents.foreground": "Agent u prvom planu radi",
   "task.backgroundAgents.waiting": "Agent u pozadini treba vaš unos",
   "task.backgroundAgents.needsInput": "Potreban unos",
   "task.backgroundAgents.dismiss": "Odbaci",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1250,7 +1250,6 @@ export const dict = {
   "task.backgroundAgents.open": "Åbn baggrundsagent",
   "task.backgroundAgents.cancel": "Stop",
   "task.backgroundAgents.continueInBackground": "Fortsæt i baggrunden",
-  "task.backgroundAgents.foreground": "Forgrundsagenten kører",
   "task.backgroundAgents.waiting": "En baggrundsagent har brug for dit input",
   "task.backgroundAgents.needsInput": "Input kræves",
   "task.backgroundAgents.dismiss": "Afvis",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1279,7 +1279,6 @@ export const dict = {
   "task.backgroundAgents.open": "Hintergrund-Agent öffnen",
   "task.backgroundAgents.cancel": "Stoppen",
   "task.backgroundAgents.continueInBackground": "Im Hintergrund fortsetzen",
-  "task.backgroundAgents.foreground": "Vordergrund-Agent läuft",
   "task.backgroundAgents.waiting": "Ein Hintergrund-Agent benötigt deine Eingabe",
   "task.backgroundAgents.needsInput": "Eingabe erforderlich",
   "task.backgroundAgents.dismiss": "Ausblenden",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1234,7 +1234,6 @@ export const dict = {
   "task.backgroundAgents.open": "Open background agent",
   "task.backgroundAgents.cancel": "Stop",
   "task.backgroundAgents.continueInBackground": "Continue in background",
-  "task.backgroundAgents.foreground": "Foreground subagent running",
   "task.backgroundAgents.waiting": "A background agent needs your input",
   "task.backgroundAgents.needsInput": "Needs input",
   "task.backgroundAgents.dismiss": "Dismiss",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1266,7 +1266,6 @@ export const dict = {
   "task.backgroundAgents.open": "Abrir agente en segundo plano",
   "task.backgroundAgents.cancel": "Detener",
   "task.backgroundAgents.continueInBackground": "Continuar en segundo plano",
-  "task.backgroundAgents.foreground": "El agente en primer plano está ejecutándose",
   "task.backgroundAgents.waiting": "Un agente en segundo plano necesita tu entrada",
   "task.backgroundAgents.needsInput": "Necesita entrada",
   "task.backgroundAgents.dismiss": "Descartar",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
@@ -1246,7 +1246,6 @@ export const dict = {
   "task.backgroundAgents.open": "باز کردن عامل پس‌زمینه",
   "task.backgroundAgents.cancel": "توقف",
   "task.backgroundAgents.continueInBackground": "ادامه در پس‌زمینه",
-  "task.backgroundAgents.foreground": "عامل پیش‌زمینه در حال اجراست",
   "task.backgroundAgents.waiting": "یک عامل پس‌زمینه به ورودی شما نیاز دارد",
   "task.backgroundAgents.needsInput": "ورودی لازم است",
   "task.backgroundAgents.dismiss": "رد کردن",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1287,7 +1287,6 @@ export const dict = {
   "task.backgroundAgents.open": "Ouvrir l'agent en arrière-plan",
   "task.backgroundAgents.cancel": "Arrêter",
   "task.backgroundAgents.continueInBackground": "Continuer en arrière-plan",
-  "task.backgroundAgents.foreground": "L'agent au premier plan est actif",
   "task.backgroundAgents.waiting": "Un agent en arrière-plan attend votre saisie",
   "task.backgroundAgents.needsInput": "Saisie requise",
   "task.backgroundAgents.dismiss": "Ignorer",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -1122,7 +1122,6 @@ export const dict = {
   "task.backgroundAgents.open": "Apri agente in background",
   "task.backgroundAgents.cancel": "Arresta",
   "task.backgroundAgents.continueInBackground": "Continua in background",
-  "task.backgroundAgents.foreground": "L'agente in primo piano è in esecuzione",
   "task.backgroundAgents.waiting": "Un agente in background richiede il tuo input",
   "task.backgroundAgents.needsInput": "Input richiesto",
   "task.backgroundAgents.dismiss": "Ignora",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1242,7 +1242,6 @@ export const dict = {
   "task.backgroundAgents.open": "バックグラウンドエージェントを開く",
   "task.backgroundAgents.cancel": "停止",
   "task.backgroundAgents.continueInBackground": "バックグラウンドで続行",
-  "task.backgroundAgents.foreground": "フォアグラウンドエージェントが実行中",
   "task.backgroundAgents.waiting": "バックグラウンドエージェントが入力を待っています",
   "task.backgroundAgents.needsInput": "入力が必要",
   "task.backgroundAgents.dismiss": "閉じる",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1229,7 +1229,6 @@ export const dict = {
   "task.backgroundAgents.open": "백그라운드 에이전트 열기",
   "task.backgroundAgents.cancel": "중지",
   "task.backgroundAgents.continueInBackground": "백그라운드에서 계속",
-  "task.backgroundAgents.foreground": "포그라운드 에이전트 실행 중",
   "task.backgroundAgents.waiting": "백그라운드 에이전트에 입력이 필요합니다",
   "task.backgroundAgents.needsInput": "입력 필요",
   "task.backgroundAgents.dismiss": "닫기",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1236,7 +1236,6 @@ export const dict = {
   "task.backgroundAgents.open": "Achtergrondagent openen",
   "task.backgroundAgents.cancel": "Stoppen",
   "task.backgroundAgents.continueInBackground": "Doorgaan op de achtergrond",
-  "task.backgroundAgents.foreground": "Voorgrondagent actief",
   "task.backgroundAgents.waiting": "Een achtergrondagent heeft je invoer nodig",
   "task.backgroundAgents.needsInput": "Invoer vereist",
   "task.backgroundAgents.dismiss": "Negeren",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1246,7 +1246,6 @@ export const dict = {
   "task.backgroundAgents.open": "Åpne bakgrunnsagent",
   "task.backgroundAgents.cancel": "Stopp",
   "task.backgroundAgents.continueInBackground": "Fortsett i bakgrunnen",
-  "task.backgroundAgents.foreground": "Forgrunnsagenten kjører",
   "task.backgroundAgents.waiting": "En bakgrunnsagent trenger innspill fra deg",
   "task.backgroundAgents.needsInput": "Innspill kreves",
   "task.backgroundAgents.dismiss": "Avvis",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1255,7 +1255,6 @@ export const dict = {
   "task.backgroundAgents.open": "Otwórz agenta w tle",
   "task.backgroundAgents.cancel": "Zatrzymaj",
   "task.backgroundAgents.continueInBackground": "Kontynuuj w tle",
-  "task.backgroundAgents.foreground": "Agent pierwszoplanowy działa",
   "task.backgroundAgents.waiting": "Agent w tle potrzebuje danych wejściowych",
   "task.backgroundAgents.needsInput": "Wymagane dane wejściowe",
   "task.backgroundAgents.dismiss": "Odrzuć",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1249,7 +1249,6 @@ export const dict = {
   "task.backgroundAgents.open": "Открыть фонового агента",
   "task.backgroundAgents.cancel": "Остановить",
   "task.backgroundAgents.continueInBackground": "Продолжить в фоне",
-  "task.backgroundAgents.foreground": "Агент на переднем плане выполняется",
   "task.backgroundAgents.waiting": "Фоновому агенту требуется ваш ввод",
   "task.backgroundAgents.needsInput": "Требуется ввод",
   "task.backgroundAgents.dismiss": "Скрыть",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1226,7 +1226,6 @@ export const dict = {
   "task.backgroundAgents.open": "เปิดเอเจนต์เบื้องหลัง",
   "task.backgroundAgents.cancel": "หยุด",
   "task.backgroundAgents.continueInBackground": "ทำต่อในเบื้องหลัง",
-  "task.backgroundAgents.foreground": "เอเจนต์เบื้องหน้ากำลังทำงาน",
   "task.backgroundAgents.waiting": "เอเจนต์เบื้องหลังต้องการข้อมูลจากคุณ",
   "task.backgroundAgents.needsInput": "ต้องการข้อมูล",
   "task.backgroundAgents.dismiss": "ยกเลิก",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1223,7 +1223,6 @@ export const dict = {
   "task.backgroundAgents.open": "Arka plan ajanını aç",
   "task.backgroundAgents.cancel": "Durdur",
   "task.backgroundAgents.continueInBackground": "Arka planda devam et",
-  "task.backgroundAgents.foreground": "Ön plan ajanı çalışıyor",
   "task.backgroundAgents.waiting": "Bir arka plan ajanı girişinizi bekliyor",
   "task.backgroundAgents.needsInput": "Giriş gerekli",
   "task.backgroundAgents.dismiss": "Kapat",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1222,7 +1222,6 @@ export const dict = {
   "task.backgroundAgents.open": "Відкрити фонового агента",
   "task.backgroundAgents.cancel": "Зупинити",
   "task.backgroundAgents.continueInBackground": "Продовжити у фоні",
-  "task.backgroundAgents.foreground": "Агент на передньому плані працює",
   "task.backgroundAgents.waiting": "Фоновому агенту потрібен ваш ввід",
   "task.backgroundAgents.needsInput": "Потрібен ввід",
   "task.backgroundAgents.dismiss": "Сховати",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1185,7 +1185,6 @@ export const dict = {
   "task.backgroundAgents.open": "打开后台智能体",
   "task.backgroundAgents.cancel": "停止",
   "task.backgroundAgents.continueInBackground": "在后台继续",
-  "task.backgroundAgents.foreground": "前台智能体正在运行",
   "task.backgroundAgents.waiting": "后台智能体需要你的输入",
   "task.backgroundAgents.needsInput": "需要输入",
   "task.backgroundAgents.dismiss": "关闭",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1189,7 +1189,6 @@ export const dict = {
   "task.backgroundAgents.open": "開啟背景 Agent",
   "task.backgroundAgents.cancel": "停止",
   "task.backgroundAgents.continueInBackground": "在背景繼續",
-  "task.backgroundAgents.foreground": "前景 Agent 執行中",
   "task.backgroundAgents.waiting": "背景 Agent 需要你的輸入",
   "task.backgroundAgents.needsInput": "需要輸入",
   "task.backgroundAgents.dismiss": "關閉",

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -57,8 +57,9 @@ export interface CancelBackgroundJobMessage {
   requestID: string
 }
 
-export interface BackgroundSubagentsMessage {
-  type: "backgroundSubagents"
+export interface PromoteBackgroundJobMessage {
+  type: "promoteBackgroundJob"
+  jobID: string
   sessionID: string
 }
 
@@ -1495,7 +1496,7 @@ export type WebviewMessage =
   | AbortRequest
   | RequestBackgroundJobsMessage
   | CancelBackgroundJobMessage
-  | BackgroundSubagentsMessage
+  | PromoteBackgroundJobMessage
   | RevertSessionRequest
   | UnrevertSessionRequest
   | DeleteMessageRequest

--- a/packages/opencode/src/kilocode/server/httpapi/groups/kilocode.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/groups/kilocode.ts
@@ -80,6 +80,7 @@ export const KilocodePaths = {
   sessionModelUsage: `/session/:sessionID/model-usage`,
   backgroundJobs: `${root}/background-jobs`,
   backgroundJobCancel: `${root}/background-jobs/:jobID/cancel`,
+  backgroundJobPromote: `${root}/background-jobs/:jobID/promote`,
 } as const
 
 export const KilocodeApi = HttpApi.make("kilocode")
@@ -270,6 +271,18 @@ export const KilocodeApi = HttpApi.make("kilocode")
             identifier: "kilocode.backgroundJob.cancel",
             summary: "Cancel background job",
             description: "Cancel one background subagent job and its session tree.",
+          }),
+        ),
+        HttpApiEndpoint.post("backgroundJobPromote", KilocodePaths.backgroundJobPromote, {
+          params: { jobID: Schema.String },
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.Boolean, "Background job promoted"),
+          error: HttpApiError.NotFound,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "kilocode.backgroundJob.promote",
+            summary: "Promote background job",
+            description: "Continue one foreground subagent in the background.",
           }),
         ),
       )

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/kilocode.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/kilocode.ts
@@ -234,6 +234,15 @@ export const kilocodeHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilocode"
       return true
     })
 
+    const backgroundJobPromote = Effect.fn("KilocodeHttpApi.backgroundJobPromote")(function* (ctx: {
+      params: { jobID: string }
+    }) {
+      const job = yield* background.get(ctx.params.jobID)
+      if (!job) return yield* new HttpApiError.NotFound({})
+      const promoted = yield* background.promote(ctx.params.jobID)
+      return promoted !== undefined
+    })
+
     return handlers
       .handle("heapSnapshot", heapSnapshot)
       .handle("commandFiles", commandFiles)
@@ -251,5 +260,6 @@ export const kilocodeHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilocode"
       .handle("sessionModelUsage", sessionModelUsage)
       .handle("backgroundJobs", backgroundJobs)
       .handle("backgroundJobCancel", backgroundJobCancel)
+      .handle("backgroundJobPromote", backgroundJobPromote)
   }),
 )

--- a/packages/opencode/test/kilocode/server/httpapi-exercise-scenarios.ts
+++ b/packages/opencode/test/kilocode/server/httpapi-exercise-scenarios.ts
@@ -587,6 +587,13 @@ export const kiloScenarios: Scenario[] = [
     }))
     .status(404),
   http.protected
+    .post("/kilocode/background-jobs/{jobID}/promote", "kilocode.backgroundJob.promote")
+    .at((ctx) => ({
+      path: route("/kilocode/background-jobs/{jobID}/promote", { jobID: "job_httpapi_missing" }),
+      headers: ctx.headers(),
+    }))
+    .status(404),
+  http.protected
     .post("/kilocode/heap/snapshot", "kilocode.heap.snapshot")
     .mutating()
     .jsonEffect(200, (body) =>

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -183,6 +183,8 @@ import type {
   KilocodeAgentManagerReplyResponses,
   KilocodeBackgroundJobCancelErrors,
   KilocodeBackgroundJobCancelResponses,
+  KilocodeBackgroundJobPromoteErrors,
+  KilocodeBackgroundJobPromoteResponses,
   KilocodeBackgroundJobsErrors,
   KilocodeBackgroundJobsResponses,
   KilocodeCommandFilesErrors,
@@ -7882,6 +7884,42 @@ export class BackgroundJob extends HeyApiClient {
       ThrowOnError
     >({
       url: "/kilocode/background-jobs/{jobID}/cancel",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Promote background job
+   *
+   * Continue one foreground subagent in the background.
+   */
+  public promote<ThrowOnError extends boolean = false>(
+    parameters: {
+      jobID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "jobID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      KilocodeBackgroundJobPromoteResponses,
+      KilocodeBackgroundJobPromoteErrors,
+      ThrowOnError
+    >({
+      url: "/kilocode/background-jobs/{jobID}/promote",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -17172,6 +17172,42 @@ export type KilocodeBackgroundJobCancelResponses = {
 export type KilocodeBackgroundJobCancelResponse =
   KilocodeBackgroundJobCancelResponses[keyof KilocodeBackgroundJobCancelResponses]
 
+export type KilocodeBackgroundJobPromoteData = {
+  body?: never
+  path: {
+    jobID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/kilocode/background-jobs/{jobID}/promote"
+}
+
+export type KilocodeBackgroundJobPromoteErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * Not found
+   */
+  404: NotFoundError
+}
+
+export type KilocodeBackgroundJobPromoteError =
+  KilocodeBackgroundJobPromoteErrors[keyof KilocodeBackgroundJobPromoteErrors]
+
+export type KilocodeBackgroundJobPromoteResponses = {
+  /**
+   * Background job promoted
+   */
+  200: boolean
+}
+
+export type KilocodeBackgroundJobPromoteResponse =
+  KilocodeBackgroundJobPromoteResponses[keyof KilocodeBackgroundJobPromoteResponses]
+
 export type AnacondaDesktopStatusData = {
   body?: never
   path?: never


### PR DESCRIPTION
Foreground subagent promotion was rendered in the parent task header and used a parent-wide endpoint. That made the action visually ambiguous and caused one click to promote every synchronous child when several subagents were running in parallel.

The action now appears on each inline subagent card. Each click sends that child job ID through a dedicated promotion endpoint, so parallel subagents can be moved to the background independently. Read-only subagent views do not expose the mutation control. The action uses a downward transfer icon and a tooltip that explains “Continue in background”. The existing background-agent strip remains available for tracking promoted work after the card scrolls away.

Before:
<img width="700" alt="Before, Continue in background appears in the parent task header" src="https://marius-kilocode.github.io/pr-assets/20260824-background-promotion-before.png" />

After:
<img width="700" alt="Hovering the downward transfer action shows the Continue in background tooltip" src="https://marius-kilocode.github.io/pr-assets/20260825-background-promotion-tooltip-attached.png" />