### PR TITLE
fix(agent-manager): prevent false GitHub CLI warnings on project switches

### DIFF
--- a/.changeset/agent-manager-project-pr-errors.md
+++ b/.changeset/agent-manager-project-pr-errors.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent false GitHub CLI installation errors when switching Agent Manager projects.

--- a/packages/kilo-vscode/src/agent-manager/PRStatusPoller.ts
+++ b/packages/kilo-vscode/src/agent-manager/PRStatusPoller.ts
@@ -1,4 +1,5 @@
 import type { ExecFileOptionsWithStringEncoding } from "child_process"
+import { existsSync } from "fs"
 import type { Worktree } from "./WorktreeStateManager"
 import type { PRStatus, PRCheck, PRComment, PRReviewer, AggregateCheckStatus } from "./types"
 import { execWithShellEnv } from "./shell-env"
@@ -287,14 +288,15 @@ export class PRStatusPoller {
 
       this.options.onStatus(worktreeId, status)
     } catch (err) {
-      this.handleError(worktreeId, wt.branch, err)
+      if (this.stale(generation)) return
+      this.handleError(worktreeId, wt.branch, wt.path, err)
       throw err // propagate so fetchAll can track failures for backoff
     }
   }
 
-  private handleError(worktreeId: string, branch: string, err: unknown): void {
+  private handleError(worktreeId: string, branch: string, cwd: string, err: unknown): void {
     const msg = err instanceof Error ? err.message : String(err)
-    const kind = classifyPRError(msg)
+    const kind = existsSync(cwd) ? classifyPRError(msg) : "unknown"
     this.options.log(`PR fetch failed for ${branch}:`, msg)
     const key = kind === "gh_missing" ? "gh_missing" : kind === "gh_auth" ? "gh_auth" : "fetch_failed"
     if (kind === "gh_missing") this.ghAvailable = false
@@ -306,7 +308,9 @@ export class PRStatusPoller {
 
   private target(worktreeId: string): Worktree | undefined {
     if (!this.options.getWorkspaceRoot()) return
-    return this.options.getWorktrees().find((worktree) => worktree.id === worktreeId)
+    const worktree = this.options.getWorktrees().find((item) => item.id === worktreeId)
+    if (!worktree || !existsSync(worktree.path)) return
+    return worktree
   }
 
   private static readonly PR_JSON_FIELDS =

--- a/packages/kilo-vscode/src/agent-manager/pr-status-bridge.ts
+++ b/packages/kilo-vscode/src/agent-manager/pr-status-bridge.ts
@@ -69,7 +69,11 @@ export class PRStatusBridge {
   replay(): void {
     this.cache.forEach((msg) => this.host.postToWebview(msg))
     if (this.lastErrorNotified === "gh_auth" || this.lastErrorNotified === "gh_missing")
-      this.host.postToWebview({ type: "agentManager.prError", error: this.lastErrorNotified } as AgentManagerOutMessage)
+      this.host.postToWebview({
+        type: "agentManager.prError",
+        error: this.lastErrorNotified,
+        ...(this.host.projectId?.() ? { projectId: this.host.projectId() } : {}),
+      })
   }
 
   snapshot(): Map<string, PRStatus> {
@@ -156,7 +160,11 @@ export class PRStatusBridge {
   notifyError(err: "gh_missing" | "gh_auth" | "fetch_failed"): void {
     if (this.lastErrorNotified === err) return
     this.lastErrorNotified = err
-    this.host.postToWebview({ type: "agentManager.prError", error: err } as AgentManagerOutMessage)
+    this.host.postToWebview({
+      type: "agentManager.prError",
+      error: err,
+      ...(this.host.projectId?.() ? { projectId: this.host.projectId() } : {}),
+    })
   }
 }
 

--- a/packages/kilo-vscode/src/agent-manager/pr-status-bridge.ts
+++ b/packages/kilo-vscode/src/agent-manager/pr-status-bridge.ts
@@ -69,11 +69,7 @@ export class PRStatusBridge {
   replay(): void {
     this.cache.forEach((msg) => this.host.postToWebview(msg))
     if (this.lastErrorNotified === "gh_auth" || this.lastErrorNotified === "gh_missing")
-      this.host.postToWebview({
-        type: "agentManager.prError",
-        error: this.lastErrorNotified,
-        ...(this.host.projectId?.() ? { projectId: this.host.projectId() } : {}),
-      })
+      this.error(this.lastErrorNotified)
   }
 
   snapshot(): Map<string, PRStatus> {
@@ -160,10 +156,15 @@ export class PRStatusBridge {
   notifyError(err: "gh_missing" | "gh_auth" | "fetch_failed"): void {
     if (this.lastErrorNotified === err) return
     this.lastErrorNotified = err
+    this.error(err)
+  }
+
+  private error(err: "gh_missing" | "gh_auth" | "fetch_failed"): void {
+    const project = this.host.projectId?.()
     this.host.postToWebview({
       type: "agentManager.prError",
       error: err,
-      ...(this.host.projectId?.() ? { projectId: this.host.projectId() } : {}),
+      ...(project ? { projectId: project } : undefined),
     })
   }
 }

--- a/packages/kilo-vscode/src/agent-manager/project/pollers.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/pollers.ts
@@ -33,6 +33,7 @@ export type StatsOutMessage =
   | { type: "agentManager.worktreeStats"; projectId?: string; stats: WorktreeStats[] }
   | { type: "agentManager.localStats"; projectId?: string; stats: LocalStats }
   | { type: "agentManager.prStatus"; projectId?: string; worktreeId: string; pr: PRStatus | null }
+  | { type: "agentManager.prError"; projectId?: string; error: "gh_missing" | "gh_auth" | "fetch_failed" }
 
 type StatsMessage = Extract<AgentManagerOutMessage, { type: "agentManager.worktreeStats" | "agentManager.localStats" }>
 

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -426,6 +426,7 @@ interface PRStatusOutMessage {
 
 interface PRErrorOutMessage {
   type: "agentManager.prError"
+  projectId?: string
   error: "gh_missing" | "gh_auth" | "fetch_failed"
 }
 

--- a/packages/kilo-vscode/tests/unit/am-pr-status-bridge.test.ts
+++ b/packages/kilo-vscode/tests/unit/am-pr-status-bridge.test.ts
@@ -75,6 +75,12 @@ describe("PRStatusBridge.notifyError", () => {
     expect(sent[0]).toEqual(expect.objectContaining({ type: "agentManager.prError", error: "gh_missing" }))
   })
 
+  it("tags errors with their owning project", () => {
+    const { bridge, sent } = harness({ projectId: "project-a" })
+    bridge.notifyError("gh_missing")
+    expect(sent).toEqual([{ type: "agentManager.prError", projectId: "project-a", error: "gh_missing" }])
+  })
+
   it("deduplicates the same error type", () => {
     const { bridge, sent } = harness()
     bridge.notifyError("gh_auth")
@@ -198,6 +204,14 @@ describe("PRStatusBridge.replay", () => {
     expect(
       sent.some((m) => m.type === "agentManager.prError" && (m as never as { error: string }).error === "gh_auth"),
     ).toBe(true)
+  })
+
+  it("preserves project ownership when replaying an error", () => {
+    const { bridge, sent, onStatus } = harness({ projectId: "project-a" })
+    onStatus("wt1", null, "gh_missing")
+    sent.length = 0
+    bridge.replay()
+    expect(sent).toEqual([{ type: "agentManager.prError", projectId: "project-a", error: "gh_missing" }])
   })
 
   it("does not replay fetch_failed errors", () => {

--- a/packages/kilo-vscode/tests/unit/am-pr-status-bridge.test.ts
+++ b/packages/kilo-vscode/tests/unit/am-pr-status-bridge.test.ts
@@ -24,6 +24,7 @@ const pr: PRStatus = {
 function harness(opts: { hasPersisted?: boolean; projectId?: string } = {}) {
   const sent: AgentManagerOutMessage[] = []
   const opened: string[] = []
+  const reads: (string | undefined)[] = []
   const worktrees: { id: string; path: string; branch: string; prUrl?: string }[] = [
     { id: "wt1", path: "/repo/wt1", branch: "feature" },
   ]
@@ -35,10 +36,13 @@ function harness(opts: { hasPersisted?: boolean; projectId?: string } = {}) {
     hasPersistedPR: () => opts.hasPersisted ?? false,
     openExternal: (url) => opened.push(url),
     log: () => {},
-    projectId: () => opts.projectId,
+    projectId: () => {
+      reads.push(opts.projectId)
+      return opts.projectId
+    },
   })
   const onStatus = (bridge.poller as unknown as { options: { onStatus: (...a: unknown[]) => void } }).options.onStatus
-  return { bridge, sent, opened, onStatus, worktrees }
+  return { bridge, sent, opened, onStatus, worktrees, reads }
 }
 
 describe("PRStatusBridge.handleMessage openPR", () => {
@@ -76,9 +80,10 @@ describe("PRStatusBridge.notifyError", () => {
   })
 
   it("tags errors with their owning project", () => {
-    const { bridge, sent } = harness({ projectId: "project-a" })
+    const { bridge, sent, reads } = harness({ projectId: "project-a" })
     bridge.notifyError("gh_missing")
     expect(sent).toEqual([{ type: "agentManager.prError", projectId: "project-a", error: "gh_missing" }])
+    expect(reads).toEqual(["project-a"])
   })
 
   it("deduplicates the same error type", () => {
@@ -207,11 +212,13 @@ describe("PRStatusBridge.replay", () => {
   })
 
   it("preserves project ownership when replaying an error", () => {
-    const { bridge, sent, onStatus } = harness({ projectId: "project-a" })
+    const { bridge, sent, onStatus, reads } = harness({ projectId: "project-a" })
     onStatus("wt1", null, "gh_missing")
     sent.length = 0
+    reads.length = 0
     bridge.replay()
     expect(sent).toEqual([{ type: "agentManager.prError", projectId: "project-a", error: "gh_missing" }])
+    expect(reads).toEqual(["project-a"])
   })
 
   it("does not replay fetch_failed errors", () => {

--- a/packages/kilo-vscode/tests/unit/gh.test.ts
+++ b/packages/kilo-vscode/tests/unit/gh.test.ts
@@ -3,6 +3,9 @@ import * as fs from "fs"
 import * as os from "os"
 import * as path from "path"
 import { execGhRead } from "../../src/agent-manager/gh"
+import { PRStatusPoller } from "../../src/agent-manager/PRStatusPoller"
+import { Semaphore } from "../../src/agent-manager/semaphore"
+import type { Worktree } from "../../src/agent-manager/WorktreeStateManager"
 
 const host = process.platform
 const platform = Object.getOwnPropertyDescriptor(process, "platform")
@@ -49,6 +52,39 @@ function unset(env: Record<string, string>, name: string): void {
   }
 }
 
+async function fixture(run: (dir: string) => Promise<void>): Promise<void> {
+  setPlatform("linux")
+  const bin = fakeBin()
+  const previous = process.env.PATH
+  process.env.PATH = bin.dir
+  try {
+    await run(bin.dir)
+  } finally {
+    if (previous === undefined) delete process.env.PATH
+    if (previous !== undefined) process.env.PATH = previous
+    bin.cleanup()
+  }
+}
+
+function poller(dir: string, errors: string[], semaphore?: Semaphore): PRStatusPoller {
+  const tree: Worktree = {
+    id: "wt1",
+    branch: "feature",
+    path: dir,
+    parentBranch: "main",
+    createdAt: "2026-01-01T00:00:00.000Z",
+  }
+  return new PRStatusPoller({
+    getWorktrees: () => [tree],
+    getWorkspaceRoot: () => path.dirname(dir),
+    onStatus: (_id, _pr, error) => {
+      if (error) errors.push(error)
+    },
+    log: () => {},
+    semaphore,
+  })
+}
+
 afterEach(() => {
   if (platform) Object.defineProperty(process, "platform", platform)
 })
@@ -91,5 +127,71 @@ describe("execGhRead", () => {
     } finally {
       bin.cleanup()
     }
+  })
+})
+
+describe("PRStatusPoller", () => {
+  it("skips a deleted worktree when gh is installed", async () => {
+    await fixture(async (dir) => {
+      const errors: string[] = []
+      const instance = poller(path.join(dir, "deleted"), errors)
+      const internal = instance as unknown as { fetchAll(): Promise<void> }
+      await internal.fetchAll()
+      expect(errors).toEqual([])
+    })
+  })
+
+  it("reports a genuinely missing GitHub CLI", async () => {
+    await fixture(async (dir) => {
+      const root = path.join(dir, "worktree")
+      fs.mkdirSync(root)
+      fs.rmSync(path.join(dir, host === "win32" ? "gh.exe" : "gh"))
+      const errors: string[] = []
+      const instance = poller(root, errors)
+      const internal = instance as unknown as { fetchAll(): Promise<void> }
+      await internal.fetchAll()
+      expect(errors).toEqual(["gh_missing"])
+    })
+  })
+
+  it("does not report gh missing when a worktree disappears before launch", async () => {
+    await fixture(async (dir) => {
+      const root = path.join(dir, "worktree")
+      fs.mkdirSync(root)
+      const errors: string[] = []
+      const gate = Promise.withResolvers<void>()
+      const semaphore = new Semaphore(1)
+      const held = semaphore.run(() => gate.promise)
+      const instance = poller(root, errors, semaphore)
+      const internal = instance as unknown as { fetchOne(id: string): Promise<void> }
+      const pending = internal.fetchOne("wt1").then(
+        () => undefined,
+        (error: Error) => error,
+      )
+      fs.rmSync(root, { recursive: true, force: true })
+      gate.resolve()
+      const [, error] = await Promise.all([held, pending])
+      expect(error?.message).toContain("ENOENT")
+      expect(errors).toEqual(["fetch_failed"])
+    })
+  })
+
+  it("ignores a stale worktree failure after its project poller stops", async () => {
+    await fixture(async (dir) => {
+      const root = path.join(dir, "worktree")
+      fs.mkdirSync(root)
+      const errors: string[] = []
+      const gate = Promise.withResolvers<void>()
+      const semaphore = new Semaphore(1)
+      const held = semaphore.run(() => gate.promise)
+      const instance = poller(root, errors, semaphore)
+      const internal = instance as unknown as { fetchOne(id: string): Promise<void> }
+      const pending = internal.fetchOne("wt1")
+      instance.stop()
+      fs.rmSync(root, { recursive: true, force: true })
+      gate.resolve()
+      await Promise.all([held, pending])
+      expect(errors).toEqual([])
+    })
   })
 })

--- a/packages/kilo-vscode/tests/unit/project-message-ownership.test.ts
+++ b/packages/kilo-vscode/tests/unit/project-message-ownership.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "bun:test"
-import { ownsParent, ownsProject } from "../../webview-ui/agent-manager/project/message-ownership"
+import { isCurrent, ownsParent, ownsProject } from "../../webview-ui/agent-manager/project/message-ownership"
 
 describe("project message ownership", () => {
   it("rejects messages from another project", () => {
     expect(ownsProject({ projectId: "a" }, "b")).toBe(false)
     expect(ownsProject({}, "b")).toBe(true)
+  })
+
+  it("rejects pull request errors from a background project", () => {
+    expect(isCurrent({ projectId: "background" }, "active")).toBe(false)
+    expect(isCurrent({ projectId: "active" }, "active")).toBe(true)
+    expect(isCurrent({}, "active")).toBe(true)
   })
 
   it("resolves parent session ownership", () => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1585,6 +1585,7 @@ const AgentManagerContent: Component = () => {
       })
 
       if (msg.type === "agentManager.prError") {
+        if (!isCurrent(msg, currentProjectId())) return
         const ev = msg as AgentManagerPRErrorMessage
         showToast({
           variant: "error",

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -1154,6 +1154,7 @@ export interface AgentManagerPRStatusMessage {
 
 export interface AgentManagerPRErrorMessage {
   type: "agentManager.prError"
+  projectId?: string
   error: "gh_missing" | "gh_auth" | "fetch_failed"
 }
 


### PR DESCRIPTION
## What Problem This Solves

Agent Manager can report that the GitHub CLI is not installed even when `gh` is available, most often while switching between projects or after a managed worktree disappears. Node returns the same `spawn gh ENOENT` failure for a missing executable and a missing working directory, while background or stopped project pollers could surface errors in the newly active project.

## Why This Change Was Made

A deleted working directory must not invalidate global GitHub CLI availability. PR errors also need the same project ownership as PR status updates so late responses, cached error replay, and background polling cannot leak notifications across project boundaries.

## User Impact

Switching Agent Manager projects and removing worktrees no longer produces misleading GitHub CLI installation warnings. Genuine missing-CLI and authentication errors remain visible for the active project, and existing single-project messages continue to work.

## Evidence

- All 4,177 VS Code extension unit tests pass.
- Extension and webview typechecks, ESLint, the production extension build, `knip`, formatting, and the Kilo-owned-file guard pass.
- Regression coverage exercises an installed CLI with a deleted worktree, a directory removed between validation and process launch, a stopped project poller, a genuinely missing executable, project-owned errors, and error replay.
- An isolated VS Code instance was tested with two real disposable Git projects. Switching in both directions produced no false warning, errors from inactive projects were suppressed, and an active-project authentication error still appeared.

<img width="420" alt="Agent Manager with two isolated projects and no false GitHub CLI warning" src="https://marius-kilocode.github.io/pr-assets/20260826-agent-manager-project-pr-errors-projects.png" />

<img width="700" alt="A genuine GitHub authentication error remains visible for the active project" src="https://marius-kilocode.github.io/pr-assets/20260826-agent-manager-project-pr-errors-active-auth.png" />