### PR TITLE
fix(vscode): handle fragmented CLI startup output

### DIFF
--- a/.changeset/fix-vscode-server-startup-output.md
+++ b/.changeset/fix-vscode-server-startup-output.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent intermittent server connection failures during VS Code startup.

--- a/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-manager.ts
@@ -6,7 +6,7 @@ import * as path from "path"
 import * as vscode from "vscode"
 import { resolveLocalBwrapEnv, resolveTreeSitterEnv } from "./cli-resources"
 import { t } from "./i18n"
-import { parseServerPort } from "./server-utils"
+import { scanServerPort } from "./server-utils"
 
 export interface ServerInstance {
   port: number
@@ -15,6 +15,7 @@ export interface ServerInstance {
 }
 
 const STARTUP_TIMEOUT_SECONDS = 30
+const STARTUP_OUTPUT_LIMIT = 1024
 
 type WorkspaceFolderLike = { uri: { fsPath: string } }
 type ServerExitListener = (code: number | null, signal: NodeJS.Signals | null) => void
@@ -162,13 +163,16 @@ export class ServerManager {
       console.log("[Kilo New] ServerManager: 📦 Process spawned with PID:", serverProcess.pid)
 
       let resolved = false
+      let output = ""
       const stderrLines: string[] = []
 
       serverProcess.stdout?.on("data", (data: Buffer) => {
-        const output = data.toString()
-        console.log("[Kilo New] ServerManager: 📥 CLI Server stdout:", output)
+        const chunk = data.toString()
+        console.log("[Kilo New] ServerManager: 📥 CLI Server stdout:", chunk)
 
-        const port = parseServerPort(output)
+        const state = scanServerPort(output, chunk, STARTUP_OUTPUT_LIMIT)
+        output = state.output
+        const port = state.port
         if (port !== null && !resolved) {
           resolved = true
           console.log("[Kilo New] ServerManager: 🎯 Port detected:", port)

--- a/packages/kilo-vscode/src/services/cli-backend/server-utils.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/server-utils.ts
@@ -3,8 +3,15 @@
  * Matches lines like: "kilo server listening on http://127.0.0.1:12345"
  * Returns the port number or null if not found.
  */
-export function parseServerPort(output: string): number | null {
-  const match = output.match(/listening on http:\/\/[\w.]+:(\d+)/)
+export function parseServerPort(output: string, complete = false): number | null {
+  const match = output.match(
+    complete ? /listening on http:\/\/[\w.]+:(\d+)\r?\n/ : /listening on http:\/\/[\w.]+:(\d+)/,
+  )
   if (!match) return null
   return parseInt(match[1]!, 10)
+}
+
+export function scanServerPort(output: string, chunk: string, limit: number) {
+  const text = `${output}${chunk}`
+  return { output: text.slice(-limit), port: parseServerPort(text, true) }
 }

--- a/packages/kilo-vscode/tests/unit/server-manager-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/server-manager-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test"
-import { parseServerPort } from "../../src/services/cli-backend/server-utils"
+import { parseServerPort, scanServerPort } from "../../src/services/cli-backend/server-utils"
 import {
   resolveServerCwd,
   resolveIndexingEnv,
@@ -60,6 +60,51 @@ describe("parseServerPort", () => {
   it("matches only first occurrence when multiple ports present", () => {
     const output = "listening on http://127.0.0.1:3000 and http://127.0.0.1:4000"
     expect(parseServerPort(output)).toBe(3000)
+  })
+
+  it("waits for the complete startup line before resolving a split port", () => {
+    const first = "kilo server listening on http://127.0.0.1:43"
+
+    expect(parseServerPort(first, true)).toBeNull()
+    expect(parseServerPort(`${first}123\n`, true)).toBe(43123)
+  })
+
+  it("detects a startup announcement split across stdout chunks", () => {
+    const first = "kilo server listening on http://127.0."
+    const second = "0.1:43123\n"
+
+    expect(parseServerPort(first, true)).toBeNull()
+    expect(parseServerPort(`${first}${second}`, true)).toBe(43123)
+  })
+
+  it("accepts complete Windows startup lines", () => {
+    expect(parseServerPort("kilo server listening on http://127.0.0.1:43123\r\n", true)).toBe(43123)
+  })
+})
+
+describe("scanServerPort", () => {
+  it("detects startup announcements split across stdout chunks", () => {
+    const first = scanServerPort("", "kilo server listening on http://127.0.", 1024)
+    const second = scanServerPort(first.output, "0.1:43123\n", 1024)
+
+    expect(first.port).toBeNull()
+    expect(second.port).toBe(43123)
+  })
+
+  it("waits for split port digits before resolving startup", () => {
+    const first = scanServerPort("", "kilo server listening on http://127.0.0.1:43", 1024)
+    const second = scanServerPort(first.output, "123\n", 1024)
+
+    expect(first.port).toBeNull()
+    expect(second.port).toBe(43123)
+  })
+
+  it("preserves startup announcements followed by oversized stdout chunks", () => {
+    const chunk = `kilo server listening on http://127.0.0.1:43123\n${"x".repeat(1024)}`
+    const state = scanServerPort("", chunk, 1024)
+
+    expect(state.port).toBe(43123)
+    expect(state.output).toHaveLength(1024)
   })
 })
 


### PR DESCRIPTION
## What Problem This Solves

The VS Code extension discovers its local CLI backend by parsing the `kilo serve --port 0` listening announcement from stdout. Process stream chunks do not preserve message boundaries, so a split announcement can make the extension wait 30 seconds for a server that is already running. A split inside the port number is worse: port `43123` can be accepted prematurely as `43`, sending the client to the wrong local address.

This is the exact defect documented in #7649. The earlier fix in #7650 was closed without merging.

Open reports with matching extension startup or backend-unavailable symptoms:

- #13089: Windows 11, Kilo 7.4.21, server startup times out after 30 seconds.
- #13130: Windows, Kilo 7.4.22, server startup times out after 30 seconds.
- #13291: the local server does not start and Kilo cannot operate.
- #13355: the VS Code extension reports "server connection failed."
- #12653: server connection failure prevents chat and model selection.
- #13135: settings cannot be saved because the CLI backend is disconnected.

These reports do not contain enough diagnostics to prove stdout fragmentation individually. They are linked as potentially affected reports, not as confirmed duplicates or automatic closures. Reports with a confirmed unrelated cause, such as SQLite migration failures or filesystem permissions, are intentionally excluded.

## Why This Change Was Made

Buffer startup stdout across chunk boundaries, require a complete LF or CRLF-terminated listening line before accepting its port, and retain only a bounded 1 KB rolling buffer. Parse the complete combined output before trimming it so a valid announcement is not discarded when the same chunk also contains a large amount of subsequent output.

## User Impact

Prevent intermittent "Server connection failed" banners, incorrect localhost port connections, and 30-second startup timeouts when opening the VS Code extension. The stream handling is platform-independent and explicitly covers Windows line endings.

## Evidence

- Reproduced the partial-port regression before the fix: `43` was accepted instead of waiting for `43123`.
- Reproduced the oversized-output regression before the fix: a valid announcement followed by 1,024 bytes returned `null` instead of `43123`.
- Added coverage for split URLs, split port digits, CRLF startup lines, oversized stdout chunks, and bounded retained output.
- `bun run test:unit`: 4,208 passing tests across 353 files.
- `bun run compile`: extension and webview typechecks, lint, and bundling passed.
- `bun run knip` and `bun run check-kilocode-change` passed.
- Manually launched the rebuilt extension in an isolated VS Code instance and verified the Kilo sidebar connected without a startup error or timeout.