### PR TITLE
docs(kilo-docs): clarify pricing and processing fees

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/platforms/cloud-agent.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cloud-agent.md
@@ -23,9 +23,17 @@ Before using Cloud Agents:
 
 ## Cost
 
-- **Compute is free during limited beta**
-  - Please provide any feedback in our Cloud Agents beta Discord channel: [Kilo Discord](https://kilo.ai/discord)
-- **Kilo Code credits are still used** when the agent performs work (model usage, operations, etc.).
+Cloud Agent compute is billed per second while the container is awake. Compute and model inference draw from the same Kilo credit balance, but they are charged separately.
+
+| Cloud Agent size | Hourly rate |
+|---|---|
+| Docker | $0.60 |
+| Small | $0.60 |
+| Standard | $1.20 |
+
+Usage is measured in whole seconds, with no rounding up to a longer billing interval and no minimum usage charge. Your balance must contain at least $5 to launch a container, but this is not an extra charge or minimum spend. BYOK users still pay for cloud compute because their provider keys cover inference only.
+
+See [Kilo Code pricing](https://kilo.ai/pricing) for current rates and pricing for other cloud products.
 
 ## How to Use
 

--- a/packages/kilo-docs/pages/collaborate/enterprise/migration.md
+++ b/packages/kilo-docs/pages/collaborate/enterprise/migration.md
@@ -13,7 +13,7 @@ Switch to **Kilo Teams** or **Kilo Enterprise** from other AI coding tools and e
 
 **Other AI coding vendors** hide their true costs behind opaque subscription models, leaving you wondering what you're actually paying for.
 
-**Kilo Teams** and **Kilo Enterprise** show you exactly what each AI request costs - no markup, no hidden fees, complete transparency.
+**Kilo Teams** and **Kilo Enterprise** show you what each AI request costs. Model inference is charged at provider rates with no markup, and credit purchases have a disclosed 5% payment-processing fee.
 
 ### No Rate Limiting
 

--- a/packages/kilo-docs/pages/collaborate/index.md
+++ b/packages/kilo-docs/pages/collaborate/index.md
@@ -23,7 +23,7 @@ Sessions are your platform-agnostic interaction with Kilo. They remember your re
 Kilo Code's paid plans provide powerful team management features:
 
 - [**About Plans**](/docs/collaborate/teams/about-plans) — Compare Teams and Enterprise plans
-- **Teams ($15/user/month)** — Zero markup on AI costs, centralized billing, team analytics
+- **Teams ($15/user/month)** — Inference at provider rates with no markup, centralized billing, team analytics; credit purchases have a 5% processing fee
 - **Enterprise ([Contact Sales](https://kilo.ai/contact-sales))** — Model controls, audit logs, SSO, dedicated support
 
 ### Team Management

--- a/packages/kilo-docs/pages/collaborate/teams/about-plans.md
+++ b/packages/kilo-docs/pages/collaborate/teams/about-plans.md
@@ -21,7 +21,7 @@ No credits are included with a Teams or Enterprise plan purchase.
 
 ## What You Get from Kilo Teams
 
-- **Zero markup** on AI provider costs - pay exactly what providers charge
+- **No inference markup** - model usage is charged at provider rates; credit purchases have a separate 5% payment-processing fee
 - **No rate limiting** or quality degradation during peak usage
 - **Centralized billing** - one invoice for your whole team
 - **Complete transparency** - see every request, cost, and usage pattern

--- a/packages/kilo-docs/pages/collaborate/teams/billing.md
+++ b/packages/kilo-docs/pages/collaborate/teams/billing.md
@@ -5,13 +5,15 @@ description: "Manage billing and subscriptions for your team"
 
 # Billing
 
-Kilo seats uses a transparent, two-part billing system: a monthly subscription per seat, plus pay-as-you-go Kilo credits with zero markup.
+Kilo seats use a transparent, two-part billing system: a monthly subscription per seat, plus pay-as-you-go Kilo credits. Model inference is charged at provider rates with no markup. A separate 5% payment-processing fee applies when you purchase credits.
 
 {% callout type="note" %}
 
 Kilo Code seats purchases of Teams or Enterprise are separate from Kilo credits.
 
 No Kilo credits are included with a Teams or Enterprise purchase.
+
+$1 of purchased credits funds $1 of usage. The 5% processing fee is charged separately and does not increase the organization's credit balance.
 
 {% /callout %}
 

--- a/packages/kilo-docs/pages/collaborate/teams/getting-started.md
+++ b/packages/kilo-docs/pages/collaborate/teams/getting-started.md
@@ -5,7 +5,7 @@ description: "Set up your Kilo Code team account"
 
 # Get Started with Kilo Seats in 10 Minutes
 
-seats for Kilo in the Teams or Enterprise subscription brings transparent AI coding to your entire engineering organization. No markup on AI costs, no vendor lock-in, complete usage visibility.
+Seats for Kilo in the Teams or Enterprise subscription bring transparent AI coding to your entire engineering organization. Model inference is charged at provider rates with no markup, while credit purchases have a separate 5% payment-processing fee.
 
 ## Before You Begin
 

--- a/packages/kilo-docs/pages/gateway/usage-and-billing.md
+++ b/packages/kilo-docs/pages/gateway/usage-and-billing.md
@@ -32,6 +32,8 @@ Costs are determined by the upstream provider's pricing based on token usage:
 
 ## Balance management
 
+Model inference is deducted from your balance at the upstream provider's rate with no markup. A 5% payment-processing fee applies when you purchase Kilo credits; the fee is charged separately and does not increase your balance. For example, $1 of purchased credits funds $1 of usage.
+
 ### Individual accounts
 
 Your account balance is the difference between total credits purchased and total usage. Check your balance in the [Kilo dashboard](https://app.kilo.ai).

--- a/packages/kilo-docs/pages/getting-started/adding-credits.md
+++ b/packages/kilo-docs/pages/getting-started/adding-credits.md
@@ -19,11 +19,12 @@ You can also use subscriptions or credits you may have purchased directly with a
 
 At Kilo Code, we believe in complete pricing transparency:
 
-- Our pricing matches the model provider's API rates exactly
-- We don't take any commission or markup.
-- $1 you give us becomes $1 of Kilo credits
-- We debit your Kilo credits exactly what the provider charges us in dollars
-- You only pay for what you use with no hidden fees
+- Model inference through Kilo Gateway matches the provider's API rates with no markup.
+- We debit your Kilo credits by the amount charged for inference or other metered Kilo services, such as cloud compute.
+- $1 of purchased credits funds $1 of usage.
+- A 5% payment-processing fee applies when you purchase credits. This fee is charged separately and does not increase your credit balance.
+
+For current platform, inference, credit purchase, and cloud compute pricing, see [Kilo Code pricing](https://kilo.ai/pricing).
 
 ## Future Plans
 

--- a/packages/kilo-docs/pages/getting-started/rate-limits-and-costs.md
+++ b/packages/kilo-docs/pages/getting-started/rate-limits-and-costs.md
@@ -73,7 +73,7 @@ Kilo automatically applies prompt caching on supported providers. Repeated conte
 
 ## How Costs Are Calculated
 
-- Costs are a pass-through of provider pricing with no general markup.
+- Inference costs are a pass-through of provider pricing with no markup. A separate 5% payment-processing fee applies when you purchase Kilo credits.
 - Kilo calculates an estimated cost for each request based on configured pricing. This estimate is shown per-request in the chat history.
 - Cache hits are billed at a discounted rate compared to regular input tokens.
 - Requests using **Auto Free** models are billed at $0 on Kilo's side.


### PR DESCRIPTION
## Summary

Align the documentation with the current public pricing information for cloud compute and Kilo credits. Replace the outdated free-beta Cloud Agent pricing, document current metering and launch-balance behavior, and distinguish provider-rate inference from the 5% credit-purchase processing fee.

The processing fee language applies only to credit purchases. Teams and Enterprise seat subscriptions remain separate and are not subject to that fee.