### PR TITLE
fix(cli): stabilize packaged PTY smoke test

### DIFF
--- a/packages/core/src/kilocode/pty/smoke.ts
+++ b/packages/core/src/kilocode/pty/smoke.ts
@@ -3,6 +3,16 @@ import { KiloPtyTermination } from "./termination"
 import { spawn } from "#pty"
 
 const TIMEOUT = 15_000
+const RENDER_TIMEOUT = 60_000
+
+export function marker(output: string) {
+  const text = output
+    .replace(/\x1b\](?:[^\x07\x1b]|\x1b(?!\\))*(?:\x07|\x1b\\)/g, "")
+    .replace(/\x1b[P^_](?:[^\x1b]|\x1b(?!\\))*\x1b\\/g, "")
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "")
+    .replace(/\x1b[@-_]/g, "")
+  return text.split(/\r?\n/).some((line) => line.trim() === "KILO_PTY_READY")
+}
 
 async function render() {
   const proc = spawn(process.execPath, ["--pure"], {
@@ -34,7 +44,7 @@ async function render() {
     state.exited = true
     ready.reject(new Error(`TUI exited before rendering (code ${event.exitCode}): ${JSON.stringify(state.output)}`))
   })
-  const timeout = AbortSignal.timeout(TIMEOUT)
+  const timeout = AbortSignal.timeout(RENDER_TIMEOUT)
 
   try {
     await Promise.race([
@@ -42,7 +52,10 @@ async function render() {
       new Promise<never>((_, reject) =>
         timeout.addEventListener(
           "abort",
-          () => reject(new Error(`TUI produced no rendered frame within ${TIMEOUT}ms: ${JSON.stringify(state.output)}`)),
+          () =>
+            reject(
+              new Error(`TUI produced no rendered frame within ${RENDER_TIMEOUT}ms: ${JSON.stringify(state.output)}`),
+            ),
           { once: true },
         ),
       ),
@@ -67,7 +80,7 @@ export async function smoke() {
   const exited = Promise.withResolvers<number>()
   const data = proc.onData((chunk) => {
     state.output += chunk
-    if (/(?:^|[\r\n])KILO_PTY_READY(?:\r?\n|$)/.test(state.output)) output.resolve()
+    if (marker(state.output)) output.resolve()
   })
   const exit = proc.onExit((event) => {
     state.exited = true

--- a/packages/core/test/kilocode/pty-durability.test.ts
+++ b/packages/core/test/kilocode/pty-durability.test.ts
@@ -183,7 +183,13 @@ describe("durable PTY registry", () => {
       const info = yield* Effect.scoped(
         Effect.gen(function* () {
           const pty = yield* Pty.Service
-          return yield* pty.create({ command: "/bin/sh", args: ["-c", "exit 7"], cwd: dir.path })
+          return yield* pty.create({ command: "/bin/sh", cwd: dir.path })
+        }).pipe(Effect.provide(locations.get(target))),
+      )
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          const pty = yield* Pty.Service
+          yield* pty.write(info.id, "exit 7\r")
         }).pipe(Effect.provide(locations.get(target))),
       )
       const exited = yield* Queue.take(queue).pipe(Effect.timeout("5 seconds"))

--- a/packages/core/test/kilocode/pty-smoke.test.ts
+++ b/packages/core/test/kilocode/pty-smoke.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { marker } from "../../src/kilocode/pty/smoke"
+
+describe("PTY smoke output", () => {
+  test("detects a marker after PowerShell formatting", () => {
+    const output =
+      "\x1b[93mecho KILO_PTY_READY\r\n\x1b[mKILO_PTY_READY\r\n\x1b]0;Administrator: PowerShell\x07PS> "
+
+    expect(marker(output)).toBe(true)
+  })
+
+  test("does not accept the echoed command", () => {
+    expect(marker("\x1b[93mecho KILO_PTY_READY\r\n\x1b[mPS> ")).toBe(false)
+  })
+
+  test("detects a marker around OSC and DCS sequences", () => {
+    const output = "\x1b]133;A\x07\x1bP+q4d73\x1b\\KILO_PTY_READY\r\n"
+
+    expect(marker(output)).toBe(true)
+  })
+})


### PR DESCRIPTION
## What Problem This Solves

The v7.5.1 prerelease run failed in CLI artifact validation after PR #13472 merged. The packaged binaries built successfully, but the new PTY smoke test produced false failures on Windows x64, macOS x64, and glibc Linux runners.

## Why This Change Was Made

PowerShell decorates the marker output with terminal control sequences, so the exact line matcher did not detect output that was visibly present in the log. Standard release runners also need more than 15 seconds to cold-start the larger non-split binary and reach the visible TUI frame.

This strips CSI, OSC, DCS, and related escape sequences before matching the PTY marker, while keeping the shell check at 15 seconds. Only the packaged TUI cold-start deadline increases to 60 seconds.

## User Impact

No runtime behavior changes. The prerelease gate continues to require a visible packaged TUI frame without failing on terminal formatting or slower cold starts.

## Evidence

- Added regression tests using the PowerShell output shape from failed job `98204019815`.
- Core typecheck passed.
- 17 targeted PTY tests passed.
- Rebuilt the Bun 1.4 macOS arm64 standalone artifact.
- Packaged `--pure __pty-smoke` reached the visible TUI prompt.
- `git diff --check` passed.

Failed run: https://github.com/Kilo-Org/kilocode/actions/runs/32976503200