### PR TITLE
feat: add LLM Tech provider

### DIFF
--- a/.changeset/add-llmtech-provider.md
+++ b/.changeset/add-llmtech-provider.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": minor
+"kilo-code": minor
+---
+
+Add LLM Tech provider

--- a/packages/kilo-docs/lib/nav/ai-providers.ts
+++ b/packages/kilo-docs/lib/nav/ai-providers.ts
@@ -74,6 +74,7 @@ export const AiProvidersNav: NavSection[] = [
     links: [
       { href: "/ai-providers/chutes-ai", children: "Chutes AI" },
       { href: "/ai-providers/inception", children: "Inception" },
+      { href: "/ai-providers/llmtech", children: "LLM Tech" },
       { href: "/ai-providers/minimax", children: "MiniMax" },
       { href: "/ai-providers/moonshot", children: "Moonshot" },
       { href: "/ai-providers/ovhcloud", children: "OVHcloud" },

--- a/packages/kilo-docs/lychee.toml
+++ b/packages/kilo-docs/lychee.toml
@@ -50,6 +50,7 @@ exclude = [
   '^https?://vercel\.link/',
   # API base URL, returns 404 when fetched directly
   '^https?://api\.apertis\.ai/v1/?$',
+  '^https?://api\.llmtech\.eu/v1/?$',
   '^https?://cloud-agent-next\.kilosessions\.ai/?$',
   # Redirects to authenticated Google Cloud console
   '^https?://console\.cloud\.google\.com',

--- a/packages/kilo-docs/pages/ai-providers/llmtech.md
+++ b/packages/kilo-docs/pages/ai-providers/llmtech.md
@@ -1,0 +1,80 @@
+---
+title: "Using LLM Tech with Kilo Code | EU-Hosted Inference"
+description: "Connect Kilo Code to LLM Tech, an EU-hosted OpenAI-compatible inference endpoint with zero data retention."
+sidebar_label: LLM Tech
+---
+
+# Using LLM Tech With Kilo Code
+
+[LLM Tech](https://llmtech.eu) is an EU-hosted inference provider with an OpenAI-compatible API and a zero data retention policy: prompts and completions are not stored after the request completes.
+
+**Website:** [https://llmtech.eu](https://llmtech.eu)
+
+## Getting an API Key
+
+API keys are currently issued manually. Email [artem@llmtech.eu](mailto:artem@llmtech.eu) to request one; self-service signup is planned. Store the key securely — it is shown only once.
+
+## Configuration in Kilo Code
+
+{% tabs %}
+{% tab label="VSCode" %}
+
+Open **Settings** (gear icon) and go to the **Providers** tab to add LLM Tech and enter your API key.
+
+The extension stores this in your `kilo.json` config file. You can also edit the config file directly — see the **CLI** tab for the file format.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the API key as an environment variable or configure it in your `kilo.json` config file:
+
+**Environment variable:**
+
+```bash
+export LLMTECH_API_KEY="your-api-key"
+```
+
+**Config file** (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```jsonc
+{
+  "provider": {
+    "llmtech": {
+      "env": ["LLMTECH_API_KEY"]
+    }
+  }
+}
+```
+
+Then set your default model:
+
+```jsonc
+{
+  "model": "llmtech/unsloth/Qwen3.8-27B-NVFP4"
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
+## Supported Models
+
+LLM Tech serves a fixed model list from its own EU hardware:
+
+| Model                       | Context | Max output | Input        | Output       | Cache reads  |
+| --------------------------- | ------- | ---------- | ------------ | ------------ | ------------ |
+| `unsloth/Qwen3.8-27B-NVFP4` | 262,144 | 32,768     | $0.38 / M    | $2.90 / M    | $0.04 / M    |
+
+The base URL is fixed: `https://api.llmtech.eu/v1`.
+
+## Tips and Notes
+
+- **Zero data retention:** requests and responses are not stored on LLM Tech servers.
+- **EU hardware:** inference runs entirely on hardware located in the EU.
+- **Prompt caching:** cached prompt reads are billed at the reduced cache-read rate.
+- **Service status:** current uptime and incidents are published at [llmtech.eu/status](https://llmtech.eu/status).
+
+## Troubleshooting
+
+- **Invalid API key:** Verify `LLMTECH_API_KEY` is set in the same environment that launches Kilo, or reconnect the provider in Settings.
+- **Slow or failing requests:** Check [llmtech.eu/status](https://llmtech.eu/status), then retry; contact [artem@llmtech.eu](mailto:artem@llmtech.eu) if the issue persists.

--- a/packages/kilo-docs/source-links.md
+++ b/packages/kilo-docs/source-links.md
@@ -11,6 +11,8 @@
   <!-- packages/opencode/src/plugin/digitalocean.ts -->
 - <https://api.kilo.ai>
   <!-- packages/opencode/src/cli/cmd/github.handler.ts -->
+- <https://api.llmtech.eu/v1>
+  <!-- packages/opencode/src/kilocode/provider/llmtech.ts -->
 - <https://api.x.ai/v1>
   <!-- packages/opencode/src/plugin/xai.ts -->
 - <https://app.kilo.ai>

--- a/packages/opencode/src/kilocode/provider/llmtech.ts
+++ b/packages/opencode/src/kilocode/provider/llmtech.ts
@@ -1,0 +1,38 @@
+// LLM Tech (llmtech.eu) is not listed on models.dev, so its static catalog is
+// injected here. The endpoint is OpenAI-compatible and serves a fixed model
+// list, so no runtime model discovery is needed.
+import type { Provider } from "@opencode-ai/core/models-dev"
+
+export const PROVIDER_ID = "llmtech"
+
+export const DEFAULT_MODEL_ID = "unsloth/Qwen3.8-27B-NVFP4"
+
+export const CatalogProvider = {
+  id: PROVIDER_ID,
+  name: "LLM Tech",
+  description: "Qwen3.8-27B (NVFP4) served from EU hardware. Zero data retention.",
+  env: ["LLMTECH_API_KEY"],
+  api: "https://api.llmtech.eu/v1",
+  npm: "@ai-sdk/openai-compatible",
+  models: {
+    [DEFAULT_MODEL_ID]: {
+      id: DEFAULT_MODEL_ID,
+      name: "Qwen3.8 27B (NVFP4)",
+      family: "qwen",
+      release_date: "",
+      attachment: false,
+      reasoning: true,
+      temperature: true,
+      tool_call: true,
+      cost: { input: 0.38, output: 2.9, cache_read: 0.04 },
+      limit: { context: 262144, output: 32768 },
+      modalities: { input: ["text"], output: ["text"] },
+    },
+  },
+} satisfies Provider
+
+/** Adds the LLM Tech catalog unless the snapshot already carries one. */
+export function overlay(providers: Record<string, Provider>): Record<string, Provider> {
+  if (providers[PROVIDER_ID]) return providers
+  return { ...providers, [PROVIDER_ID]: CatalogProvider }
+}

--- a/packages/opencode/src/provider/models.ts
+++ b/packages/opencode/src/provider/models.ts
@@ -6,6 +6,7 @@ import * as Core from "@opencode-ai/core/models-dev"
 import { Context, Effect, Layer } from "effect"
 import { AI_SDK_PROVIDERS, KILO_OPENROUTER_BASE, PROMPTS } from "@kilocode/kilo-gateway"
 import { overlay } from "@/kilocode/anaconda-desktop/provider"
+import { overlay as withLLMTech } from "@/kilocode/provider/llmtech"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder" // kilocode_change
 
@@ -43,7 +44,7 @@ export const layer: Layer.Layer<Service, never, Core.Service | Config.Service | 
       const cache = yield* ModelCache.Service
 
       const get = Effect.fn("ModelsDev.get")(function* () {
-        const providers = overlay(yield* core.get())
+        const providers = withLLMTech(overlay(yield* core.get()))
         const fallback = providers.kilo
         delete providers.kilo
 

--- a/packages/opencode/test/kilocode/provider-llmtech.test.ts
+++ b/packages/opencode/test/kilocode/provider-llmtech.test.ts
@@ -1,0 +1,118 @@
+// Tests that the LLM Tech catalog is injected next to the models.dev snapshot.
+
+import { expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { FetchHttpClient } from "effect/unstable/http"
+import * as CoreModels from "@opencode-ai/core/models-dev"
+import { ModelsDev } from "../../src/provider/models"
+import { ModelCache } from "../../src/provider/model-cache"
+import { Provider } from "../../src/provider/provider"
+import { Auth } from "../../src/auth"
+import { CatalogProvider, DEFAULT_MODEL_ID, PROVIDER_ID, overlay } from "../../src/kilocode/provider/llmtech"
+import { TestConfig } from "../fixture/config"
+import { testEffect } from "../lib/effect"
+import { provideInstance, testInstanceStoreLayer } from "../fixture/fixture"
+
+function layer(seed: Record<string, ModelsDev.Provider> = {}) {
+  const cfg = TestConfig.layer({ get: () => Effect.succeed({ disabled_providers: ["kilo"] }) })
+  const auth = Layer.mock(Auth.Service)({ get: () => Effect.succeed(undefined) })
+  const kiloModels = Layer.succeed(
+    ModelCache.KiloModelsService,
+    ModelCache.KiloModelsService.of({ fetch: () => Effect.succeed({ models: {} }) }),
+  )
+  const cache = Layer.fresh(ModelCache.layer).pipe(
+    Layer.provide(FetchHttpClient.layer),
+    Layer.provide(cfg),
+    Layer.provide(auth),
+    Layer.provide(kiloModels),
+  )
+  const core = Layer.succeed(
+    CoreModels.Service,
+    CoreModels.Service.of({ get: () => Effect.succeed(seed), refresh: () => Effect.void }),
+  )
+  return Layer.fresh(ModelsDev.layer).pipe(
+    Layer.provide(core),
+    Layer.provide(FetchHttpClient.layer),
+    Layer.provide(cfg),
+    Layer.provide(auth),
+    Layer.provide(cache),
+  )
+}
+
+const it = testEffect(testInstanceStoreLayer)
+
+it.live("injects the LLM Tech catalog with its static model", () =>
+  Effect.gen(function* () {
+    const providers = yield* ModelsDev.Service.use((models) => models.get()).pipe(
+      Effect.provide(layer()),
+      provideInstance(process.cwd()),
+    )
+
+    expect(providers[PROVIDER_ID]).toMatchObject({
+      id: PROVIDER_ID,
+      name: "LLM Tech",
+      env: ["LLMTECH_API_KEY"],
+      api: "https://api.llmtech.eu/v1",
+      npm: "@ai-sdk/openai-compatible",
+    })
+    expect(Object.keys(providers[PROVIDER_ID].models)).toEqual([DEFAULT_MODEL_ID])
+    expect(providers[PROVIDER_ID].models[DEFAULT_MODEL_ID]).toMatchObject({
+      id: DEFAULT_MODEL_ID,
+      attachment: false,
+      tool_call: true,
+      cost: { input: 0.38, output: 2.9, cache_read: 0.04 },
+      limit: { context: 262144, output: 32768 },
+    })
+  }),
+)
+
+it.live("prefers a models.dev LLM Tech entry over the bundled catalog", () =>
+  Effect.gen(function* () {
+    const seeded: ModelsDev.Provider = {
+      id: PROVIDER_ID,
+      name: "LLM Tech (remote)",
+      env: ["LLMTECH_API_KEY"],
+      models: {},
+    }
+    const providers = yield* ModelsDev.Service.use((models) => models.get()).pipe(
+      Effect.provide(layer({ [PROVIDER_ID]: seeded })),
+      provideInstance(process.cwd()),
+    )
+
+    expect(providers[PROVIDER_ID].name).toBe("LLM Tech (remote)")
+    expect(Object.keys(providers[PROVIDER_ID].models)).toEqual([])
+  }),
+)
+
+it.effect("keeps snapshot entries and adds the catalog only when missing", () =>
+  Effect.sync(() => {
+    const existing: Record<string, ModelsDev.Provider> = {
+      [PROVIDER_ID]: { id: PROVIDER_ID, name: "custom", env: [], models: {} },
+    }
+    expect(overlay(existing)[PROVIDER_ID].name).toBe("custom")
+    expect(overlay({})[PROVIDER_ID]).toBe(CatalogProvider)
+  }),
+)
+
+it.effect("maps the static model into provider catalog capabilities", () =>
+  Effect.sync(() => {
+    const info = Provider.fromModelsDevProvider(CatalogProvider)
+    const model = info.models[DEFAULT_MODEL_ID]
+
+    expect(info.name).toBe("LLM Tech")
+    expect(model.api).toMatchObject({
+      id: DEFAULT_MODEL_ID,
+      url: "https://api.llmtech.eu/v1",
+      npm: "@ai-sdk/openai-compatible",
+    })
+    expect(model.capabilities).toMatchObject({
+      temperature: true,
+      reasoning: true,
+      attachment: false,
+      toolcall: true,
+    })
+    expect(model.capabilities.input.image).toBe(false)
+    expect(model.cost).toMatchObject({ input: 0.38, output: 2.9, cache: { read: 0.04, write: 0 } })
+    expect(model.limit).toMatchObject({ context: 262144, output: 32768 })
+  }),
+)


### PR DESCRIPTION
Adds LLM Tech (llmtech.eu) as a static catalog provider, following the same pattern as `apertis` / `anaconda-desktop` (provider not listed on models.dev, injected locally with a models.dev-wins guard).

**What's included:**
- `packages/opencode/src/kilocode/provider/llmtech.ts` — static catalog: OpenAI-compatible endpoint `https://api.llmtech.eu/v1` via `@ai-sdk/openai-compatible`, env `LLMTECH_API_KEY`, one model `unsloth/Qwen3.8-27B-NVFP4` (262,144 context, reasoning + tool calls, prompt caching)
- overlay wired into `provider/models.ts`
- tests: catalog injection, models.dev precedence, clean overlay, capability/cost mapping (4 passing)
- docs page + nav entry + lychee exclusion for the API root
- changeset (minor)

**About the provider:** LLM Tech is an EU-based inference provider serving Qwen3.8-27B (NVFP4 on Blackwell) in production — zero data retention, live measured status at https://llmtech.eu/status. 262K native context is a good fit for long agentic coding sessions.

Checks run locally: provider tests 4/4, adjacent models.ts-area tests 20/20, `tsgo --noEmit` clean, kilo-docs vitest 22/22, oxlint clean, prettier clean, full pre-push typecheck (incl. JetBrains) passed.