### PR TITLE
fix(vscode): remove top-level Auto-Approve permission on onboarding

### DIFF
--- a/.changeset/onboarding-tool-permissions.md
+++ b/.changeset/onboarding-tool-permissions.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep Review-first onboarding permissions editable in Auto-Approve settings.

--- a/packages/kilo-vscode/src/shared/work-style-presets.ts
+++ b/packages/kilo-vscode/src/shared/work-style-presets.ts
@@ -67,7 +67,6 @@ export const WORK_STYLE_PRESETS: Record<WorkStyle, WorkStylePreset> = {
       terminal_command_display: "expanded",
       auto_collapse_reasoning: false,
       permission: {
-        "*": "ask",
         read: {
           "*": "allow",
           "*.env": "ask",

--- a/packages/kilo-vscode/tests/unit/permission-editor.test.ts
+++ b/packages/kilo-vscode/tests/unit/permission-editor.test.ts
@@ -4,6 +4,7 @@ import {
   clearGroupedPatch,
   clearWildcardPatch,
   DEFAULT_RULES,
+  effectiveConfigLevel,
   inheritedWildcard,
   mostRestrictive,
   permissionExceptions,
@@ -15,6 +16,8 @@ import {
   wildcardAction,
   effectiveRuleLevel,
 } from "../../webview-ui/src/components/settings/permission-utils"
+import { ConfigState } from "../../webview-ui/src/utils/config-utils"
+import { WORK_STYLE_PRESETS } from "../../src/shared/work-style-presets"
 import type { PermissionRule, PermissionRuleItem } from "../../webview-ui/src/types/messages"
 
 describe("effectiveRuleLevel", () => {
@@ -44,6 +47,33 @@ describe("effectiveRuleLevel", () => {
   it("falls back to ask when no resolved wildcard rule is available", () => {
     expect(effectiveRuleLevel(undefined, "bash")).toBe("ask")
     expect(effectiveRuleLevel([], "bash")).toBe("ask")
+  })
+})
+
+describe("Auto-Approve onboarding state", () => {
+  const permission = WORK_STYLE_PRESETS["human-in-the-loop"].config.permission ?? {}
+
+  it("reflects onboarding permissions in Auto-Approve", () => {
+    expect(effectiveConfigLevel(permission, "edit")).toBe("ask")
+    expect(effectiveConfigLevel(permission, "bash")).toBe("ask")
+    expect(effectiveConfigLevel(permission, "glob")).toBe("allow")
+    expect(effectiveConfigLevel(permission, "grep")).toBe("allow")
+  })
+
+  it("keeps an Auto-Approve change selected after saving", () => {
+    const state = new ConfigState()
+    state.handleConfigLoaded({ permission })
+
+    expect(effectiveConfigLevel(state.config.permission ?? {}, "edit")).toBe("ask")
+
+    state.updateConfig({ permission: { edit: "allow" } })
+    expect(effectiveConfigLevel(state.config.permission ?? {}, "edit")).toBe("allow")
+    expect(state.draft).toEqual({ permission: { edit: "allow" } })
+
+    state.saveConfig()
+    state.handleConfigUpdated(state.config)
+    expect(effectiveConfigLevel(state.config.permission ?? {}, "edit")).toBe("allow")
+    expect(state.dirty).toBe(false)
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/work-style-apply.test.ts
+++ b/packages/kilo-vscode/tests/unit/work-style-apply.test.ts
@@ -10,6 +10,7 @@ function setup(input?: {
 }) {
   const settings = new Map<string, unknown>([["agentWorkStyle", "unset"]])
   const events: string[] = []
+  const patches: WorkStyleConfig[] = []
   const store: WorkStyleStore = {
     read: async () => input?.config ?? {},
     inspect: (key) => ({
@@ -23,10 +24,11 @@ function setup(input?: {
     },
     patch: async (config) => {
       events.push(`patch:${Object.keys(config).sort().join(",")}`)
+      patches.push(config)
       if (input?.failPatch) throw new Error("Failed to patch config")
     },
   }
-  return { store, settings, events }
+  return { store, settings, events, patches }
 }
 
 describe("applyWorkStyle", () => {
@@ -43,6 +45,20 @@ describe("applyWorkStyle", () => {
       "write:agentWorkStyle:human-in-the-loop",
       "patch:auto_collapse_reasoning,permission,terminal_command_display",
     ])
+  })
+
+  it("does not write a top-level permission choice when creating global config", async () => {
+    const state = setup({ config: {} })
+
+    expect(await applyWorkStyle("human-in-the-loop", state.store)).toEqual({ ok: true })
+    expect(state.patches).toHaveLength(1)
+    expect(["ask", "allow", "deny"]).not.toContain(state.patches[0].permission?.["*"])
+    expect(state.patches[0].permission).toMatchObject({
+      edit: "ask",
+      glob: "allow",
+      grep: "allow",
+      bash: { "*": "ask" },
+    })
   })
 
   it("rolls extension settings back when the CLI config update fails", async () => {

--- a/packages/kilo-vscode/tests/unit/work-style-presets.test.ts
+++ b/packages/kilo-vscode/tests/unit/work-style-presets.test.ts
@@ -15,7 +15,7 @@ describe("work style presets", () => {
     const bash = cfg.permission?.bash as Record<string, string>
     expect(cfg.terminal_command_display).toBe("expanded")
     expect(cfg.auto_collapse_reasoning).toBe(false)
-    expect(cfg.permission?.["*"]).toBe("ask")
+    expect(cfg.permission?.["*"]).toBeUndefined()
     expect(cfg.permission?.edit).toBe("ask")
     expect(bash).toMatchObject({ "*": "ask", "rg *": "allow", "*>*": "ask" })
     expect(Object.keys(bash).at(-1)).toBe("*>*")
@@ -48,6 +48,12 @@ describe("work style presets", () => {
     expect(WORK_STYLE_PRESETS.autonomous.settings).toEqual({
       showTaskTimeline: false,
     })
+  })
+
+  it("never defines a top-level permission choice in onboarding presets", () => {
+    for (const preset of Object.values(WORK_STYLE_PRESETS)) {
+      expect(["ask", "allow", "deny"]).not.toContain(preset.config.permission?.["*"])
+    }
   })
 
   it("does not overwrite existing new-user settings", () => {

--- a/packages/kilo-vscode/webview-ui/src/components/settings/PermissionEditor.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/PermissionEditor.tsx
@@ -9,12 +9,11 @@ import {
   addExceptionPatch,
   clearGroupedPatch,
   clearWildcardPatch,
-  effectiveRuleLevel,
+  effectiveConfigLevel,
   inheritedWildcard,
   mostRestrictive,
   permissionExceptions,
   removeExceptionPatch,
-  ruleset,
   setExceptionPatch,
   setGroupedPatch,
   setWildcardPatch,
@@ -140,9 +139,8 @@ const PermissionEditor: Component<{
   onChange: (patch: PermissionPatch) => void
 }> = (props) => {
   const perms = createMemo(() => props.permissions ?? {})
-  const rules = createMemo(() => [...(props.rules ?? []), ...ruleset(perms())])
 
-  const levelFor = (tool: string): PermissionLevel => effectiveRuleLevel(rules(), tool)
+  const levelFor = (tool: string): PermissionLevel => effectiveConfigLevel(perms(), tool, props.rules)
 
   const ruleFor = (tool: string): PermissionRule | undefined => perms()[tool]
 

--- a/packages/kilo-vscode/webview-ui/src/components/settings/permission-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/permission-utils.ts
@@ -28,6 +28,14 @@ export function effectiveRuleLevel(rules: PermissionRuleItem[] | undefined, tool
   return "ask"
 }
 
+export function effectiveConfigLevel(
+  config: PermissionConfig,
+  tool: string,
+  defaults: PermissionRuleItem[] = DEFAULT_RULES,
+): PermissionLevel {
+  return effectiveRuleLevel([...defaults, ...ruleset(config)], tool)
+}
+
 export function ruleset(config: PermissionConfig): PermissionRuleItem[] {
   const result: PermissionRuleItem[] = []
   for (const [permission, rule] of Object.entries(config)) {


### PR DESCRIPTION
## What changed

Review-first onboarding no longer writes a top-level `permission["*"]` rule. Tool-specific defaults such as Bash Ask remain explicit, so Auto-Approve selections can override onboarding defaults and persist without being shadowed by a global wildcard.

The Auto-Approve effective-level calculation is shared with regression tests covering the initial onboarding state and the Ask-to-Allow save flow. Onboarding persistence tests also prevent future presets from writing top-level Ask, Allow, or Deny rules when creating Global Config.

## Behavior for new Review-first users

Review-first now configures explicit review boundaries instead of applying Ask to every tool through a global wildcard.

The onboarding preset still asks before:

- Editing files.
- Accessing directories outside the workspace, except paths allowed by the CLI defaults.
- Running Bash commands not covered by the preset’s read-only allowlist, including commands that redirect output.
- Continuing after a detected doom loop.
- Reading `.env` and `.env.*` files, while allowing `.env.example`.

The preset still allows:

- Normal file reads.
- Glob, Grep, and List discovery operations.
- Questions.
- Web Fetch and Web Search.
- The preset’s read-only Bash commands, such as `ls`, `pwd`, `grep`, `rg`, `head`, and `tail`.

Tools not listed by the Review-first preset now inherit the CLI’s normal per-tool defaults instead of being forced to Ask by `permission["*"]`. This prevents onboarding from silently changing the behavior of every current and future tool, while retaining explicit Ask rules around the operations Review-first is intended to review.

Users can subsequently change any displayed Auto-Approve permission from Ask to Allow or Deny. That explicit tool choice becomes effective immediately and remains effective after saving and reloading because there is no generated top-level wildcard that can shadow it.

This PR affects newly applied Review-first presets. It does not rewrite existing Global Config files or remove top-level wildcard rules that users may have authored intentionally.

Closes #13434