### PR TITLE
feat(remote): add directory listing and create_session directory

### DIFF
--- a/packages/opencode/src/kilo-sessions/remote-command.ts
+++ b/packages/opencode/src/kilo-sessions/remote-command.ts
@@ -10,6 +10,7 @@ import z from "zod"
 
 export namespace RemoteCommand {
   export const MAX_COMMANDS = 256
+  export const MAX_DIRECTORIES = 256
   export const MAX_STRING_LENGTH = 2_000
   export const MAX_ARGUMENTS_LENGTH = 32_768
   export const MAX_HINTS = 32
@@ -20,6 +21,31 @@ export namespace RemoteCommand {
       protocolVersion: z.literal(1),
     })
     .strict()
+
+  export const ListDirectoriesRequest = z
+    .object({
+      protocolVersion: z.literal(1),
+      path: z.string().min(1).max(MAX_STRING_LENGTH).optional(),
+    })
+    .strict()
+  export type ListDirectoriesRequest = z.infer<typeof ListDirectoriesRequest>
+
+  export const ListDirectoriesEntry = z
+    .object({
+      name: z.string().min(1).max(MAX_STRING_LENGTH),
+      path: z.string().min(1).max(MAX_STRING_LENGTH),
+    })
+    .strict()
+  export type ListDirectoriesEntry = z.infer<typeof ListDirectoriesEntry>
+
+  export const ListDirectoriesResponse = z
+    .object({
+      protocolVersion: z.literal(1),
+      path: z.string(),
+      directories: z.array(ListDirectoriesEntry).max(MAX_DIRECTORIES),
+    })
+    .strict()
+  export type ListDirectoriesResponse = z.infer<typeof ListDirectoriesResponse>
 
   export const ExitRequest = z
     .object({

--- a/packages/opencode/src/kilo-sessions/remote-sender.ts
+++ b/packages/opencode/src/kilo-sessions/remote-sender.ts
@@ -22,6 +22,9 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import z from "zod"
 import { zodObject } from "@opencode-ai/core/effect-zod"
 import { Effect, Option, Schema } from "effect"
+import { readdir } from "node:fs/promises"
+import { isAbsolute, join, relative, sep } from "path"
+import { Filesystem } from "@/util/filesystem"
 
 type Provide = typeof import("@/kilocode/instance").provide
 
@@ -61,6 +64,7 @@ const CreateSessionRequest = z
     agent: z.string().min(1).optional(),
     model: CreateSessionModel.optional(),
     orgId: z.string().uuid().optional(),
+    directory: z.string().min(1).max(RemoteCommand.MAX_STRING_LENGTH).optional(),
   })
   .strict()
 
@@ -89,6 +93,21 @@ function errorName(error: unknown): string {
   return typeof error
 }
 // kilocode_change end
+
+// kilocode_change - k1: resolve a client-supplied directory path under the
+// launch directory. Reuses Filesystem.resolve (canonicalize) and
+// Filesystem.contains (lexical containment on canonical paths) so a symlink
+// that escapes the launch directory is rejected, not a bespoke check.
+function resolveUnderLaunch(launchDir: string, relative: string | undefined): string {
+  const launchReal = Filesystem.resolve(launchDir)
+  if (relative === undefined) return launchReal
+  if (isAbsolute(relative)) throw new Error("absolute directory paths are not allowed")
+  const requestedReal = Filesystem.resolve(join(launchDir, relative))
+  if (!Filesystem.contains(launchReal, requestedReal)) {
+    throw new Error("directory path escapes the launch directory")
+  }
+  return requestedReal
+}
 
 // kilocode_change start — lazy init to avoid circular dependency
 // (Server → RemoteRoutes → RemoteSender → SessionPrompt at module load time)
@@ -643,6 +662,67 @@ export namespace RemoteSender {
         })()
         return
       }
