### PR TITLE
fix(cli): address startup review feedback

### DIFF
--- a/.changeset/fix-cli-startup-followup.md
+++ b/.changeset/fix-cli-startup-followup.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix CLI help disposal and shell completion after startup optimization.

--- a/packages/opencode/src/kilocode/cli/lazy-commands.ts
+++ b/packages/opencode/src/kilocode/cli/lazy-commands.ts
@@ -19,6 +19,10 @@ export function hasLazyCommandSelection() {
   return selected
 }
 
+export function markLazyCommandSelection() {
+  selected = true
+}
+
 export function lazy<T = {}, U = {}>(input: {
   command: string | readonly string[]
   aliases?: string | readonly string[]
@@ -29,9 +33,11 @@ export function lazy<T = {}, U = {}>(input: {
   const load = () => (state.task ??= input.load())
   if (completion) {
     tasks.push(
-      load().then((command) => {
-        state.command = command
-      }),
+      load()
+        .then((command) => {
+          state.command = command
+        })
+        .catch(() => undefined),
     )
   }
   return {
@@ -39,7 +45,7 @@ export function lazy<T = {}, U = {}>(input: {
     aliases: input.aliases,
     describe: input.describe,
     builder: ((args: Argv<T>) => {
-      selected = true
+      markLazyCommandSelection()
       if (state.command) return build(state.command, args)
       return load().then((command) => build(command, args))
     }) as never,

--- a/packages/opencode/src/kilocode/cli/lazy-commands.ts
+++ b/packages/opencode/src/kilocode/cli/lazy-commands.ts
@@ -19,6 +19,10 @@ export function hasLazyCommandSelection() {
   return selected
 }
 
+export function resetLazyCommandSelection() {
+  selected = false
+}
+
 export function markLazyCommandSelection() {
   selected = true
 }

--- a/packages/opencode/src/kilocode/cli/setup.ts
+++ b/packages/opencode/src/kilocode/cli/setup.ts
@@ -153,6 +153,7 @@ export namespace KiloCli {
       if (narrow) {
         const { KiloCliBootstrapRuntime } = await import("@/kilocode/cli/bootstrap-runtime")
         await KiloCliBootstrapRuntime.dispose()
+        return
       }
       const { InstanceRuntime } = await import("@/project/instance-runtime")
       await InstanceRuntime.disposeAllInstances() // safety net (no-op if already disposed)

--- a/packages/opencode/src/kilocode/cli/setup.ts
+++ b/packages/opencode/src/kilocode/cli/setup.ts
@@ -153,7 +153,6 @@ export namespace KiloCli {
       if (narrow) {
         const { KiloCliBootstrapRuntime } = await import("@/kilocode/cli/bootstrap-runtime")
         await KiloCliBootstrapRuntime.dispose()
-        return
       }
       const { InstanceRuntime } = await import("@/project/instance-runtime")
       await InstanceRuntime.disposeAllInstances() // safety net (no-op if already disposed)

--- a/packages/opencode/src/kilocode/help-command.ts
+++ b/packages/opencode/src/kilocode/help-command.ts
@@ -1,13 +1,15 @@
 import { cmd } from "../cli/cmd/cmd"
 import { generateHelp } from "./help"
 import type { Argv } from "yargs"
+import { markLazyCommandSelection } from "@/kilocode/cli/lazy-commands"
 
 export function createHelpCommand(root?: () => Argv) {
   return cmd({
     command: "help [command]",
     describe: "show full CLI reference",
-    builder: (yargs) =>
-      yargs
+    builder: (yargs) => {
+      markLazyCommandSelection()
+      return yargs
         .positional("command", {
           describe: "command to show help for",
           type: "string",
@@ -22,7 +24,8 @@ export function createHelpCommand(root?: () => Argv) {
           type: "string",
           choices: ["md", "text"] as const,
           default: "md" as const,
-        }),
+        })
+    },
     async handler(args) {
       if (!args.command && !args.all) {
         if (root) {

--- a/packages/opencode/test/kilocode/cli/bootstrap-runtime.test.ts
+++ b/packages/opencode/test/kilocode/cli/bootstrap-runtime.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { KiloCli } from "../../../src/kilocode/cli/setup"
 import { createHelpCommand } from "../../../src/kilocode/help-command"
+import { resetLazyCommandSelection } from "../../../src/kilocode/cli/lazy-commands"
 import yargs from "yargs"
 
 describe("CLI bootstrap runtime selection", () => {
+  beforeEach(resetLazyCommandSelection)
+  afterEach(resetLazyCommandSelection)
+
   test("uses the narrow runtime for worker-backed TUI launches", () => {
     expect(KiloCli.workerTui({ _: [] })).toBe(true)
     expect(KiloCli.workerTui({ _: ["./project"] })).toBe(true)

--- a/packages/opencode/test/kilocode/cli/bootstrap-runtime.test.ts
+++ b/packages/opencode/test/kilocode/cli/bootstrap-runtime.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { KiloCli } from "../../../src/kilocode/cli/setup"
+import { createHelpCommand } from "../../../src/kilocode/help-command"
+import yargs from "yargs"
 
 describe("CLI bootstrap runtime selection", () => {
   test("uses the narrow runtime for worker-backed TUI launches", () => {
@@ -10,5 +12,12 @@ describe("CLI bootstrap runtime selection", () => {
   test("keeps full bootstrap for explicit, mini, and worktree commands", () => {
     expect(KiloCli.workerTui({ _: [], mini: true })).toBe(false)
     expect(KiloCli.workerTui({ _: [], worktree: "feature" })).toBe(false)
+  })
+
+  test("keeps full bootstrap when the eager help command is selected", () => {
+    const command = createHelpCommand()
+    if (typeof command.builder !== "function") throw new Error("help builder is not a function")
+    command.builder(yargs([]))
+    expect(KiloCli.workerTui({ _: [] })).toBe(false)
   })
 })


### PR DESCRIPTION
## What Problem This Solves

The CLI startup optimization merged in #13412 had three review findings:

- The eager `help` command could be mistaken for a worker-backed default TUI launch.
- Narrow bootstrap shutdown could return before the instance disposal safety net.
- A failure loading one lazy command during shell completion could abort the entire completion request.

## Why This Change Was Made

This follow-up applies only the confirmed review fixes:

- Mark the eager `help` command as an explicit command selection.
- Always run `InstanceRuntime.disposeAllInstances()` after narrow bootstrap cleanup.
- Catch completion preload failures per command so one unrelated module does not reject the top-level completion setup.

## User Impact

- `kilo help` and `kilo help <command>` use the full bootstrap path instead of the worker-only bootstrap path.
- Narrow TUI cleanup still disposes any project instances as a safety net.
- Shell completion remains available when an unrelated lazy command module fails to preload.
- Default TUI startup and normal lazy command loading are unchanged.

## Evidence

- CLI typecheck passed.
- Focused bootstrap selection, lazy command, completion, and shutdown tests passed.
- Shared upstream annotation guard passed.
- Promise-facade guard passed.
- Diff check passed.

The original PR #13412 is already merged. This is a separate follow-up PR containing only the review fixes.