### PR TITLE
fix(agent-manager): fix project-scoped history routing

### DIFF
--- a/.changeset/agent-manager-history-routing-fix.md
+++ b/.changeset/agent-manager-history-routing-fix.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix project-scoped Agent Manager history activation and session placement.

--- a/packages/kilo-vscode/src/agent-manager/project/messages.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/messages.ts
@@ -45,6 +45,8 @@ export interface ProjectMessageDeps {
   expand: (ctx: ProjectContext) => void
   /** Push the current project snapshots to the webview. */
   push: () => void
+  /** Push one project's managed state to the webview. */
+  pushState?: (ctx: ProjectContext) => void
   /** Acknowledge an atomically validated sidebar selection. */
   selected: (target: SidebarTarget) => void
   /** Show a user-facing error. */
@@ -156,6 +158,7 @@ async function openSessionLocally(projectId: string, sessionId: string, deps: Pr
   }
   state?.moveSession(sessionId, null)
   deps.routeSession?.(projectId, sessionId, ctx.root, ctx.generation)
+  deps.pushState?.(ctx)
   deps.push()
   finish({ projectId, kind: "session", sessionId }, deps)
 }

--- a/packages/kilo-vscode/src/agent-manager/project/wiring.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/wiring.ts
@@ -67,6 +67,7 @@ export function createProjectWiring(opts: {
     expand: opts.expand,
     ready: opts.ready,
     push: opts.push,
+    pushState: opts.pushState,
     selected: opts.selected,
     routeSession: opts.routeSession,
     error: (message) => opts.host.showError(message),

--- a/packages/kilo-vscode/tests/unit/agent-project-selection.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-project-selection.test.ts
@@ -19,6 +19,7 @@ function fakeState(persisted?: { current?: unknown }) {
   return {
     getWorktree: (id: string) => (id === "wt1" ? { path: "/repo/prj-extra/wt1" } : undefined),
     getSession: (id: string) => (id === "sess1" ? {} : undefined),
+    moveSession: () => {},
     getActiveTarget: () => store.current,
     setActiveTarget: (target: unknown) => {
       store.current = target
@@ -169,6 +170,27 @@ describe("activateSelection — cross-project selection", () => {
     expect(contexts.active()?.id).toBe(extra)
     expect(calls.activate).toEqual([])
     expect(calls.selected).toEqual(["worktree"])
+    expect(calls.error).toEqual([])
+  })
+
+  it("pushes moved-session state before acknowledging local activation", async () => {
+    const { contexts, deps, calls, extra } = setup()
+    const ctx = contexts.expand(extra)!
+    ctx.stateManager()
+    await ctx.ensureReady(async () => ({ ok: true, refsFixed: 0 }))
+    contexts.activate(extra)
+
+    const order: string[] = []
+    deps.push = () => order.push("projects")
+    deps.pushState = () => order.push("state")
+    deps.selected = () => order.push("selected")
+
+    await handleProjectMessage(
+      { type: "agentManager.openSessionLocally", projectId: extra, sessionId: "sess1" } as never,
+      deps,
+    )
+
+    expect(order).toEqual(["state", "projects", "projects", "selected"])
     expect(calls.error).toEqual([])
   })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -300,13 +300,18 @@ const AgentManagerContent: Component = () => {
   const [history, setHistory] = createSignal(false)
   /** Project whose sessions the history view is scoped to (multi-project). */
   const [historyProject, setHistoryProject] = createSignal<string | undefined>()
+  const [historySwitch, setHistorySwitch] = createSignal<string | undefined>()
   const closeHistory = () => {
     setHistory(false)
     setHistoryProject(undefined)
+    setHistorySwitch(undefined)
   }
   /** Open the sessions view; a project id scopes it and activates that project. */
   const openHistory = (pid?: string) => {
     const scoped = pid !== undefined && multiProject()
+    setHistorySwitch(scoped && currentProjectId() !== pid ? pid : undefined)
+    setHistoryProject(scoped ? pid : undefined)
+    setHistory(true)
     if (scoped) {
       // Activating the target project first lets the shared session store and
       // the pick routing operate in that project only.
@@ -315,8 +320,6 @@ const AgentManagerContent: Component = () => {
         target: { projectId: pid, kind: "local" },
       } as never)
     }
-    setHistoryProject(scoped ? pid : undefined)
-    setHistory(true)
   }
   const [sidePanel, setSidePanel] = createSignal<SidePanelState>(null)
   const diffOpen = () => sidePanel() === SidePanel.Diff
@@ -765,7 +768,7 @@ const AgentManagerContent: Component = () => {
     const pid = historyProject()
     if (!pid || !multiProject()) return undefined
     const sessions = projectSessionsLive()[pid]
-    if (!sessions) return undefined
+    if (!sessions) return new Set<string>()
     return new Set(sessions.filter(isKnownRootSession).map((s) => s.id))
   })
 
@@ -1161,7 +1164,7 @@ const AgentManagerContent: Component = () => {
       first: () => undefined,
       close: () => setReviewActive(false),
       hide: () => setSidePanel(null),
-      history: () => closeHistory(),
+      history: () => (historySwitch() === state.projectId ? setHistorySwitch(undefined) : closeHistory()),
       reset: subagents.reset,
     })
   }

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -298,18 +298,16 @@ const AgentManagerContent: Component = () => {
   let sidebarRaf: number | undefined
   let pendingSidebarWidth: number | undefined
   const [history, setHistory] = createSignal(false)
-  /** Project whose sessions the history view is scoped to (multi-project). */
   const [historyProject, setHistoryProject] = createSignal<string | undefined>()
-  const [historySwitch, setHistorySwitch] = createSignal<string | undefined>()
+  const [historySwitches, setHistorySwitches] = createSignal<string[]>([])
   const closeHistory = () => {
     setHistory(false)
     setHistoryProject(undefined)
-    setHistorySwitch(undefined)
+    setHistorySwitches([])
   }
-  /** Open the sessions view; a project id scopes it and activates that project. */
   const openHistory = (pid?: string) => {
     const scoped = pid !== undefined && multiProject()
-    setHistorySwitch(scoped && currentProjectId() !== pid ? pid : undefined)
+    if (scoped) setHistorySwitches((prev) => (prev.includes(pid) ? prev : [...prev, pid]))
     setHistoryProject(scoped ? pid : undefined)
     setHistory(true)
     if (scoped) {
@@ -1164,7 +1162,10 @@ const AgentManagerContent: Component = () => {
       first: () => undefined,
       close: () => setReviewActive(false),
       hide: () => setSidePanel(null),
-      history: () => (historySwitch() === state.projectId ? setHistorySwitch(undefined) : closeHistory()),
+      history: () =>
+        state.projectId && historySwitches().includes(state.projectId)
+          ? setHistorySwitches((prev) => prev.filter((id) => id !== state.projectId))
+          : closeHistory(),
       reset: subagents.reset,
     })
   }


### PR DESCRIPTION
Follow-up to #13407.

Project-scoped Agent Manager history had three edge cases after the sessions list moved behind a project button:

- Moving a worktree session to local updated the project catalog but not the managed project state before the selection acknowledgement. The UI could immediately resolve the session back to its old worktree.
- Opening history for a background project could be closed by the project-switch transition that followed the button click.
- A missing project session listing was interpreted as no filter, allowing the active project's sessions to appear while the requested project was still loading.

This change pushes the target project's managed state before acknowledging local activation, preserves history during the intentional project switch, and uses an empty filter until the scoped listing exists so project isolation is maintained.