+      // kilocode_change - k1: connection-scoped directory listing for the
+      // instance-picker folder tree. Lists exactly one level, directories
+      // only, with symlink escapes skipped.
+      if (msg.command === "list_directories") {
+        const parsed = RemoteCommand.ListDirectoriesRequest.safeParse(msg.data)
+        if (!parsed.success) {
+          options.conn.send({
+            type: "response",
+            id: msg.id,
+            error: "invalid list_directories request",
+          })
+          return
+        }
+        const launchReal = Filesystem.resolve(options.directory)
+        let listed: string
+        try {
+          listed = resolveUnderLaunch(options.directory, parsed.data.path)
+        } catch {
+          options.conn.send({
+            type: "response",
+            id: msg.id,
+            error: "invalid list_directories path",
+          })
+          return
+        }
+        void (async () => {
+          try {
+            const entries = await readdir(listed, { withFileTypes: true })
+            const directories: RemoteCommand.ListDirectoriesEntry[] = []
+            for (const entry of entries) {
+              if (directories.length >= RemoteCommand.MAX_DIRECTORIES) break
+              const childReal = Filesystem.resolve(join(listed, entry.name))
+              // A symlink whose canonical path equals the launch directory
+              // resolves to launchReal, so its relative path is "" and would
+              // violate ListDirectoriesEntry.path min(1). Never emit it.
+              const childPath = relative(launchReal, childReal).split(sep).join("/")
+              if (!childPath) continue
+              if (entry.isDirectory()) {
+                directories.push({ name: entry.name, path: childPath })
+                continue
+              }
+              if (entry.isSymbolicLink()) {
+                const realIsDir = Filesystem.stat(childReal)?.isDirectory() === true
+                if (realIsDir && Filesystem.contains(launchReal, childReal)) {
+                  directories.push({ name: entry.name, path: childPath })
+                }
+              }
+            }
+            const listedRelative = relative(launchReal, listed).split(sep).join("/")
+            options.conn.send({
+              type: "response",
+              id: msg.id,
+              result: { protocolVersion: 1, path: listedRelative, directories },
+            })
+          } catch (error) {
+            options.log.error("list directories failed", { id: msg.id, error: errorName(error) })
+            options.conn.send({ type: "response", id: msg.id, error: "failed to list directories" })
+          }
+        })()
+        return
+      }
       if (msg.command === "send_command") {
         const parsed = RemoteCommand.SendRequest.safeParse(msg.data)
         const session = msg.sessionId ? decodeSessionID(msg.sessionId) : Option.none<SessionID>()
@@ -830,18 +910,44 @@ export namespace RemoteSender {
             : {}),
           ...(parsed.data.orgId ? { metadata: { orgId: parsed.data.orgId } } : {}),
         }
