### PR TITLE
fix(vscode): space review follow-up messages

### DIFF
--- a/.changeset/review-followup-spacing.md
+++ b/.changeset/review-followup-spacing.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add consistent spacing between review comments and their follow-up message in chat.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/user-message-many-review-comments-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/user-message-many-review-comments-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fbdc00f26ece2fc49d25c26b128b9f69fa562c2c0b2d54c4fd88f8c476145046
-size 25076
+oid sha256:13eac6bc48399a603b5c339d392babe871dc049b41921a628b1b66b146d277d5
+size 25120

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/user-message-review-comments-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/user-message-review-comments-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:efeff70e266d94ae5b40b05694eb2011c84d2da9e91eafe2dc01f775797e9135
-size 19048
+oid sha256:e304be0d46ff4090863282dd248bd48c868e80541e9aa4eceec028120ff9e309
+size 19091

--- a/packages/kilo-vscode/webview-ui/src/styles/prompt-input.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/prompt-input.css
@@ -44,7 +44,7 @@
 }
 
 .prompt-review-comments--message {
-  margin: 0;
+  margin: 0 0 6px;
 }
 
 .prompt-review-comments-header {


### PR DESCRIPTION
## What Problem This Solves

Review comment messages and their follow-up text can touch at the boundary. The review card border meets the follow-up bubble, which makes the two message parts look merged.

## Why This Change Was Made

The review comments component is rendered as the user-message header. Add a small message-only bottom margin so the review card and follow-up bubble remain visually distinct without changing draft review comments or general user-message spacing.

## User Impact

Sent review-comment messages now have a consistent 6px separation before the follow-up text. Draft review comments are unchanged.

## Evidence

Before:
<img width="420" alt="Before: review comments touch the follow-up message" src="https://marius-kilocode.github.io/pr-assets/20260826-review-followup-spacing-before.png" />

After:
<img width="420" alt="After: review comments have a 6px gap before the follow-up message" src="https://marius-kilocode.github.io/pr-assets/20260826-review-followup-spacing-after.png" />

The screenshots use the same 8-comment Storybook scenario. The before state forces the old `0px` margin; the after state uses the new message-only rule.
