### PR TITLE
fix(cli): align file location cache keys

### DIFF
--- a/.changeset/steady-location-keys.md
+++ b/.changeset/steady-location-keys.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep file route location services on the same cache key as workspace-aware server routes.

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
@@ -1,4 +1,5 @@
 import * as InstanceState from "@/effect/instance-state"
+import { WorkspaceRef } from "@/effect/instance-ref" // kilocode_change - preserve the shared location key shape
 import { FileSystem } from "@opencode-ai/core/filesystem"
 import { LocationServiceMap, locationServiceMapLayer } from "@opencode-ai/core/location-services"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
@@ -17,11 +18,19 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
     const locations = yield* LocationServiceMap.Service
 
     const filesystem = Effect.fnUntraced(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
+      // kilocode_change start - preserve the shared location key shape
+      const workspaceID = yield* WorkspaceRef
       return yield* effect.pipe(
         Effect.provide(
-          locations.get(Location.Ref.make({ directory: AbsolutePath.make((yield* InstanceState.context).directory) })),
+          locations.get(
+            Location.Ref.make({
+              directory: AbsolutePath.make((yield* InstanceState.context).directory),
+              workspaceID,
+            }),
+          ),
         ),
       )
+      // kilocode_change end
     })
 
     const findText = Effect.fn("FileHttpApi.findText")(function* (ctx: { query: { pattern: string } }) {

--- a/packages/opencode/test/kilocode/shared-location-map-key.test.ts
+++ b/packages/opencode/test/kilocode/shared-location-map-key.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import { Equal, Hash } from "effect"
+import { readFileSync } from "node:fs"
+import { Location } from "@opencode-ai/core/location"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+
+const opencode = new URL("../../src/", import.meta.url)
+const server = new URL("../../../server/src/", import.meta.url)
+
+function source(root: URL, path: string) {
+  return readFileSync(new URL(path, root), "utf8")
+}
+
+describe("shared location service map keys", () => {
+  test("all location route consumers include workspaceID in their cache key", () => {
+    const consumers = [
+      [opencode, "server/routes/instance/httpapi/handlers/file.ts"],
+      [opencode, "server/routes/instance/httpapi/handlers/pty.ts"],
+      [server, "middleware/session-location.ts"],
+    ] as const
+
+    for (const [root, path] of consumers) {
+      expect(source(root, path), path).toMatch(/Location\.Ref\.make\(\{[^}]*workspaceID/)
+    }
+  })
+
+  test("omitted and explicit undefined workspace IDs are distinct keys", () => {
+    const directory = AbsolutePath.make("/workspace")
+    const omitted = Location.Ref.make({ directory })
+    const explicit = Location.Ref.make({ directory, workspaceID: undefined })
+
+    expect(Object.hasOwn(omitted, "workspaceID")).toBe(false)
+    expect(Object.hasOwn(explicit, "workspaceID")).toBe(true)
+    expect(Equal.equals(omitted, explicit)).toBe(false)
+    expect(Hash.hash(omitted)).not.toBe(Hash.hash(explicit))
+  })
+})


### PR DESCRIPTION
Follow-up to #13378. Merge after #13378.

## What Problem This Solves
The file route can construct a different `Location.Ref` cache key from the pty and session routes when `workspaceID` is absent. After #13378 shares the location service map, that prevents file requests from reusing the intended per-directory service stack.

## Why This Change Was Made
`Location.Ref.make({ directory })` omits the optional `workspaceID` property, while passing `workspaceID: undefined` retains it. Effect `Equal` and `Hash` treat those objects as different `LayerMap` keys. The file route now carries the request workspace context into the ref, and the regression test checks all location route consumers plus the actual key behavior.

## User Impact
File route location services use the same cache key shape as workspace-aware pty and session routes, so the shared map and its invalidation lifecycle apply consistently.

## Evidence
- `bun test test/kilocode/shared-location-map-key.test.ts`
- `bun test test/location-layer.test.ts`
- `bun run typecheck` from `packages/opencode`
- Annotation and Prettier checks pass
- Focused Oxlint reports one pre-existing unused `directory` warning in the file handler and no errors