### PR TITLE
refactor(vscode): simplify manual interruption handling

### DIFF
--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -4129,7 +4129,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     if (!client) return Promise.resolve(false)
     const dir = this.getWorkspaceDirectory(sid)
     this.aborts.preserve(sid, this.sessionStatusMap.get(sid), dir)
-    return this.aborts.stop(client, sid, dir, (dir, action) => this.connectionService.runExplicitAbort(sid, dir, action))
+    return this.aborts.stop(client, sid, dir, (dir, action) =>
+      this.connectionService.runExplicitAbort(sid, dir, action),
+    )
   }
 
   private async handleAbort(sessionID?: string): Promise<void> {

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -4127,15 +4127,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.cancelRetry(sid)
     const client = this.client
     if (!client) return Promise.resolve(false)
-    const directory = this.getWorkspaceDirectory(sid)
-    const dirs = this.aborts.directories(sid, directory)
-    const ids = new Map(dirs.map((dir) => [dir, this.connectionService.beginExplicitAbort(sid, dir)]))
-    return this.aborts.stop(client, sid, directory, dirs).then((result) => {
-      for (const attempt of result.attempts) {
-        this.connectionService.finishExplicitAbort(sid, attempt.dir, ids.get(attempt.dir)!, attempt.aborted)
-      }
-      return result.complete
-    })
+    const dir = this.getWorkspaceDirectory(sid)
+    this.aborts.preserve(sid, this.sessionStatusMap.get(sid), dir)
+    return this.aborts.stop(client, sid, dir, (dir, action) => this.connectionService.runExplicitAbort(sid, dir, action))
   }
 
   private async handleAbort(sessionID?: string): Promise<void> {

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -1804,7 +1804,7 @@ export class AgentManagerProvider implements Disposable {
     await continueInWorktree(
       {
         root,
-        connection: this.connectionService,
+        getClient: () => this.connectionService.getClient(),
         createWorktreeOnDisk: (opts) => this.createWorktreeOnDisk(opts),
         runSetupScript: (p, b, id) => this.runSetupScriptForWorktree(p, b, id),
         cleanupWorktree: async (id) => {

--- a/packages/kilo-vscode/src/agent-manager/continue-in-worktree.ts
+++ b/packages/kilo-vscode/src/agent-manager/continue-in-worktree.ts
@@ -31,7 +31,7 @@ export type StepResult<T> = { ok: true; value: T } | { ok: false; error: string 
 export async function abortSession(ctx: ContinueContext, sessionId: string): Promise<void> {
   try {
     const client = ctx.getClient()
-    await client.session.abort({ sessionID: sessionId }).catch((err) => {
+    await client.session.abort({ sessionID: sessionId }, { throwOnError: true }).catch((err) => {
       ctx.log("Session abort failed (may already be idle):", getErrorMessage(err))
     })
   } catch (err) {

--- a/packages/kilo-vscode/src/agent-manager/continue-in-worktree.ts
+++ b/packages/kilo-vscode/src/agent-manager/continue-in-worktree.ts
@@ -8,10 +8,7 @@ import { recordForkHandoff } from "./fork-handoff"
 
 export interface ContinueContext {
   root: string
-  connection: {
-    getClient: () => KiloClient
-    runExplicitAbort: <T>(sessionId: string, directory: string, action: () => Promise<T>) => Promise<T>
-  }
+  getClient: () => KiloClient
   createWorktreeOnDisk: (opts: { baseBranch: string; baseRef: string }) => Promise<{
     worktree: { id: string }
     result: CreateWorktreeResult
@@ -33,13 +30,10 @@ export type StepResult<T> = { ok: true; value: T } | { ok: false; error: string 
 /** Abort a running session. Best-effort — failures are logged but not fatal. */
 export async function abortSession(ctx: ContinueContext, sessionId: string): Promise<void> {
   try {
-    await ctx.connection
-      .runExplicitAbort(sessionId, ctx.root, async () => {
-        await ctx.connection.getClient().session.abort({ sessionID: sessionId }, { throwOnError: true })
-      })
-      .catch((err) => {
-        ctx.log("Session abort failed (may already be idle):", getErrorMessage(err))
-      })
+    const client = ctx.getClient()
+    await client.session.abort({ sessionID: sessionId }).catch((err) => {
+      ctx.log("Session abort failed (may already be idle):", getErrorMessage(err))
+    })
   } catch (err) {
     ctx.log("Client not available for abort, continuing:", getErrorMessage(err))
   }
@@ -102,7 +96,7 @@ async function rollback(
 export async function forkSession(ctx: ContinueContext, sessionId: string, dir: string): Promise<StepResult<Session>> {
   let client: KiloClient
   try {
-    client = ctx.connection.getClient()
+    client = ctx.getClient()
   } catch (err) {
     ctx.log("Client not available for session fork:", getErrorMessage(err))
     return { ok: false, error: "Not connected to CLI backend" }

--- a/packages/kilo-vscode/src/kilo-provider/abort.ts
+++ b/packages/kilo-vscode/src/kilo-provider/abort.ts
@@ -27,27 +27,30 @@ export class SessionAbort {
     this.observe(sessionID, status, dir)
   }
 
-  directories(sessionID: string, fallback: string) {
+  async stop(
+    client: KiloClient,
+    sessionID: string,
+    fallback: string,
+    run?: (dir: string, action: () => Promise<void>) => Promise<void>,
+  ) {
+    const known = this.active.has(sessionID)
     const dirs = [...(this.active.get(sessionID) ?? [])]
     if (!dirs.some((dir) => sameDirectory(dir, fallback))) dirs.push(fallback)
-    return dirs
-  }
-
-  async stop(client: KiloClient, sessionID: string, fallback: string, dirs = this.directories(sessionID, fallback)) {
-    const known = this.active.has(sessionID)
-    const results = await Promise.allSettled(dirs.map((dir) => abortSession({ client, sessionID, dir })))
+    const results = await Promise.allSettled(
+      dirs.map((dir) => {
+        const action = () => abortSession({ client, sessionID, dir })
+        return known && run ? run(dir, action) : action()
+      }),
+    )
     const failures = results.flatMap((result, index) =>
       result.status === "rejected" ? [{ dir: dirs[index], error: result.reason }] : [],
     )
     if (failures.length > 0) {
       console.error("[Kilo New] KiloProvider: Failed to abort session in one or more directories:", failures)
-      return {
-        complete: false,
-        attempts: results.map((result, index) => ({ dir: dirs[index], aborted: result.status === "fulfilled" })),
-      }
+      return false
     }
     if (known) this.active.delete(sessionID)
-    return { complete: known, attempts: dirs.map((dir) => ({ dir, aborted: true })) }
+    return known
   }
 
   dispose(dir: string) {

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.test.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.test.ts
@@ -46,65 +46,43 @@ describe("KiloConnectionService explicit aborts", () => {
     type: "session.turn.close",
     properties: { sessionID: "session", reason: "interrupted" },
   } as SSEPayload
-  const status = {
-    type: "session.status",
-    properties: { sessionID: "session", status: { type: "busy" } },
-  } as SSEPayload
 
-  test("suppresses a successful explicit abort for every subscriber", () => {
+  function setup() {
     const service = new KiloConnectionService({} as any)
     const raw: SSEPayload[] = []
     const first: SSEPayload[] = []
     const second: SSEPayload[] = []
     service.onEvent((event) => raw.push(event))
-    service.onEventFiltered(
-      () => true,
-      (event) => first.push(event),
-    )
-    service.onEventFiltered(
-      () => true,
-      (event) => second.push(event),
-    )
-    ;(service as any).broadcast(status, "/repo")
-    raw.length = 0
-    first.length = 0
-    second.length = 0
+    service.onEventFiltered(() => true, (event) => first.push(event))
+    service.onEventFiltered(() => true, (event) => second.push(event))
+    return { service, raw, first, second }
+  }
 
-    const id = service.beginExplicitAbort("session", "/repo")
-    ;(service as any).broadcast(close, "/repo")
-    service.finishExplicitAbort("session", "/repo", id, true)
+  test("suppresses a successful explicit abort for filtered subscribers", async () => {
+    const state = setup()
 
-    expect(first).toEqual([])
-    expect(second).toEqual([])
-    expect(raw).toEqual([close])
+    await state.service.runExplicitAbort("session", "/repo", async () => {
+      ;(state.service as any).broadcast(close, "/repo")
+    })
+
+    expect(state.first).toEqual([])
+    expect(state.second).toEqual([])
+    expect(state.raw).toEqual([close])
   })
 
-  test("replays a failed explicit abort for every subscriber", () => {
-    const service = new KiloConnectionService({} as any)
-    const raw: SSEPayload[] = []
-    const first: SSEPayload[] = []
-    const second: SSEPayload[] = []
-    service.onEvent((event) => raw.push(event))
-    service.onEventFiltered(
-      () => true,
-      (event) => first.push(event),
-    )
-    service.onEventFiltered(
-      () => true,
-      (event) => second.push(event),
-    )
-    ;(service as any).broadcast(status, "/repo")
-    raw.length = 0
-    first.length = 0
-    second.length = 0
+  test("replays a failed explicit abort for filtered subscribers", async () => {
+    const state = setup()
 
-    const id = service.beginExplicitAbort("session", "/repo")
-    ;(service as any).broadcast(close, "/repo")
-    service.finishExplicitAbort("session", "/repo", id, false)
+    await expect(
+      state.service.runExplicitAbort("session", "/repo", async () => {
+        ;(state.service as any).broadcast(close, "/repo")
+        throw new Error("abort failed")
+      }),
+    ).rejects.toThrow("abort failed")
 
-    expect(first).toEqual([close])
-    expect(second).toEqual([close])
-    expect(raw).toEqual([close])
+    expect(state.first).toEqual([close])
+    expect(state.second).toEqual([close])
+    expect(state.raw).toEqual([close])
   })
 })
 

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.test.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.test.ts
@@ -53,8 +53,14 @@ describe("KiloConnectionService explicit aborts", () => {
     const first: SSEPayload[] = []
     const second: SSEPayload[] = []
     service.onEvent((event) => raw.push(event))
-    service.onEventFiltered(() => true, (event) => first.push(event))
-    service.onEventFiltered(() => true, (event) => second.push(event))
+    service.onEventFiltered(
+      () => true,
+      (event) => first.push(event),
+    )
+    service.onEventFiltered(
+      () => true,
+      (event) => second.push(event),
+    )
     return { service, raw, first, second }
   }
 

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -286,24 +286,17 @@ export class KiloConnectionService {
     }
   }
 
-  beginExplicitAbort(sessionID: string, directory: string): number | undefined {
-    return this.explicitAborts.begin(sessionID, directory)
-  }
-
-  finishExplicitAbort(sessionID: string, directory: string, id: number | undefined, stopped: boolean): void {
-    for (const item of this.explicitAborts.finish(sessionID, directory, id, stopped))
-      this.broadcastFiltered(item.event, item.directory)
-  }
-
   async runExplicitAbort<T>(sessionID: string, directory: string, action: () => Promise<T>): Promise<T> {
-    const id = this.beginExplicitAbort(sessionID, directory)
+    const id = this.explicitAborts.begin(sessionID, directory)
     return action().then(
       (result) => {
-        this.finishExplicitAbort(sessionID, directory, id, true)
+        this.explicitAborts.finish(sessionID, directory, id, true)
         return result
       },
       (error) => {
-        this.finishExplicitAbort(sessionID, directory, id, false)
+        for (const item of this.explicitAborts.finish(sessionID, directory, id, false)) {
+          this.broadcastFiltered(item.event, item.directory)
+        }
         throw error
       },
     )

--- a/packages/kilo-vscode/src/services/cli-backend/explicit-abort.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/explicit-abort.ts
@@ -2,111 +2,85 @@ import path from "node:path"
 import type { SSEPayload } from "./sdk-sse-adapter"
 
 type Buffered = { event: SSEPayload; directory?: string }
-type State = { attempts: Set<number>; stopped: boolean; buffered: Buffered[]; generation: number; idle: boolean }
+type State = { attempts: Set<number>; stopped: boolean; buffered?: Buffered; idle: boolean }
 
 export class ExplicitAbortState {
-  private readonly active = new Set<string>()
   private readonly states = new Map<string, State>()
-  private readonly generations = new Map<string, number>()
   private next = 0
 
-  begin(sessionID: string, directory: string): number | undefined {
+  begin(sessionID: string, directory: string): number {
     const key = scope(sessionID, directory)
-    if (!this.active.has(key)) return
     const id = ++this.next
-    const state = this.states.get(key) ?? {
-      attempts: new Set(),
-      stopped: false,
-      buffered: [],
-      generation: this.generations.get(key) ?? 0,
-      idle: false,
-    }
+    const state = this.states.get(key) ?? { attempts: new Set<number>(), stopped: false, idle: false }
     state.attempts.add(id)
     this.states.set(key, state)
     return id
   }
 
-  finish(sessionID: string, directory: string, id: number | undefined, stopped: boolean): Buffered[] {
-    if (id === undefined) return []
+  finish(sessionID: string, directory: string, id: number, stopped: boolean): Buffered[] {
     const key = scope(sessionID, directory)
     const state = this.states.get(key)
     if (!state || !state.attempts.delete(id)) return []
     if (stopped) {
-      state.stopped = true
-      state.buffered = []
+      if (state.buffered) this.states.delete(key)
+      else state.stopped = true
       return []
     }
     if (state.stopped || state.attempts.size > 0) return []
     this.states.delete(key)
-    return state.buffered
+    return state.buffered ? [state.buffered] : []
   }
 
   event(event: SSEPayload, directory?: string): boolean {
-    if (event.type === "session.status" && directory) return this.status(event, directory)
-    if (event.type === "session.turn.open") return this.open(event.properties.sessionID, directory)
+    if (event.type === "session.status" && directory) {
+      const key = scope(event.properties.sessionID, directory)
+      const state = this.states.get(key)
+      if (!state) return true
+      if (event.properties.status.type === "idle") state.idle = true
+      else if (state.idle) this.states.delete(key)
+      return true
+    }
+    if (event.type === "session.turn.open") {
+      for (const key of this.keys(event.properties.sessionID, directory)) this.states.delete(key)
+      return true
+    }
     if (event.type !== "session.turn.close") return true
-    const keys = this.keys(event.properties.sessionID, directory).filter((key) => this.states.has(key))
+    const keys = this.keys(event.properties.sessionID, directory)
     if (keys.length !== 1) return true
-    const key = keys[0]
+    const key = keys[0]!
     const state = this.states.get(key)
     if (!state) return true
-    if (state.generation !== (this.generations.get(key) ?? 0) || event.properties.reason !== "interrupted") {
+    if (event.properties.reason !== "interrupted") {
       this.states.delete(key)
       return true
     }
-    if (state.stopped) return false
-    if (state.attempts.size === 0) {
+    if (state.stopped) {
       this.states.delete(key)
-      return true
+      return false
     }
-    state.buffered.push({ event, directory })
+    state.buffered ??= { event, directory }
     return false
   }
 
-  private status(event: Extract<SSEPayload, { type: "session.status" }>, directory: string) {
-    const key = scope(event.properties.sessionID, directory)
-    const state = this.states.get(key)
-    if (event.properties.status.type === "idle") {
-      this.active.delete(key)
-      if (state) state.idle = true
-      return true
-    }
-    this.active.add(key)
-    if (state?.idle) this.states.delete(key)
-    return true
-  }
-
-  private open(sessionID: string, directory?: string) {
-    for (const key of this.keys(sessionID, directory)) {
-      this.generations.set(key, (this.generations.get(key) ?? 0) + 1)
-      this.states.delete(key)
-    }
-    return true
-  }
-
   clear() {
-    this.active.clear()
     this.states.clear()
-    this.generations.clear()
   }
 
   remove(sessionID: string) {
-    for (const key of this.keys(sessionID)) {
-      this.active.delete(key)
-      this.states.delete(key)
-      this.generations.delete(key)
-    }
+    for (const key of this.keys(sessionID)) this.states.delete(key)
   }
 
   private keys(sessionID: string, directory?: string): string[] {
-    if (directory) return [scope(sessionID, directory)]
+    if (directory) {
+      const key = scope(sessionID, directory)
+      return this.states.has(key) ? [key] : []
+    }
     const prefix = `${sessionID}\0`
-    return [...new Set([...this.active, ...this.states.keys(), ...this.generations.keys()])].filter((key) =>
-      key.startsWith(prefix),
-    )
+    return [...this.states.keys()].filter((key) => key.startsWith(prefix))
   }
 }
 
 function scope(sessionID: string, directory: string) {
-  return `${sessionID}\0${path.resolve(directory)}`
+  const dir = path.resolve(directory)
+  return `${sessionID}\0${process.platform === "win32" ? dir.toLowerCase() : dir}`
 }

--- a/packages/kilo-vscode/tests/unit/abort.test.ts
+++ b/packages/kilo-vscode/tests/unit/abort.test.ts
@@ -20,13 +20,7 @@ describe("SessionAbort", () => {
     const aborts = new SessionAbort()
     aborts.observe("session_1", "busy", "/repo")
 
-    expect(await aborts.stop(client(calls), "session_1", "/repo/worktree")).toEqual({
-      complete: true,
-      attempts: [
-        { dir: "/repo", aborted: true },
-        { dir: "/repo/worktree", aborted: true },
-      ],
-    })
+    expect(await aborts.stop(client(calls), "session_1", "/repo/worktree")).toBe(true)
     expect(calls).toEqual([
       {
         type: "abort",
@@ -47,10 +41,7 @@ describe("SessionAbort", () => {
     aborts.observe("session_1", "busy", "/repo")
     aborts.observe("session_1", "idle", "/repo")
 
-    expect(await aborts.stop(client(calls), "session_1", "/repo/worktree")).toEqual({
-      complete: false,
-      attempts: [{ dir: "/repo/worktree", aborted: true }],
-    })
+    expect(await aborts.stop(client(calls), "session_1", "/repo/worktree")).toBe(false)
     expect(calls).toEqual([
       {
         type: "abort",
@@ -65,22 +56,8 @@ describe("SessionAbort", () => {
     const aborts = new SessionAbort()
     aborts.observe("session_1", "busy", "/repo/worktree")
 
-    expect(await aborts.stop(client(calls), "session_1", "/repo/worktree/.")).toEqual({
-      complete: true,
-      attempts: [{ dir: "/repo/worktree", aborted: true }],
-    })
+    expect(await aborts.stop(client(calls), "session_1", "/repo/worktree/.")).toBe(true)
     expect(calls).toHaveLength(1)
-  })
-
-  it("reports a failed HTTP abort separately from ownership", async () => {
-    const calls: unknown[] = []
-    const aborts = new SessionAbort()
-    aborts.observe("session_1", "busy", "/repo")
-
-    expect(await aborts.stop(client(calls, true), "session_1", "/repo")).toEqual({
-      complete: false,
-      attempts: [{ dir: "/repo", aborted: false }],
-    })
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/continue-in-worktree.test.ts
+++ b/packages/kilo-vscode/tests/unit/continue-in-worktree.test.ts
@@ -96,31 +96,28 @@ describe("continue-in-worktree steps", () => {
       await abortSession(c, "session-1")
     })
 
-    it("does not throw when abort rejects", async () => {
+    it("logs backend failures without interrupting the transfer", async () => {
+      const log = mock(() => {})
       const c = ctx({
         getClient: () =>
           ({
             session: { abort: () => Promise.reject(new Error("fail")) },
           }) as never,
+        log,
       })
+
       await abortSession(c, "session-1")
+
+      expect(log).toHaveBeenCalledWith("Session abort failed (may already be idle):", "fail")
     })
 
-    it("calls abort on the client", async () => {
-      let called = false
-      const c = ctx({
-        getClient: () =>
-          ({
-            session: {
-              abort: () => {
-                called = true
-                return Promise.resolve()
-              },
-            },
-          }) as never,
-      })
+    it("requests thrown backend errors when aborting", async () => {
+      const abort = mock(async () => undefined)
+      const c = ctx({ getClient: () => ({ session: { abort } }) as never })
+
       await abortSession(c, "session-1")
-      expect(called).toBe(true)
+
+      expect(abort).toHaveBeenCalledWith({ sessionID: "session-1" }, { throwOnError: true })
     })
   })
 

--- a/packages/kilo-vscode/tests/unit/continue-in-worktree.test.ts
+++ b/packages/kilo-vscode/tests/unit/continue-in-worktree.test.ts
@@ -72,11 +72,8 @@ function result(path: string): CreateWorktreeResult {
 function ctx(overrides: Partial<ContinueContext> = {}): ContinueContext {
   return {
     root: "/tmp/test",
-    connection: {
-      getClient: () => {
-        throw new Error("no client")
-      },
-      runExplicitAbort: async (_sessionId, _directory, action) => action(),
+    getClient: () => {
+      throw new Error("no client")
     },
     createWorktreeOnDisk: async () => null,
     runSetupScript: async () => {},
@@ -101,12 +98,10 @@ describe("continue-in-worktree steps", () => {
 
     it("does not throw when abort rejects", async () => {
       const c = ctx({
-        connection: {
-          getClient: () => ({ session: { abort: async () => undefined } }) as never,
-          runExplicitAbort: async () => {
-            throw new Error("fail")
-          },
-        },
+        getClient: () =>
+          ({
+            session: { abort: () => Promise.reject(new Error("fail")) },
+          }) as never,
       })
       await abortSession(c, "session-1")
     })
@@ -114,17 +109,15 @@ describe("continue-in-worktree steps", () => {
     it("calls abort on the client", async () => {
       let called = false
       const c = ctx({
-        connection: {
-          getClient: () =>
-            ({
-              session: {
-                abort: async () => {
-                  called = true
-                },
+        getClient: () =>
+          ({
+            session: {
+              abort: () => {
+                called = true
+                return Promise.resolve()
               },
-            }) as never,
-          runExplicitAbort: async (_sessionId, _directory, action) => action(),
-        },
+            },
+          }) as never,
       })
       await abortSession(c, "session-1")
       expect(called).toBe(true)
@@ -141,13 +134,10 @@ describe("continue-in-worktree steps", () => {
 
     it("returns error when fork rejects", async () => {
       const c = ctx({
-        connection: {
-          getClient: () =>
-            ({
-              session: { fork: () => Promise.reject(new Error("fork failed")) },
-            }) as never,
-          runExplicitAbort: async (_s, _d, action) => action(),
-        },
+        getClient: () =>
+          ({
+            session: { fork: () => Promise.reject(new Error("fork failed")) },
+          }) as never,
       })
       const res = await forkSession(c, "session-1", "/tmp/wt")
       expect(res.ok).toBe(false)
@@ -158,13 +148,10 @@ describe("continue-in-worktree steps", () => {
       const forked = session("forked-1")
       const promptAsync = mock(async () => ({}))
       const c = ctx({
-        connection: {
-          getClient: () =>
-            ({
-              session: { fork: () => Promise.resolve({ data: forked }), promptAsync },
-            }) as never,
-          runExplicitAbort: async (_s, _d, action) => action(),
-        },
+        getClient: () =>
+          ({
+            session: { fork: () => Promise.resolve({ data: forked }), promptAsync },
+          }) as never,
       })
       const res = await forkSession(c, "session-1", "/tmp/wt")
       expect(res.ok).toBe(true)
@@ -228,7 +215,7 @@ describe("continueInWorktree", () => {
     let created: CreateWorktreeResult | undefined
     const c = ctx({
       root,
-      connection: { getClient: () => api, runExplicitAbort: async (_s, _d, action) => action() },
+      getClient: () => api,
       createWorktreeOnDisk: async (opts) => {
         const value = await manager.createWorktree(opts)
         created = value
@@ -259,7 +246,7 @@ describe("continueInWorktree", () => {
     let created: CreateWorktreeResult | undefined
     const c = ctx({
       root,
-      connection: { getClient: () => client(), runExplicitAbort: async (_s, _d, action) => action() },
+      getClient: () => client(),
       createWorktreeOnDisk: async (opts) => {
         const value = await manager.createWorktree(opts)
         created = value

--- a/packages/kilo-vscode/tests/unit/explicit-abort.test.ts
+++ b/packages/kilo-vscode/tests/unit/explicit-abort.test.ts
@@ -13,32 +13,29 @@ const close = (reason: "completed" | "interrupted", sessionID = "session") =>
 
 describe("explicit abort state", () => {
   it("does not suppress an unexpected interruption", () => {
-    const state = new ExplicitAbortState()
-
-    expect(state.event(close("interrupted"))).toBe(true)
+    expect(new ExplicitAbortState().event(close("interrupted"))).toBe(true)
   })
 
-  it("drops an interrupted close after an explicit abort succeeds", () => {
+  it("suppresses an abort without requiring an earlier busy event", () => {
     const state = new ExplicitAbortState()
-    state.event(status("busy"), "/repo")
     const id = state.begin("session", "/repo")
 
     expect(state.event(close("interrupted"), "/repo")).toBe(false)
     expect(state.finish("session", "/repo", id, true)).toEqual([])
+    expect(state.event(close("interrupted"), "/repo")).toBe(true)
   })
 
-  it("drops an interrupted close that arrives after abort success", () => {
+  it("suppresses a close that arrives after abort success only once", () => {
     const state = new ExplicitAbortState()
-    state.event(status("busy"), "/repo")
     const id = state.begin("session", "/repo")
     state.finish("session", "/repo", id, true)
 
     expect(state.event(close("interrupted"), "/repo")).toBe(false)
+    expect(state.event(close("interrupted"), "/repo")).toBe(true)
   })
 
   it("replays an interrupted close when the abort fails", () => {
     const state = new ExplicitAbortState()
-    state.event(status("busy"), "/repo")
     const id = state.begin("session", "/repo")
     const event = close("interrupted")
     state.event(event, "/repo")
@@ -48,15 +45,13 @@ describe("explicit abort state", () => {
 
   it("never suppresses a completed close", () => {
     const state = new ExplicitAbortState()
-    state.event(status("busy"), "/repo")
     state.begin("session", "/repo")
 
-    expect(state.event(close("completed"))).toBe(true)
+    expect(state.event(close("completed"), "/repo")).toBe(true)
   })
 
   it("waits for concurrent abort attempts before replaying", () => {
     const state = new ExplicitAbortState()
-    state.event(status("busy"), "/repo")
     const first = state.begin("session", "/repo")
     const second = state.begin("session", "/repo")
     state.event(close("interrupted"), "/repo")
@@ -65,23 +60,8 @@ describe("explicit abort state", () => {
     expect(state.finish("session", "/repo", second, true)).toEqual([])
   })
 
-  it("allows a later real interruption in the same session", () => {
-    const state = new ExplicitAbortState()
-    state.event(open(), "/repo")
-    state.event(status("busy"), "/repo")
-    const id = state.begin("session", "/repo")
-    state.finish("session", "/repo", id, true)
-    expect(state.event(close("interrupted"), "/repo")).toBe(false)
-    state.event(status("idle"), "/repo")
-    state.event(open(), "/repo")
-    state.event(status("busy"), "/repo")
-
-    expect(state.event(close("interrupted"), "/repo")).toBe(true)
-  })
-
   it("clears a pending abort when a new turn opens", () => {
     const state = new ExplicitAbortState()
-    state.event(status("busy"), "/repo")
     const id = state.begin("session", "/repo")
     state.event(open(), "/repo")
 
@@ -91,7 +71,6 @@ describe("explicit abort state", () => {
 
   it("isolates identical session ids by directory", () => {
     const state = new ExplicitAbortState()
-    state.event(status("busy"), "/repo/a")
     const id = state.begin("session", "/repo/a")
     state.finish("session", "/repo/a", id, true)
 
@@ -99,32 +78,12 @@ describe("explicit abort state", () => {
     expect(state.event(close("interrupted"), "/repo/a")).toBe(false)
   })
 
-  it("does not mark an already idle session", () => {
+  it("clears suppression when an idle session becomes busy again", () => {
     const state = new ExplicitAbortState()
-    state.event(status("idle"), "/repo")
-
-    expect(state.begin("session", "/repo")).toBeUndefined()
-    expect(state.event(close("interrupted"), "/repo")).toBe(true)
-  })
-
-  it("clears suppression on a later busy status without turn-open", () => {
-    const state = new ExplicitAbortState()
-    state.event(status("busy"), "/repo")
     const id = state.begin("session", "/repo")
     state.finish("session", "/repo", id, true)
     state.event(status("idle"), "/repo")
     state.event(status("busy"), "/repo")
-
-    expect(state.event(close("interrupted"), "/repo")).toBe(true)
-  })
-
-  it("does not carry a pending abort into a new busy turn", () => {
-    const state = new ExplicitAbortState()
-    state.event(status("busy"), "/repo")
-    const id = state.begin("session", "/repo")
-    state.event(status("idle"), "/repo")
-    state.event(status("busy"), "/repo")
-    state.finish("session", "/repo", id, true)
 
     expect(state.event(close("interrupted"), "/repo")).toBe(true)
   })

--- a/packages/kilo-vscode/tests/unit/kilo-provider-load-messages.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-load-messages.test.ts
@@ -191,8 +191,7 @@ function createConnection(client: ReturnType<typeof createClient>) {
     },
     connect: async () => {},
     getClient: () => client,
-    beginExplicitAbort: () => 1 as number | undefined,
-    finishExplicitAbort: () => undefined,
+    runExplicitAbort: async (_sid: string, _dir: string, action: () => Promise<void>) => action(),
     onEventFiltered: () => () => undefined,
     onStateChange: (_l: (s: State) => void) => () => undefined,
     onNotificationDismissed: () => () => undefined,
@@ -223,6 +222,7 @@ type ProviderInternals = {
   currentSession: { id: string; directory?: string; cost?: number; revert?: { messageID: string } } | null
   contextSessionID: string | undefined
   sessionDirectories: Map<string, string>
+  sessionStatusMap: Map<string, string>
   trackedSessionIds: Set<string>
   openSessionIds: Set<string>
   draftSessions: Map<string, { sid: string; dir: string; expires: number }>
@@ -268,6 +268,18 @@ function mockMaxCost(internal: ProviderInternals, value: number) {
 }
 
 describe("KiloProvider.handleAbort", () => {
+  it("aborts a session whose busy status was seeded without an SSE event", async () => {
+    const client = createClient()
+    const { internal, sent } = makeProvider(client)
+    internal.sessionStatusMap.set("s1", "busy")
+
+    await internal.handleAbort("s1")
+
+    expect(client.aborted).toEqual([{ sessionID: "s1", directory: "/repo" }])
+    expect(sent.at(-1)).toMatchObject({ type: "sessionStatus", sessionID: "s1", status: "idle" })
+    expect(sent).not.toContainEqual({ type: "sessionTurnClosed", sessionID: "s1", reason: "interrupted" })
+  })
+
   it("aborts the original owner after a running session moves to a worktree", async () => {
     const client = createClient()
     const { provider, internal, sent } = makeProvider(client)


### PR DESCRIPTION
## What Problem This Solves

The manual interruption fix in #13376 introduced unnecessary session state, turn generations, structured abort results, and Agent Manager worktree-transfer changes. It also missed sessions that were already running when their status was loaded through HTTP.

## Why This Change Was Made

Keep cancellation ownership in the existing abort flow and wrap each backend abort with one shared connection-service operation. Restore the original abort and worktree-transfer interfaces, remove redundant tracking, clear consumed state, and normalize Windows directory casing.

## User Impact

Stopping a response in the sidebar or Agent Manager remains quiet, including sessions that were already running when the extension connected. Genuine interruptions and failed aborts remain visible.

## Evidence

Immediate Stop was exercised in both the VS Code sidebar and Agent Manager. Neither surface displayed an interruption warning.