### PR TITLE
fix(agent-manager): speed up worktree session startup

### DIFF
--- a/.changeset/faster-agent-manager-worktree-start.md
+++ b/.changeset/faster-agent-manager-worktree-start.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Speed up Agent Manager worktree creation and show ready sessions immediately.

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -361,8 +361,8 @@ export class WorktreeManager {
     }
 
     const existing = await this.git
-      .branch()
-      .then((result) => result.all)
+      .raw(["for-each-ref", "--format=%(refname:lstrip=2)", "refs/heads"])
+      .then((refs) => refs.trim().split(/\r?\n/).filter(Boolean))
       .catch(() => [] as string[])
     const sanitized = params.branchName ? sanitizeBranchName(params.branchName) : undefined
     const branch = sanitized || generateBranchName(params.prompt || "agent-task", existing)
@@ -392,7 +392,13 @@ export class WorktreeManager {
    */
   private async runWorktreeAdd(args: string[], wtPath: string): Promise<void> {
     try {
-      await this.git.raw(args)
+      const workers = await this.git.getConfig("checkout.workers").catch((error: unknown) => {
+        this.log(
+          `Failed to inspect checkout worker configuration: ${error instanceof Error ? error.message : String(error)}`,
+        )
+        return undefined
+      })
+      await this.git.raw(workers?.value === null ? ["-c", "checkout.workers=2", ...args] : args)
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error)
       if (this.isHookError(msg) && (await this.worktreeRegistered(wtPath))) {

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -1152,3 +1152,14 @@ describe("Shared webview provider shell", () => {
     expect(fs.readFileSync(PROVIDER_SHELL_FILE, "utf-8")).not.toContain("WorktreeModeProvider")
   })
 })
+
+describe("Agent Manager worktree setup", () => {
+  it("dismisses successful setup overlays immediately and retains the error delay", () => {
+    const source = fs.readFileSync(AGENT_MANAGER_APP_FILE, "utf-8")
+    expect(source).toContain('globalThis.setTimeout(() => setSetup({ active: false, message: "" }), error ? 3000 : 0)')
+    expect(source).not.toContain(
+      'globalThis.setTimeout(() => setSetup({ active: false, message: "" }), error ? 3000 : 500)',
+    )
+    expect(source).toContain("globalThis.setTimeout")
+  })
+})

--- a/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
@@ -332,6 +332,45 @@ describe("WorktreeManager.createWorktree", () => {
 
     expect(result.parentBranch).toBe(branch)
   })
+
+  it("uses two checkout workers without changing Git configuration", async () => {
+    const root = await createTempRepo()
+    const hook = path.join(root, ".git", "hooks", "post-checkout")
+    const file = path.join(root, "workers")
+    await fs.writeFile(hook, `#!/bin/sh\ngit config --get checkout.workers > "${file}"\n`)
+    await fs.chmod(hook, 0o755)
+
+    await createManager(root).createWorktree({ branchName: "parallel-checkout" })
+
+    expect((await fs.readFile(file, "utf8")).trim()).toBe("2")
+    expect((await simpleGit(root).getConfig("checkout.workers")).value).toBeNull()
+  })
+
+  it("preserves an explicitly configured checkout worker count", async () => {
+    const root = await createTempRepo()
+    const hook = path.join(root, ".git", "hooks", "post-checkout")
+    const file = path.join(root, "workers")
+    gitExec(["git", "-C", root, "config", "checkout.workers", "1"])
+    await fs.writeFile(hook, `#!/bin/sh\ngit config --get checkout.workers > "${file}"\n`)
+    await fs.chmod(hook, 0o755)
+
+    await createManager(root).createWorktree({ branchName: "configured-checkout" })
+
+    expect((await fs.readFile(file, "utf8")).trim()).toBe("1")
+    expect((await simpleGit(root).getConfig("checkout.workers")).value).toBe("1")
+  })
+
+  it("retains post-checkout hook failure tolerance with parallel checkout", async () => {
+    const root = await fs.realpath(await createTempRepo())
+    const hook = path.join(root, ".git", "hooks", "post-checkout")
+    await fs.writeFile(hook, "#!/bin/sh\nprintf 'post-checkout hook failed' >&2\nexit 1\n")
+    await fs.chmod(hook, 0o755)
+
+    const result = await createManager(root).createWorktree({ branchName: "hook-failure" })
+
+    expect(existsSync(result.path)).toBe(true)
+    expect((await simpleGit(root).raw(["worktree", "list", "--porcelain"])).includes(result.path)).toBe(true)
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -812,6 +851,17 @@ describe("WorktreeManager.createWorktree branch collision", () => {
 
     expect(second.branch).toBe("collide-2")
     expect((await fs.stat(path.join(second.path, ".git"))).isFile()).toBe(true)
+  })
+
+  it("does not treat remote-tracking refs as local branch collisions", async () => {
+    const root = await createTempRepo()
+    const git = simpleGit(root)
+    const hash = (await git.revparse(["HEAD"])).trim()
+    await git.raw(["update-ref", "refs/remotes/origin/remote-name", hash])
+
+    const result = await createManager(root).createWorktree({ branchName: "remote-name" })
+
+    expect(result.branch).toBe("remote-name")
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1416,7 +1416,7 @@ const AgentManagerContent: Component = () => {
             worktreeId: ev.worktreeId,
             errorCode: ev.errorCode,
           })
-          globalThis.setTimeout(() => setSetup({ active: false, message: "" }), error ? 3000 : 500)
+          globalThis.setTimeout(() => setSetup({ active: false, message: "" }), error ? 3000 : 0)
           if (!error && ev.sessionId) {
             session.selectSession(ev.sessionId)
             const ms = managedSessions().find((s) => s.id === ev.sessionId)


### PR DESCRIPTION
## What Problem This Solves

Creating an Agent Manager worktree waits on Git checkout and then keeps the successful setup overlay visible after the session is ready. Large repositories also spend unnecessary time enumerating remote-tracking branches during local branch collision checks.

## Why This Change Was Made

Use Git's built-in parallel checkout with two workers when the repository has no explicit `checkout.workers` setting, while preserving explicit user configuration. Limit collision detection to local branch refs, which are the only refs that can conflict with a new local branch. Dismiss successful setup feedback immediately after readiness while retaining the error delay.

## User Impact

The first usable Agent Manager session was measured at approximately 4.37 seconds before these changes and 2.65 seconds after them.

| Measurement | Before | After | Improvement |
|---|---:|---:|---:|
| Complete startup to usable session | 4.37 s | 2.65 s | 1.72 s, 39% |
| Git checkout | 3.15 s | 2.12 s | 1.03 s, 33% |
| Local branch collision lookup | 218 ms | 25 ms | 193 ms, 89% |
| Successful setup overlay delay | 500 ms | Immediate | 500 ms |

The measurements used a disposable repository with 9,640 tracked files and 424 Git LFS files. The total varies with repository size, Git LFS content, disk speed, hooks, setup scripts, remote latency, and host load.

## Safety Validation

The checkout still uses a fresh remote commit, standard `git worktree add`, Git LFS, and post-checkout hooks. Explicit user-defined `checkout.workers` values remain unchanged. Branch collision tests cover local branches and remote-tracking refs.

- Focused Agent Manager tests passed, including explicit worker configuration, branch collisions, post-checkout hook failure tolerance, and setup overlay timing.
- Extension typecheck, lint, compile, formatting, and `check-kilocode-change` passed.