+        // kilocode_change - k1: a present `directory` starts the session in a
+        // contained relative path under the launch directory. Resolve it before
+        // the create try/catch so a bad path is a request error ("invalid
+        // create_session directory"), not a create failure. Old clients omit
+        // `directory`; keep the sessionId/options.directory fallback below until
+        // every supported client sends it.
+        const targetOverride = (() => {
+          if (parsed.data.directory === undefined) return undefined
+          try {
+            return resolveUnderLaunch(options.directory, parsed.data.directory)
+          } catch {
+            return undefined
+          }
+        })()
+        if (parsed.data.directory !== undefined && targetOverride === undefined) {
+          options.conn.send({
+            type: "response",
+            id: msg.id,
+            error: "invalid create_session directory",
+          })
+          return
+        }
         const run = options.provide ?? provide
         void (async () => {
           try {
-            // Resolve the target directory: a present `sessionId` keeps the
-            // legacy mobile /new-inside-a-session behavior (target = that
-            // session's directory); an absent `sessionId` targets the
-            // instance's own launch directory (the new instance-picker path).
-            const targetDirectory = await current.pipe(
-              Option.map((sid) => session.get(sid)),
-              Option.map((p) => p.then((info) => info.directory)),
-              Option.getOrElse(() => Promise.resolve(options.directory)),
-            )
+            // Resolve the target directory: a present `directory` field wins
+            // (contained relative path under the launch directory); otherwise a
+            // present `sessionId` keeps the legacy mobile
+            // /new-inside-a-session behavior (target = that session's
+            // directory); an absent `sessionId` targets the instance's own
+            // launch directory (the new instance-picker path).
+            const targetDirectory =
+              targetOverride ??
+              (await current.pipe(
+                Option.map((sid) => session.get(sid)),
+                Option.map((p) => p.then((info) => info.directory)),
+                Option.getOrElse(() => Promise.resolve(options.directory)),
+              ))
             const result = await run({
               directory: targetDirectory,
               fn: async () => {

--- a/packages/opencode/src/kilo-sessions/remote-sender.ts
+++ b/packages/opencode/src/kilo-sessions/remote-sender.ts
@@ -719,19 +719,32 @@ export namespace RemoteSender {
             const directories: RemoteCommand.ListDirectoriesEntry[] = []
             for (const entry of entries) {
               if (directories.length >= RemoteCommand.MAX_DIRECTORIES) break
-              const childReal = Filesystem.resolve(join(listed, entry.name))
+              let childReal: string
+              try {
+                childReal = Filesystem.resolve(join(listed, entry.name))
+              } catch {
+                continue // skip a child whose canonical path cannot be resolved (ELOOP, EACCES)
+              }
               // A symlink whose canonical path equals the launch directory
               // resolves to launchReal, so its relative path is "" and would
               // violate ListDirectoriesEntry.path min(1). Never emit it.
               const childPath = relative(launchReal, childReal).split(sep).join("/")
               if (!childPath) continue
+              // Windows junctions report isDirectory() without isSymbolicLink(), so apply
+              // the containment check to every entry, not only symlinks.
+              if (!Filesystem.contains(launchReal, childReal)) continue
               if (entry.isDirectory()) {
                 directories.push({ name: entry.name, path: childPath })
                 continue
               }
               if (entry.isSymbolicLink()) {
-                const realIsDir = Filesystem.stat(childReal)?.isDirectory() === true
-                if (realIsDir && Filesystem.contains(launchReal, childReal)) {
+                let realIsDir = false
+                try {
+                  realIsDir = Filesystem.stat(childReal)?.isDirectory() === true
+                } catch {
+                  continue
+                }
+                if (realIsDir) {
                   directories.push({ name: entry.name, path: childPath })
                 }
               }

--- a/packages/opencode/src/kilo-sessions/remote-sender.ts
+++ b/packages/opencode/src/kilo-sessions/remote-sender.ts
@@ -106,7 +106,15 @@ function resolveUnderLaunch(launchDir: string, relative: string | undefined): st
   const launchReal = Filesystem.resolve(launchDir)
   if (relative === undefined) return launchReal
   if (isAbsolute(relative)) throw new Error("absolute directory paths are not allowed")
-  const requestedReal = Filesystem.resolve(join(launchDir, relative))
+  // Require the target to exist and be a directory before canonicalizing:
+  // Filesystem.resolve falls back to the lexical path on ENOENT, so a
+  // symlinked ancestor with a missing final component would pass the
+  // containment test below. Both callers select an existing folder.
+  const requested = join(launchDir, relative)
+  if (!Filesystem.stat(requested)?.isDirectory()) {
+    throw new Error("directory does not exist")
+  }
+  const requestedReal = Filesystem.resolve(requested)
   if (!Filesystem.contains(launchReal, requestedReal)) {
     throw new Error("directory path escapes the launch directory")
   }

--- a/packages/opencode/test/kilocode/sessions/remote-command.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-command.test.ts
@@ -12,6 +12,36 @@ describe("RemoteCommand", () => {
     expect(RemoteCommand.ListRequest.safeParse({ protocolVersion: 1, extra: true }).success).toBe(false)
   })
 
+  test("validates list_directories requests and responses", () => {
+    expect(RemoteCommand.ListDirectoriesRequest.safeParse({ protocolVersion: 1 }).success).toBe(true)
+    expect(RemoteCommand.ListDirectoriesRequest.safeParse({ protocolVersion: 1, path: "sub/dir" }).success).toBe(true)
+    expect(RemoteCommand.ListDirectoriesRequest.safeParse({ protocolVersion: 2 }).success).toBe(false)
+    expect(RemoteCommand.ListDirectoriesRequest.safeParse({ protocolVersion: 1, extra: true }).success).toBe(false)
+    expect(RemoteCommand.ListDirectoriesRequest.safeParse({ protocolVersion: 1, path: "" }).success).toBe(false)
+    expect(
+      RemoteCommand.ListDirectoriesRequest.safeParse({
+        protocolVersion: 1,
+        path: "x".repeat(RemoteCommand.MAX_STRING_LENGTH + 1),
+      }).success,
+    ).toBe(false)
+
+    expect(
+      RemoteCommand.ListDirectoriesResponse.safeParse({
+        protocolVersion: 1,
+        path: "",
+        directories: [{ name: "src", path: "src" }],
+      }).success,
+    ).toBe(true)
+    expect(
+      RemoteCommand.ListDirectoriesResponse.safeParse({
+        protocolVersion: 1,
+        path: "",
+        directories: [],
+        extra: true,
+      }).success,
+    ).toBe(false)
+  })
+
   test("validates strict exit CLI requests", () => {
     expect(RemoteCommand.ExitRequest.safeParse({ protocolVersion: 1 }).success).toBe(true)
     expect(RemoteCommand.ExitRequest.safeParse({}).success).toBe(false)

--- a/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
@@ -4382,7 +4382,12 @@ describe("RemoteSender slash commands", () => {
       subscribe: fakeBus().subscribe,
     })
 
-    sender.handle({ type: "command", id: "req_escape", command: "list_directories", data: { protocolVersion: 1, path: ".." } })
+    sender.handle({
+      type: "command",
+      id: "req_escape",
+      command: "list_directories",
+      data: { protocolVersion: 1, path: ".." },
+    })
 
     expect(sent).toEqual([{ type: "response", id: "req_escape", error: "invalid list_directories path" }])
   })
@@ -4601,8 +4606,18 @@ describe("RemoteSender slash commands", () => {
       },
     })
 
-    sender.handle({ type: "command", id: "req_escape", command: "create_session", data: { protocolVersion: 1, directory: ".." } })
-    sender.handle({ type: "command", id: "req_abs", command: "create_session", data: { protocolVersion: 1, directory: "/tmp" } })
+    sender.handle({
+      type: "command",
+      id: "req_escape",
+      command: "create_session",
+      data: { protocolVersion: 1, directory: ".." },
+    })
+    sender.handle({
+      type: "command",
+      id: "req_abs",
+      command: "create_session",
+      data: { protocolVersion: 1, directory: "/tmp" },
+    })
 
     expect(sent).toEqual([
       { type: "response", id: "req_escape", error: "invalid create_session directory" },
@@ -4610,6 +4625,58 @@ describe("RemoteSender slash commands", () => {
     ])
     expect(createCalls).toEqual([])
     expect(attachCalls).toEqual([])
+  })
+
+  test("create_session rejects a missing target under a symlinked ancestor that escapes", async () => {
+    await using outside = await tmpdir()
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await symlink(outside.path, join(dir, "link"), "dir")
+      },
+    })
+    const { conn, sent } = fakeConn()
+    const provideCalls: unknown[] = []
+    const createCalls: unknown[] = []
+    const sender = RemoteSender.create({
+      conn,
+      directory: tmp.path,
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async <R>(input: { directory: string; fn: () => R }) => {
+        provideCalls.push(input.directory)
+        return input.fn()
+      },
+      session: {
+        get: async () => {
+          throw new Error("session.get must not be called")
+        },
+        children: async () => [],
+        create: async (input) => {
+          createCalls.push(input)
+          return { id: SessionID.make("ses_x"), directory: tmp.path } as any
+        },
+      },
+    })
+
+    sender.handle({
+      type: "command",
+      id: "req_missing",
+      command: "create_session",
+      data: { protocolVersion: 1, directory: "link/missing" },
+    })
+    sender.handle({
+      type: "command",
+      id: "req_list_missing",
+      command: "list_directories",
+      data: { protocolVersion: 1, path: "link/missing" },
+    })
+
+    expect(sent).toEqual([
+      { type: "response", id: "req_missing", error: "invalid create_session directory" },
+      { type: "response", id: "req_list_missing", error: "invalid list_directories path" },
+    ])
+    expect(provideCalls).toEqual([])
+    expect(createCalls).toEqual([])
   })
 })
 // kilocode_change end

--- a/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-sender.test.ts
@@ -18,6 +18,9 @@ import { SessionID } from "../../../src/session/schema"
 import { Session } from "../../../src/session/session"
 import { Suggestion } from "../../../src/kilocode/suggestion"
 import { KiloSessionPromptQueue } from "../../../src/kilocode/session/prompt-queue"
+import { mkdir, symlink, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "../../fixture/fixture"
 
 function fakeConn() {
   const sent: any[] = []
@@ -4065,6 +4068,311 @@ describe("RemoteSender slash commands", () => {
     expect(sawMarkInsideSetTitle).toBe(true)
     // Production catch must clear the re-mark so a later local write is not skipped.
     expect(consumeRenameAdoption(sid, "Cloud title")).toBe(false)
+  })
+
+  // k1: list_directories — one level, directories only, no recursion, symlink
+  // escapes skipped.
+  test("list_directories lists one level of directories at launch and omits files", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await mkdir(join(dir, "alpha"))
+        await mkdir(join(dir, "beta", "nested"), { recursive: true })
+        await writeFile(join(dir, "file.txt"), "x")
+      },
+    })
+    const { conn, sent } = fakeConn()
+    const sender = RemoteSender.create({
+      conn,
+      directory: tmp.path,
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+    })
+
+    const response = expectResponse(conn, sent, "req_list")
+    sender.handle({ type: "command", id: "req_list", command: "list_directories", data: { protocolVersion: 1 } })
+    await response.promise
+    response.restore()
+
+    const result = sent[0]?.result
+    expect(result.protocolVersion).toBe(1)
+    expect(result.path).toBe("")
+    expect(result.directories.map((d: any) => d.name).sort()).toEqual(["alpha", "beta"])
+    expect(result.directories.map((d: any) => d.name)).not.toContain("file.txt")
+    expect(result.directories.find((d: any) => d.name === "beta")?.path).toBe("beta")
+  })
+
+  test("list_directories lists only the requested child level, not grandchildren", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await mkdir(join(dir, "beta", "nested", "deep"), { recursive: true })
+        await writeFile(join(dir, "beta", "nested", "file.txt"), "x")
+      },
+    })
+    const { conn, sent } = fakeConn()
+    const sender = RemoteSender.create({
+      conn,
+      directory: tmp.path,
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+    })
+
+    const response = expectResponse(conn, sent, "req_child")
+    sender.handle({
+      type: "command",
+      id: "req_child",
+      command: "list_directories",
+      data: { protocolVersion: 1, path: "beta" },
+    })
+    await response.promise
+    response.restore()
+
+    expect(sent).toEqual([
+      {
+        type: "response",
+        id: "req_child",
+        result: { protocolVersion: 1, path: "beta", directories: [{ name: "nested", path: "beta/nested" }] },
+      },
+    ])
+  })
+
+  test("list_directories rejects a relative path outside the launch directory", async () => {
+    await using tmp = await tmpdir()
+    const { conn, sent } = fakeConn()
+    const sender = RemoteSender.create({
+      conn,
+      directory: tmp.path,
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+    })
+
+    sender.handle({ type: "command", id: "req_escape", command: "list_directories", data: { protocolVersion: 1, path: ".." } })
+
+    expect(sent).toEqual([{ type: "response", id: "req_escape", error: "invalid list_directories path" }])
+  })
+
+  test("list_directories omits a symlink child that resolves outside the launch directory", async () => {
+    await using outside = await tmpdir({
+      init: async (dir) => {
+        await mkdir(join(dir, "escape"))
+      },
+    })
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await mkdir(join(dir, "alpha"))
+        await symlink(join(outside.path, "escape"), join(dir, "link-out"))
+      },
+    })
+    const { conn, sent } = fakeConn()
+    const sender = RemoteSender.create({
+      conn,
+      directory: tmp.path,
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+    })
+
+    const response = expectResponse(conn, sent, "req_symlink")
+    sender.handle({ type: "command", id: "req_symlink", command: "list_directories", data: { protocolVersion: 1 } })
+    await response.promise
+    response.restore()
+
+    const names = sent[0]?.result.directories.map((d: any) => d.name)
+    expect(names).toContain("alpha")
+    expect(names).not.toContain("link-out")
+  })
+
+  test("list_directories keeps a symlink to a contained directory and omits a symlink to a file", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await mkdir(join(dir, "real-dir"))
+        await writeFile(join(dir, "real-file.txt"), "x")
+        await symlink(join(dir, "real-dir"), join(dir, "link-dir"))
+        await symlink(join(dir, "real-file.txt"), join(dir, "link-file"))
+      },
+    })
+    const { conn, sent } = fakeConn()
+    const sender = RemoteSender.create({
+      conn,
+      directory: tmp.path,
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+    })
+
+    const response = expectResponse(conn, sent, "req_symlink_in")
+    sender.handle({ type: "command", id: "req_symlink_in", command: "list_directories", data: { protocolVersion: 1 } })
+    await response.promise
+    response.restore()
+
+    const names = sent[0]?.result.directories.map((d: any) => d.name).sort()
+    expect(names).toEqual(["link-dir", "real-dir"])
+    expect(names).not.toContain("link-file")
+    expect(names).not.toContain("real-file.txt")
+  })
+
+  test("list_directories omits a symlink whose canonical path equals the launch directory", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await mkdir(join(dir, "alpha"))
+        await symlink(dir, join(dir, "link-self"))
+      },
+    })
+    const { conn, sent } = fakeConn()
+    const sender = RemoteSender.create({
+      conn,
+      directory: tmp.path,
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+    })
+
+    const response = expectResponse(conn, sent, "req_self_symlink")
+    sender.handle({
+      type: "command",
+      id: "req_self_symlink",
+      command: "list_directories",
+      data: { protocolVersion: 1 },
+    })
+    await response.promise
+    response.restore()
+
+    const directories = sent[0]?.result.directories
+    expect(directories.map((d: any) => d.name).sort()).toEqual(["alpha"])
+    expect(directories.every((d: any) => d.path !== "")).toBe(true)
+  })
+
+  test("list_directories caps the response at MAX_DIRECTORIES entries", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        for (let i = 0; i < RemoteCommand.MAX_DIRECTORIES + 5; i++) {
+          await mkdir(join(dir, `dir-${String(i).padStart(3, "0")}`))
+        }
+      },
+    })
+    const { conn, sent } = fakeConn()
+    const sender = RemoteSender.create({
+      conn,
+      directory: tmp.path,
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+    })
+
+    const response = expectResponse(conn, sent, "req_cap")
+    sender.handle({ type: "command", id: "req_cap", command: "list_directories", data: { protocolVersion: 1 } })
+    await response.promise
+    response.restore()
+
+    const directories = sent[0]?.result.directories
+    expect(directories).toHaveLength(RemoteCommand.MAX_DIRECTORIES)
+  })
+
+  test("list_directories rejects an invalid request", () => {
+    const { conn, sent } = fakeConn()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+    })
+
+    sender.handle({ type: "command", id: "req_bad", command: "list_directories", data: { protocolVersion: 2 } })
+
+    expect(sent).toEqual([{ type: "response", id: "req_bad", error: "invalid list_directories request" }])
+  })
+
+  test("list_directories does not shadow the unknown-command fallback for other names", () => {
+    const { conn, sent } = fakeConn()
+    const sender = RemoteSender.create({
+      conn,
+      directory: "/tmp/test",
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+    })
+
+    sender.handle({ type: "command", id: "req_unknown", command: "list_dirs", data: {} } as RemoteProtocol.Command)
+
+    expect(sent).toEqual([{ type: "response", id: "req_unknown", error: "unknown command: list_dirs" }])
+  })
+
+  // k1: create_session.directory — contained relative path override.
+  test("create_session starts in the contained relative directory when directory is set", async () => {
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await mkdir(join(dir, "child"))
+      },
+    })
+    const { conn, sent } = fakeConn()
+    const dirs: string[] = []
+    const attachCalls: SessionID[] = []
+    const sender = RemoteSender.create({
+      conn,
+      directory: tmp.path,
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      provide: async <R>(input: { directory: string; fn: () => R }) => {
+        dirs.push(input.directory)
+        return input.fn()
+      },
+      session: {
+        get: async () => {
+          throw new Error("session.get must not be called when directory overrides")
+        },
+        children: async () => [],
+        create: async () => ({ id: SessionID.make("ses_dir"), directory: join(tmp.path, "child") }) as any,
+      },
+      attachSession: async (input) => {
+        attachCalls.push(input)
+        return
+      },
+    })
+
+    const response = expectResponse(conn, sent, "req_dir")
+    sender.handle({
+      type: "command",
+      id: "req_dir",
+      command: "create_session",
+      data: { protocolVersion: 1, directory: "child" },
+    })
+    await response.promise
+    response.restore()
+
+    expect(dirs).toEqual([join(tmp.path, "child")])
+    expect(attachCalls).toEqual([SessionID.make("ses_dir")])
+    expect(sent).toEqual([{ type: "response", id: "req_dir", result: { protocolVersion: 1, sessionID: "ses_dir" } }])
+  })
+
+  test("create_session rejects an escaped or absolute directory and does not create a session", async () => {
+    await using tmp = await tmpdir()
+    const { conn, sent } = fakeConn()
+    const createCalls: unknown[] = []
+    const attachCalls: unknown[] = []
+    const sender = RemoteSender.create({
+      conn,
+      directory: tmp.path,
+      log: nolog,
+      subscribe: fakeBus().subscribe,
+      session: {
+        get: async () => {
+          throw new Error("session.get must not be called")
+        },
+        children: async () => [],
+        create: async (input) => {
+          createCalls.push(input)
+          return { id: SessionID.make("ses_x"), directory: tmp.path } as any
+        },
+      },
+      attachSession: async (input) => {
+        attachCalls.push(input)
+        return
+      },
+    })
+
+    sender.handle({ type: "command", id: "req_escape", command: "create_session", data: { protocolVersion: 1, directory: ".." } })
+    sender.handle({ type: "command", id: "req_abs", command: "create_session", data: { protocolVersion: 1, directory: "/tmp" } })
+
+    expect(sent).toEqual([
+      { type: "response", id: "req_escape", error: "invalid create_session directory" },
+      { type: "response", id: "req_abs", error: "invalid create_session directory" },
+    ])
+    expect(createCalls).toEqual([])
+    expect(attachCalls).toEqual([])
   })
 })
 // kilocode_change end


