### PR TITLE
test(jetbrains): stop frontend tests opening a real browser

### DIFF
--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/AgentManagerPanelTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/AgentManagerPanelTest.kt
@@ -24,6 +24,7 @@ import ai.kilocode.client.testing.TestCoroutines
 import ai.kilocode.client.testing.pumpEdt
 import ai.kilocode.client.testing.TestUiTimers
 import ai.kilocode.client.testing.fire
+import ai.kilocode.client.testing.installBrowser
 import ai.kilocode.client.ui.list.ActiveListBadge
 import ai.kilocode.client.ui.list.ActiveListItem
 import ai.kilocode.client.ui.list.ActiveListMetrics
@@ -69,6 +70,7 @@ class AgentManagerPanelTest : BasePlatformTestCase() {
 
     override fun setUp() {
         super.setUp()
+        installBrowser()
         coroutines = TestCoroutines()
         rpc = FakeWorktreeRpcApi()
         service = KiloWorktreeService(coroutines.scope, rpc)

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/worktree/GhBannerTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/worktree/GhBannerTest.kt
@@ -4,6 +4,7 @@ import ai.kilocode.client.testing.FakeWorktreeRpcApi
 import ai.kilocode.client.testing.TestCoroutines
 import ai.kilocode.client.testing.pumpEdt
 import ai.kilocode.client.testing.TestUiTimers
+import ai.kilocode.client.testing.installBrowser
 import ai.kilocode.client.util.edtWait
 import ai.kilocode.rpc.dto.GhAvailability
 import com.intellij.openapi.application.ApplicationManager
@@ -22,6 +23,7 @@ class GhBannerTest : BasePlatformTestCase() {
 
     override fun setUp() {
         super.setUp()
+        installBrowser()
         coroutines = TestCoroutines()
         rpc = FakeWorktreeRpcApi()
         timers = TestUiTimers()

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/worktree/GhStatusCoordinatorTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/worktree/GhStatusCoordinatorTest.kt
@@ -4,6 +4,7 @@ import ai.kilocode.client.testing.FakeWorktreeRpcApi
 import ai.kilocode.client.testing.TestCoroutines
 import ai.kilocode.client.testing.pumpEdt
 import ai.kilocode.client.testing.TestUiTimers
+import ai.kilocode.client.testing.installBrowser
 import ai.kilocode.client.util.edtWait
 import ai.kilocode.rpc.dto.GhAvailability
 import com.intellij.openapi.application.ApplicationManager
@@ -21,6 +22,7 @@ class GhStatusCoordinatorTest : BasePlatformTestCase() {
 
     override fun setUp() {
         super.setUp()
+        installBrowser()
         coroutines = TestCoroutines()
         rpc = FakeWorktreeRpcApi()
         timers = TestUiTimers()

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/settings/providers/ProvidersSettingsUiTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/settings/providers/ProvidersSettingsUiTest.kt
@@ -4,6 +4,7 @@ import ai.kilocode.client.util.edtWait
 import ai.kilocode.client.app.KiloProviderService
 import ai.kilocode.client.plugin.KiloBundle
 import ai.kilocode.client.testing.FakeProviderRpcApi
+import ai.kilocode.client.testing.installBrowser
 import ai.kilocode.client.ui.UiStyle
 import ai.kilocode.client.ui.list.ActiveListActionCell
 import ai.kilocode.client.ui.list.ActiveListConfig
@@ -985,6 +986,7 @@ class ProvidersSettingsUiTest : BasePlatformTestCase() {
 
     fun `test provider oauth auto response shows device auth panel`() {
         val callback = CompletableDeferred<ai.kilocode.rpc.dto.ProviderActionResultDto>()
+        val browser = installBrowser()
         val rpc = installProvider(
             ProviderSettingsDto(
                 providers = listOf(provider("openai", "OpenAI")),
@@ -1016,6 +1018,7 @@ class ProvidersSettingsUiTest : BasePlatformTestCase() {
             assertTrue(t, t.contains("Open Browser"))
             assertTrue(t, t.contains("Cancel"))
             assertEquals("https://auth.openai.com/device", fieldsByName(panel, "kilo.provider.oauth.url").single().text)
+            assertEquals(listOf("https://auth.openai.com/device"), browser.urls)
             val qr = components(panel).filterIsInstance<JBLabel>().single { it.name == "kilo.provider.oauth.qr" }
             assertNotNull(qr.icon)
         }

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/testing/FakeBrowserLauncher.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/testing/FakeBrowserLauncher.kt
@@ -1,0 +1,37 @@
+package ai.kilocode.client.testing
+
+import com.intellij.ide.browsers.BrowserLauncher
+import com.intellij.ide.browsers.WebBrowser
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.testFramework.replaceService
+import java.nio.file.Path
+
+class FakeBrowserLauncher : BrowserLauncher() {
+    val urls = mutableListOf<String>()
+    val files = mutableListOf<Path>()
+
+    override fun open(url: String) {
+        urls.add(url)
+    }
+
+    @Suppress("DEPRECATION")
+    override fun browse(file: java.io.File) {
+        files.add(file.toPath())
+    }
+
+    override fun browse(file: Path) {
+        files.add(file)
+    }
+
+    override fun browse(url: String, browser: WebBrowser?, project: Project?) {
+        urls.add(url)
+    }
+}
+
+fun BasePlatformTestCase.installBrowser(): FakeBrowserLauncher {
+    val fake = FakeBrowserLauncher()
+    ApplicationManager.getApplication().replaceService(BrowserLauncher::class.java, fake, testRootDisposable)
+    return fake
+}


### PR DESCRIPTION
## Issue

No existing issue. Found while diagnosing a recurring "Your session has ended" ChatGPT page that kept appearing on a developer machine; the cause turned out to be our own test suite.

## Context

Running the JetBrains frontend test suite opens a real browser tab on the developer's machine.

`ProvidersSettingsUiTest` seeds a fixture OAuth URL of `https://auth.openai.com/device` and then drives the real production UI. `ProvidersSettingsUi.oauth()` calls `BrowserUtil.browse(ready.url)`, and `BrowserUtil` is only a static facade over the `BrowserLauncher` application service — nothing was stubbing it. So the test genuinely handed the URL to the default browser.

Confirmed from the macOS unified log: on every occurrence a short-lived `java` process calls `LaunchServices.launchViaCSUA` and Chrome receives a `GURL` Apple Event with `target=GradleWorkerMain` (the Gradle test worker), matching Chrome history visits to `auth.openai.com/device` with an `AUTO_TOPLEVEL` transition. Because the browser profile is not signed in to ChatGPT, OpenAI serves its logged-out "Your session has ended" page — which is what made this look like a broken Kilo auth flow rather than a test leak.

Beyond the interruption, this is a correctness gap: the test asserted the URL rendered in the panel field but never asserted that the browser was actually asked to open it.

## Implementation

Fixed entirely on the test side — no production change.

`BrowserUtil.browse` resolves `BrowserLauncher` through `ApplicationManager.getApplication().getService(...)`, so a test can replace that service. This is preferable to threading a new `browse` lambda through `ProvidersSettingsUi`: `packages/kilo-jetbrains/AGENTS.md` explicitly forbids adding production seams whose only purpose is test access, and `replaceService` + `testRootDisposable` is already the established pattern in this test tree.

- Added `FakeBrowserLauncher`, a recording `BrowserLauncher` implementation, plus an `installBrowser()` extension on `BasePlatformTestCase` that installs it for the lifetime of the test.
- `ProvidersSettingsUiTest` now installs the fake for the device-auth test and asserts the recorded URL, turning a silent real side effect into a real assertion.
- Installed the same fake in `AgentManagerPanelTest`, `GhBannerTest`, and `GhStatusCoordinatorTest`, which reach other unguarded `BrowserUtil` call sites (PR URLs, git-scm / cli.github.com links), so future click assertions there cannot escape to a browser either.

Note that ~10 direct `BrowserUtil` call sites remain in the frontend (`SessionUi`, `WorktreeStatsView`, `PrHeaderView`, `ModelDetailsPanel`, and others). Their current tests do not trigger a browse, so they are left alone rather than churned; `installBrowser()` is the one-line guard to add if that changes.

## Screenshots / Video

N/A — test-only change, no user-visible UI difference.

## How to Test

### Manual/local verification

Executed by the agent, from `packages/kilo-jetbrains/`:

- `./gradlew :frontend:test --tests 'ai.kilocode.client.settings.providers.ProvidersSettingsUiTest'` — passes, and the new assertion proves the browse call is intercepted.
- `./gradlew :frontend:test` for all four touched classes (`ProvidersSettingsUiTest`, `AgentManagerPanelTest`, `GhBannerTest`, `GhStatusCoordinatorTest`) — passes.
- `./gradlew typecheck` — passes.
- Confirmed no browser handoff during those runs: `/usr/bin/log show --last 2m --info --debug --style compact | grep -E 'target=GradleWorkerMain|launchViaCSUA'` returned nothing, where it previously logged a `GURL` event to Chrome on every run.

### Reviewer test steps

1. From `packages/kilo-jetbrains/`, run `./gradlew :frontend:test --tests 'ai.kilocode.client.settings.providers.ProvidersSettingsUiTest'`.
2. Confirm no browser tab opens and the run passes.
3. To see the old behaviour, stash this commit and rerun step 1 — a tab opens to `auth.openai.com/device` (showing OpenAI's logged-out page unless you are signed in).
4. On macOS you can watch the handoff directly with `/usr/bin/log show --last 2m --info --debug --style compact | grep target=GradleWorkerMain`. Note `log` is shadowed by a zsh function in some shells, so use the absolute path.

### Blocked checks and substitute verification

- The full `./gradlew test` suite was not run; verification was scoped to `./gradlew typecheck` plus the four affected test classes, since the change only touches those test files and a new test-only helper.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes — not needed, test-only with no shipped behaviour change
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

@kirillk
