### PR TITLE
fix(ci): skip unsupported PTY smoke targets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -249,12 +249,10 @@ jobs:
               export XDG_CACHE_HOME="$root/cache"
               export XDG_CONFIG_HOME="$root/config"
               export XDG_STATE_HOME="$root/state"
-              export KILO_PTY_SMOKE=1 # kilocode_change
               export KILO_DISABLE_MODELS_FETCH=1
               export KILO_DISABLE_PROJECT_CONFIG=1
               export KILO_CONFIG_CONTENT='\''{"enabled_providers":["anthropic"]}'\''
               export ANTHROPIC_API_KEY=dummy
-              "$binary" --pure __pty-smoke # kilocode_change
               "$binary" --pure models anthropic | grep -q "^anthropic/"
             '
 
@@ -311,13 +309,15 @@ jobs:
             $env:XDG_CACHE_HOME = Join-Path $root "cache"
             $env:XDG_CONFIG_HOME = Join-Path $root "config"
             $env:XDG_STATE_HOME = Join-Path $root "state"
-            $env:KILO_PTY_SMOKE = "1" # kilocode_change
             $env:KILO_DISABLE_MODELS_FETCH = "1"
             $env:KILO_DISABLE_PROJECT_CONFIG = "1"
             $env:KILO_CONFIG_CONTENT = '{"enabled_providers":["anthropic"]}'
             $env:ANTHROPIC_API_KEY = "dummy"
-            & $binary --pure __pty-smoke # kilocode_change
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE } # kilocode_change
+            if ("${{ matrix.arch }}" -eq "x64") {
+              $env:KILO_PTY_SMOKE = "1"
+              & $binary --pure __pty-smoke
+              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            }
             $output = & $binary --pure models anthropic
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
             if (-not ($output -match "(?m)^anthropic/")) {


### PR DESCRIPTION
## What Problem This Solves

The release PTY smoke test was enabled for Alpine/musl and Windows ARM64 before those packaged targets had compatible PTY libraries. The next publish would fail during target validation even though the ordinary CLI checks remain valid.

## Why This Change Was Made

Local OrbStack Docker testing ran the exact merged repository PTY smoke implementation:

- Debian/glibc x64 and ARM64 passed with the current `bun-pty@0.4.8`.
- Alpine/musl x64 and ARM64 failed with the current dependency.
- Replacing it with `bun-pty@0.4.10` made both Alpine smoke tests pass.
- Windows ARM64 still requires an ARM64-compatible PTY DLL.

This PR keeps PTY smoke coverage for macOS, glibc Linux, and Windows x64. Alpine and Windows ARM64 continue to run version, model, and artifact checks without claiming PTY support.

Remaining platform and rollout work is tracked in issue #13451.

## User Impact

Release validation no longer blocks on PTY checks for unsupported targets. No runtime behavior or user-facing terminal behavior changes in this PR.

## Evidence

- Exact repository smoke test: `packages/core/src/kilocode/pty/smoke.ts`.
- Preserved Docker checks pass for Debian x64 and ARM64.
- Alpine failures and the required dependency upgrade are documented in issue #13451.
- Workflow syntax, upstream annotation, workflow allowlist, formatting, and whitespace checks pass.

This PR is the temporary release-gating fix; issue #13451 remains open for the compatibility work.