### PR DESCRIPTION
## Summary

When starting a session on a connected remote instance, a new Folder field lets the user pick a child folder of the instance's launch directory. The user can drill down any number of levels, and Start then opens the session in that folder.

An older connected instance that cannot list folders shows that message, and Start still opens the session in the instance's launch folder.

---

The kilocode CLI adds two launch-directory-scoped contracts: a `list_directories` command that lists one directory level, and an optional `create_session.directory` field that starts the session in a chosen child folder. Both resolve a client-supplied relative path under the launch directory through one helper that rejects absolute paths, escapes, and symlinks that resolve outside it, so the CLI owns path safety. A listing is capped at 256 entries, and old clients that omit `directory` keep the legacy sessionId or launch-directory fallback.

<details>
<summary>Files</summary>

- `packages/opencode/src/kilo-sessions/remote-command.ts` — adds the `list_directories` request, entry, and response schemas and the `MAX_DIRECTORIES` cap.
- `packages/opencode/src/kilo-sessions/remote-sender.ts` — dispatches `list_directories`, resolves `create_session.directory`, and adds the `resolveUnderLaunch` helper plus the one-level `readdir` loop.

</details>

A new SDK helper `listDirectoriesOnConnection` sends a connection-scoped `list_directories` command and classifies every outcome into `ok`, `unsupported`, `invalid`, or `transport`. It never throws and never logs, so the mobile hook maps outcomes to UI states without error handling. The strict `listDirectoriesV1Schema` fails closed on protocol drift, over-limit entries, and malformed entry strings.

