### PR TITLE
fix(vscode): deduplicate sync event delivery

### DIFF
--- a/.changeset/calm-agent-manager-streams.md
+++ b/.changeset/calm-agent-manager-streams.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Reduce duplicate event processing across VS Code when multiple sessions run concurrently.

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -3,7 +3,7 @@ import { ServerManager } from "./server-manager"
 import { createKiloClient, type KiloClient } from "@kilocode/sdk/v2/client"
 import { SdkSSEAdapter, type SSEPayload } from "./sdk-sse-adapter"
 import type { ServerConfig } from "./types"
-import { resolveEventSessionId as resolveEventSessionIdPure } from "./connection-utils"
+import { createDuplicateEventFilter, resolveEventSessionId as resolveEventSessionIdPure } from "./connection-utils"
 import { SandboxPreference } from "../sandbox-preference"
 
 export type ConnectionState = "connecting" | "connected" | "disconnected" | "error"
@@ -96,6 +96,7 @@ export class KiloConnectionService {
   private remoteService: import("../RemoteStatusService").RemoteStatusService | null = null
 
   private readonly eventListeners: Set<SSEEventListener> = new Set()
+  private readonly duplicateEvent = createDuplicateEventFilter()
   private readonly stateListeners: Set<StateListener> = new Set()
   private readonly notificationDismissListeners: Set<NotificationDismissListener> = new Set()
   private readonly languageChangeListeners: Set<LanguageChangeListener> = new Set()
@@ -837,6 +838,8 @@ export class KiloConnectionService {
     // Wire SSE events → broadcast to all registered listeners
     sse.onEvent((event, directory) => {
       if (this.sseClient !== sse) return
+      // EventV2Bridge also emits these durable compatibility envelopes after their normal live events.
+      if (this.duplicateEvent(event)) return
       this.handlePermissionEvent(event, directory)
       this.handleQuestionEvent(event, directory)
       for (const listener of this.eventListeners) {

--- a/packages/kilo-vscode/src/services/cli-backend/connection-utils.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-utils.ts
@@ -4,6 +4,33 @@ export type { SSEPayload } from "./sdk-sse-adapter"
 type SyncPayload = Extract<SSEPayload, { type: "sync" }>
 type TransientPayload = Exclude<SSEPayload, SyncPayload>
 
+const duplicateSyncEvents = new Set([
+  "message.updated.1",
+  "message.removed.1",
+  "message.part.updated.1",
+  "message.part.removed.1",
+  "session.created.1",
+  "session.deleted.1",
+])
+
+const duplicateLiveEvents = new Set([...duplicateSyncEvents].map((name) => name.slice(0, -2)))
+const DUPLICATE_EVENT_LIMIT = 1024
+
+export function createDuplicateEventFilter() {
+  const seen = new Set<string>()
+  return (event: SSEPayload): boolean => {
+    if (event.type === "sync") {
+      return duplicateSyncEvents.has(event.name) && seen.delete(event.id)
+    }
+
+    if (duplicateLiveEvents.has(event.type)) {
+      seen.add(event.id)
+      if (seen.size > DUPLICATE_EVENT_LIMIT) seen.delete(seen.values().next().value!)
+    }
+    return false
+  }
+}
+
 /**
  * Pure session ID resolution for SSE events.
  * The lookupMessageSessionId callback remains part of the public resolver contract for

--- a/packages/kilo-vscode/tests/unit/connection-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/connection-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { resolveEventSessionId } from "../../src/services/cli-backend/connection-utils"
+import { createDuplicateEventFilter, resolveEventSessionId } from "../../src/services/cli-backend/connection-utils"
 import type { SSEPayload as Payload } from "../../src/services/cli-backend/sdk-sse-adapter"
 
 const noLookup = (_: string) => undefined
@@ -170,5 +170,67 @@ describe("resolveEventSessionId", () => {
     const event = { id: "e12", type: "server.connected", properties: {} } satisfies Payload
 
     expect(resolveEventSessionId(event, noLookup)).toBeUndefined()
+  })
+})
+
+describe("isDuplicateSyncEvent", () => {
+  it("drops a compatibility envelope only after its live event", () => {
+    const filter = createDuplicateEventFilter()
+    const live = {
+      id: "e13",
+      type: "message.part.updated",
+      properties: { sessionID: "s6", part, delta: "x" },
+    } satisfies Payload
+    expect(filter(live)).toBe(false)
+    expect(
+      filter(
+        sync({
+          type: "sync",
+          name: "message.part.updated.1",
+          id: "e13",
+          seq: 5,
+          aggregateID: "s6",
+          data: { sessionID: "s6", part, time: 0 },
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it("keeps replay-only compatibility envelopes", () => {
+    const filter = createDuplicateEventFilter()
+    expect(
+      filter(
+        sync({
+          type: "sync",
+          name: "session.next.model.switched.1",
+          id: "e14",
+          seq: 6,
+          aggregateID: "s6",
+          data: { sessionID: "s6", messageID: "m1", model: { id: "test", providerID: "kilo" } },
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it("keeps session updates because the provider consumes their sync metadata", () => {
+    const filter = createDuplicateEventFilter()
+    const live = {
+      id: "e15",
+      type: "session.updated",
+      properties: { sessionID: "s6", info: { id: "s6", time: { created: 0, updated: 1 } } },
+    } as Payload
+    expect(filter(live)).toBe(false)
+    expect(
+      filter(
+        sync({
+          type: "sync",
+          name: "session.updated.1",
+          id: "e15",
+          seq: 7,
+          aggregateID: "s6",
+          data: { sessionID: "s6", info: { id: "s6", time: { created: 0, updated: 1 } } },
+        }),
+      ),
+    ).toBe(false)
   })
 })


### PR DESCRIPTION
## What Problem This Solves

When multiple sessions stream concurrently, the shared VS Code connection receives two representations of several events: the normal live event and a compatibility `sync` envelope with the same event ID. Both representations currently reach every registered provider. This duplicates session resolution, event mapping, stream scheduling, and webview update work across the Kilo sidebar, editor tabs, and Agent Manager.

The duplication is especially costly during high-rate `message.part.updated` streaming. It increases extension-host and webview work even though the second representation carries no new information for those event types.

## Why This Change Was Made

The connection now records the IDs of recently delivered live events and drops only a matching compatibility envelope that follows the live event. The filter is bounded to 1,024 IDs. It does not use time-based cleanup or scan the set on every event.

The filter intentionally preserves compatibility events that may contain information not present in the normal event path:

| Event category | Behavior |
|---|---|
| `message.updated`, `message.removed` | Drop matching later `sync` envelope |
| `message.part.updated`, `message.part.removed` | Drop matching later `sync` envelope |
| `session.created`, `session.deleted` | Drop matching later `sync` envelope |
| `session.updated` | Preserve `sync` envelope for reconciliation sequence metadata |
| Replay-only `sync` events | Preserve |

This is a VS Code client optimization only. It does not change the CLI server, database persistence, network delivery, or replay APIs.

## User Impact

Users running multiple concurrent sessions should see less duplicate processing in the VS Code extension. Normal live updates, replay-only events, session reconciliation, and existing UI behavior remain available. The change applies to all VS Code clients using the shared connection service, including the sidebar, editor tabs, and Agent Manager.

## Evidence

The same synthetic workload was run through the real `SdkSSEAdapter` path with 5,000,000 wire events, 11 sessions, and 8 downstream listeners.

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Wire events received | 5,000,000 | 5,000,000 | No change |
| Events forwarded downstream | 5,000,000 | 2,500,000 | 50% fewer |
| Downstream listener calls | 40,000,000 | 20,000,000 | 50% fewer |
| CPU time | 1,149 ms | 1,113 ms | 3.1% lower |
| Wall time | 1,040 ms | 993 ms | 4.5% lower |

The full SSE path is dominated by parsing and heartbeat timer work, so the end-to-end CPU reduction is smaller than the downstream reduction. The measurement proves that duplicate downstream dispatch is removed; it does not claim a reduction in CLI server CPU or total device CPU.

| Validation | Result |
|---|---|
| Event-path unit tests | 85 passed |
| VS Code typecheck | Passed |
| Formatting and diff checks | Passed |
| Replay-only sync behavior | Covered |
| `session.updated` reconciliation behavior | Covered |

