### PR TITLE
fix(agent-manager): use valid terminal close code

### DIFF
--- a/.changeset/terminal-replay-close-code.md
+++ b/.changeset/terminal-replay-close-code.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Use a browser-valid close code when Agent Manager terminal replay exceeds its buffer limit

--- a/packages/kilo-vscode/tests/unit/agent-manager-terminal-layout.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-terminal-layout.test.ts
@@ -85,6 +85,11 @@ test("orders local terminal status lines through the output batcher", () => {
   expect(terminal).not.toContain("term.writeln(")
 })
 
+test("uses a browser-valid close code when replay overflows", () => {
+  expect(terminal).not.toContain("close(1009,")
+  expect(terminal).toContain('close(4009, "terminal replay exceeded limit")')
+})
+
 test("keeps raw PTY line endings and initializes Unicode widths before attaching", () => {
   expect(terminal).toContain("convertEol: false")
   expect(terminal).toContain('term.unicode.activeVersion = "15-graphemes"')

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/TerminalTab.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/TerminalTab.tsx
@@ -334,7 +334,7 @@ export const TerminalTab: Component<Props> = (props) => {
         if (typeof event.data === "string") {
           if (!replay.output(event.data)) {
             input.clear()
-            next.close(1009, "terminal replay exceeded limit")
+            next.close(4009, "terminal replay exceeded limit")
             return
           }
           scheduleFlush()
@@ -345,7 +345,7 @@ export const TerminalTab: Component<Props> = (props) => {
           if (replay.frame(bytes)) return
           if (!replay.output(bytes)) {
             input.clear()
-            next.close(1009, "terminal replay exceeded limit")
+            next.close(4009, "terminal replay exceeded limit")
             return
           }
           scheduleFlush()


### PR DESCRIPTION
Follow-up to #13413.

## What Problem This Solves
The terminal replay overflow path passed close code 1009 to the browser WebSocket API. Chromium rejects that code synchronously, so the overflow socket was not closed.

## Why This Change Was Made
The WebSocket API accepts 1000 or application-defined codes from 3000 through 4999. Code 4009 preserves the overflow-specific intent while remaining valid in Chromium.

## User Impact
Oversized terminal replay now closes the socket instead of throwing from the message handler.

## Evidence
A live WebSocket message test in VS Code 1.134.0 (Chrome 148.0.7778.280) reproduced InvalidAccessError for 1009 and accepted 4009. The focused Agent Manager replay and layout tests pass.