### PR TITLE
fix(jetbrains): prune deleted sessions in the merged activity snapshot

### DIFF
--- a/.changeset/jetbrains-deleted-session-badge.md
+++ b/.changeset/jetbrains-deleted-session-badge.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-jetbrains": patch
+---
+
+Stop showing a running badge for a session that was just deleted.

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/app/KiloSessionService.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/app/KiloSessionService.kt
@@ -124,10 +124,14 @@ class KiloSessionService internal constructor(
      * Per-session activity for history and session lists. [activity] is the richer source — it also
      * carries waiting and failed sessions, and it covers sessions that are not open — but it drops
      * sessions whose directory the backend cannot resolve, so the busy statuses stay as a fallback.
+     *
+     * [statuses] and [activity] prune [removed] through separate collectors, so one can still carry
+     * a deleted session while the other has already dropped it. Subtracting [removed] here keeps the
+     * merged snapshot consistent instead of briefly badging a deleted session as running.
      */
     internal fun activitySnapshot(): Map<String, SessionActivityKind> {
         val busy = statuses.value.filterValues { it.type == "busy" }.mapValues { SessionActivityKind.RUNNING }
-        return busy + activity.value.mapValues { it.value.kind.toKind() }
+        return (busy + activity.value.mapValues { it.value.kind.toKind() }) - removed.value
     }
 
     suspend fun list(dir: String): SessionListDto {

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/app/KiloSessionServiceTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/app/KiloSessionServiceTest.kt
@@ -151,7 +151,9 @@ class KiloSessionServiceTest : BasePlatformTestCase() {
             "ses_failed" to SessionActivityDto("/repo/wt", SessionActivityKindDto.ERROR),
             "ses_asking" to SessionActivityDto("/repo/wt", SessionActivityKindDto.QUESTION),
         )
-        service.activity.first { it.isNotEmpty() }
+        // Both maps feed the snapshot through separate collectors, so wait for each one.
+        service.statuses.first { it.isNotEmpty() }
+        service.activity.first { it.size == 2 }
 
         assertEquals(
             mapOf(


### PR DESCRIPTION
## What

`KiloSessionService.activitySnapshot()` now subtracts the locally-removed session set when merging `statuses` and `activity`.

## Why

The `test` workflow on `main` failed in `KiloSessionServiceTest`:

```
expected:<{ses_failed=ERROR}> but was:<{ses_asking=RUNNING, ses_failed=ERROR}>
```

`statuses` and `activity` are two separate `StateFlow`s, each pruning the `removed` set through its own `combine` collector. When a session is deleted, there is no ordering guarantee between them — one can still carry the session while the other has already dropped it. `activitySnapshot()` merged both raw values, so during that window a deleted session was reported as `RUNNING`.

That is not just a test artifact: every snapshot consumer (session list badges, worktree list, tab attention dot, history rows) could read the inconsistent merge and paint a badge for a session that no longer exists. This is the exact lingering-badge class of bug the `removed` set was introduced to prevent, so the fix belongs in the snapshot rather than in the test's wait condition.

The same latent race existed in `test activity snapshot carries every kind the backend reports`, which only waited on `activity` before asserting on data sourced from both flows; it now waits on both.

## Verification

- `./gradlew :frontend:test --tests 'ai.kilocode.client.app.KiloSessionServiceTest' --rerun-tasks` x3
- `./gradlew typecheck`
- `./gradlew test` (full JetBrains suite)