### PR TITLE
feat(remote-sender): forward messageID and drop queued prompts

### DIFF
--- a/packages/opencode/src/kilo-sessions/remote-sender.ts
+++ b/packages/opencode/src/kilo-sessions/remote-sender.ts
@@ -14,7 +14,7 @@ import { Suggestion } from "@/kilocode/suggestion" // kilocode_change
 import { KiloSessionPromptQueue } from "@/kilocode/session/prompt-queue"
 import { Permission } from "@/permission"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
-import { SessionID } from "@/session/schema"
+import { MessageID, SessionID } from "@/session/schema"
 import { QuestionID } from "@/question/schema"
 import { Provider } from "@/provider/provider"
 import { ProviderV2 } from "@opencode-ai/core/provider"
@@ -47,6 +47,10 @@ const PermissionData = z.object({
 const SuggestionData = z.object({
   requestID: z.string(),
   index: z.number().int().nonnegative(),
+})
+
+const DropQueuedMessageData = z.object({
+  messageID: z.string().startsWith("msg"),
 })
 
 // kilocode_change start - create_session: strict v1 request with optional inheritance fields
@@ -117,6 +121,10 @@ function normalizeModel(model: string | RemoteModelCatalog.ModelRef | undefined)
 }
 
 function normalizePrompt(input: RemotePromptInput): SessionPrompt.PromptInput {
+  // messageID passes through unchanged: new clients send it, old ones omit it.
+  // Leave the field unset when absent so SessionPrompt assigns the CLI-side ID
+  // via `input.messageID ?? MessageID.ascending()`. Remove this implicit
+  // fallback once every client sends messageID.
   return {
     ...input,
     model: normalizeModel(input.model),
@@ -985,6 +993,30 @@ export namespace RemoteSender {
         dispatchQuick(msg, directoryFor(session.value), () => cancel(session.value))
         return
       }
+      // kilocode_change start - drop a queued (not yet running) remote message
+      if (msg.command === "drop_queued_message") {
+        const parsed = DropQueuedMessageData.safeParse(msg.data)
+        const session = msg.sessionId ? decodeSessionID(msg.sessionId) : Option.none<SessionID>()
+        if (!parsed.success || Option.isNone(session)) {
+          options.conn.send({
+            type: "response",
+            id: msg.id,
+            error: "invalid drop_queued_message command",
+          })
+          return
+        }
+        const messageID = MessageID.make(parsed.data.messageID)
+        // drop() publishes queue.changed itself. A false result means the ID
+        // is unknown or the actively running prompt, so leave the active run
+        // unchanged and never cancel the prompt.
+        dispatchQuick(msg, directoryFor(session.value), async () => {
+          if (!Effect.runSync(KiloSessionPromptQueue.drop(session.value, messageID))) {
+            throw new Error("message not queued")
+          }
+        })
+        return
+      }
+      // kilocode_change end
       if (msg.command === "question_reply") {
         const parsed = QuestionData.safeParse(msg.data)
         if (!parsed.success) {

--- a/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
@@ -14,7 +14,7 @@ import { Permission } from "../../../src/permission"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
-import { SessionID } from "../../../src/session/schema"
+import { MessageID, SessionID } from "../../../src/session/schema"
 import { Session } from "../../../src/session/session"
 import { Suggestion } from "../../../src/kilocode/suggestion"
 import { KiloSessionPromptQueue } from "../../../src/kilocode/session/prompt-queue"
@@ -734,6 +734,122 @@ describe("RemoteSender", () => {
     expect(sent).toEqual([{ type: "response", id: "req_interrupt", result: {} }])
   })
 
+  test("drop_queued_message drops a waiting message and ACKs success", async () => {
+    const { conn, sent } = fakeConn()
+    const sessionID = SessionID.make("ses_drop_cmd_waiting")
+    const activeID = MessageID.make("msg_drop_cmd_active_1")
+    const queuedID = MessageID.make("msg_drop_cmd_queued_1")
+    const activeStarted = Promise.withResolvers<void>()
+    const activeRelease = Promise.withResolvers<void>()
+
+    const active = Effect.runPromise(
+      KiloSessionPromptQueue.enqueue(
+        sessionID,
+        activeID,
+        Effect.promise(async () => {
+          activeStarted.resolve()
+          await activeRelease.promise
+          return "active"
+        }),
+        Effect.succeed("active-cancelled"),
+      ),
+    )
+    await activeStarted.promise
+
+    const queued = Effect.runPromise(
+      KiloSessionPromptQueue.enqueue(
+        sessionID,
+        queuedID,
+        Effect.sync(() => "queued"),
+        Effect.succeed("queued-cancelled"),
+      ),
+    )
+
+    expect(KiloSessionPromptQueue.snapshot(sessionID)).toEqual([queuedID])
+
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async <R>(input: { directory: string; fn: () => R }) => input.fn(),
+      session: {
+        get: async (id) => info(id),
+        children: async () => [],
+      },
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_drop_waiting",
+      command: "drop_queued_message",
+      sessionId: sessionID,
+      data: { messageID: queuedID },
+    })
+
+    await new Promise((r) => setTimeout(r, 0))
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(sent).toContainEqual({ type: "response", id: "req_drop_waiting", result: {} })
+
+    activeRelease.resolve()
+    expect(await active).toBe("active")
+    expect(await queued).toBe("queued-cancelled")
+  })
+
+  test("drop_queued_message leaves the active run untouched and returns an error", async () => {
+    const { conn, sent } = fakeConn()
+    const sessionID = SessionID.make("ses_drop_cmd_active")
+    const activeID = MessageID.make("msg_drop_cmd_active_2")
+    const activeStarted = Promise.withResolvers<void>()
+    const activeRelease = Promise.withResolvers<void>()
+
+    const active = Effect.runPromise(
+      KiloSessionPromptQueue.enqueue(
+        sessionID,
+        activeID,
+        Effect.promise(async () => {
+          activeStarted.resolve()
+          await activeRelease.promise
+          return "active"
+        }),
+        Effect.succeed("active-cancelled"),
+      ),
+    )
+    await activeStarted.promise
+
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async <R>(input: { directory: string; fn: () => R }) => input.fn(),
+      session: {
+        get: async (id) => info(id),
+        children: async () => [],
+      },
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_drop_active",
+      command: "drop_queued_message",
+      sessionId: sessionID,
+      data: { messageID: activeID },
+    })
+
+    await new Promise((r) => setTimeout(r, 0))
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0].type).toBe("response")
+    expect(sent[0].id).toBe("req_drop_active")
+    expect(sent[0].error).toContain("message not queued")
+
+    activeRelease.resolve()
+    expect(await active).toBe("active")
+  })
+
   test("send_message with invalid data sends error response immediately", () => {
     const { conn, sent } = fakeConn()
     const sender = RemoteSender.create({
@@ -1421,6 +1537,63 @@ describe("RemoteSender", () => {
         ephemeralTools: { interactive_terminal: false },
       },
     ])
+  })
+
+  test("send_message forwards messageID to prompt when present", async () => {
+    const { conn, sent } = fakeConn()
+    const calls: SessionPrompt.PromptInput[] = []
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async <R>(input: { directory: string; init?: Effect.Effect<void>; fn: () => R }) => input.fn(),
+      prompt: prompts(calls),
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_message_id",
+      command: "send_message",
+      data: {
+        sessionID: "ses_x",
+        messageID: "msg_remote_1",
+        parts: [{ type: "text", text: "hello" }],
+      },
+    })
+
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(sent[0]).toEqual({ type: "response", id: "req_message_id", result: {} })
+    expect(calls[0]?.messageID).toBe(MessageID.make("msg_remote_1"))
+  })
+
+  test("send_message leaves messageID unset when absent", async () => {
+    const { conn, sent } = fakeConn()
+    const calls: SessionPrompt.PromptInput[] = []
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async <R>(input: { directory: string; init?: Effect.Effect<void>; fn: () => R }) => input.fn(),
+      prompt: prompts(calls),
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_no_message_id",
+      command: "send_message",
+      data: {
+        sessionID: "ses_x",
+        parts: [{ type: "text", text: "hello" }],
+      },
+    })
+
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(sent[0]).toEqual({ type: "response", id: "req_no_message_id", result: {} })
+    expect(calls[0]?.messageID).toBeUndefined()
   })
   // kilocode_change end
 


