### PR TITLE
fix(agent-manager): avoid stale history switch entries

### DIFF
--- a/.changeset/agent-manager-history-switch-queue.md
+++ b/.changeset/agent-manager-history-switch-queue.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent overlapping Agent Manager history activations from leaving stale project-switch state.

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -307,12 +307,12 @@ const AgentManagerContent: Component = () => {
   }
   const openHistory = (pid?: string) => {
     const scoped = pid !== undefined && multiProject()
-    if (scoped) setHistorySwitches((prev) => (prev.includes(pid) ? prev : [...prev, pid]))
+    if (scoped && (currentProjectId() !== pid || historySwitches().length > 0))
+      setHistorySwitches((prev) => (prev.includes(pid) ? prev : [...prev, pid]))
     setHistoryProject(scoped ? pid : undefined)
     setHistory(true)
     if (scoped) {
-      // Activating the target project first lets the shared session store and
-      // the pick routing operate in that project only.
+      // Activate the target so the session store and pick routing use that project.
       vscode.postMessage({
         type: "agentManager.activateSelection",
         target: { projectId: pid, kind: "local" },


### PR DESCRIPTION
Follow-up to #13421.

Opening history for the current project does not trigger a project switch, so adding that project to the pending-switch queue leaves an entry that can incorrectly keep history open during a later normal project activation.

Only enqueue the current project when another history-initiated switch is already pending. Background-project activations and overlapping history opens continue to preserve the intended history view.