### PR TITLE
fix(security): @hey-api/openapi-ts updated due dependabot warnings

### DIFF
--- a/.changeset/hey-api-security-update.md
+++ b/.changeset/hey-api-security-update.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/sdk": patch
+---
+
+Fix a prototype pollution vulnerability in the generated SDK client request parameters (CVE-2026-48819).

--- a/bun.lock
+++ b/bun.lock
@@ -818,7 +818,7 @@
         "cross-spawn": "catalog:",
       },
       "devDependencies": {
-        "@hey-api/openapi-ts": "0.90.10",
+        "@hey-api/openapi-ts": "0.97.3",
         "@tsconfig/node22": "catalog:",
         "@types/cross-spawn": "catalog:",
         "@types/node": "catalog:",
@@ -1572,13 +1572,17 @@
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 
-    "@hey-api/codegen-core": ["@hey-api/codegen-core@0.5.5", "", { "dependencies": { "@hey-api/types": "0.1.2", "ansi-colors": "4.1.3", "c12": "3.3.3", "color-support": "1.1.3" }, "peerDependencies": { "typescript": ">=5.5.3" } }, "sha512-f2ZHucnA2wBGAY8ipB4wn/mrEYW+WUxU2huJmUvfDO6AE2vfILSHeF3wCO39Pz4wUYPoAWZByaauftLrOfC12Q=="],
+    "@hey-api/codegen-core": ["@hey-api/codegen-core@0.8.2", "", { "dependencies": { "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "c12": "3.3.4", "color-support": "1.1.3" } }, "sha512-R2NMf3wq97rh1mjz33WJQU8svz3F0RYUjvx/QzXucjpSqQ3O5huTdDjErG4fMxSr1X+X56NuDrqtGfHmo1TRUQ=="],
 
-    "@hey-api/json-schema-ref-parser": ["@hey-api/json-schema-ref-parser@1.2.2", "", { "dependencies": { "@jsdevtools/ono": "^7.1.3", "@types/json-schema": "^7.0.15", "js-yaml": "^4.1.1", "lodash": "^4.17.21" } }, "sha512-oS+5yAdwnK20lSeFO1d53Ku+yaGCsY8PcrmSq2GtSs3bsBfRnHAbpPKSVzQcaxAOrzj5NB+f34WhZglVrNayBA=="],
+    "@hey-api/json-schema-ref-parser": ["@hey-api/json-schema-ref-parser@1.4.2", "", { "dependencies": { "@jsdevtools/ono": "7.1.3", "@types/json-schema": "7.0.15", "js-yaml": "4.1.1" } }, "sha512-ZhCFSKI2ipZHEbgmtUHdyddvRU3wJ4elgCfYUC7T7hZa4EivSrVflTQf2w+v3TuaYxR1Y2V2kq3otqTttrrK8Q=="],
 
-    "@hey-api/openapi-ts": ["@hey-api/openapi-ts@0.90.10", "", { "dependencies": { "@hey-api/codegen-core": "^0.5.5", "@hey-api/json-schema-ref-parser": "1.2.2", "@hey-api/types": "0.1.2", "ansi-colors": "4.1.3", "color-support": "1.1.3", "commander": "14.0.2", "open": "11.0.0", "semver": "7.7.3" }, "peerDependencies": { "typescript": ">=5.5.3" }, "bin": { "openapi-ts": "bin/run.js" } }, "sha512-o0wlFxuLt1bcyIV/ZH8DQ1wrgODTnUYj/VfCHOOYgXUQlLp9Dm2PjihOz+WYrZLowhqUhSKeJRArOGzvLuOTsg=="],
+    "@hey-api/openapi-ts": ["@hey-api/openapi-ts@0.97.3", "", { "dependencies": { "@hey-api/codegen-core": "0.8.2", "@hey-api/json-schema-ref-parser": "1.4.2", "@hey-api/shared": "0.4.5", "@hey-api/spec-types": "0.2.0", "@hey-api/types": "0.1.4", "@lukeed/ms": "2.0.2", "ansi-colors": "4.1.3", "color-support": "1.1.3", "commander": "14.0.3", "get-tsconfig": "4.14.0" }, "peerDependencies": { "typescript": ">=5.5.3 || >=6.0.0 || 6.0.1-rc" }, "bin": { "openapi-ts": "./bin/run.js" } }, "sha512-4sR6/E/POuy7aPZW9DDjhObzZCq7eSJWiW0+epXeKNczoTWEwdOyWFy9Ca/CnXYlZ3oJsrv0ZD0OO+YuczT7CA=="],
 
-    "@hey-api/types": ["@hey-api/types@0.1.2", "", {}, "sha512-uNNtiVAWL7XNrV/tFXx7GLY9lwaaDazx1173cGW3+UEaw4RUPsHEmiB4DSpcjNxMIcrctfz2sGKLnVx5PBG2RA=="],
+    "@hey-api/shared": ["@hey-api/shared@0.4.5", "", { "dependencies": { "@hey-api/codegen-core": "0.8.2", "@hey-api/json-schema-ref-parser": "1.4.2", "@hey-api/spec-types": "0.2.0", "@hey-api/types": "0.1.4", "ansi-colors": "4.1.3", "cross-spawn": "7.0.6", "open": "11.0.0", "semver": "7.7.4" } }, "sha512-au4eHpBXAe1du0iMp6ESYuEaMS2jsoEyrbcT246btRhI9rMeQFEs7ZjtcMGXGsxhpaR38A8cPGNHx7QOrWAdMw=="],
+
+    "@hey-api/spec-types": ["@hey-api/spec-types@0.2.0", "", { "dependencies": { "@hey-api/types": "0.1.4" } }, "sha512-ibQ8Is7evMavzr8GNyJCcTg975d8DpaMUyLmOrQ85UBdy1l6t1KuRAwgChAbesJsIlNV6gjmlXruWyegDX18Fg=="],
+
+    "@hey-api/types": ["@hey-api/types@0.1.4", "", {}, "sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.17", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ=="],
 
@@ -2978,7 +2982,7 @@
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
-    "c12": ["c12@3.3.3", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.2", "defu": "^6.1.4", "dotenv": "^17.2.3", "exsolve": "^1.0.8", "giget": "^2.0.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.0.0", "pkg-types": "^2.3.0", "rc9": "^2.1.2" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q=="],
+    "c12": ["c12@3.3.4", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.4", "defu": "^6.1.6", "dotenv": "^17.3.1", "exsolve": "^1.0.8", "giget": "^3.2.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.1.0", "pkg-types": "^2.3.0", "rc9": "^3.0.1" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA=="],
 
     "c8": ["c8@10.1.3", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.1", "@istanbuljs/schema": "^0.1.3", "find-up": "^5.0.0", "foreground-child": "^3.1.1", "istanbul-lib-coverage": "^3.2.0", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.1.6", "test-exclude": "^7.0.1", "v8-to-istanbul": "^9.0.0", "yargs": "^17.7.2", "yargs-parser": "^21.1.1" }, "peerDependencies": { "monocart-coverage-reports": "^2" }, "optionalPeers": ["monocart-coverage-reports"], "bin": { "c8": "bin/c8.js" } }, "sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA=="],
 
@@ -3029,8 +3033,6 @@
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
     "ci-parallel-vars": ["ci-parallel-vars@1.0.1", "", {}, "sha512-uvzpYrpmidaoxvIQHM+rKSrigjOe9feHYbw4uOI2gdfe1C3xIlxO+kVXq83WQWNniTf8bAxVpy+cQeFQsMERKg=="],
-
-    "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
 
     "classcat": ["classcat@5.0.5", "", {}, "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="],
 
@@ -3089,8 +3091,6 @@
     "concordance": ["concordance@5.0.4", "", { "dependencies": { "date-time": "^3.1.0", "esutils": "^2.0.3", "fast-diff": "^1.2.0", "js-string-escape": "^1.0.1", "lodash": "^4.17.15", "md5-hex": "^3.0.1", "semver": "^7.3.2", "well-known-symbols": "^2.0.0" } }, "sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw=="],
 
     "confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
-
-    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
@@ -3530,7 +3530,7 @@
 
     "ghostty-web": ["ghostty-web@0.4.0", "", {}, "sha512-0puDBik2qapbD/QQBW9o5ZHfXnZBqZWx/ctBiVtKZ6ZLds4NYb+wZuw1cRLXZk9zYovIQ908z3rvFhexAvc5Hg=="],
 
-    "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
+    "giget": ["giget@3.3.1", "", { "bin": { "giget": "dist/cli.mjs" } }, "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg=="],
 
     "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
@@ -4018,8 +4018,6 @@
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
-    "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
-
     "node-forge": ["node-forge@1.4.0", "", {}, "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ=="],
 
     "node-gyp": ["node-gyp@12.4.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "graceful-fs": "^4.2.6", "nopt": "^9.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5", "tar": "^7.5.4", "tinyglobby": "^0.2.12", "undici": "^6.25.0", "which": "^6.0.0" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw=="],
@@ -4059,8 +4057,6 @@
     "npm-run-path": ["npm-run-path@5.3.0", "", { "dependencies": { "path-key": "^4.0.0" } }, "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ=="],
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
-
-    "nypm": ["nypm@0.6.9", "", { "dependencies": { "citty": "^0.2.2", "pathe": "^2.0.3", "tinyexec": "^1.2.4" }, "bin": { "nypm": "./dist/cli.mjs" } }, "sha512-zxlE2yvSWZWmHcNdT3+5zV2lrCogeE9YOklHrR3dFjqutq5wO7GFDYLFDRXLsYnJzwvy/im9fYoxePvS0VTW0w=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -4302,7 +4298,7 @@
 
     "rc-config-loader": ["rc-config-loader@4.1.4", "", { "dependencies": { "debug": "^4.4.3", "js-yaml": "^4.1.1", "json5": "^2.2.3", "require-from-string": "^2.0.2" } }, "sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ=="],
 
-    "rc9": ["rc9@2.1.2", "", { "dependencies": { "defu": "^6.1.4", "destr": "^2.0.3" } }, "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg=="],
+    "rc9": ["rc9@3.0.1", "", { "dependencies": { "defu": "^6.1.6", "destr": "^2.0.5" } }, "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ=="],
 
     "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 
@@ -5126,11 +5122,15 @@
 
     "@gitlab/gitlab-ai-provider/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@hey-api/openapi-ts/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+    "@hey-api/json-schema-ref-parser/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
-    "@hey-api/openapi-ts/open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
+    "@hey-api/openapi-ts/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
-    "@hey-api/openapi-ts/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+    "@hey-api/openapi-ts/get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
+    "@hey-api/shared/open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
+
+    "@hey-api/shared/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 
@@ -5532,8 +5532,6 @@
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
-    "nypm/citty": ["citty@0.2.2", "", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
-
     "openid-client/jose": ["jose@4.15.9", "", {}, "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="],
 
     "openid-client/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
@@ -5782,7 +5780,9 @@
 
     "@eslint/eslintrc/minimatch/brace-expansion": ["brace-expansion@1.1.18", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw=="],
 
-    "@hey-api/openapi-ts/open/wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
+    "@hey-api/json-schema-ref-parser/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "@hey-api/shared/open/wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
     "@joshwooding/vite-plugin-react-docgen-typescript/glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 

--- a/packages/opencode/test/server/httpapi-sdk.test.ts
+++ b/packages/opencode/test/server/httpapi-sdk.test.ts
@@ -45,7 +45,7 @@ const original = {
 
 type ServerPath = "default" | "raw"
 type Sdk = ReturnType<typeof createKiloClient>
-type SdkResult = { response: Response; data?: unknown; error?: unknown }
+type SdkResult = { response?: Response; data?: unknown; error?: unknown }
 type Captured = { status: number; data?: unknown; error?: unknown }
 type ProjectFixture = { sdk: Sdk; directory: string }
 type LlmProjectFixture = ProjectFixture & { llm: TestLLMServer["Service"] }
@@ -115,7 +115,7 @@ function call<T>(request: () => Promise<T>) {
 function capture(request: () => Promise<SdkResult>) {
   return call(request).pipe(
     Effect.map((result) => ({
-      status: result.response.status,
+      status: result.response!.status,
       data: result.data,
       error: result.error,
     })),
@@ -132,9 +132,9 @@ function captureThrown(request: () => Promise<unknown>) {
   })
 }
 
-function expectStatus(request: () => Promise<{ response: Response }>, status: number) {
+function expectStatus(request: () => Promise<{ response?: Response }>, status: number) {
   return call(request).pipe(
-    Effect.tap((result) => Effect.sync(() => expect(result.response.status).toBe(status))),
+    Effect.tap((result) => Effect.sync(() => expect(result.response!.status).toBe(status))),
     Effect.asVoid,
   )
 }
@@ -351,12 +351,12 @@ describe("HttpApi SDK", () => {
       const health = yield* call(() => sdk.global.health())
       const log = yield* call(() => sdk.app.log({ service: "httpapi-sdk-test", level: "info", message: "hello" }))
 
-      expect(health.response.status).toBe(200)
+      expect(health.response!.status).toBe(200)
       expect(health.data).toMatchObject({ healthy: true })
       expect(yield* firstEvent((signal) => sdk.global.event({ signal }))).toMatchObject({
         payload: { type: "server.connected" },
       })
-      expect(log.response.status).toBe(200)
+      expect(log.response!.status).toBe(200)
       expect(log.data).toBe(true)
       yield* expectStatus(() => sdk.auth.set({ providerID: "test" }), 400)
     }),
@@ -373,21 +373,21 @@ describe("HttpApi SDK", () => {
         const v2session = yield* call(() => sdk.v2.session.create({ agent: "build" })) // kilocode_change
         const listed = yield* call(() => sdk.session.list({ roots: true, limit: 10 }))
 
-        expect(file.response.status).toBe(200)
+        expect(file.response!.status).toBe(200)
         expect(file.data).toMatchObject({ content: "hello" })
         // kilocode_change start
-        expect(raw.response.status).toBe(200)
+        expect(raw.response!.status).toBe(200)
         const body = raw.data
         if (!body) throw new Error("missing V2 file body")
         const content =
           body instanceof Blob ? yield* Effect.promise(() => body.text()) : Buffer.from(body as unknown as Uint8Array).toString()
         expect(content).toBe("hello")
         // kilocode_change end
-        expect(session.response.status).toBe(200)
+        expect(session.response!.status).toBe(200)
         expect(session.data).toMatchObject({ title: "sdk" })
-        expect({ status: v2session.response.status, error: v2session.error }).toEqual({ status: 200, error: undefined }) // kilocode_change
+        expect({ status: v2session.response!.status, error: v2session.error }).toEqual({ status: 200, error: undefined }) // kilocode_change
         expect(v2session.data).toMatchObject({ data: { location: { directory } } }) // kilocode_change
-        expect(listed.response.status).toBe(200)
+        expect(listed.response!.status).toBe(200)
         expect(listed.data?.map((item) => item.id)).toContain(session.data?.id)
 
         yield* Effect.all([
@@ -417,7 +417,7 @@ describe("HttpApi SDK", () => {
         )
         const url = new URL(request!.url)
 
-        expect(found.response.status).toBe(200)
+        expect(found.response!.status).toBe(200)
         expect(found.data).toMatchObject({ data: [{ path: "hello.txt", type: "file" }] })
         expect(url.searchParams.get("directory")).toBe(directory)
         expect(url.searchParams.get("workspace")).toBe(workspaceID)
@@ -431,7 +431,7 @@ describe("HttpApi SDK", () => {
           headers: { "x-kilo-directory": encodeURIComponent(directory) },
         })
         const legacySession = yield* call(() => legacy.v2.session.create({ agent: "build" }))
-        expect(legacySession.response.status).toBe(200)
+        expect(legacySession.response!.status).toBe(200)
         expect(legacySession.data).toMatchObject({ data: { location: { directory } } })
         // kilocode_change end
       }),

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "devDependencies": {
-    "@hey-api/openapi-ts": "0.90.10",
+    "@hey-api/openapi-ts": "0.97.3",
     "@tsconfig/node22": "catalog:",
     "@types/cross-spawn": "catalog:",
     "@types/node": "catalog:",

--- a/packages/sdk/js/script/build.ts
+++ b/packages/sdk/js/script/build.ts
@@ -94,24 +94,6 @@ if (historySdkPatched === generatedSdk) {
 }
 await Bun.write("./src/v2/gen/sdk.gen.ts", historySdkPatched)
 
-// Patch a @hey-api/openapi-ts codegen bug: SseFn incorrectly passes the
-// endpoint's TError into the second generic of ServerSentEventsResult, which
-// is the AsyncGenerator's TReturn slot. Iterator return values have nothing
-// to do with HTTP errors, and any consumer that calls `.return()` or returns
-// from a mock generator gets type-checked against the wrong shape. Drop the
-// arg so TReturn defaults to void.
-const sseTypesPath = "./src/v2/gen/client/types.gen.ts"
-const sseTypesFile = Bun.file(sseTypesPath)
-const sseTypesSource = await sseTypesFile.text()
-const sseTypesPatched = sseTypesSource.replace(
-  "=> Promise<ServerSentEventsResult<TData, TError>>",
-  "=> Promise<ServerSentEventsResult<TData>>",
-)
-if (sseTypesPatched === sseTypesSource) {
-  throw new Error(`SseFn patch did not apply; @hey-api/openapi-ts output may have changed (${sseTypesPath})`)
-}
-await Bun.write(sseTypesPath, sseTypesPatched)
-
 // The legacy SDK generator is retired, but this public Config type remains exported.
 // Keep Kilo's released sandbox settings aligned with the current generated client.
 const legacyTypesPath = "./src/gen/types.gen.ts"

--- a/packages/sdk/js/src/v2/gen/client/client.gen.ts
+++ b/packages/sdk/js/src/v2/gen/client/client.gen.ts
@@ -31,20 +31,24 @@ export const createClient = (config: Config = {}): Client => {
 
   const interceptors = createInterceptors<Request, Response, unknown, ResolvedRequestOptions>()
 
-  const beforeRequest = async (options: RequestOptions) => {
+  const beforeRequest = async <
+    TData = unknown,
+    TResponseStyle extends "data" | "fields" = "fields",
+    ThrowOnError extends boolean = boolean,
+    Url extends string = string,
+  >(
+    options: RequestOptions<TData, TResponseStyle, ThrowOnError, Url>,
+  ) => {
     const opts = {
       ..._config,
       ...options,
       fetch: options.fetch ?? _config.fetch ?? globalThis.fetch,
       headers: mergeHeaders(_config.headers, options.headers),
-      serializedBody: undefined,
+      serializedBody: undefined as string | undefined,
     }
 
     if (opts.security) {
-      await setAuthParams({
-        ...opts,
-        security: opts.security,
-      })
+      await setAuthParams(opts)
     }
 
     if (opts.requestValidator) {
@@ -52,7 +56,7 @@ export const createClient = (config: Config = {}): Client => {
     }
 
     if (opts.body !== undefined && opts.bodySerializer) {
-      opts.serializedBody = opts.bodySerializer(opts.body)
+      opts.serializedBody = opts.bodySerializer(opts.body) as string | undefined
     }
 
     // remove Content-Type header if body is empty to avoid sending invalid requests
@@ -60,176 +64,159 @@ export const createClient = (config: Config = {}): Client => {
       opts.headers.delete("Content-Type")
     }
 
-    const url = buildUrl(opts)
+    const resolvedOpts = opts as typeof opts & ResolvedRequestOptions<TResponseStyle, ThrowOnError, Url>
+    const url = buildUrl(resolvedOpts)
 
-    return { opts, url }
+    return { opts: resolvedOpts, url }
   }
 
   const request: Client["request"] = async (options) => {
-    // @ts-expect-error
-    const { opts, url } = await beforeRequest(options)
-    const requestInit: ReqInit = {
-      redirect: "follow",
-      ...opts,
-      body: getValidRequestBody(opts),
-    }
+    const throwOnError = options.throwOnError ?? _config.throwOnError
+    const responseStyle = options.responseStyle ?? _config.responseStyle
 
-    let request = new Request(url, requestInit)
-
-    for (const fn of interceptors.request.fns) {
-      if (fn) {
-        request = await fn(request, opts)
-      }
-    }
-
-    // fetch must be assigned here, otherwise it would throw the error:
-    // TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation
-    const _fetch = opts.fetch!
-    let response: Response
+    let request: Request | undefined
+    let response: Response | undefined
 
     try {
-      response = await _fetch(request)
-    } catch (error) {
-      // Handle fetch exceptions (AbortError, network errors, etc.)
-      let finalError = error
+      const { opts, url } = await beforeRequest(options)
+      const requestInit: ReqInit = {
+        redirect: "follow",
+        ...opts,
+        body: getValidRequestBody(opts),
+      }
 
-      for (const fn of interceptors.error.fns) {
+      request = new Request(url, requestInit)
+
+      for (const fn of interceptors.request.fns) {
         if (fn) {
-          finalError = (await fn(error, undefined as any, request, opts)) as unknown
+          request = await fn(request, opts)
         }
       }
 
-      finalError = finalError || ({} as unknown)
+      // fetch must be assigned here, otherwise it would throw the error:
+      // TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation
+      const _fetch = opts.fetch!
 
-      if (opts.throwOnError) {
-        throw finalError
+      response = await _fetch(request)
+
+      for (const fn of interceptors.response.fns) {
+        if (fn) {
+          response = await fn(response, request, opts)
+        }
       }
 
-      // Return error response
-      return opts.responseStyle === "data"
-        ? undefined
-        : {
-            error: finalError,
-            request,
-            response: undefined as any,
+      const result = {
+        request,
+        response,
+      }
+
+      if (response.ok) {
+        const parseAs =
+          (opts.parseAs === "auto" ? getParseAs(response.headers.get("Content-Type")) : opts.parseAs) ?? "json"
+
+        if (response.status === 204 || response.headers.get("Content-Length") === "0") {
+          let emptyData: any
+          switch (parseAs) {
+            case "arrayBuffer":
+            case "blob":
+            case "text":
+              emptyData = await response[parseAs]()
+              break
+            case "formData":
+              emptyData = new FormData()
+              break
+            case "stream":
+              emptyData = response.body
+              break
+            case "json":
+            default:
+              emptyData = {}
+              break
           }
-    }
+          return opts.responseStyle === "data"
+            ? emptyData
+            : {
+                data: emptyData,
+                ...result,
+              }
+        }
 
-    for (const fn of interceptors.response.fns) {
-      if (fn) {
-        response = await fn(response, request, opts)
-      }
-    }
-
-    const result = {
-      request,
-      response,
-    }
-
-    if (response.ok) {
-      const parseAs =
-        (opts.parseAs === "auto" ? getParseAs(response.headers.get("Content-Type")) : opts.parseAs) ?? "json"
-
-      if (response.status === 204 || response.headers.get("Content-Length") === "0") {
-        let emptyData: any
+        let data: any
         switch (parseAs) {
           case "arrayBuffer":
           case "blob":
-          case "text":
-            emptyData = await response[parseAs]()
-            break
           case "formData":
-            emptyData = new FormData()
+          case "text":
+            data = await response[parseAs]()
             break
+          case "json": {
+            // Some servers return 200 with no Content-Length and empty body.
+            // response.json() would throw; read as text and parse if non-empty.
+            const text = await response.text()
+            data = text ? JSON.parse(text) : {}
+            break
+          }
           case "stream":
-            emptyData = response.body
-            break
-          case "json":
-          default:
-            emptyData = {}
-            break
+            return opts.responseStyle === "data"
+              ? response.body
+              : {
+                  data: response.body,
+                  ...result,
+                }
         }
+
+        if (parseAs === "json") {
+          if (opts.responseValidator) {
+            await opts.responseValidator(data)
+          }
+
+          if (opts.responseTransformer) {
+            data = await opts.responseTransformer(data)
+          }
+        }
+
         return opts.responseStyle === "data"
-          ? emptyData
+          ? data
           : {
-              data: emptyData,
+              data,
               ...result,
             }
       }
 
-      let data: any
-      switch (parseAs) {
-        case "arrayBuffer":
-        case "blob":
-        case "formData":
-        case "text":
-          data = await response[parseAs]()
-          break
-        case "json": {
-          // Some servers return 200 with no Content-Length and empty body.
-          // response.json() would throw; read as text and parse if non-empty.
-          const text = await response.text()
-          data = text ? JSON.parse(text) : {}
-          break
-        }
-        case "stream":
-          return opts.responseStyle === "data"
-            ? response.body
-            : {
-                data: response.body,
-                ...result,
-              }
+      const textError = await response.text()
+      let jsonError: unknown
+
+      try {
+        jsonError = JSON.parse(textError)
+      } catch {
+        // noop
       }
 
-      if (parseAs === "json") {
-        if (opts.responseValidator) {
-          await opts.responseValidator(data)
-        }
+      throw jsonError ?? textError
+    } catch (error) {
+      let finalError = error
 
-        if (opts.responseTransformer) {
-          data = await opts.responseTransformer(data)
+      for (const fn of interceptors.error.fns) {
+        if (fn) {
+          finalError = await fn(finalError, response, request, options as ResolvedRequestOptions)
         }
       }
 
-      return opts.responseStyle === "data"
-        ? data
+      finalError = finalError || {}
+
+      if (throwOnError) {
+        throw finalError
+      }
+
+      // TODO: we probably want to return error and improve types
+      return responseStyle === "data"
+        ? undefined
         : {
-            data,
-            ...result,
+            error: finalError,
+            request,
+            response,
           }
     }
-
-    const textError = await response.text()
-    let jsonError: unknown
-
-    try {
-      jsonError = JSON.parse(textError)
-    } catch {
-      // noop
-    }
-
-    const error = jsonError ?? textError
-    let finalError = error
-
-    for (const fn of interceptors.error.fns) {
-      if (fn) {
-        finalError = (await fn(error, response, request, opts)) as string
-      }
-    }
-
-    finalError = finalError || ({} as string)
-
-    if (opts.throwOnError) {
-      throw finalError
-    }
-
-    // TODO: we probably want to return error and improve types
-    return opts.responseStyle === "data"
-      ? undefined
-      : {
-          error: finalError,
-          ...result,
-        }
   }
 
   const makeMethodFn = (method: Uppercase<HttpMethod>) => (options: RequestOptions) => request({ ...options, method })
@@ -239,7 +226,6 @@ export const createClient = (config: Config = {}): Client => {
     return createSseClient({
       ...opts,
       body: opts.body as BodyInit | null | undefined,
-      headers: opts.headers as unknown as Record<string, string>,
       method,
       onRequest: async (url, init) => {
         let request = new Request(url, init)
@@ -255,8 +241,10 @@ export const createClient = (config: Config = {}): Client => {
     })
   }
 
+  const _buildUrl: Client["buildUrl"] = (options) => buildUrl({ ..._config, ...options })
+
   return {
-    buildUrl,
+    buildUrl: _buildUrl,
     connect: makeMethodFn("CONNECT"),
     delete: makeMethodFn("DELETE"),
     get: makeMethodFn("GET"),

--- a/packages/sdk/js/src/v2/gen/client/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/client/types.gen.ts
@@ -62,7 +62,7 @@ export interface RequestOptions<
     }>,
     Pick<
       ServerSentEventsOptions<TData>,
-      "onSseError" | "onSseEvent" | "sseDefaultRetryDelay" | "sseMaxRetryAttempts" | "sseMaxRetryDelay"
+      "onRequest" | "onSseError" | "onSseEvent" | "sseDefaultRetryDelay" | "sseMaxRetryAttempts" | "sseMaxRetryDelay"
     > {
   /**
    * Any body that you want to add to your request.
@@ -84,6 +84,7 @@ export interface ResolvedRequestOptions<
   ThrowOnError extends boolean = boolean,
   Url extends string = string,
 > extends RequestOptions<unknown, TResponseStyle, ThrowOnError, Url> {
+  headers: Headers
   serializedBody?: string
 }
 
@@ -117,8 +118,10 @@ export type RequestResult<
                 error: TError extends Record<string, unknown> ? TError[keyof TError] : TError
               }
           ) & {
-            request: Request
-            response: Response
+            /** request may be undefined, because error may be from building the request object itself */
+            request?: Request
+            /** response may be undefined, because error may be from building the request object itself or from a network error */
+            response?: Response
           }
     >
 
@@ -139,11 +142,12 @@ type MethodFn = <
 
 type SseFn = <
   TData = unknown,
-  TError = unknown,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _TError = unknown,
   ThrowOnError extends boolean = false,
   TResponseStyle extends ResponseStyle = "fields",
 >(
-  options: Omit<RequestOptions<TData, TResponseStyle, ThrowOnError>, "method">,
+  options: Omit<RequestOptions<never, TResponseStyle, ThrowOnError>, "method">,
 ) => Promise<ServerSentEventsResult<TData>>
 
 type RequestFn = <

--- a/packages/sdk/js/src/v2/gen/client/utils.gen.ts
+++ b/packages/sdk/js/src/v2/gen/client/utils.gen.ts
@@ -105,14 +105,12 @@ const checkForExistence = (
   return false
 }
 
-export const setAuthParams = async ({
-  security,
-  ...options
-}: Pick<Required<RequestOptions>, "security"> &
-  Pick<RequestOptions, "auth" | "query"> & {
+export async function setAuthParams(
+  options: Pick<RequestOptions, "auth" | "query" | "security"> & {
     headers: Headers
-  }) => {
-  for (const auth of security) {
+  },
+): Promise<void> {
+  for (const auth of options.security ?? []) {
     if (checkForExistence(options, auth.name)) {
       continue
     }
@@ -189,7 +187,7 @@ export const mergeHeaders = (...headers: Array<Required<Config>["headers"] | und
           mergedHeaders.append(key, v as string)
         }
       } else if (value !== undefined) {
-        // assume object headers are meant to be JSON stringified, i.e. their
+        // assume object headers are meant to be JSON stringified, i.e., their
         // content value in OpenAPI specification is 'application/json'
         mergedHeaders.set(key, typeof value === "object" ? JSON.stringify(value) : (value as string))
       }
@@ -200,8 +198,10 @@ export const mergeHeaders = (...headers: Array<Required<Config>["headers"] | und
 
 type ErrInterceptor<Err, Res, Req, Options> = (
   error: Err,
-  response: Res,
-  request: Req,
+  /** response may be undefined due to a network error where no response object is produced */
+  response: Res | undefined,
+  /** request may be undefined, because error may be from building the request object itself */
+  request: Req | undefined,
   options: Options,
 ) => Err | Promise<Err>
 

--- a/packages/sdk/js/src/v2/gen/core/bodySerializer.gen.ts
+++ b/packages/sdk/js/src/v2/gen/core/bodySerializer.gen.ts
@@ -4,7 +4,7 @@ import type { ArrayStyle, ObjectStyle, SerializerOptions } from "./pathSerialize
 
 export type QuerySerializer = (query: Record<string, unknown>) => string
 
-export type BodySerializer = (body: any) => any
+export type BodySerializer = (body: unknown) => unknown
 
 type QuerySerializerOptionsObject = {
   allowReserved?: boolean
@@ -39,10 +39,10 @@ const serializeUrlSearchParamsPair = (data: URLSearchParams, key: string, value:
 }
 
 export const formDataBodySerializer = {
-  bodySerializer: <T extends Record<string, any> | Array<Record<string, any>>>(body: T): FormData => {
+  bodySerializer: (body: unknown): FormData => {
     const data = new FormData()
 
-    Object.entries(body).forEach(([key, value]) => {
+    Object.entries(body as Record<string, unknown>).forEach(([key, value]) => {
       if (value === undefined || value === null) {
         return
       }
@@ -58,15 +58,15 @@ export const formDataBodySerializer = {
 }
 
 export const jsonBodySerializer = {
-  bodySerializer: <T>(body: T): string =>
+  bodySerializer: (body: unknown): string =>
     JSON.stringify(body, (_key, value) => (typeof value === "bigint" ? value.toString() : value)),
 }
 
 export const urlSearchParamsBodySerializer = {
-  bodySerializer: <T extends Record<string, any> | Array<Record<string, any>>>(body: T): string => {
+  bodySerializer: (body: unknown): string => {
     const data = new URLSearchParams()
 
-    Object.entries(body).forEach(([key, value]) => {
+    Object.entries(body as Record<string, unknown>).forEach(([key, value]) => {
       if (value === undefined || value === null) {
         return
       }

--- a/packages/sdk/js/src/v2/gen/core/params.gen.ts
+++ b/packages/sdk/js/src/v2/gen/core/params.gen.ts
@@ -96,7 +96,7 @@ interface Params {
 
 const stripEmptySlots = (params: Params) => {
   for (const [slot, value] of Object.entries(params)) {
-    if (value && typeof value === "object" && !Object.keys(value).length) {
+    if (value && typeof value === "object" && !Array.isArray(value) && !Object.keys(value).length) {
       delete params[slot as Slot]
     }
   }
@@ -104,10 +104,10 @@ const stripEmptySlots = (params: Params) => {
 
 export const buildClientParams = (args: ReadonlyArray<unknown>, fields: FieldsConfig) => {
   const params: Params = {
-    body: {},
-    headers: {},
-    path: {},
-    query: {},
+    body: Object.create(null),
+    headers: Object.create(null),
+    path: Object.create(null),
+    query: Object.create(null),
   }
 
   const map = buildKeyMap(fields)

--- a/packages/sdk/js/src/v2/gen/core/serverSentEvents.gen.ts
+++ b/packages/sdk/js/src/v2/gen/core/serverSentEvents.gen.ts
@@ -75,7 +75,7 @@ export type ServerSentEventsResult<TData = unknown, TReturn = void, TNext = unkn
   stream: AsyncGenerator<TData extends Record<string, unknown> ? TData[keyof TData] : TData, TReturn, TNext>
 }
 
-export const createSseClient = <TData = unknown>({
+export function createSseClient<TData = unknown>({
   onRequest,
   onSseError,
   onSseEvent,
@@ -87,7 +87,7 @@ export const createSseClient = <TData = unknown>({
   sseSleepFn,
   url,
   ...options
-}: ServerSentEventsOptions): ServerSentEventsResult<TData> => {
+}: ServerSentEventsOptions): ServerSentEventsResult<TData> {
   let lastEventId: string | undefined
 
   const sleep = sseSleepFn ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)))
@@ -151,8 +151,7 @@ export const createSseClient = <TData = unknown>({
             const { done, value } = await reader.read()
             if (done) break
             buffer += value
-            // Normalize line endings: CRLF -> LF, then CR -> LF
-            buffer = buffer.replace(/\r\n/g, "\n").replace(/\r/g, "\n")
+            buffer = buffer.replace(/\r\n?/g, "\n") // normalize line endings
 
             const chunks = buffer.split("\n\n")
             buffer = chunks.pop() ?? ""

--- a/packages/sdk/js/src/v2/gen/core/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/core/types.gen.ts
@@ -62,7 +62,7 @@ export interface Config {
   requestValidator?: (data: unknown) => Promise<unknown>
   /**
    * A function transforming response data before it's returned. This is useful
-   * for post-processing data, e.g. converting ISO strings into Date objects.
+   * for post-processing data, e.g., converting ISO strings into Date objects.
    */
   responseTransformer?: (data: unknown) => Promise<unknown>
   /**

--- a/packages/sdk/js/src/v2/gen/core/utils.gen.ts
+++ b/packages/sdk/js/src/v2/gen/core/utils.gen.ts
@@ -123,7 +123,7 @@ export function getValidRequestBody(options: {
       return hasSerializedBody ? options.serializedBody : null
     }
 
-    // not all clients implement a serializedBody property (i.e. client-axios)
+    // not all clients implement a serializedBody property (i.e., client-axios)
     return options.body !== "" ? options.body : null
   }
 

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -73,6 +73,7 @@ import type {
   ConfigWarningsResponses,
   EnhancePromptEnhanceErrors,
   EnhancePromptEnhanceResponses,
+  EventSubscribeResponse,
   EventSubscribeResponses,
   EventTuiCommandExecute2,
   EventTuiPromptAppend2,
@@ -132,6 +133,7 @@ import type {
   GlobalDisposeErrors,
   GlobalDisposeResponses,
   GlobalEventErrors,
+  GlobalEventResponse,
   GlobalEventResponses,
   GlobalHealthErrors,
   GlobalHealthResponses,
@@ -220,6 +222,7 @@ import type {
   KiloEditErrors,
   KiloEditResponses,
   KiloFimErrors,
+  KiloFimResponse,
   KiloFimResponses,
   KiloModelsImagesErrors,
   KiloModelsImagesResponses,
@@ -482,6 +485,7 @@ import type {
   V2CredentialUpdateErrors,
   V2CredentialUpdateResponses,
   V2EventSubscribeErrors,
+  V2EventSubscribeResponse,
   V2EventSubscribeResponses,
   V2FsFindErrors,
   V2FsFindResponses,
@@ -552,6 +556,7 @@ import type {
   V2SessionCreateErrors,
   V2SessionCreateResponses,
   V2SessionEventsErrors,
+  V2SessionEventsResponse,
   V2SessionEventsResponses,
   V2SessionGetErrors,
   V2SessionGetResponses,
@@ -624,10 +629,11 @@ import type {
   WorktreeResetResponses,
 } from "./types.gen.js"
 
-export type Options<TData extends TDataShape = TDataShape, ThrowOnError extends boolean = boolean> = Options2<
-  TData,
-  ThrowOnError
-> & {
+export type Options<
+  TData extends TDataShape = TDataShape,
+  ThrowOnError extends boolean = boolean,
+  TResponse = unknown,
+> = Options2<TData, ThrowOnError, TResponse> & {
   /**
    * You can provide a client instance returned by `createClient()` instead of
    * individual options. This might be also useful if you want to implement a
@@ -730,12 +736,12 @@ export class App extends HeyApiClient {
    * Write a log entry to the server logs with specified level and metadata.
    */
   public log<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      service?: string
-      level?: "debug" | "info" | "error" | "warn"
-      message?: string
+      service: string
+      level: "debug" | "info" | "error" | "warn"
+      message: string
       extra?: {
         [key: string]: unknown
       }
@@ -837,9 +843,9 @@ export class ControlPlane extends HeyApiClient {
    * Move a session to another project directory, optionally transferring local changes.
    */
   public moveSession<ThrowOnError extends boolean = false>(
-    parameters?: {
-      sessionID?: string
-      destination?: MoveSessionDestination
+    parameters: {
+      sessionID: string
+      destination: MoveSessionDestination
       moveChanges?: boolean
     },
     options?: Options<never, ThrowOnError>,
@@ -984,11 +990,11 @@ export class Console extends HeyApiClient {
    * Persist a new active Console account/org selection for the current local Kilo state.
    */
   public switchOrg<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      accountID?: string
-      orgID?: string
+      accountID: string
+      orgID: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -1266,11 +1272,11 @@ export class Workspace extends HeyApiClient {
    * Create a workspace for the current project.
    */
   public create<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
       id?: string
-      type?: string
+      type: string
       branch?: string | null
       extra?: unknown | null
     },
@@ -1417,11 +1423,11 @@ export class Workspace extends HeyApiClient {
    * Move a session's sync history into the target workspace, or detach it to the local project.
    */
   public warp<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      id?: string | null
-      sessionID?: string
+      id: string | null
+      sessionID: string
       copyChanges?: boolean
     },
     options?: Options<never, ThrowOnError>,
@@ -1555,7 +1561,7 @@ export class Global extends HeyApiClient {
    *
    * Subscribe to global events from the Kilo system using server-sent events.
    */
-  public event<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+  public event<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError, GlobalEventResponse>) {
     return (options?.client ?? this.client).sse.get<GlobalEventResponses, GlobalEventErrors, ThrowOnError>({
       url: "/global/event",
       ...options,
@@ -1604,7 +1610,7 @@ export class Global extends HeyApiClient {
   }
 }
 
-export class Event extends HeyApiClient {
+export class Event_ extends HeyApiClient {
   /**
    * Subscribe to events
    *
@@ -1615,7 +1621,7 @@ export class Event extends HeyApiClient {
       directory?: string
       workspace?: string
     },
-    options?: Options<never, ThrowOnError>,
+    options?: Options<never, ThrowOnError, EventSubscribeResponse>,
   ) {
     const params = buildClientParams(
       [parameters],
@@ -1802,10 +1808,10 @@ export class Config2 extends HeyApiClient {
    * Apply a minimal global or project config patch, including unset paths for reverting local overrides.
    */
   public overlayUpdate<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      scope?: "global" | "project"
+      scope: "global" | "project"
       set?: {
         [key: string]: unknown
       }
@@ -1946,11 +1952,11 @@ export class Config2 extends HeyApiClient {
    * Create or update the project AGENTS.md rules file.
    */
   public rulesUpdate<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
       scope?: "project"
-      content?: string
+      content: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -2465,7 +2471,7 @@ export class Find extends HeyApiClient {
   }
 }
 
-export class File extends HeyApiClient {
+export class File_ extends HeyApiClient {
   /**
    * List files
    *
@@ -2788,10 +2794,10 @@ export class Vcs extends HeyApiClient {
    * Apply a raw patch to the current working tree.
    */
   public apply<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      patch?: string
+      patch: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -2996,7 +3002,7 @@ export class Auth2 extends HeyApiClient {
       name: string
       directory?: string
       workspace?: string
-      code?: string
+      code: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3097,11 +3103,11 @@ export class Mcp extends HeyApiClient {
    * Dynamically add a new Model Context Protocol (MCP) server to the system.
    */
   public add<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      name?: string
-      config?: McpLocalConfig | McpRemoteConfig
+      name: string
+      config: McpLocalConfig | McpRemoteConfig
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3196,11 +3202,11 @@ export class Mcp extends HeyApiClient {
    * Read a resource from a connected MCP server by URI. Used by MCP Apps to load UI resources.
    */
   public readResource<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      uri?: string
-      server?: string
+      uri: string
+      server: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3235,11 +3241,11 @@ export class Mcp extends HeyApiClient {
    * Call a tool on a connected MCP server. Used by MCP Apps for widget-initiated tool calls.
    */
   public callTool<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      server?: string
-      name?: string
+      server: string
+      name: string
       arguments?: {
         [key: string]: unknown
       }
@@ -3778,7 +3784,7 @@ export class Question extends HeyApiClient {
       requestID: string
       directory?: string
       workspace?: string
-      answers?: Array<QuestionAnswer>
+      answers: Array<QuestionAnswer>
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -3881,7 +3887,7 @@ export class Permission extends HeyApiClient {
       requestID: string
       directory?: string
       workspace?: string
-      reply?: "once" | "always" | "reject"
+      reply: "once" | "always" | "reject"
       message?: string
       interactive?: boolean
     },
@@ -3965,10 +3971,10 @@ export class Permission extends HeyApiClient {
    * Enable or disable allowing all permissions without prompts.
    */
   public allowEverything<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      enable?: boolean
+      enable: boolean
       requestID?: string
       sessionID?: string
     },
@@ -4017,7 +4023,7 @@ export class Permission extends HeyApiClient {
       permissionID: string
       directory?: string
       workspace?: string
-      response?: "once" | "always" | "reject"
+      response: "once" | "always" | "reject"
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -4059,7 +4065,7 @@ export class Oauth extends HeyApiClient {
       providerID: string
       directory?: string
       workspace?: string
-      method?: number
+      method: number
       inputs?: {
         [key: string]: string
       }
@@ -4106,7 +4112,7 @@ export class Oauth extends HeyApiClient {
       providerID: string
       directory?: string
       workspace?: string
-      method?: number
+      method: number
       code?: string
     },
     options?: Options<never, ThrowOnError>,
@@ -4624,7 +4630,7 @@ export class Session2 extends HeyApiClient {
         activeFile?: string
         shell?: string
       }
-      parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+      parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -4816,9 +4822,9 @@ export class Session2 extends HeyApiClient {
       sessionID: string
       directory?: string
       workspace?: string
-      modelID?: string
-      providerID?: string
-      messageID?: string
+      modelID: string
+      providerID: string
+      messageID: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -4923,8 +4929,8 @@ export class Session2 extends HeyApiClient {
       sessionID: string
       directory?: string
       workspace?: string
-      providerID?: string
-      modelID?: string
+      providerID: string
+      modelID: string
       auto?: boolean
     },
     options?: Options<never, ThrowOnError>,
@@ -4988,7 +4994,7 @@ export class Session2 extends HeyApiClient {
         activeFile?: string
         shell?: string
       }
-      parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+      parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -5040,8 +5046,8 @@ export class Session2 extends HeyApiClient {
       messageID?: string
       agent?: string
       model?: string
-      arguments?: string
-      command?: string
+      arguments: string
+      command: string
       variant?: string
       snapshotInitialization?: "wait"
       parts?: Array<{
@@ -5098,12 +5104,12 @@ export class Session2 extends HeyApiClient {
       directory?: string
       workspace?: string
       messageID?: string
-      agent?: string
+      agent: string
       model?: {
         providerID: string
         modelID: string
       }
-      command?: string
+      command: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -5145,7 +5151,7 @@ export class Session2 extends HeyApiClient {
       sessionID: string
       directory?: string
       workspace?: string
-      messageID?: string
+      messageID: string
       partID?: string
     },
     options?: Options<never, ThrowOnError>,
@@ -5214,15 +5220,15 @@ export class Session2 extends HeyApiClient {
    * Notify the server which sessions the user is currently viewing, or clear all.
    */
   public viewed<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      viewer?: {
+      viewer: {
         id: string
         active: boolean
       }
-      attached?: Array<string>
-      visible?: Array<string>
+      attached: Array<string>
+      visible: Array<string>
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -5408,11 +5414,11 @@ export class Sync extends HeyApiClient {
    * Validate and replay a complete sync event history.
    */
   public replay<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       query_directory?: string
       workspace?: string
-      body_directory?: string
-      events?: Array<{
+      body_directory: string
+      events: Array<{
         id: string
         aggregateID: string
         seq: number
@@ -5463,10 +5469,10 @@ export class Sync extends HeyApiClient {
    * Update a session to belong to the current workspace through the sync event system.
    */
   public steal<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      sessionID?: string
+      sessionID: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -5718,10 +5724,10 @@ export class Tui extends HeyApiClient {
    * Append prompt to the TUI.
    */
   public appendPrompt<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      text?: string
+      text: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -5935,10 +5941,10 @@ export class Tui extends HeyApiClient {
    * Execute a TUI command.
    */
   public executeCommand<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      command?: string
+      command: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -5972,12 +5978,12 @@ export class Tui extends HeyApiClient {
    * Show a toast notification in the TUI.
    */
   public showToast<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
       title?: string
-      message?: string
-      variant?: "info" | "success" | "warning" | "error"
+      message: string
+      variant: "info" | "success" | "warning" | "error"
       duration?: number
     },
     options?: Options<never, ThrowOnError>,
@@ -6052,10 +6058,10 @@ export class Tui extends HeyApiClient {
    * Navigate the TUI to display the specified session.
    */
   public selectSession<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      sessionID?: string
+      sessionID: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -6106,10 +6112,10 @@ export class AgentBuilder extends HeyApiClient {
    * Validate an agent builder payload and return the canonical agent markdown without writing it.
    */
   public preview<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      id?: string
+      id: string
       scope?: "global" | "project"
       description?: string
       mode?: "primary" | "subagent" | "all"
@@ -6120,7 +6126,7 @@ export class AgentBuilder extends HeyApiClient {
       permission?: {
         [key: string]: unknown
       }
-      prompt?: string
+      prompt: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -6180,7 +6186,7 @@ export class AgentBuilder extends HeyApiClient {
       permission?: {
         [key: string]: unknown
       }
-      prompt?: string
+      prompt: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -6454,7 +6460,7 @@ export class BranchName extends HeyApiClient {
       sessionID: string
       directory?: string
       workspace?: string
-      prompt?: string
+      prompt: string
       providerID?: string
       modelID?: string
     },
@@ -6495,10 +6501,10 @@ export class CommitMessage extends HeyApiClient {
    * Generate a commit message using AI based on the current git diff.
    */
   public generate<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      path?: string
+      path: string
       selectedFiles?: Array<string>
       previousMessage?: string
       language?: string
@@ -6544,10 +6550,10 @@ export class EnhancePrompt extends HeyApiClient {
    * Rewrite a user's draft prompt into a clearer, more specific, and more effective prompt.
    */
   public enhance<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      text?: string
+      text: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -6677,10 +6683,10 @@ export class Indexing extends HeyApiClient {
    * Set machine-local code indexing consent for the active project.
    */
   public consent<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      enabled?: boolean
+      enabled: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -6910,11 +6916,11 @@ export class Audio extends HeyApiClient {
    * Proxy an audio transcription request to the Kilo Gateway
    */
   public transcriptions<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      model?: string
-      input_audio?: {
+      model: string
+      input_audio: {
         data: string
         format: string
       }
@@ -7030,10 +7036,10 @@ export class Organization extends HeyApiClient {
    * Switch to a different Kilo Gateway organization
    */
   public set<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      organizationId?: string | null
+      organizationId: string | null
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -7169,10 +7175,10 @@ export class Session3 extends HeyApiClient {
    * Download a cloud-synced session and write it to local storage with fresh IDs.
    */
   public import<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      sessionId?: string
+      sessionId: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -7309,17 +7315,17 @@ export class Kilo extends HeyApiClient {
    * Proxy a Fill-in-the-Middle completion request to the Kilo Gateway
    */
   public fim<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      prefix?: string
-      suffix?: string
+      prefix: string
+      suffix: string
       provider?: string
       model?: string
       maxTokens?: number
       temperature?: number
     },
-    options?: Options<never, ThrowOnError>,
+    options?: Options<never, ThrowOnError, KiloFimResponse>,
   ) {
     const params = buildClientParams(
       [parameters],
@@ -7356,23 +7362,23 @@ export class Kilo extends HeyApiClient {
    * Proxy a Mercury-style Next Edit request. The client supplies structured editor context; the gateway assembles the sentinel-tagged prompt and forwards to the upstream edit endpoint.
    */
   public edit<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
       provider?: string
       model?: string
       maxTokens?: number
-      currentFilePath?: string
-      currentFileContent?: string
-      cursorLine?: number
-      cursorCharacter?: number
-      editableRegionStartLine?: number
-      editableRegionEndLine?: number
-      recentlyViewedSnippets?: Array<{
+      currentFilePath: string
+      currentFileContent: string
+      cursorLine: number
+      cursorCharacter: number
+      editableRegionStartLine: number
+      editableRegionEndLine: number
+      recentlyViewedSnippets: Array<{
         filepath: string
         content: string
       }>
-      editDiffHistory?: Array<string>
+      editDiffHistory: Array<string>
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -7653,7 +7659,7 @@ export class Notebook extends HeyApiClient {
       requestID: NotebookRequestId
       directory?: string
       workspace?: string
-      result?: NotebookResult
+      result: NotebookResult
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -7696,7 +7702,7 @@ export class Notebook extends HeyApiClient {
       requestID: NotebookRequestId
       directory?: string
       workspace?: string
-      error?: NotebookFailure
+      error: NotebookFailure
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -7775,7 +7781,7 @@ export class AgentManager extends HeyApiClient {
       requestID: AgentManagerRequestId
       directory?: string
       workspace?: string
-      result?: AgentManagerResult
+      result: AgentManagerResult
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -7818,7 +7824,7 @@ export class AgentManager extends HeyApiClient {
       requestID: AgentManagerRequestId
       directory?: string
       workspace?: string
-      error?: AgentManagerFailure
+      error: AgentManagerFailure
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -7933,19 +7939,19 @@ export class SessionImport extends HeyApiClient {
    * Insert or update a project row used by legacy session import.
    */
   public project<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      id?: string
-      worktree?: string
+      id: string
+      worktree: string
       vcs?: string
       name?: string
       iconUrl?: string
       iconColor?: string
-      timeCreated?: number
-      timeUpdated?: number
+      timeCreated: number
+      timeUpdated: number
       timeInitialized?: number
-      sandboxes?: Array<string>
+      sandboxes: Array<string>
       commands?: {
         start?: string
       }
@@ -7996,18 +8002,18 @@ export class SessionImport extends HeyApiClient {
    * Insert or update a session row used by legacy session import.
    */
   public session<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       query_directory?: string
       workspace?: string
-      id?: string
-      projectID?: string
+      id: string
+      projectID: string
       force?: boolean
       workspaceID?: string
       parentID?: string
-      slug?: string
-      body_directory?: string
-      title?: string
-      version?: string
+      slug: string
+      body_directory: string
+      title: string
+      version: string
       shareURL?: string
       summary?: {
         additions: number
@@ -8027,8 +8033,8 @@ export class SessionImport extends HeyApiClient {
       permission?: {
         [key: string]: unknown
       }
-      timeCreated?: number
-      timeUpdated?: number
+      timeCreated: number
+      timeUpdated: number
       timeCompacting?: number
       timeArchived?: number
     },
@@ -8092,13 +8098,13 @@ export class SessionImport extends HeyApiClient {
    * Insert or update a message row used by legacy session import.
    */
   public message<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      id?: string
-      sessionID?: string
-      timeCreated?: number
-      data?:
+      id: string
+      sessionID: string
+      timeCreated: number
+      data:
         | {
             role: "user"
             time: {
@@ -8184,14 +8190,14 @@ export class SessionImport extends HeyApiClient {
    * Insert or update a part row used by legacy session import.
    */
   public part<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      id?: string
-      messageID?: string
-      sessionID?: string
+      id: string
+      messageID: string
+      sessionID: string
       timeCreated?: number
-      data?:
+      data:
         | {
             type: "text"
             text: string
@@ -8352,10 +8358,10 @@ export class Kilocode extends HeyApiClient {
    * Remove a command by deleting its markdown file from disk and clearing it from cache.
    */
   public removeCommand<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      location?: string
+      location: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -8393,10 +8399,10 @@ export class Kilocode extends HeyApiClient {
    * Remove a skill by deleting its manifest from disk and clearing it from cache.
    */
   public removeSkill<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      location?: string
+      location: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -8432,10 +8438,10 @@ export class Kilocode extends HeyApiClient {
    * Remove a custom (non-native) agent from one writable configuration scope, or every writable scope when omitted, and dispose cached instance state.
    */
   public removeAgent<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      name?: string
+      name: string
       scope?: "global" | "project"
     },
     options?: Options<never, ThrowOnError>,
@@ -9002,7 +9008,7 @@ export class Suggestion extends HeyApiClient {
       requestID: string
       directory?: string
       workspace?: string
-      index?: number
+      index: number
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -9071,10 +9077,10 @@ export class Telemetry extends HeyApiClient {
    * Forward a telemetry event to PostHog via kilo-telemetry.
    */
   public capture<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      event?: string
+      event: string
       properties?: {
         [key: string]: unknown
       }
@@ -9112,10 +9118,10 @@ export class Telemetry extends HeyApiClient {
    * Update the PostHog client's opt-in/out state at runtime. The CLI reads KILO_TELEMETRY_LEVEL once at spawn — this route lets clients (e.g. the VS Code extension) propagate runtime telemetry consent changes.
    */
   public setEnabled<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      enabled?: boolean
+      enabled: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -9342,10 +9348,10 @@ export class Memory extends HeyApiClient {
    * Persist explicit user-provided memory text through the deterministic operation pipeline.
    */
   public remember<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      text?: string
+      text: string
       key?: string
       file?: "project.md" | "environment.md" | "corrections.md"
       section?: string
@@ -9387,10 +9393,10 @@ export class Memory extends HeyApiClient {
    * Persist explicit corrective memory under corrections.md.
    */
   public correct<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      text?: string
+      text: string
       key?: string
       sessionID?: string
     },
@@ -9428,10 +9434,10 @@ export class Memory extends HeyApiClient {
    * Remove memory lines by exact key, id, or normalized key text and rebuild the index.
    */
   public forget<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      query?: string
+      query: string
       sessionID?: string
     },
     options?: Options<never, ThrowOnError>,
@@ -9467,10 +9473,10 @@ export class Memory extends HeyApiClient {
    * Delete all project memory files for the active workspace.
    */
   public purge<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      confirm?: true
+      confirm: true
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -9570,7 +9576,7 @@ export class Revert extends HeyApiClient {
   public stage<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
-      messageID?: string
+      messageID: string
       files?: boolean
     },
     options?: Options<never, ThrowOnError>,
@@ -9679,8 +9685,8 @@ export class Permission2 extends HeyApiClient {
     parameters: {
       sessionID: string
       id?: string
-      action?: string
-      resources?: Array<string>
+      action: string
+      resources: Array<string>
       save?: Array<string>
       metadata?: {
         [key: string]: unknown
@@ -9766,7 +9772,7 @@ export class Permission2 extends HeyApiClient {
     parameters: {
       sessionID: string
       requestID: string
-      reply?: PermissionV2Reply
+      reply: PermissionV2Reply
       message?: string
     },
     options?: Options<never, ThrowOnError>,
@@ -10022,7 +10028,7 @@ export class Session4 extends HeyApiClient {
   public switchAgent<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
-      agent?: string
+      agent: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -10061,7 +10067,7 @@ export class Session4 extends HeyApiClient {
   public switchModel<ThrowOnError extends boolean = false>(
     parameters: {
       sessionID: string
-      model?: ModelRef
+      model: ModelRef
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -10101,7 +10107,7 @@ export class Session4 extends HeyApiClient {
     parameters: {
       sessionID: string
       id?: string
-      prompt?: PromptInput
+      prompt: PromptInput
       delivery?: "steer" | "queue"
       resume?: boolean
     },
@@ -10232,7 +10238,7 @@ export class Session4 extends HeyApiClient {
       sessionID: string
       after?: string
     },
-    options?: Options<never, ThrowOnError>,
+    options?: Options<never, ThrowOnError, V2SessionEventsResponse>,
   ) {
     const params = buildClientParams(
       [parameters],
@@ -10445,7 +10451,7 @@ export class Connect extends HeyApiClient {
         directory?: string
         workspace?: string
       }
-      key?: string
+      key: string
       label?: string
     },
     options?: Options<never, ThrowOnError>,
@@ -10491,8 +10497,8 @@ export class Connect extends HeyApiClient {
         directory?: string
         workspace?: string
       }
-      methodID?: string
-      inputs?: {
+      methodID: string
+      inputs: {
         [key: string]: string
       }
       label?: string
@@ -10765,7 +10771,7 @@ export class Credential extends HeyApiClient {
         directory?: string
         workspace?: string
       }
-      label?: string
+      label: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -10794,7 +10800,7 @@ export class Credential extends HeyApiClient {
   }
 }
 
-export class Request extends HeyApiClient {
+export class Request_ extends HeyApiClient {
   /**
    * List pending permission requests
    *
@@ -10871,9 +10877,9 @@ export class Saved extends HeyApiClient {
 }
 
 export class Permission3 extends HeyApiClient {
-  private _request?: Request
-  get request(): Request {
-    return (this._request ??= new Request({ client: this.client }))
+  private _request?: Request_
+  get request(): Request_ {
+    return (this._request ??= new Request_({ client: this.client }))
   }
 
   private _saved?: Saved
@@ -11041,7 +11047,9 @@ export class Event2 extends HeyApiClient {
    *
    * Subscribe to native event payloads for the server.
    */
-  public subscribe<ThrowOnError extends boolean = false>(options?: Options<never, ThrowOnError>) {
+  public subscribe<ThrowOnError extends boolean = false>(
+    options?: Options<never, ThrowOnError, V2EventSubscribeResponse>,
+  ) {
     return (options?.client ?? this.client).sse.get<V2EventSubscribeResponses, V2EventSubscribeErrors, ThrowOnError>({
       url: "/api/event",
       ...options,
@@ -11375,8 +11383,8 @@ export class ProjectCopy2 extends HeyApiClient {
         directory?: string
         workspace?: string
       }
-      directory?: string
-      force?: boolean
+      directory: string
+      force: boolean
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -11416,8 +11424,8 @@ export class ProjectCopy2 extends HeyApiClient {
         directory?: string
         workspace?: string
       }
-      strategy?: string
-      directory?: string
+      strategy: string
+      directory: string
       name?: string
     },
     options?: Options<never, ThrowOnError>,
@@ -11598,9 +11606,9 @@ export class KiloClient extends HeyApiClient {
     return (this._global ??= new Global({ client: this.client }))
   }
 
-  private _event?: Event
-  get event(): Event {
-    return (this._event ??= new Event({ client: this.client }))
+  private _event?: Event_
+  get event(): Event_ {
+    return (this._event ??= new Event_({ client: this.client }))
   }
 
   private _config?: Config2
@@ -11623,9 +11631,9 @@ export class KiloClient extends HeyApiClient {
     return (this._find ??= new Find({ client: this.client }))
   }
 
-  private _file?: File
-  get file(): File {
-    return (this._file ??= new File({ client: this.client }))
+  private _file?: File_
+  get file(): File_ {
+    return (this._file ??= new File_({ client: this.client }))
   }
 
   private _instance?: Instance

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2334,31 +2334,7 @@ export type AgentConfig = {
   steps?: number
   maxSteps?: number
   permission?: PermissionConfig
-  [key: string]:
-    | unknown
-    | string
-    | number
-    | {
-        [key: string]: boolean
-      }
-    | boolean
-    | "subagent"
-    | "primary"
-    | "all"
-    | {
-        [key: string]: unknown
-      }
-    | string
-    | "primary"
-    | "secondary"
-    | "accent"
-    | "success"
-    | "warning"
-    | "error"
-    | "info"
-    | number
-    | PermissionConfig
-    | undefined
+  [key: string]: unknown
 }
 
 export type ProviderConfig = {
@@ -2383,7 +2359,7 @@ export type ProviderConfig = {
      */
     headerTimeout?: number | false
     chunkTimeout?: number
-    [key: string]: unknown | string | boolean | number | false | number | false | number | undefined
+    [key: string]: unknown
   }
   models?: {
     [key: string]: {
@@ -2446,7 +2422,7 @@ export type ProviderConfig = {
       variants?: {
         [key: string]: {
           disabled?: boolean
-          [key: string]: unknown | boolean | undefined
+          [key: string]: unknown
         }
       }
     }


### PR DESCRIPTION
## What

Bumps `@hey-api/openapi-ts` from `0.90.10` to `0.97.3` in `packages/sdk/js` and regenerates the committed SDK (`packages/sdk/js/src/v2/gen`).

## Why

Resolves Dependabot advisory **GHSA-hhx9-57xq-r5rw / CVE-2026-48819** (prototype pollution, CWE-1321): the `buildClientParams` template copied into every generated SDK wrote unknown `$<slot>___proto__` keys directly into the slot object, letting `$query___proto__` substitute the `params.query` prototype chain. Fixed in `0.97.3` by building slots with `Object.create(null)`. The regenerated `core/params.gen.ts` now carries the fix.

## Changes

- `packages/sdk/js/package.json` + `bun.lock`: `@hey-api/openapi-ts` `0.90.10` → `0.97.3`
- `packages/sdk/js/src/v2/gen/**`: regenerated SDK (includes the null-prototype params fix)
- `packages/sdk/js/script/build.ts`: removed the now-obsolete SseFn codegen patch (the bug it worked around is fixed upstream in 0.97.3)
- `packages/opencode/test/server/httpapi-sdk.test.ts`: adapted to the regenerated client typing where `request`/`response` are now optional (`kilocode_change`-marked)
- `.changeset/hey-api-security-update.md`: `patch` changeset for `@kilocode/sdk`

## Verification

- SDK regen + build: `bun ./packages/sdk/js/script/build.ts` (patches apply, `tsc` clean)
- SDK tests: 7 pass; `httpapi-sdk.test.ts`: 21 pass
- `bun turbo typecheck` (all packages except `kilo-jetbrains`): 29/29 pass — JetBrains needs a Java 21 toolchain not present on this machine
- `bun run lint`: 0 errors
- Extension: typecheck + 4218 unit tests pass
- `bun run script/check-opencode-annotations.ts --worktree`: clean