### PR DESCRIPTION
- In a connected remote session, you can remove one waiting prompt while the active prompt continues. Other waiting prompts stay in the queue.

---

## Implementation

The new `drop_queued_message` command uses `DropQueuedMessageData` to require a `msg`-prefixed `messageID` and validates `sessionId` before targeting one queued prompt. `KiloSessionPromptQueue.drop` emits `session.queue.changed`; success returns `{}`, while unknown or active messages return an error without stopping the active prompt. `send_message` retains optional `messageID` forwarding; new comments document the command-line interface (CLI) fallback for older clients that omit it.

<details>
<summary>Files</summary>

- `packages/opencode/src/kilo-sessions/remote-sender.ts` — Source; modified (M), 34 changed lines: adds validated queued-message removal and documents the existing message identity fallback.

</details>

Tests: 1 test file modified — `packages/opencode/test/kilocode/sessions/remote-sender.test.ts` (M; 175 changed lines).
Generated: 0 files changed.

---

## Issue

No separate issue was supplied; this pull request accompanies the Cloud Agent contract implementation.

## Context

This pull request supplies the Kilo CLI handler for targeted cancellation from Cloud Agent clients.

- Paired Cloud Agent contract: https://github.com/Kilo-Org/cloud/pull/5537.
- Kilo-Org/kilocode worktree: `/Users/igor/Projects/.worktrees/agent-composers-c07a-kilocode`; branch `agent-composers-c07a`, base `origin/main`, immutable head `b9537ae089`.
- Kilo-Org/cloud worktree: `/Users/igor/Projects/.worktrees/agent-composers-c07a`; branch `agent-composers-c07a-s6`, cloud reference only.
- Scope: 2 modified Kilo CLI files, 207 added lines, and 2 removed lines. This description includes no cloud changes.

