### PR TITLE
fix(vscode): bound sync filter state

### DIFF
--- a/.changeset/fix-sync-filter-lifecycle.md
+++ b/.changeset/fix-sync-filter-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent duplicate-event tracking from suppressing delayed sync events after reconnects or high event bursts.

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -96,7 +96,6 @@ export class KiloConnectionService {
   private remoteService: import("../RemoteStatusService").RemoteStatusService | null = null
 
   private readonly eventListeners: Set<SSEEventListener> = new Set()
-  private readonly duplicateEvent = createDuplicateEventFilter()
   private readonly stateListeners: Set<StateListener> = new Set()
   private readonly notificationDismissListeners: Set<NotificationDismissListener> = new Set()
   private readonly languageChangeListeners: Set<LanguageChangeListener> = new Set()
@@ -821,6 +820,7 @@ export class KiloConnectionService {
       },
     })
     const sse = new SdkSSEAdapter(client)
+    const duplicateEvent = createDuplicateEventFilter()
     this.client = client
     this.sseClient = sse
 
@@ -839,7 +839,7 @@ export class KiloConnectionService {
     sse.onEvent((event, directory) => {
       if (this.sseClient !== sse) return
       // EventV2Bridge also emits these durable compatibility envelopes after their normal live events.
-      if (this.duplicateEvent(event)) return
+      if (duplicateEvent(event)) return
       this.handlePermissionEvent(event, directory)
       this.handleQuestionEvent(event, directory)
       for (const listener of this.eventListeners) {

--- a/packages/kilo-vscode/src/services/cli-backend/connection-utils.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-utils.ts
@@ -24,7 +24,8 @@ export function createDuplicateEventFilter() {
     }
 
     if (duplicateLiveEvents.has(event.type)) {
-      if (seen.size < DUPLICATE_EVENT_LIMIT) seen.add(event.id)
+      if (seen.size >= DUPLICATE_EVENT_LIMIT) seen.delete(seen.values().next().value!)
+      seen.add(event.id)
     }
     return false
   }

--- a/packages/kilo-vscode/src/services/cli-backend/connection-utils.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-utils.ts
@@ -24,8 +24,7 @@ export function createDuplicateEventFilter() {
     }
 
     if (duplicateLiveEvents.has(event.type)) {
-      seen.add(event.id)
-      if (seen.size > DUPLICATE_EVENT_LIMIT) seen.delete(seen.values().next().value!)
+      if (seen.size < DUPLICATE_EVENT_LIMIT) seen.add(event.id)
     }
     return false
   }

--- a/packages/kilo-vscode/tests/unit/connection-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/connection-utils.test.ts
@@ -173,7 +173,7 @@ describe("resolveEventSessionId", () => {
   })
 })
 
