### PR TITLE
fix(agent-manager): restore promoted session metadata

### DIFF
--- a/.changeset/restore-promoted-worktree-title.md
+++ b/.changeset/restore-promoted-worktree-title.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Restore the session title and branch subtitle immediately when opening an existing session in a worktree.

--- a/packages/kilo-vscode/tests/unit/project-sessions-live.test.ts
+++ b/packages/kilo-vscode/tests/unit/project-sessions-live.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test"
+import { createRoot, createSignal } from "solid-js"
+import { createProjectSessionsLive } from "../../webview-ui/agent-manager/project/sessions-live"
+import type { ProjectSessionInfo, SessionInfo } from "../../webview-ui/src/types/messages"
+
+const session = (worktreeId: string | null): ProjectSessionInfo => ({
+  id: "session-1",
+  parentID: null,
+  title: "Restore worktree metadata",
+  createdAt: "2026-08-26T10:00:00.000Z",
+  updatedAt: "2026-08-26T10:00:00.000Z",
+  worktreeId,
+})
+
+describe("project session live state", () => {
+  it("uses managed placement while the project session cache is stale", () => {
+    createRoot((dispose) => {
+      const [base] = createSignal<Record<string, ProjectSessionInfo[]>>({ project: [session(null)] })
+      const [store] = createSignal<SessionInfo[]>([session(null)])
+      const live = createProjectSessionsLive({
+        base,
+        pid: () => "project",
+        enabled: () => true,
+        store,
+        managed: () => [{ id: "session-1", worktreeId: "worktree-1", createdAt: "2026-08-26T10:00:00.000Z" }],
+        locals: () => new Set(),
+      })
+
+      expect(live().project?.[0]).toMatchObject({
+        id: "session-1",
+        title: "Restore worktree metadata",
+        worktreeId: "worktree-1",
+      })
+      dispose()
+    })
+  })
+})

--- a/packages/kilo-vscode/webview-ui/agent-manager/project/sessions-live.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/project/sessions-live.ts
@@ -30,7 +30,8 @@ export function createProjectSessionsLive(opts: {
     const live = new Map(store.filter(isKnownRootSession).map((item) => [item.id, item]))
     const merged = pushed.map((item) => {
       const fresh = live.get(item.id)
-      return fresh ? { ...fresh, worktreeId: item.worktreeId } : item
+      const worktreeId = managed.has(item.id) ? managed.get(item.id)! : item.worktreeId
+      return fresh ? { ...fresh, worktreeId } : worktreeId === item.worktreeId ? item : { ...item, worktreeId }
     })
     const known = new Set(pushed.map((item) => item.id))
     const owned = (id: string) => managed.has(id) || opts.locals().has(id)


### PR DESCRIPTION
## What Problem This Solves
Opening an older session in a new Agent Manager worktree could leave the sidebar using stale local placement metadata. The worktree then lacked the expected session title and branch subtitle.

## Why This Change Was Made
Managed session placement is the authoritative source after promotion, including while the project session cache is being refreshed. The live session merge now applies that placement before rendering. A regression test covers the stale-cache case.

## User Impact
When an older session is opened in a worktree, the worktree card immediately shows the session title and branch name.

## Evidence
- `bun test tests/unit/project-sessions-live.test.ts tests/unit/agent-project-sessions.test.ts tests/unit/project-session-filter.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx prettier --check webview-ui/agent-manager/project/sessions-live.ts tests/unit/project-sessions-live.test.ts`
- Isolated VS Code self-test: opened Agent Manager history, selected Open in worktree, and verified the live DOM showed the session title and `almond-scorpio` branch subtitle.
- Final isolated VS Code console contained no errors.