### PR TITLE
fix(vscode): prevent duplicate reasoning with subagent inspectors

### DIFF
--- a/.changeset/isolated-reasoning-streams.md
+++ b/.changeset/isolated-reasoning-streams.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent duplicate reasoning and response text while subagent sessions are open.

--- a/packages/kilo-vscode/tests/unit/session-parts.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-parts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test"
-import { mergeOptimisticPart, mergeParts, sameParts } from "../../webview-ui/src/context/session-parts"
+import { createStore, produce } from "solid-js/store"
+import { isolate, mergeOptimisticPart, mergeParts, sameParts } from "../../webview-ui/src/context/session-parts"
 import type { Part } from "../../webview-ui/src/types/messages"
 
 function text(id: string, value: string, time: { start?: number; end?: number } = {}): Part {
@@ -19,6 +20,39 @@ function value(parts: Part[], id: string) {
   if (!part || part.type !== "text") return
   return part.text
 }
+
+describe("isolate", () => {
+  it("keeps shared reasoning snapshots independent across session stores", () => {
+    const shared = {
+      id: "r1",
+      messageID: "m1",
+      type: "reasoning",
+      text: "Thinking",
+      time: { start: 1 },
+    } satisfies Part
+    const [first, setFirst] = createStore({ parts: [shared].map(isolate) })
+    const [second, setSecond] = createStore({ parts: [shared].map(isolate) })
+
+    setFirst(
+      "parts",
+      produce((parts) => {
+        const part = parts[0]
+        if (part?.type === "reasoning") part.text += " once"
+      }),
+    )
+    setSecond(
+      "parts",
+      produce((parts) => {
+        const part = parts[0]
+        if (part?.type === "reasoning") part.text += " once"
+      }),
+    )
+
+    expect(first.parts[0]?.type === "reasoning" && first.parts[0].text).toBe("Thinking once")
+    expect(second.parts[0]?.type === "reasoning" && second.parts[0].text).toBe("Thinking once")
+    expect(shared.text).toBe("Thinking")
+  })
+})
 
 describe("mergeParts", () => {
   it("keeps a final streamed tail part created after the reconcile snapshot started", () => {
@@ -119,6 +153,31 @@ describe("mergeOptimisticPart", () => {
 
     expect(result.parts.map((part) => part.id)).toEqual(["client-text", "server-file"])
     expect(result.replaced).toBe("client-file")
+  })
+
+  it("keeps streamed deltas independent across session stores", () => {
+    const shared = text("server", "start")
+    const [first, setFirst] = createStore({ parts: mergeOptimisticPart([], new Set(), shared).parts })
+    const [second, setSecond] = createStore({ parts: mergeOptimisticPart([], new Set(), shared).parts })
+
+    setFirst(
+      "parts",
+      produce((parts) => {
+        const part = parts[0]
+        if (part?.type === "text") part.text += " chunk"
+      }),
+    )
+    setSecond(
+      "parts",
+      produce((parts) => {
+        const part = parts[0]
+        if (part?.type === "text") part.text += " chunk"
+      }),
+    )
+
+    expect(value(first.parts, "server")).toBe("start chunk")
+    expect(value(second.parts, "server")).toBe("start chunk")
+    expect(value([shared], "server")).toBe("start")
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/src/context/session-parts.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-parts.ts
@@ -1,5 +1,9 @@
 import type { Part } from "../types/messages"
 
+export function isolate(part: Part): Part {
+  return { ...part }
+}
+
 function stream(part: Part): part is Extract<Part, { type: "text" | "reasoning" }> {
   return part.type === "text" || part.type === "reasoning"
 }
@@ -27,10 +31,11 @@ export function sameParts(local: Part[] = [], snapshot: Part[] = []): boolean {
 
 export function mergeOptimisticPart(current: Part[], ids: ReadonlySet<string>, part: Part) {
   const index = current.findIndex((item) => ids.has(item.id) && item.type === part.type)
-  if (index < 0) return { parts: [...current, part] }
+  const copy = isolate(part)
+  if (index < 0) return { parts: [...current, copy] }
   const old = current[index]!
   const next = current.slice()
-  next[index] = part
+  next[index] = copy
   return { parts: next, replaced: old.id }
 }
 

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -79,7 +79,7 @@ import { getAgentModel } from "./session-model-store"
 import { resolveMessagePrefs } from "./session-preferences"
 import { errorIDs, preserveSessionErrors, withoutResolvedSessionErrors } from "./session-errors"
 import { PartStash } from "./part-stash"
-import { mergeOptimisticPart, mergeParts } from "./session-parts"
+import { isolate, mergeOptimisticPart, mergeParts } from "./session-parts"
 import { mergeMessages, sameReconcileShape } from "./session-merge"
 import { state as todoState } from "./todo-revert"
 import { sessionVariantKeys, transferVariants, variantKey } from "./session-variant-store"
@@ -1457,7 +1457,7 @@ export const SessionProvider: ParentComponent = (props) => {
       const cutoff = Math.max(0, messages.length - 15)
       for (let i = 0; i < messages.length; i++) {
         const msg = messages[i]!
-        const parts = msg.parts ?? []
+        const parts = msg.parts?.map(isolate) ?? []
         if (mode === "reconcile" && store.parts[msg.id] && !optimisticParts.has(msg.id)) {
           const merged = mergeParts(store.parts[msg.id], parts, input.since ?? Number.POSITIVE_INFINITY)
           setStore("parts", msg.id, reconcile(merged, { key: "id" }))
@@ -1546,7 +1546,7 @@ export const SessionProvider: ParentComponent = (props) => {
     if (message.parts && message.parts.length > 0) {
       optimisticParts.delete(message.id)
       stash.remove(message.id)
-      setStore("parts", message.id, message.parts)
+      setStore("parts", message.id, message.parts.map(isolate))
     }
     rebuildToolParts(message.sessionID, store.messages[message.sessionID] ?? [])
   }
@@ -1624,7 +1624,7 @@ export const SessionProvider: ParentComponent = (props) => {
           }
         } else {
           // Add new part
-          list.push(part)
+          list.push(isolate(part))
         }
       }),
     )
@@ -2067,7 +2067,7 @@ export const SessionProvider: ParentComponent = (props) => {
       setStore("messages", key, messages)
       for (const msg of messages) {
         if (msg.parts && msg.parts.length > 0) {
-          setStore("parts", msg.id, msg.parts)
+          setStore("parts", msg.id, msg.parts.map(isolate))
         }
       }
       rebuildToolParts(key, messages)


### PR DESCRIPTION
## What Problem This Solves

Assistant reasoning and response text could appear twice while a turn was still streaming in Agent Manager. The duplication disappeared when the turn finished because the final persisted `message.part.updated` event replaced the temporary client-side text with the canonical server value.

This was especially easy to misdiagnose as duplicate SSE delivery because the persisted conversation and completed transcript were correct.

## Why This Change Was Made

This fixes a regression introduced by #13173, **feat(vscode): add subagent inspector tabs**, merged on August 18. Its nested `SessionProvider` in `SubagentPanel.tsx` allowed the main Agent Manager transcript and an open subagent inspector to consume the same webview message object.

Solid stores proxy their underlying objects instead of copying them. When both providers adopted the same incoming reasoning or text part, their stores shared the same raw part object. Each provider then processed the same valid streaming delta and mutated `part.text` in place. A single `" chunk"` therefore changed `"start"` into `"start chunk chunk"`. The original event payload was also mutated.

A live backend capture recorded **494 SSE frames, including 172 `message.part.delta` events, with zero duplicate event IDs**. The regression was shared client-side object ownership, not duplicate backend events, reconnects, or durable live/sync compatibility envelopes.

The fix creates a shallow, provider-owned copy whenever incoming parts enter a session store, including history snapshots, initial message parts, new streamed parts, optimistic replacements, and cloud-session history. Shallow copies preserve existing nested data without copying streamed strings or dropping legitimate repeated provider output.

## User Impact

Reasoning and response fragments now appear exactly once when the subagent inspector is open, including when multiple session providers process the same webview event. Final turn reconciliation, optimistic attachment replacement, session history, and completed reasoning rendering retain their existing behavior.

## Evidence

- Reproduced the original failure with two real Solid stores: one shared part plus one valid delta produced `"start chunk chunk"` before the fix.
- Added regression coverage for both shared reasoning snapshots and streamed optimistic/canonical text parts.
- Ran **4,149 extension unit tests**, all passing.
- Passed extension lint, extension/webview typechecks, Knip, the complete extension build, and the changeset check.
- In an isolated VS Code instance, opened Agent Manager and its real subagent inspector so **two `SessionProvider` instances** were mounted, dispatched one reasoning delta through the actual webview message path, and verified exactly one rendered fragment plus an unchanged original event payload.

<img width="700" alt="Subagent inspector reasoning renders a streamed fragment exactly once" src="https://marius-kilocode.github.io/pr-assets/20260825-agent-manager-reasoning-isolation.png" />
