### PR TITLE
docs: add SCX.ai provider page

### DIFF
--- a/packages/kilo-docs/lib/nav/ai-providers.ts
+++ b/packages/kilo-docs/lib/nav/ai-providers.ts
@@ -51,6 +51,7 @@ export const AiProvidersNav: NavSection[] = [
       { href: "/ai-providers/cerebras", children: "Cerebras" },
       { href: "/ai-providers/fireworks", children: "Fireworks AI" },
       { href: "/ai-providers/mixlayer", children: "Mixlayer" },
+      { href: "/ai-providers/scx-ai", children: "SCX.ai" },
     ],
   },
   {

--- a/packages/kilo-docs/pages/ai-providers/scx-ai.md
+++ b/packages/kilo-docs/pages/ai-providers/scx-ai.md
@@ -1,0 +1,80 @@
+---
+title: "Using SCX.ai with Kilo Code | Australian-Hosted Open Models"
+description: "Run open models like MiniMax, GLM, and Qwen on SCX.ai's OpenAI-compatible API in Kilo Code. Setup guide for VS Code and the CLI."
+---
+
+# Using SCX.ai with Kilo Code
+
+[SCX.ai](https://scx.ai) is an Australian sovereign AI platform serving open models such as MiniMax, GLM, and Qwen over an OpenAI-compatible API, hosted on renewable-powered infrastructure in Australia. It is available as a built-in provider in Kilo Code under the provider ID `scx-ai`, and reads your API key from `SCX_API_KEY`.
+
+**Website:** [https://scx.ai](https://scx.ai)
+
+## Getting an API key
+
+1. **Sign up/sign in:** Go to the [SCX.ai platform](https://platform.scx.ai) and create an account or sign in.
+2. **Create a key:** Generate an API key from the platform and copy it.
+
+## Configuration in Kilo Code
+
+SCX.ai is a **built-in provider** in Kilo Code, so you can connect it directly — no custom provider setup needed.
+
+{% tabs %}
+{% tab label="VSCode" %}
+
+1. Open **Settings** (gear icon) and go to the **Providers** tab.
+2. Click **Connect provider**, search for **SCX.ai**, and select it. If it is not visible, click **Show more providers**.
+3. Enter your SCX.ai API key.
+4. Pick a model, such as **MiniMax-M2.7** or **GLM-5.2**.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+**Method 1 — `/connect` (recommended)**
+
+Run `kilo`, then use the `/connect` command, select **SCX.ai**, and paste your API key when prompted:
+
+```bash
+kilo
+# then, inside Kilo, run:
+/connect
+```
+
+**Method 2 — config file**
+
+Keep the key in the environment and declare the provider in your `kilo.json` config file (`~/.config/kilo/kilo.json` or `./kilo.json`):
+
+```bash
+export SCX_API_KEY="your-api-key"
+```
+
+```jsonc
+{
+  "provider": {
+    "scx-ai": {
+      "env": ["SCX_API_KEY"],
+    },
+  },
+  "model": "scx-ai/MiniMax-M2.7",
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
+## Models
+
+The model picker lists the SCX.ai models published in the catalogue Kilo refreshes:
+
+- `MiniMax-M2.7`
+- `GLM-5.2`
+- `Qwen3.8-Max`
+- `gpt-oss-120b`
+
+All four support tool calling and reasoning. SCX.ai serves a larger catalogue than the picker shows; any model on the platform can be used by declaring it yourself, as described in [Custom Models](/docs/code-with-ai/agents/custom-models). A model declared this way inherits the SCX.ai API base and protocol, so nothing else needs configuring. Declare `cost` and `limit` on it if you want spend reporting and the context gauge to be right — Kilo defaults both to zero for a model it does not already know.
+
+## Tips and notes
+
+- **Model IDs are case-sensitive.** Use them exactly as shown: `MiniMax-M2.7` and `GLM-5.2` are mixed case, `gpt-oss-120b` is lowercase.
+- **Reasoning effort levels vary by model.** `GLM-5.2` and `Qwen3.8-Max` accept the full range from `none` to `max`; `MiniMax-M2.7` and `gpt-oss-120b` accept `low`, `medium`, and `high`.
+- **Billing:** SCX.ai meters usage in AUD through Service Token Units. The spend Kilo Code shows is an estimate derived from token counts; your [SCX.ai platform](https://platform.scx.ai) dashboard is the authoritative figure.
+- **Documentation:** See the [SCX.ai docs](https://platform.scx.ai/docs) for the full model list and supported parameters.


### PR DESCRIPTION
## Issue

No linked issue — small docs-only addition, following the pattern of #12500 (Mixlayer) and #13169 (Eden AI).

## Context

[SCX.ai](https://scx.ai) is already in the `models.dev` catalog that Kilo refreshes (provider ID `scx-ai`, added there in August), so the provider is selectable today, but there is no Kilo-specific setup page for it. This adds one under **Cloud Providers**, where the other open-model inference platforms (Groq, Cerebras, Fireworks, Mixlayer) live.

Disclosure: I work with SCX.ai, so this is the vendor documenting their own provider.

## Implementation

Docs only. Two files, no provider code and no static model catalog — modeled on the existing Mixlayer and Eden AI pages:

- `packages/kilo-docs/pages/ai-providers/scx-ai.md`, new page
- `packages/kilo-docs/lib/nav/ai-providers.ts`, nav entry appended to **Cloud Providers**

Values come from the published `providers/scx-ai/provider.toml` in `models.dev`: provider ID `scx-ai`, `env = ["SCX_API_KEY"]`, `api = "https://api.scx.ai/v1"`, `npm = "@ai-sdk/openai-compatible"`. Because the catalog already supplies `api` and `npm`, the config examples deliberately omit both. The model list, model-ID casing, and per-model reasoning-effort ranges on the page were verified against the live SCX.ai API.

## Screenshots / Video

Not applicable — documentation-only change with no product UI change. The page renders under **Cloud Providers** in the sidebar.

## How to Test

### Manual/local verification

- Ran the `kilo-docs` test suite (`vitest run`): 22 tests passed, including the content-integrity checks
- Ran `tsc --noEmit` for the package: clean
- Verified `prettier --check` passes on the nav file
- Verified all external links on the page resolve (scx.ai, platform.scx.ai, platform.scx.ai/docs)

### Reviewer test steps

- Open `/ai-providers/scx-ai` on the docs dev server and confirm the page renders with the VS Code / CLI tabs
- Confirm **SCX.ai** appears under **Cloud Providers** in the sidebar

## Checklist

- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes. None added: this publishes documentation only, and `@kilocode/kilo-docs` is a private, unpublished package.
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