<details>
<summary>Files</summary>

- `packages/cloud-agent-sdk/src/list-directories.ts` — new helper with the outcome classification and the unsupported relay-code set; imports the shared retryable set.
- `packages/cloud-agent-sdk/src/instance-model-catalog.ts` — exports the `RETRYABLE_RELAY_CODES` set that the helper now imports.
- `packages/cloud-agent-sdk/src/schemas.ts` — adds `listDirectoriesV1Schema` with the 256-entry and 2000-character caps; the caps stop being exported.
- `packages/cloud-agent-sdk/package.json` — exports the `./list-directories` subpath.

</details>

`createRemoteSessionOnConnection` now forwards an optional `directory` field, and the `:ext`/`:bare` old-CLI retry treats `directory` as an extended field. An old CLI that rejects the extended body still gets the bare `{protocolVersion: 1}` retry, which omits `directory`, so a folder choice degrades to the launch directory instead of failing the spawn. The two retries keep distinct durable mutation identities, so the relay does not replay the extended attempt's error to the bare retry.

<details>
<summary>Files</summary>

- `packages/cloud-agent-sdk/src/create-session.ts` — includes `directory` in the wire data and the extended-field check.
- `packages/cloud-agent-sdk/src/transport.ts` — adds `directory` to `CreateRemoteSessionInput`.