-describe("isDuplicateSyncEvent", () => {
+describe("createDuplicateEventFilter", () => {
   it("drops a compatibility envelope only after its live event", () => {
     const filter = createDuplicateEventFilter()
     const live = {
@@ -229,6 +229,139 @@ describe("isDuplicateSyncEvent", () => {
           seq: 7,
           aggregateID: "s6",
           data: { sessionID: "s6", info: { id: "s6", time: { created: 0, updated: 1 } } },
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it("does not evict pending live events when the cap is reached", () => {
+    const filter = createDuplicateEventFilter()
+    for (let index = 0; index < 1024; index++) {
+      expect(
+        filter({
+          id: `live-${index}`,
+          type: "message.part.updated",
+          properties: { sessionID: "s6", part, delta: "x" },
+        }),
+      ).toBe(false)
+    }
+
+    expect(
+      filter(
+        sync({
+          type: "sync",
+          name: "message.part.updated.1",
+          id: "live-0",
+          seq: 8,
+          aggregateID: "s6",
+          data: { sessionID: "s6", part, time: 0 },
+        }),
+      ),
+    ).toBe(true)
+    expect(
+      filter({
+        id: "live-1024",
+        type: "message.part.updated",
+        properties: { sessionID: "s6", part, delta: "x" },
+      }),
+    ).toBe(false)
+    expect(
+      filter(
+        sync({
+          type: "sync",
+          name: "message.part.updated.1",
+          id: "live-1024",
+          seq: 9,
+          aggregateID: "s6",
+          data: { sessionID: "s6", part, time: 0 },
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it("passes overflow events through without evicting pending IDs", () => {
+    const filter = createDuplicateEventFilter()
+    for (let index = 0; index < 1024; index++) {
+      expect(
+        filter({
+          id: `pending-${index}`,
+          type: "message.part.updated",
+          properties: { sessionID: "s6", part, delta: "x" },
+        }),
+      ).toBe(false)
+    }
+
+    expect(
+      filter({
+        id: "overflow",
+        type: "message.part.updated",
+        properties: { sessionID: "s6", part, delta: "x" },
+      }),
+    ).toBe(false)
+    expect(
+      filter(
+        sync({
+          type: "sync",
+          name: "message.part.updated.1",
+          id: "overflow",
+          seq: 8,
+          aggregateID: "s6",
+          data: { sessionID: "s6", part, time: 0 },
+        }),
+      ),
+    ).toBe(false)
+    expect(
+      filter(
+        sync({
+          type: "sync",
+          name: "message.part.updated.1",
+          id: "pending-0",
+          seq: 9,
+          aggregateID: "s6",
+          data: { sessionID: "s6", part, time: 0 },
+        }),
+      ),
+    ).toBe(true)
+    expect(
+      filter({
+        id: "after-free",
+        type: "message.part.updated",
+        properties: { sessionID: "s6", part, delta: "x" },
+      }),
+    ).toBe(false)
+    expect(
+      filter(
+        sync({
+          type: "sync",
+          name: "message.part.updated.1",
+          id: "after-free",
+          seq: 10,
+          aggregateID: "s6",
+          data: { sessionID: "s6", part, time: 0 },
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it("does not carry duplicate IDs between connections", () => {
+    const first = createDuplicateEventFilter()
+    const second = createDuplicateEventFilter()
+    const live = {
+      id: "connection-event",
+      type: "message.part.updated",
+      properties: { sessionID: "s6", part, delta: "x" },
+    } satisfies Payload
+
+    expect(first(live)).toBe(false)
+    expect(
+      second(
+        sync({
+          type: "sync",
+          name: "message.part.updated.1",
+          id: "connection-event",
+          seq: 11,
+          aggregateID: "s6",
+          data: { sessionID: "s6", part, time: 0 },
         }),
       ),
     ).toBe(false)

--- a/packages/kilo-vscode/tests/unit/connection-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/connection-utils.test.ts
@@ -234,7 +234,7 @@ describe("createDuplicateEventFilter", () => {
     ).toBe(false)
   })
 
-  it("does not evict pending live events when the cap is reached", () => {
+  it("continues tracking new live events after the cap is reached", () => {
     const filter = createDuplicateEventFilter()
     for (let index = 0; index < 1024; index++) {
       expect(
@@ -246,18 +246,6 @@ describe("createDuplicateEventFilter", () => {
       ).toBe(false)
     }
 
-    expect(
-      filter(
-        sync({
-          type: "sync",
-          name: "message.part.updated.1",
-          id: "live-0",
-          seq: 8,
-          aggregateID: "s6",
-          data: { sessionID: "s6", part, time: 0 },
-        }),
-      ),
-    ).toBe(true)
     expect(
       filter({
         id: "live-1024",
@@ -277,9 +265,33 @@ describe("createDuplicateEventFilter", () => {
         }),
       ),
     ).toBe(true)
+    expect(
+      filter(
+        sync({
+          type: "sync",
+          name: "message.part.updated.1",
+          id: "live-0",
+          seq: 8,
+          aggregateID: "s6",
+          data: { sessionID: "s6", part, time: 0 },
+        }),
+      ),
+    ).toBe(false)
+    expect(
+      filter(
+        sync({
+          type: "sync",
+          name: "message.part.updated.1",
+          id: "live-1024",
+          seq: 9,
+          aggregateID: "s6",
+          data: { sessionID: "s6", part, time: 0 },
+        }),
+      ),
+    ).toBe(false)
   })
 
-  it("passes overflow events through without evicting pending IDs", () => {
+  it("forwards delayed envelopes for evicted IDs", () => {
     const filter = createDuplicateEventFilter()
     for (let index = 0; index < 1024; index++) {
       expect(
@@ -303,7 +315,7 @@ describe("createDuplicateEventFilter", () => {
         sync({
           type: "sync",
           name: "message.part.updated.1",
-          id: "overflow",
+          id: "pending-0",
           seq: 8,
           aggregateID: "s6",
           data: { sessionID: "s6", part, time: 0 },
@@ -315,27 +327,8 @@ describe("createDuplicateEventFilter", () => {
         sync({
           type: "sync",
           name: "message.part.updated.1",
-          id: "pending-0",
+          id: "pending-1023",
           seq: 9,
-          aggregateID: "s6",
-          data: { sessionID: "s6", part, time: 0 },
-        }),
-      ),
-    ).toBe(true)
-    expect(
-      filter({
-        id: "after-free",
-        type: "message.part.updated",
-        properties: { sessionID: "s6", part, delta: "x" },
-      }),
-    ).toBe(false)
-    expect(
-      filter(
-        sync({
-          type: "sync",
-          name: "message.part.updated.1",
-          id: "after-free",
-          seq: 10,
           aggregateID: "s6",
           data: { sessionID: "s6", part, time: 0 },
         }),


### PR DESCRIPTION
## What Problem This Solves

The shared VS Code connection receives both normal live events and compatibility `sync` envelopes for several session, message, and message-part events. PR #13410 suppresses a matching `sync` envelope after the same live event has been delivered.

The first follow-up implementation introduced two edge cases in that tracking state:

- It could stop recording new live event IDs after the tracking set reached its cap, so duplicate suppression stopped during sustained event bursts.
- The tracking state needed to be scoped to one SSE connection so IDs from a previous connection could not affect a reconnect.

## Why This Change Was Made

Use a bounded sliding window for recently delivered live event IDs. When the 1,024-entry cap is reached, the oldest ID is evicted and the new live ID is tracked. Promptly arriving compatibility envelopes continue to be deduplicated. If an envelope arrives after its live ID has left the bounded window, it is forwarded instead of being incorrectly suppressed.

Create the filter inside `doConnect()` so each `SdkSSEAdapter` connection has independent state. Reconnects and server restarts cannot reuse stale IDs.

## User Impact

The duplicate-event optimization continues to reduce downstream processing across the VS Code sidebar, editor tabs, and Agent Manager. Delayed or replay-only compatibility events remain deliverable, and reconnects do not carry stale deduplication state.

| Event scenario | Behavior |
|---|---|
| Matching live event and prompt `sync` envelope | Suppress the duplicate envelope |
| Matching envelope after the 1,024-entry window | Forward the envelope |
| Replay-only `sync` event | Forward the event |
| Event ID from an earlier SSE connection | Do not reuse the ID |
| `session.updated` reconciliation envelope | Preserve the envelope |

## Evidence

| Validation | Result |
|---|---|
| Focused event regression tests | 88 passed |
| Sliding-window overflow behavior | Covered |
| Delayed envelope behavior | Covered |
| Connection lifecycle isolation | Covered |
| VS Code typecheck | Passed |
| VS Code lint | Passed |
| CI | Green |

