### PR TITLE
docs: add Synthorai provider page

### DIFF
--- a/packages/kilo-docs/lib/nav/ai-providers.ts
+++ b/packages/kilo-docs/lib/nav/ai-providers.ts
@@ -29,6 +29,7 @@ export const AiProvidersNav: NavSection[] = [
     links: [
       { href: "/ai-providers/openrouter", children: "OpenRouter" },
       { href: "/ai-providers/trustedrouter", children: "TrustedRouter" },
+      { href: "/ai-providers/synthorai", children: "Synthorai" },
       { href: "/ai-providers/requesty", children: "Requesty" },
       { href: "/ai-providers/daoxe", children: "DaoXE" },
       { href: "/ai-providers/unbound", children: "Unbound" },

--- a/packages/kilo-docs/pages/ai-providers/index.md
+++ b/packages/kilo-docs/pages/ai-providers/index.md
@@ -48,6 +48,7 @@ Route requests through unified APIs with additional features:
 - **[TrustedRouter](/docs/ai-providers/trustedrouter)** - OpenAI-compatible access to attested routing, ZDR routing, and E2E encrypted model routes
 - **[Requesty](/docs/ai-providers/requesty)** - Smart routing and fallbacks
 - **[DaoXE](/docs/ai-providers/daoxe)** - Connect multiple model families through one API
+- **[Synthorai](/docs/ai-providers/synthorai)** - OpenAI- and Anthropic-compatible surfaces on one base URL and one key
 - **[Cloudflare AI Gateway](/docs/ai-providers/cloudflare)** - Route providers through your Cloudflare account
 - **[Eden AI](/docs/ai-providers/edenai)** - EU-based gateway with one key across vendors
 

--- a/packages/kilo-docs/pages/ai-providers/synthorai.md
+++ b/packages/kilo-docs/pages/ai-providers/synthorai.md
@@ -1,0 +1,100 @@
+---
+title: "Using Synthorai with Kilo Code | OpenAI- and Anthropic-compatible gateway"
+description: "Configure Synthorai in Kilo Code as a custom provider — one base URL and one key serve both the OpenAI Chat Completions and Anthropic Messages APIs."
+sidebar_label: Synthorai
+---
+
+# Using Synthorai With Kilo Code
+
+[Synthorai](https://synthorai.io) is an AI gateway that serves models from Anthropic, OpenAI, Google, DeepSeek, Qwen, Moonshot and Z.ai. It has no dedicated Kilo Code provider — you add it through the **Custom provider** flow described on the [OpenAI Compatible](/docs/ai-providers/openai-compatible) page.
+
+What's worth knowing before you set it up: **the same base URL and the same key serve both wire formats.** `POST /v1/chat/completions` and `POST /v1/messages` answer on the same host, so you can pick either **OpenAI Compatible** or **Anthropic Messages** as the Provider API without changing the URL or issuing a second key.
+
+## Before you begin
+
+1. Create an account at [synthorai.io](https://synthorai.io).
+2. Create an API key in the [console](https://synthorai.io/console/api-keys). Copy it immediately — it is shown once.
+3. Pick a model id from the [catalog](https://synthorai.io/models/). Ids are **bare, not vendor-prefixed** — `claude-opus-5`, not `anthropic/claude-opus-5`.
+
+## Configure Kilo Code
+
+{% tabs %}
+{% tab label="VSCode" %}
+
+1. Open **Settings** (gear icon) and go to the **Providers** tab.
+2. Scroll to the bottom and click **Custom provider**.
+3. Fill in the dialog:
+
+- **Provider ID** — `synthorai`
+- **Display name** — `Synthorai`
+- **Provider API** — **OpenAI Compatible**
+- **Base URL** — `https://synthorai.io/v1`
+- **API key** — your key
+
+Kilo auto-fetches the model list from `https://synthorai.io/v1/models`, so you should not need to add models by hand.
+
+4. Click **Submit**. The models appear in the model picker.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+Set the key as an environment variable:
+
+```bash
+export SYNTHORAI_API_KEY="your-api-key"
+```
+
+Then declare the provider in `kilo.json`:
+
+```jsonc
+{
+  "provider": {
+    "synthorai": {
+      "npm": "@ai-sdk/openai-compatible",
+      "env": ["SYNTHORAI_API_KEY"],
+      "models": {
+        "claude-opus-5": {
+          "name": "Claude Opus 5",
+          "limit": { "context": 1000000, "output": 128000 },
+        },
+        "deepseek-v4-pro": {
+          "name": "DeepSeek V4 Pro",
+          "limit": { "context": 1000000, "output": 384000 },
+        },
+      },
+      "options": {
+        "baseURL": "https://synthorai.io/v1",
+      },
+    },
+  },
+}
+```
+
+Then set the default model with the `provider-id/model-id` form:
+
+```jsonc
+{
+  "model": "synthorai/claude-opus-5",
+}
+```
+
+{% /tab %}
+{% /tabs %}
+
+## Using the Anthropic surface instead
+
+If you would rather Kilo speak the Anthropic Messages format — for Anthropic-native behaviour — create a second custom provider with **Provider API** set to **Anthropic Messages** and the **same** base URL `https://synthorai.io/v1` and the same key.
+
+Note this differs from the plain Anthropic SDK, which takes the host root and appends `/v1/messages` itself. Here the base URL already includes `/v1`.
+
+## Troubleshooting
+
+**404 on every request.** The base URL must end in `/v1`. Kilo appends paths such as `/chat/completions`, so a base URL without it resolves to the wrong path.
+
+**Model not found.** Ids are case-sensitive and bare. Check what your key can reach with:
+
+```bash
+curl https://synthorai.io/v1/models -H "Authorization: Bearer $SYNTHORAI_API_KEY"
+```
+
+**Models didn't auto-fetch.** Confirm the base URL is exactly `https://synthorai.io/v1` and that the key is valid — an invalid key returns 401 and the list stays empty.

--- a/packages/kilo-docs/pages/ai-providers/synthorai.md
+++ b/packages/kilo-docs/pages/ai-providers/synthorai.md
@@ -59,7 +59,7 @@ Then declare the provider in `kilo.json`:
         },
         "deepseek-v4-pro": {
           "name": "DeepSeek V4 Pro",
-          "limit": { "context": 1000000, "output": 384000 },
+          "limit": { "context": 1000000, "output": 393216 },
         },
       },
       "options": {
@@ -69,6 +69,11 @@ Then declare the provider in `kilo.json`:
   },
 }
 ```
+
+Both models above are only examples. `limit.context` and `limit.output` for **any** model
+come from the catalog — `max_input_tokens` and `max_output_tokens` at
+[https://synthorai.io/api/models](https://synthorai.io/api/models), which is public and needs
+no key. Copy the values from there rather than from this page, in case they move.
 
 Then set the default model with the `provider-id/model-id` form:
 


### PR DESCRIPTION
Adds a Synthorai provider page — same shape as **#13023 (TrustedRouter)** and **#13169 (Eden AI)**: one page, one nav entry, one line in the providers index. Three files, docs only.

**Disclosure: I'm affiliated with Synthorai.** Vendor writing its own page, not a user request, and I'm not claiming demand.

### One deliberate difference from those two pages, which is worth your attention

Both precedents tell the reader to use a *built-in* provider — `trustedrouter.md` says "use it from Kilo Code with the built-in TrustedRouter provider", and `daoxe.md` says "Kilo Code uses the `daoxe` provider ID".

I went looking for those providers before copying the wording, and **neither `trustedrouter` nor `daoxe` appears anywhere in this repository outside `packages/kilo-docs/`.** No provider definition, no enum entry, nothing. I can't tell from outside whether they live in a dependency, ship only in the built extension, or are stale — but I couldn't verify them, so I didn't copy the claim.

This page therefore documents the **Custom provider** flow from [openai-compatible.md](/docs/ai-providers/openai-compatible), which demonstrably exists. If Synthorai should instead get a built-in provider entry, tell me where it goes and I'll write that PR instead — I'd rather do it properly than assert a feature I couldn't find.

(Flagging the `trustedrouter`/`daoxe` observation in case those pages are describing something that no longer exists. Entirely possible I'm looking in the wrong place.)

### The rest

- The `kilo.json` example follows the schema documented on the OpenAI Compatible page: credentials through the `env` field (not string interpolation — I had that wrong first), and `limit.context` / `limit.output` per model.
- **Only two models are listed**, not the whole catalog. Those are the two whose context and output limits we've published with supporting measurements. A `limit` here is read as fact by the agent's context management, and I'm not willing to put a guessed number there.
- The genuinely useful bit for Kilo users: the same base URL and key serve **both** `POST /v1/chat/completions` and `POST /v1/messages`, so **OpenAI Compatible** and **Anthropic Messages** both work without a second endpoint or key. The page also notes that this differs from the plain Anthropic SDK, which takes the host root — getting that backwards is a silent 404.

All URLs cited return 200. Happy to change anything about the framing.