## Screenshots / Video

Visual Changes: N/A

## How to Test

### Verification

E2E report: none attached; the cumulative report belongs to cloud tip PR 5617.

### Manual/local verification

The handoff supplies these results:

- Current-head CI and Kilobot approve this PR.
- Remote session relay verification passed; deterministic queued-message cancellation has automated coverage but no live verification.

This agent did not run product checks. The handoff does not identify whether an agent or a human ran the runtime checks.

### Reviewer test steps

Run the `remote-sender` unit tests in the opencode package. The added cases cover dropping a waiting prompt, leaving an active run untouched, and `messageID` pass-through.

Run `bun test ./test/kilocode/sessions/remote-sender.test.ts` from `packages/opencode/`.

1. Connect the updated Kilo CLI to the paired Cloud Agent implementation.
2. Keep one prompt active while queuing two more prompts.
3. Remove one waiting prompt through the remote connection.
4. Confirm that the active prompt continues, the removed prompt never runs, and the other waiting prompt remains.
5. Request removal of an unknown or active prompt.
6. Confirm that the request returns an error without stopping the active prompt.

### Blocked checks and substitute verification

The handoff names no blocked command. Automated coverage substitutes for live verification of deterministic queued-message cancellation.

## Human steps

- **before merge — Complete the required review.**
- **before merge — Verify deterministic queued-message cancellation with the paired Cloud Agent changes.**
- **after merge — Update remote hosts to a Kilo CLI release with `drop_queued_message` before clients use it.**

No new environment value, secret, migration, or flag change is required.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [ ] Changeset considered for user-facing changes
- [ ] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

No Discord handle provided.

## Notes

Cumulative runtime verification and its limits are recorded in https://github.com/Kilo-Org/cloud/pull/5617.