</details>

The user-web relay now admits `list_directories` as a viewer command and maps an old CLI's `unknown command: list_directories` to the structured `CLI_UPGRADE_REQUIRED` error. That mapping is temporary and must be removed once every supported CLI ships the command.

<details>
<summary>Files</summary>

- `services/session-ingest/src/dos/UserConnectionDO.ts` — adds `list_directories` to `ALLOWED_VIEWER_COMMANDS` and `CLI_UPGRADE_REQUIRED_COMMANDS`.

</details>

A new formSheet route lists one directory level at a time beneath the chosen instance's launch directory, with drill-down, in-sheet Back, per-path caching, and skeleton, empty, retryable, and unsupported states. The leading header control is relabeled Back when nested, and Done keeps the launch directory when the CLI cannot list folders. New copy covers the Folder field, the list hint, the empty state, and the retryable and unsupported messages, and the same strings are translated into every other catalog.

<details>
<summary>Files</summary>

- `apps/mobile/src/app/(app)/agent-chat/folder-picker.tsx` — the picker screen with the drill stack and per-phase rendering.
- `apps/mobile/src/lib/hooks/use-list-directories.ts` — the one-level listing client with a generation counter and per-path cache.
- `apps/mobile/src/app/(app)/_layout.tsx` — registers the `agent-chat/folder-picker` formSheet route.
- `apps/mobile/src/components/picker-sheet.tsx` — threads the `cancelLabel` override to the header.
- `apps/mobile/src/components/sheet-header.tsx` — resolves the leading-control label override so Back is announced as Back.
- `apps/mobile/src/i18n/locales/en.json` — adds the `folderPicker` strings.
- `apps/mobile/src/i18n/locales/*.json` — the translation pass fills the `folderPicker` keys in the 86 other catalogs.

</details>

The new-session configure form shows a Folder field for remote targets, whose confirmed relative path is held per instance and cleared when the connection changes. The field hands the connection, project, current path, and callback to the picker through a new folder-picker registry slot, and the confirmed path is threaded into the spawn dispatch as `create_session.directory`. The field shows the project name at launch and the selected folder path once the user has drilled in.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/folder-selector.tsx` — the Folder field and its handoff to the picker route; the component export is pruned.
- `apps/mobile/src/lib/hooks/use-launch-folder.ts` — per-instance folder state that resets when the connection changes.
- `apps/mobile/src/components/agents/new-session-configure-form.tsx` — renders the Folder field for remote targets.
- `apps/mobile/src/components/agents/new-session-screen-body.tsx` — owns the folder state and passes it to the form and the spawn dispatch.
- `apps/mobile/src/components/agents/use-remote-spawn-dispatch.ts` — accepts `directory`, reads it at press time, and keys the operation on it.
- `apps/mobile/src/lib/use-new-session-share-remote.ts` — forwards `folderPath` as `directory` to the dispatch.
- `apps/mobile/src/lib/hooks/remote-instance-spawn-classifier.ts` — includes `directory` in the built `create_session` input.
- `apps/mobile/src/lib/picker-bridge.ts` — adds the `FolderPickerBridge` type.
- `apps/mobile/src/lib/route-registry.ts` — adds the `folderPicker` slot kind.

</details>

Tests: 11 test files changed (9 in `Kilo-Org/cloud`, 2 in `Kilo-Org/kilocode`).
Generated: none.

---

## Verification

On iOS, three cases ran across the six folder rounds.

| Case | What it proves | Platform | Result |
|---|---|---|---|
| fp-confirm-and-start | Done confirms the child path, and Start opens a session that runs in that child folder. | ios | passed |
| fp-happy-open-and-drill | The sheet lists child folders with the tap-to-list hint and chevron rows, and drill-in and Back navigate. | ios | passed |
| fp-dismiss-and-instance-reset | A swipe-down dismiss keeps the confirmed folder, the re-shown sheet keeps Done tappable, and an instance change resets the folder. | ios | passed after the fix in round folder-r5 |

The folder-r2 round report is missing: the handoff names `e2e-folder-r2-ODY7BP/e2e-round.md`, but that directory is empty. The folder-r3 carry-forward that cites it is unverified; the fp-happy-open-and-drill result rests on folder-r6.

Defects:

- Re-presentation defect (Done and Back unresponsive on the re-shown sheet after a swipe-down dismiss): round folder-r4 reproduced it twice on the unfixed build; commit 48922812a fixed it; rounds folder-r5 and folder-r6 no longer reproduce it.
- ExpoScreenCapture native-module redbox on cold load: repro-r1 reproduced it; it is an environment residual, not a product defect; out of scope, not fixed.

Recordings exist: `repro-r0-ios.mp4` and `repro-r1-ios.mp4` in the scratch folder.

## Visual Changes

### Folder picker sheet

The user now sees a sheet that lists the remote folders as rows, with a tap-to-list hint and a Done button.
In the sheet, the hint sits above the rows `.config`, `node_modules`, and `xdg`; each row ends in a chevron, not a radio mark.

![03-fp-sheet-rows-ready.png](https://github.com/user-attachments/assets/22e1ee70-7a5d-472c-bf82-57f4e9409821)

### New-session form after folder confirmation

After the user picks a child folder and taps Done, the Folder field shows the child path.
Under the Run on row, the Folder field reads `.config`, and the Start session button sits below it.

![02-fp-drill-config-done.png](https://github.com/user-attachments/assets/1895b618-7261-4874-b13c-42c3c276fe9e)

### Started session in the chosen folder

The session runs in the confirmed child folder, and the pwd reply shows that path.
The agent reply path ends in `remote-session-ux-8f16/.config`, below the `Print working directory` tool row.

![01-fp-probe-pwd.png](https://github.com/user-attachments/assets/9fd39599-9450-4b91-bc0e-17ed7645d602)

## Reviewer Notes

Human steps: none known. The code adds no environment value, secret, migration, or flag to flip, and old CLIs degrade gracefully through the existing retry and unsupported paths.

Notes:
- Folder picking lets the user start a remote session in a chosen child folder.
- Live-list latency is out of scope for this PR (the latency work was not landed; a reproduction did not name the cause).
- This change spans `Kilo-Org/cloud` and `Kilo-Org/kilocode`; the `Kilo-Org/kilocode` PR is this PR's sibling. Both PRs share one body and cross-link.
