### PR TITLE
fix(agent-manager): show background worktree activity

### DIFF
--- a/.changeset/background-worktree-activity.md
+++ b/.changeset/background-worktree-activity.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep Agent Manager worktree spinners active while background agents are running.

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -46,6 +46,7 @@ import { forkSession } from "./fork-session"
 import { AgentManagerVisiblePresence } from "./am-visible-presence"
 import { continueInWorktree } from "./continue-in-worktree"
 import { WorktreeDiffController } from "./worktree-diff-controller"
+import { createWorktreeActivity } from "./worktree-activity"
 import { sendDiffBranches as postDiffBranches } from "./project/diff-branches"
 import { WorktreeImporter } from "./worktree-importer"
 import {
@@ -106,8 +107,7 @@ export class AgentManagerProvider implements Disposable {
   private cachedWorktreeStats: { type: "agentManager.worktreeStats"; stats: WorktreeStats[] } | undefined
   private cachedLocalStats: { type: "agentManager.localStats"; stats: LocalStats } | undefined
   private unsubTool: (() => void) | undefined
-  private unsubStatus: (() => void) | undefined
-  private unsubSessions: (() => void) | undefined
+  private activity: ReturnType<typeof createWorktreeActivity>
   private unsubFont: (() => void) | undefined
   private unsubProjects: (() => void) | undefined
   /** Scratch set returned when no active context exists; mutations are discarded. */
@@ -284,22 +284,15 @@ export class AgentManagerProvider implements Disposable {
       (event) => (event as { type?: string }).type === "kilocode.agent_manager.start",
       (event, directory) => this.onToolEvent(event, directory),
     )
-    this.unsubStatus = this.connectionService.onEventFiltered(
-      (event) => (event as { type?: string }).type === "session.status",
-      (event) => this.onSessionStatus(event),
-    )
-    this.unsubSessions = this.connectionService.onEventFiltered(
-      (event) => {
-        const type = (event as { type?: string }).type
-        return (
-          type === "session.created" ||
-          type === "session.updated" ||
-          type === "session.deleted" ||
-          type === "session.error"
-        )
-      },
-      (event) => this.onSessionLifecycle(event),
-    )
+    this.activity = createWorktreeActivity({
+      connection: this.connectionService,
+      paths: () =>
+        [...this.contexts.values()].flatMap((ctx) => ctx.peekState()?.getWorktrees() ?? []).map((wt) => wt.path),
+      post: (active) => this.postToWebview({ type: "agentManager.worktreeActivity", active }),
+      status: (event) => this.onSessionStatus(event),
+      lifecycle: (event) => this.onSessionLifecycle(event),
+      log: (err) => this.log("Failed to load worktree activity:", err),
+    })
   }
   /**
    * Keep each project's cached sidebar session list in sync with backend
@@ -906,6 +899,7 @@ export class AgentManagerProvider implements Disposable {
     // instance are reaped by the router's generation guard.
     void this.terminalRouter.dispose()
     this.scripts.manager.snapshot()
+    void this.activity.sync(true)
     this.log(
       `onRequestState: stateReady=${this.stateReady ? "pending" : "missing"}, state=${this.state ? "ok" : "missing"}`,
     )
@@ -1428,6 +1422,7 @@ export class AgentManagerProvider implements Disposable {
       activeTarget: state.getActiveTarget(),
       ...(active ? this.runStateFor(target) : {}),
     })
+    void this.activity.sync()
     void pushProjectSessions(target, this.panel?.sessions, (message) => this.postToWebview(message))
     if (!active) return
 
@@ -1872,8 +1867,7 @@ export class AgentManagerProvider implements Disposable {
     await this.stateReady?.catch((err) => this.log("dispose: stateReady rejected:", err))
     await this.contexts.dispose()
     this.unsubTool?.()
-    this.unsubStatus?.()
-    this.unsubSessions?.()
+    this.activity.dispose()
     this.unsubFont?.()
     this.unsubProjects?.()
     this.unsubDestination?.()

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -1436,6 +1436,7 @@ export class AgentManagerProvider implements Disposable {
 
   /** Push empty state when the folder is not a git repo or has no folder open. */
   private pushEmptyState(): void {
+    void this.activity.sync()
     this.staleWorktreeIds.clear()
     this.postToWebview({
       type: "agentManager.state",
@@ -1616,6 +1617,7 @@ export class AgentManagerProvider implements Disposable {
 
   private pushProjects(): void {
     const projects = this.contexts.snapshots()
+    void this.activity.sync()
     this.postToWebview({
       type: "agentManager.projects",
       multiProject: this.host.multiProject(),

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -127,6 +127,11 @@ interface WorktreeStatsMessage {
   stats: WorktreeStats[]
 }
 
+interface WorktreeActivityMessage {
+  type: "agentManager.worktreeActivity"
+  active: string[]
+}
+
 interface LocalStatsMessage {
   type: "agentManager.localStats"
   /** Owning project; absent in single-project mode. */
@@ -452,6 +457,7 @@ interface RunStatusMessage extends RunStatus {
 
 /** All messages the Agent Manager extension sends to the webview. */
 export type AgentManagerOutMessage =
+  | WorktreeActivityMessage
   | WorktreeStatsMessage
   | LocalStatsMessage
   | WorktreeSetupMessage

--- a/packages/kilo-vscode/src/agent-manager/worktree-activity.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-activity.ts
@@ -1,0 +1,397 @@
+import { samePath } from "./project/paths"
+import type { KiloConnectionService } from "../services/cli-backend"
+
+type Snapshot = {
+  statuses: Record<string, { type: string }>
+  permissions: Array<{ id: string; sessionID: string }>
+  questions: Array<{ id: string; sessionID: string }>
+}
+
+type Change =
+  | { kind: "status"; sessionID: string; type: string }
+  | { kind: "permission.add"; id: string; sessionID: string }
+  | { kind: "permission.remove"; id: string; sessionID: string }
+  | { kind: "question.add"; id: string; sessionID: string }
+  | { kind: "question.remove"; id: string; sessionID: string }
+  | { kind: "clear"; sessionID: string }
+
+type State = {
+  dir: string
+  loaded: boolean
+  statuses: Map<string, string>
+  permissions: Map<string, string>
+  questions: Map<string, string>
+  request?: Request
+}
+
+type Request = {
+  state: State
+  events: Change[]
+  promise: Promise<void>
+}
+
+type Options = {
+  paths: () => string[]
+  load: (dir: string) => Promise<Snapshot>
+  post: (active: string[]) => void
+  log: (err: unknown) => void
+}
+
+type FactoryOptions = {
+  connection: KiloConnectionService
+  paths: () => string[]
+  post: (active: string[]) => void
+  status: (event: unknown) => void
+  lifecycle: (event: unknown) => void
+  log: (err: unknown) => void
+}
+
+const TYPES = new Set([
+  "session.status",
+  "session.deleted",
+  "session.error",
+  "permission.asked",
+  "permission.replied",
+  "question.asked",
+  "question.replied",
+  "question.rejected",
+  "server.instance.disposed",
+])
+
+function normalize(dir: string): string {
+  const value = dir.replace(/\\/g, "/")
+  if (/^[A-Za-z]:\/+$/u.test(value)) return `${value.slice(0, 2)}/`
+  const result = value.replace(/\/+$/u, "")
+  return result || "/"
+}
+
+function matches(a: string, b: string): boolean {
+  return samePath(normalize(a), normalize(b))
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined
+}
+
+function string(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined
+}
+
+export class WorktreeActivity {
+  private states: State[] = []
+  private cache: string[] = []
+  private dead = false
+
+  constructor(private readonly opts: Options) {}
+
+  static accepts(event: unknown): boolean {
+    const value = record(event)
+    return value !== undefined && typeof value.type === "string" && TYPES.has(value.type)
+  }
+
+  async sync(force = false): Promise<void> {
+    if (this.dead) return
+
+    let changed = false
+    const wanted: State[] = []
+    const current = this.states
+    for (const dir of this.opts.paths()) {
+      const state = this.find(current, wanted, dir)
+      if (!state) continue
+      if (wanted.includes(state)) continue
+      if (state.dir !== dir) changed = true
+      state.dir = dir
+      wanted.push(state)
+    }
+
+    changed = this.prune(current, wanted) || changed
+    if (wanted.length !== current.length) changed = true
+    this.states = wanted
+
+    const jobs: Promise<void>[] = []
+    changed = this.load(wanted, force, jobs) || changed
+    await Promise.all(jobs)
+    if (changed) this.publish()
+  }
+
+  replay(): void {
+    if (this.dead) return
+    this.opts.post(this.cache.slice())
+  }
+
+  event(event: unknown, directory?: string): void {
+    if (this.dead || !WorktreeActivity.accepts(event)) return
+    const value = record(event)
+    if (!value) return
+
+    const type = value.type
+    if (type === "server.instance.disposed") {
+      const props = record(value.properties)
+      const dir = string(props?.directory) ?? directory
+      if (!dir) return
+      const state = this.states.find((item) => matches(item.dir, dir))
+      if (!state) return
+      this.invalidate(state)
+      state.loaded = false
+      this.publish()
+      return
+    }
+    if (!directory) return
+    const state = this.states.find((item) => matches(item.dir, directory))
+    if (!state) return
+
+    const change = this.change(type, value.properties)
+    if (!change) return
+    if (state.request) state.request.events.push(change)
+    this.apply(state, change)
+    this.publish()
+  }
+
+  clear(): void {
+    if (this.dead) return
+    for (const state of this.states) this.invalidate(state)
+    this.states = []
+    this.cache = []
+    this.opts.post([])
+  }
+
+  dispose(): void {
+    if (this.dead) return
+    this.dead = true
+    for (const state of this.states) this.invalidate(state)
+    this.states = []
+    this.cache = []
+  }
+
+  private state(dir: string): State {
+    return {
+      dir,
+      loaded: false,
+      statuses: new Map(),
+      permissions: new Map(),
+      questions: new Map(),
+    }
+  }
+
+  private find(current: State[], wanted: State[], dir: unknown): State | undefined {
+    if (typeof dir !== "string" || !dir) return undefined
+    return (
+      current.find((item) => matches(item.dir, dir)) ?? wanted.find((item) => matches(item.dir, dir)) ?? this.state(dir)
+    )
+  }
+
+  private prune(current: State[], wanted: State[]): boolean {
+    let changed = false
+    for (const state of current) {
+      if (wanted.includes(state)) continue
+      this.invalidate(state)
+      changed = true
+    }
+    return changed
+  }
+
+  private load(wanted: State[], force: boolean, jobs: Promise<void>[]): boolean {
+    let changed = false
+    for (const state of wanted) {
+      const req = state.request ?? (!state.loaded || force ? this.request(state) : undefined)
+      if (req) jobs.push(req.promise)
+      if (req || !state.loaded || force) changed = true
+    }
+    return changed
+  }
+
+  private request(state: State): Request {
+    const req: Request = {
+      state,
+      events: [],
+      promise: Promise.resolve(),
+    }
+    state.request = req
+    req.promise = Promise.resolve()
+      .then(() => this.opts.load(state.dir))
+      .then((snapshot) => this.finish(req, snapshot))
+      .catch((err: unknown) => {
+        if (this.valid(req)) req.state.loaded = false
+        this.opts.log(err)
+      })
+      .finally(() => {
+        if (state.request === req) state.request = undefined
+      })
+    return req
+  }
+
+  private finish(req: Request, snapshot: Snapshot): void {
+    if (!this.valid(req)) return
+    const state = req.state
+    state.statuses = new Map()
+    for (const [sessionID, status] of Object.entries(snapshot.statuses ?? {})) {
+      if (typeof status?.type === "string") state.statuses.set(sessionID, status.type)
+    }
+    state.permissions = new Map()
+    for (const item of snapshot.permissions ?? []) {
+      if (typeof item?.id === "string" && typeof item.sessionID === "string")
+        state.permissions.set(item.id, item.sessionID)
+    }
+    state.questions = new Map()
+    for (const item of snapshot.questions ?? []) {
+      if (typeof item?.id === "string" && typeof item.sessionID === "string")
+        state.questions.set(item.id, item.sessionID)
+    }
+    for (const change of req.events) this.apply(state, change)
+    state.loaded = true
+    this.publish()
+  }
+
+  private valid(req: Request): boolean {
+    return !this.dead && req.state.request === req && this.states.includes(req.state)
+  }
+
+  private invalidate(state: State): void {
+    state.request = undefined
+    state.loaded = false
+    state.statuses.clear()
+    state.permissions.clear()
+    state.questions.clear()
+  }
+
+  private change(type: unknown, props: unknown): Change | undefined {
+    const value = record(props)
+    if (!value) return undefined
+    if (type === "session.status") return this.status(value)
+    if (type === "session.deleted" || type === "session.error") return this.cleared(value)
+    if (type === "permission.asked" || type === "question.asked") return this.add(type, value)
+    if (type === "permission.replied" || type === "question.replied" || type === "question.rejected")
+      return this.remove(type, value)
+    return undefined
+  }
+
+  private status(value: Record<string, unknown>): Change | undefined {
+    const sessionID = string(value.sessionID)
+    const status = record(value.status)
+    const type = string(status?.type)
+    return sessionID && type ? { kind: "status", sessionID, type } : undefined
+  }
+
+  private cleared(value: Record<string, unknown>): Change | undefined {
+    const info = record(value.info)
+    const sessionID = string(value.sessionID) ?? string(info?.id)
+    return sessionID ? { kind: "clear", sessionID } : undefined
+  }
+
+  private add(type: unknown, value: Record<string, unknown>): Change | undefined {
+    const id = string(value.id)
+    const sessionID = string(value.sessionID)
+    if (!id || !sessionID) return undefined
+    return type === "permission.asked"
+      ? { kind: "permission.add", id, sessionID }
+      : { kind: "question.add", id, sessionID }
+  }
+
+  private remove(type: unknown, value: Record<string, unknown>): Change | undefined {
+    const id = string(value.requestID)
+    const sessionID = string(value.sessionID)
+    if (!id || !sessionID) return undefined
+    return type === "permission.replied"
+      ? { kind: "permission.remove", id, sessionID }
+      : { kind: "question.remove", id, sessionID }
+  }
+
+  private apply(state: State, change: Change): void {
+    if (change.kind === "status") {
+      state.statuses.set(change.sessionID, change.type)
+      return
+    }
+    if (change.kind === "permission.add") {
+      state.permissions.set(change.id, change.sessionID)
+      return
+    }
+    if (change.kind === "permission.remove") {
+      if (state.permissions.get(change.id) === change.sessionID) state.permissions.delete(change.id)
+      return
+    }
+    if (change.kind === "question.add") {
+      state.questions.set(change.id, change.sessionID)
+      return
+    }
+    if (change.kind === "question.remove") {
+      if (state.questions.get(change.id) === change.sessionID) state.questions.delete(change.id)
+      return
+    }
+    state.statuses.delete(change.sessionID)
+    for (const [id, sessionID] of state.permissions) {
+      if (sessionID === change.sessionID) state.permissions.delete(id)
+    }
+    for (const [id, sessionID] of state.questions) {
+      if (sessionID === change.sessionID) state.questions.delete(id)
+    }
+  }
+
+  private active(state: State): boolean {
+    const blocked = new Set([...state.permissions.values(), ...state.questions.values()])
+    for (const [sessionID, type] of state.statuses) {
+      if ((type === "busy" || type === "retry") && !blocked.has(sessionID)) return true
+    }
+    return false
+  }
+
+  private publish(): void {
+    if (this.dead) return
+    const active = this.states.filter((state) => this.active(state)).map((state) => state.dir)
+    this.cache = active.slice()
+    this.opts.post(active)
+  }
+}
+
+export function createWorktreeActivity(opts: FactoryOptions) {
+  const activity = new WorktreeActivity({
+    paths: opts.paths,
+    load: async (dir) => {
+      const client = opts.connection.getClient()
+      const [status, permission, question] = await Promise.all([
+        client.session.status({ directory: dir }, { throwOnError: true }),
+        client.permission.list({ directory: dir }, { throwOnError: true }),
+        client.question.list({ directory: dir }, { throwOnError: true }),
+      ])
+      return {
+        statuses: status.data ?? {},
+        permissions: permission.data ?? [],
+        questions: question.data ?? [],
+      }
+    },
+    post: opts.post,
+    log: opts.log,
+  })
+  const filter = (event: unknown) => {
+    const type = record(event)?.type
+    return WorktreeActivity.accepts(event) || type === "session.created" || type === "session.updated"
+  }
+  const unsubEvent = opts.connection.onEventFiltered(filter, (event, directory) => {
+    activity.event(event, directory)
+    const type = record(event)?.type
+    if (type === "session.status") opts.status(event)
+    if (
+      type === "session.created" ||
+      type === "session.updated" ||
+      type === "session.deleted" ||
+      type === "session.error"
+    )
+      opts.lifecycle(event)
+  })
+  const sync = (force = false) => {
+    if (force) activity.replay()
+    if (opts.connection.getConnectionState() !== "connected") return Promise.resolve()
+    return activity.sync(force)
+  }
+  const unsubState = opts.connection.onStateChange((state) => {
+    if (state !== "connected") return activity.clear()
+    void sync(true)
+  })
+  return {
+    sync,
+    dispose: () => {
+      unsubEvent()
+      unsubState()
+      activity.dispose()
+    },
+  }
+}

--- a/packages/kilo-vscode/src/agent-manager/worktree-activity.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-activity.ts
@@ -4,7 +4,7 @@ import type { KiloConnectionService } from "../services/cli-backend"
 type Snapshot = {
   statuses: Record<string, { type: string }>
   permissions: Array<{ id: string; sessionID: string }>
-  questions: Array<{ id: string; sessionID: string }>
+  questions: Array<{ id: string; sessionID: string; blocking?: boolean }>
 }
 
 type Change =
@@ -234,7 +234,7 @@ export class WorktreeActivity {
     }
     state.questions = new Map()
     for (const item of snapshot.questions ?? []) {
-      if (typeof item?.id === "string" && typeof item.sessionID === "string")
+      if (item?.blocking !== false && typeof item?.id === "string" && typeof item.sessionID === "string")
         state.questions.set(item.id, item.sessionID)
     }
     for (const change of req.events) this.apply(state, change)
@@ -282,6 +282,7 @@ export class WorktreeActivity {
     const id = string(value.id)
     const sessionID = string(value.sessionID)
     if (!id || !sessionID) return undefined
+    if (type === "question.asked" && value.blocking === false) return { kind: "question.remove", id, sessionID }
     return type === "permission.asked"
       ? { kind: "permission.add", id, sessionID }
       : { kind: "question.add", id, sessionID }

--- a/packages/kilo-vscode/src/agent-manager/worktree-activity.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-activity.ts
@@ -25,9 +25,9 @@ type State = {
 }
 
 type Request = {
-  state: State
-  events: Change[]
-  promise: Promise<void>
+  readonly state: State
+  readonly events: Change[]
+  readonly promise: Promise<void>
 }
 
 type Options = {
@@ -204,41 +204,42 @@ export class WorktreeActivity {
     const req: Request = {
       state,
       events: [],
-      promise: Promise.resolve(),
+      promise: Promise.resolve()
+        .then(() => this.opts.load(state.dir))
+        .then((snapshot) => this.finish(req, snapshot))
+        .catch((err: unknown) => {
+          if (this.valid(req)) req.state.loaded = false
+          this.opts.log(err)
+        })
+        .finally(() => {
+          if (state.request === req) state.request = undefined
+        }),
     }
     state.request = req
-    req.promise = Promise.resolve()
-      .then(() => this.opts.load(state.dir))
-      .then((snapshot) => this.finish(req, snapshot))
-      .catch((err: unknown) => {
-        if (this.valid(req)) req.state.loaded = false
-        this.opts.log(err)
-      })
-      .finally(() => {
-        if (state.request === req) state.request = undefined
-      })
     return req
   }
 
   private finish(req: Request, snapshot: Snapshot): void {
     if (!this.valid(req)) return
-    const state = req.state
-    state.statuses = new Map()
+    const next = this.state(req.state.dir)
     for (const [sessionID, status] of Object.entries(snapshot.statuses ?? {})) {
-      if (typeof status?.type === "string") state.statuses.set(sessionID, status.type)
+      if (typeof status?.type === "string") next.statuses.set(sessionID, status.type)
     }
-    state.permissions = new Map()
     for (const item of snapshot.permissions ?? []) {
       if (typeof item?.id === "string" && typeof item.sessionID === "string")
-        state.permissions.set(item.id, item.sessionID)
+        next.permissions.set(item.id, item.sessionID)
     }
-    state.questions = new Map()
     for (const item of snapshot.questions ?? []) {
       if (item?.blocking !== false && typeof item?.id === "string" && typeof item.sessionID === "string")
-        state.questions.set(item.id, item.sessionID)
+        next.questions.set(item.id, item.sessionID)
     }
-    for (const change of req.events) this.apply(state, change)
-    state.loaded = true
+    for (const change of req.events) this.apply(next, change)
+    Object.assign(req.state, {
+      statuses: next.statuses,
+      permissions: next.permissions,
+      questions: next.questions,
+      loaded: true,
+    })
     this.publish()
   }
 

--- a/packages/kilo-vscode/tests/unit/project-session-busy.test.ts
+++ b/packages/kilo-vscode/tests/unit/project-session-busy.test.ts
@@ -30,6 +30,19 @@ describe("createSessionBusy", () => {
     expect(busy({ working: { type } }).agent("wt-working")).toBe(true)
   })
 
+  it("keeps running for non-blocking questions", () => {
+    const questions: { sessionID: string; blocking?: boolean }[] = [{ sessionID: "working", blocking: false }]
+    const state = createSessionBusy({
+      ...options({ working: { type: "busy" } }),
+      questions: () => questions,
+    })
+    expect(state.agent("wt-working")).toBe(true)
+    questions[0].blocking = true
+    expect(state.agent("wt-working")).toBe(false)
+    delete questions[0].blocking
+    expect(state.agent("wt-working")).toBe(false)
+  })
+
   it("does not keep a spinner for an offline session", () => {
     const state = busy({ working: { type: "offline" }, unknown: { type: "offline" } })
 

--- a/packages/kilo-vscode/tests/unit/project-session-busy.test.ts
+++ b/packages/kilo-vscode/tests/unit/project-session-busy.test.ts
@@ -1,20 +1,21 @@
 import { describe, expect, it } from "bun:test"
-import { createSessionBusy } from "../../webview-ui/agent-manager/project/session-busy"
+import { createSessionBusy, createWorktreeBusy } from "../../webview-ui/agent-manager/project/session-busy"
+import type { ExtensionMessage } from "../../webview-ui/src/types/messages"
 
-const busy = (statuses: Record<string, { type: string }>) =>
-  createSessionBusy({
-    statuses: () => statuses,
-    permissions: () => [],
-    questions: () => [],
-    managed: () => [
-      { id: "unknown", worktreeId: "wt-unknown" },
-      { id: "idle", worktreeId: "wt-idle" },
-      { id: "working", worktreeId: "wt-working" },
-    ],
-    local: () => [],
-    projects: () => ({ background: [{ id: "unknown", worktreeId: "wt-unknown" }] }),
-    active: () => "project-a",
-  })
+const options = (statuses: Record<string, { type: string }>) => ({
+  statuses: () => statuses,
+  permissions: () => [],
+  questions: () => [],
+  managed: () => [
+    { id: "unknown", worktreeId: "wt-unknown" },
+    { id: "idle", worktreeId: "wt-idle" },
+    { id: "working", worktreeId: "wt-working" },
+  ],
+  local: () => [],
+  projects: () => ({ background: [{ id: "unknown", worktreeId: "wt-unknown" }] }),
+  active: () => "project-a",
+})
+const busy = (statuses: Record<string, { type: string }>) => createSessionBusy(options(statuses))
 
 describe("createSessionBusy", () => {
   it("does not mark stopped or unknown sessions as busy", () => {
@@ -25,7 +26,52 @@ describe("createSessionBusy", () => {
     expect(state.project("background", "wt-unknown")).toBe(false)
   })
 
-  it("marks sessions with an active status as busy", () => {
-    expect(busy({ working: { type: "busy" } }).agent("wt-working")).toBe(true)
+  it.each(["busy", "retry"])("marks sessions with an active %s status as busy", (type) => {
+    expect(busy({ working: { type } }).agent("wt-working")).toBe(true)
+  })
+
+  it("does not keep a spinner for an offline session", () => {
+    const state = busy({ working: { type: "offline" }, unknown: { type: "offline" } })
+
+    expect(state.agent("wt-working")).toBe(false)
+    expect(state.session("working")).toBe(false)
+    expect(state.project("background", "wt-unknown")).toBe(false)
+  })
+})
+
+describe("createWorktreeBusy", () => {
+  it("keeps directory activity separate from parent status and other projects", () => {
+    const listeners = new Set<(message: ExtensionMessage) => void>()
+    const state = createWorktreeBusy({
+      ...options({ idle: { type: "idle" }, working: { type: "busy" } }),
+      worktrees: (project) => [
+        { id: "wt-idle", path: project === "background" ? "/other/worktree" : "/repo/worktree" },
+      ],
+      subscribe: (callback) => {
+        listeners.add(callback)
+        return () => listeners.delete(callback)
+      },
+    })
+    const send = (active: string[]) => {
+      for (const callback of listeners) callback({ type: "agentManager.worktreeActivity", active })
+    }
+
+    expect(state.agent("wt-idle")).toBe(false)
+    expect(state.agent("wt-working")).toBe(true)
+    send(["/repo/worktree"])
+    expect(state.agent("wt-idle")).toBe(true)
+    expect(state.project("project-a", "wt-idle")).toBe(true)
+    expect(state.project("background", "wt-idle")).toBe(false)
+    expect(state.project("background", null)).toBe(false)
+    expect(state.agent("missing")).toBe(false)
+    expect(state.session("idle")).toBe(false)
+    expect(state.local()).toBe(false)
+
+    send(["/other/worktree"])
+    expect(state.agent("wt-idle")).toBe(false)
+    expect(state.project("background", "wt-idle")).toBe(true)
+    send([])
+    expect(state.project("background", "wt-idle")).toBe(false)
+    expect(state.agent("wt-working")).toBe(true)
   })
 })

--- a/packages/kilo-vscode/tests/unit/worktree-activity.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-activity.test.ts
@@ -229,6 +229,46 @@ describe("WorktreeActivity", () => {
     expect(test.posted.at(-1)).toEqual(["/repo/new"])
   })
 
+  it("defers the loader and recovers from synchronous failures", async () => {
+    const error = new Error("load failed")
+    let calls = 0
+    const test = setup(["/repo"], () => {
+      calls += 1
+      if (calls === 1) throw error
+      return Promise.resolve(snapshot({ child: "busy" }))
+    })
+    const pending = test.activity.sync()
+    expect(calls).toBe(0)
+    await pending
+    expect(test.errors).toEqual([error])
+
+    await test.activity.sync()
+    expect(calls).toBe(2)
+    expect(test.posted.at(-1)).toEqual(["/repo"])
+    await test.activity.sync()
+    expect(calls).toBe(2)
+  })
+
+  it("commits snapshots to the tracked state used by later events and refreshes", async () => {
+    const initial = snapshot({ child: "busy" }, [["p1", "child"]], [["q1", "child"]])
+    const snapshots = [initial, snapshot({ child: "retry" })]
+    const test = setup(["/repo"], async () => snapshots.shift()!)
+    await test.activity.sync()
+    expect(test.posted.at(-1)).toEqual([])
+
+    test.activity.event(replied("permission", "p1", "child"), "/repo")
+    expect(test.posted.at(-1)).toEqual([])
+    test.activity.event(replied("question", "q1", "child"), "/repo")
+    expect(test.posted.at(-1)).toEqual(["/repo"])
+
+    await test.activity.sync(true)
+    expect(test.posted.at(-1)).toEqual(["/repo"])
+    test.activity.event(status("child", "idle"), "/repo")
+    expect(test.posted.at(-1)).toEqual([])
+    expect(initial).toEqual(snapshot({ child: "busy" }, [["p1", "child"]], [["q1", "child"]]))
+    expect(test.errors).toEqual([])
+  })
+
   it("does not let a snapshot overwrite newer events or remove other active children", async () => {
     const gate = defer<Snapshot>()
     const test = setup(["/repo"], () => gate.promise)

--- a/packages/kilo-vscode/tests/unit/worktree-activity.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-activity.test.ts
@@ -4,7 +4,7 @@ import { createWorktreeActivity, WorktreeActivity } from "../../src/agent-manage
 type Snapshot = {
   statuses: Record<string, { type: string }>
   permissions: Array<{ id: string; sessionID: string }>
-  questions: Array<{ id: string; sessionID: string }>
+  questions: Array<{ id: string; sessionID: string; blocking?: boolean }>
 }
 
 function defer<T>() {
@@ -137,6 +137,23 @@ describe("WorktreeActivity", () => {
     expect(test.posted.at(-1)).toEqual([])
   })
 
+  it("ignores non-blocking questions in snapshots and live events", async () => {
+    const test = setup(["/repo"], async () => ({
+      ...snapshot({ child: "busy" }),
+      questions: [{ id: "note", sessionID: "child", blocking: false }],
+    }))
+    await test.activity.sync()
+    expect(test.posted.at(-1)).toEqual(["/repo"])
+
+    const question = asked("question", "live", "child")
+    test.activity.event({ ...question, properties: { ...question.properties, blocking: false } }, "/repo")
+    expect(test.posted.at(-1)).toEqual(["/repo"])
+    test.activity.event(question, "/repo")
+    expect(test.posted.at(-1)).toEqual([])
+    test.activity.event({ ...question, properties: { ...question.properties, blocking: false } }, "/repo")
+    expect(test.posted.at(-1)).toEqual(["/repo"])
+  })
+
   it("clears sessions on completion, deletion, errors, and offline status", async () => {
     const test = setup(["/repo"], async () => snapshot())
     await test.activity.sync()
@@ -236,6 +253,8 @@ describe("WorktreeActivity", () => {
     test.activity.event(status("s1", "busy"), "/repo")
     dirs.length = 0
     await test.activity.sync()
+    expect(test.posted.at(-1)).toEqual([])
+    test.activity.event(status("s1", "busy"), "/repo")
     expect(test.posted.at(-1)).toEqual([])
     gate.resolve(snapshot({ s1: "busy" }))
     await pending

--- a/packages/kilo-vscode/tests/unit/worktree-activity.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-activity.test.ts
@@ -1,0 +1,417 @@
+import { describe, expect, it } from "bun:test"
+import { createWorktreeActivity, WorktreeActivity } from "../../src/agent-manager/worktree-activity"
+
+type Snapshot = {
+  statuses: Record<string, { type: string }>
+  permissions: Array<{ id: string; sessionID: string }>
+  questions: Array<{ id: string; sessionID: string }>
+}
+
+function defer<T>() {
+  return Promise.withResolvers<T>()
+}
+
+function snapshot(
+  statuses: Record<string, string> = {},
+  permissions: string[][] = [],
+  questions: string[][] = [],
+): Snapshot {
+  return {
+    statuses: Object.fromEntries(Object.entries(statuses).map(([id, type]) => [id, { type }])),
+    permissions: permissions.map(([id, sessionID]) => ({ id, sessionID })),
+    questions: questions.map(([id, sessionID]) => ({ id, sessionID })),
+  }
+}
+
+function status(sessionID: string, type: string) {
+  return { type: "session.status", properties: { sessionID, status: { type } } }
+}
+
+function asked(type: "permission" | "question", id: string, sessionID: string) {
+  return { type: `${type}.asked`, properties: { id, sessionID } }
+}
+
+function replied(type: "permission" | "question", requestID: string, sessionID: string, kind = "replied") {
+  return { type: `${type}.${kind}`, properties: { requestID, sessionID } }
+}
+
+function setup(dirs: string[], load: (dir: string) => Promise<Snapshot>) {
+  const posted: string[][] = []
+  const errors: unknown[] = []
+  const activity = new WorktreeActivity({
+    paths: () => dirs,
+    load,
+    post: (active) => posted.push(active),
+    log: (err) => errors.push(err),
+  })
+  return { activity, posted, errors }
+}
+
+function connection(client: unknown, state = "connected") {
+  let stateListener: ((value: string) => void) | undefined
+  let eventListener: ((event: unknown, directory?: string) => void) | undefined
+  let eventFilter: ((event: unknown) => boolean) | undefined
+  const value = {
+    getClient: () => client,
+    getConnectionState: () => state,
+    onStateChange: (listener: (value: string) => void) => {
+      stateListener = listener
+      return () => {
+        stateListener = undefined
+      }
+    },
+    onEventFiltered: (filter: (event: unknown) => boolean, listener: (event: unknown, directory?: string) => void) => {
+      eventFilter = filter
+      eventListener = listener
+      return () => {
+        eventFilter = undefined
+        eventListener = undefined
+      }
+    },
+    change: (next: string) => {
+      state = next
+      stateListener?.(next)
+    },
+    set: (next: string) => {
+      state = next
+    },
+    emit: (event: unknown, directory?: string) => {
+      if (eventFilter?.(event)) eventListener?.(event, directory)
+    },
+  }
+  return value
+}
+
+describe("WorktreeActivity", () => {
+  it("accepts only relevant SDK events", () => {
+    expect(WorktreeActivity.accepts({ type: "session.status" })).toBe(true)
+    expect(WorktreeActivity.accepts({ type: "session.deleted" })).toBe(true)
+    expect(WorktreeActivity.accepts({ type: "session.error" })).toBe(true)
+    expect(WorktreeActivity.accepts({ type: "permission.asked" })).toBe(true)
+    expect(WorktreeActivity.accepts({ type: "permission.replied" })).toBe(true)
+    expect(WorktreeActivity.accepts({ type: "question.asked" })).toBe(true)
+    expect(WorktreeActivity.accepts({ type: "question.replied" })).toBe(true)
+    expect(WorktreeActivity.accepts({ type: "question.rejected" })).toBe(true)
+    expect(WorktreeActivity.accepts({ type: "server.instance.disposed" })).toBe(true)
+    expect(WorktreeActivity.accepts({ type: "session.created" })).toBe(false)
+    expect(WorktreeActivity.accepts(null)).toBe(false)
+    expect(WorktreeActivity.accepts("session.status")).toBe(false)
+  })
+
+  it("counts busy and retry children while ignoring idle and offline sessions", async () => {
+    const test = setup(["/repo"], async () => snapshot({ parent: "idle", child: "busy" }))
+    await test.activity.sync()
+    expect(test.posted.at(-1)).toEqual(["/repo"])
+
+    test.activity.event(status("child", "idle"), "/repo")
+    expect(test.posted.at(-1)).toEqual([])
+    test.activity.event(status("parent", "retry"), "/repo")
+    expect(test.posted.at(-1)).toEqual(["/repo"])
+    test.activity.event(status("parent", "offline"), "/repo")
+    expect(test.posted.at(-1)).toEqual([])
+  })
+
+  it("excludes blocked children without suppressing active siblings", async () => {
+    const test = setup(["/repo"], async () => snapshot({ child: "busy", sibling: "idle" }))
+    await test.activity.sync()
+
+    test.activity.event(asked("permission", "p1", "child"), "/repo")
+    test.activity.event(asked("permission", "p2", "child"), "/repo")
+    test.activity.event(asked("question", "q1", "child"), "/repo")
+    expect(test.posted.at(-1)).toEqual([])
+
+    test.activity.event(status("sibling", "busy"), "/repo")
+    test.activity.event(replied("permission", "p1", "child"), "/repo")
+    test.activity.event(replied("question", "q1", "child"), "/repo")
+    expect(test.posted.at(-1)).toEqual(["/repo"])
+
+    test.activity.event(replied("permission", "p2", "child"), "/repo")
+    expect(test.posted.at(-1)).toEqual(["/repo"])
+    test.activity.event(status("sibling", "idle"), "/repo")
+    expect(test.posted.at(-1)).toEqual(["/repo"])
+    test.activity.event(status("child", "idle"), "/repo")
+    expect(test.posted.at(-1)).toEqual([])
+
+    test.activity.event(asked("question", "q2", "child"), "/repo")
+    test.activity.event(replied("question", "q2", "child", "rejected"), "/repo")
+    expect(test.posted.at(-1)).toEqual([])
+  })
+
+  it("clears sessions on completion, deletion, errors, and offline status", async () => {
+    const test = setup(["/repo"], async () => snapshot())
+    await test.activity.sync()
+    test.activity.event(status("s1", "busy"), "/repo")
+    test.activity.event(status("s1", "complete"), "/repo")
+    expect(test.posted.at(-1)).toEqual([])
+
+    test.activity.event(status("s1", "busy"), "/repo")
+    test.activity.event({ type: "session.error", properties: { sessionID: "s1" } }, "/repo")
+    expect(test.posted.at(-1)).toEqual([])
+
+    test.activity.event(status("s1", "busy"), "/repo")
+    test.activity.event({ type: "session.deleted", properties: { info: { id: "s1" } } }, "/repo")
+    expect(test.posted.at(-1)).toEqual([])
+
+    test.activity.event(status("s1", "busy"), "/repo")
+    test.activity.event(status("s1", "offline"), "/repo")
+    expect(test.posted.at(-1)).toEqual([])
+  })
+
+  it("isolates normalized directories and ignores unknown ownership", async () => {
+    const dirs = ["/repo/a/", "/repo/b"]
+    const test = setup(dirs, async () => snapshot())
+    await test.activity.sync()
+
+    test.activity.event(status("a1", "busy"), "\\repo\\a\\")
+    expect(test.posted.at(-1)).toEqual(["/repo/a/"])
+    test.activity.event(status("b1", "busy"), "/repo/b/")
+    expect(test.posted.at(-1)).toEqual(["/repo/a/", "/repo/b"])
+    test.activity.event(status("unknown", "busy"), "/repo/unknown")
+    expect(test.posted.at(-1)).toEqual(["/repo/a/", "/repo/b"])
+  })
+
+  it("deduplicates loads, hydrates new paths, force refreshes, and replays cached output", async () => {
+    const dirs = ["/repo"]
+    const firstGate = defer<Snapshot>()
+    const forceGate = defer<Snapshot>()
+    const newGate = defer<Snapshot>()
+    const gates = [firstGate, forceGate, newGate]
+    const calls: string[] = []
+    const test = setup(dirs, (dir) => {
+      calls.push(dir)
+      const gate = gates.shift()
+      if (!gate) return Promise.resolve(snapshot())
+      return gate.promise
+    })
+
+    const first = test.activity.sync()
+    const second = test.activity.sync()
+    await Bun.sleep(0)
+    expect(calls).toEqual(["/repo"])
+    test.activity.event(status("s1", "busy"), "/repo")
+    expect(test.posted.at(-1)).toEqual(["/repo"])
+    firstGate.resolve(snapshot({ s1: "busy" }))
+    await Promise.all([first, second])
+    expect(calls).toEqual(["/repo"])
+
+    test.activity.replay()
+    expect(test.posted.at(-1)).toEqual(["/repo"])
+    const force = test.activity.sync(true)
+    await Bun.sleep(0)
+    expect(calls).toEqual(["/repo", "/repo"])
+    forceGate.resolve(snapshot())
+    await force
+    expect(test.posted.at(-1)).toEqual([])
+
+    dirs.push("/repo/new")
+    const add = test.activity.sync()
+    await Bun.sleep(0)
+    expect(calls).toEqual(["/repo", "/repo", "/repo/new"])
+    newGate.resolve(snapshot({ newSession: "retry" }))
+    await add
+    expect(test.posted.at(-1)).toEqual(["/repo/new"])
+  })
+
+  it("does not let a snapshot overwrite newer events or remove other active children", async () => {
+    const gate = defer<Snapshot>()
+    const test = setup(["/repo"], () => gate.promise)
+    const pending = test.activity.sync()
+    test.activity.event(status("one", "idle"), "/repo")
+    test.activity.event(status("two", "idle"), "/repo")
+    test.activity.event(status("one", "busy"), "/repo")
+    test.activity.event(status("two", "busy"), "/repo")
+    test.activity.event(status("one", "idle"), "/repo")
+    gate.resolve(snapshot({ one: "busy", two: "busy" }))
+    await pending
+    expect(test.posted.at(-1)).toEqual(["/repo"])
+    test.activity.event(status("two", "idle"), "/repo")
+    expect(test.posted.at(-1)).toEqual([])
+  })
+
+  it("prunes removed paths and prevents old loads from reviving activity", async () => {
+    const dirs = ["/repo"]
+    const gate = defer<Snapshot>()
+    const test = setup(dirs, () => gate.promise)
+    const pending = test.activity.sync()
+    test.activity.event(status("s1", "busy"), "/repo")
+    dirs.length = 0
+    await test.activity.sync()
+    expect(test.posted.at(-1)).toEqual([])
+    gate.resolve(snapshot({ s1: "busy" }))
+    await pending
+    expect(test.posted.at(-1)).toEqual([])
+  })
+
+  it("clears on disconnect and disposal, then allows a fresh sync", async () => {
+    const dirs = ["/repo"]
+    const firstGate = defer<Snapshot>()
+    const nextGate = defer<Snapshot>()
+    const gates = [firstGate, nextGate]
+    const test = setup(dirs, () => gates.shift()!.promise)
+    const first = test.activity.sync()
+    test.activity.event(status("s1", "busy"), "/repo")
+    test.activity.event({ type: "server.instance.disposed", properties: { directory: "/repo" } }, "/repo")
+    expect(test.posted.at(-1)).toEqual([])
+    firstGate.resolve(snapshot({ s1: "busy" }))
+    await first
+    expect(test.posted.at(-1)).toEqual([])
+
+    test.activity.clear()
+    expect(test.posted.at(-1)).toEqual([])
+    const next = test.activity.sync()
+    nextGate.resolve(snapshot({ s2: "busy" }))
+    await next
+    expect(test.posted.at(-1)).toEqual(["/repo"])
+
+    test.activity.dispose()
+    const count = test.posted.length
+    test.activity.event(status("s3", "busy"), "/repo")
+    await test.activity.sync()
+    test.activity.replay()
+    expect(test.posted).toHaveLength(count)
+  })
+
+  it("logs failed paths without erasing successful siblings and retries them", async () => {
+    const dirs = ["/repo/a", "/repo/b"]
+    const a = defer<Snapshot>()
+    const b = defer<Snapshot>()
+    const retry = defer<Snapshot>()
+    const calls: string[] = []
+    const test = setup(dirs, (dir) => {
+      calls.push(dir)
+      if (dir === "/repo/a") return a.promise
+      if (calls.filter((item) => item === "/repo/b").length === 1) return b.promise
+      return retry.promise
+    })
+    const pending = test.activity.sync()
+    a.resolve(snapshot({ a1: "busy" }))
+    b.reject(new Error("b failed"))
+    await pending
+    expect(test.errors).toHaveLength(1)
+    expect(test.posted.at(-1)).toEqual(["/repo/a"])
+    expect(calls).toEqual(["/repo/a", "/repo/b"])
+
+    const again = test.activity.sync()
+    await Bun.sleep(0)
+    expect(calls).toEqual(["/repo/a", "/repo/b", "/repo/b"])
+    retry.resolve(snapshot())
+    await again
+    expect(test.posted.at(-1)).toEqual(["/repo/a"])
+  })
+
+  it("does not replay failed-load events over a newer recovery snapshot", async () => {
+    const first = defer<Snapshot>()
+    const next = defer<Snapshot>()
+    const gates = [first, next]
+    const test = setup(["/repo"], () => gates.shift()!.promise)
+    const pending = test.activity.sync()
+    test.activity.event(status("child", "busy"), "/repo")
+    first.reject(new Error("snapshot failed"))
+    await pending
+    expect(test.posted.at(-1)).toEqual(["/repo"])
+
+    const recovery = test.activity.sync(true)
+    next.resolve(snapshot())
+    await recovery
+    expect(test.posted.at(-1)).toEqual([])
+  })
+
+  it("publishes a ready worktree while another snapshot is still loading", async () => {
+    const gate = defer<Snapshot>()
+    const ready = defer<string[]>()
+    const activity = new WorktreeActivity({
+      paths: () => ["/fast", "/slow"],
+      load: async (dir) => (dir === "/fast" ? snapshot({ child: "busy" }) : gate.promise),
+      post: (active) => ready.resolve(active),
+      log: (err) => {
+        throw err
+      },
+    })
+    const pending = activity.sync()
+    expect(await ready.promise).toEqual(["/fast"])
+    gate.resolve(snapshot())
+    await pending
+    activity.dispose()
+  })
+
+  it("wires the activity wrapper to the connection without loading histories", async () => {
+    const calls: string[] = []
+    const client = {
+      session: {
+        status: async (input: { directory: string }, options: { throwOnError: true }) => {
+          calls.push(`status:${input.directory}:${options.throwOnError}`)
+          return { data: { s1: { type: "busy" } } }
+        },
+      },
+      permission: {
+        list: async (input: { directory: string }, options: { throwOnError: true }) => {
+          calls.push(`permission:${input.directory}:${options.throwOnError}`)
+          return { data: [] }
+        },
+      },
+      question: {
+        list: async (input: { directory: string }, options: { throwOnError: true }) => {
+          calls.push(`question:${input.directory}:${options.throwOnError}`)
+          return { data: [] }
+        },
+      },
+    }
+    const conn = connection(client)
+    const posted: string[][] = []
+    const statuses: unknown[] = []
+    const lifecycle: unknown[] = []
+    const wrapper = createWorktreeActivity({
+      connection: conn as never,
+      paths: () => ["/repo"],
+      post: (active) => posted.push(active),
+      status: (event) => statuses.push(event),
+      lifecycle: (event) => lifecycle.push(event),
+      log: () => {},
+    })
+
+    await wrapper.sync()
+    expect(calls).toEqual(["status:/repo:true", "permission:/repo:true", "question:/repo:true"])
+    expect(posted.at(-1)).toEqual(["/repo"])
+    expect(conn.emit({ type: "session.created", properties: {} }, "/repo")).toBeUndefined()
+    expect(conn.emit(status("s1", "idle"), "/repo")).toBeUndefined()
+    expect(statuses).toHaveLength(1)
+    expect(lifecycle).toHaveLength(1)
+    expect(posted.at(-1)).toEqual([])
+
+    conn.change("disconnected")
+    expect(posted.at(-1)).toEqual([])
+    await wrapper.sync()
+    expect(calls).toHaveLength(3)
+
+    conn.change("connected")
+    await Bun.sleep(0)
+    expect(calls).toHaveLength(6)
+    wrapper.dispose()
+    conn.emit(status("s1", "busy"), "/repo")
+    expect(statuses).toHaveLength(1)
+  })
+
+  it("replays before a forced sync checks connection state", async () => {
+    const client = {
+      session: { status: async () => ({ data: { s1: { type: "busy" } } }) },
+      permission: { list: async () => ({ data: [] }) },
+      question: { list: async () => ({ data: [] }) },
+    }
+    const conn = connection(client)
+    const posted: string[][] = []
+    const wrapper = createWorktreeActivity({
+      connection: conn as never,
+      paths: () => ["/repo"],
+      post: (active) => posted.push(active),
+      status: () => {},
+      lifecycle: () => {},
+      log: () => {},
+    })
+    await wrapper.sync()
+    conn.set("disconnected")
+    posted.length = 0
+    await wrapper.sync(true)
+    expect(posted).toEqual([["/repo"]])
+    wrapper.dispose()
+  })
+})

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -91,7 +91,7 @@ import { createProjectRegistry, type PersistedProjectTabs } from "./project/regi
 import type { WorktreeBusyState } from "./project/store"
 import { rememberTarget, restoreProjectTarget } from "./project/restore"
 import { createProjectStateRouter } from "./project/state"
-import { createSessionBusy } from "./project/session-busy"
+import { createWorktreeBusy } from "./project/session-busy"
 import { switchProject } from "./project/switch"
 import { createProjectStateHandlers } from "./project/state-handlers"
 import { ownsParent as ownsParentSession, isCurrent } from "./project/message-ownership"
@@ -900,7 +900,7 @@ const AgentManagerContent: Component = () => {
 
   const isStaleWorktree = (worktreeId: string): boolean => staleWorktreeIds().has(worktreeId)
 
-  const busy = createSessionBusy({
+  const busy = createWorktreeBusy({
     statuses: session.allStatusMap,
     permissions: session.permissions,
     questions: session.questions,
@@ -908,6 +908,8 @@ const AgentManagerContent: Component = () => {
     local: localSessionIDs,
     projects: projectSessionsLive,
     active: activeProjectId,
+    worktrees: (id) => (id ? registry.ensure(id) : registry.active()).worktrees(),
+    subscribe: vscode.onMessage,
   })
   const isAgentBusy = busy.agent
   const isLocalBusy = busy.local

--- a/packages/kilo-vscode/webview-ui/agent-manager/project/session-busy.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/project/session-busy.ts
@@ -1,3 +1,6 @@
+import { createSignal, onCleanup } from "solid-js"
+import type { ExtensionMessage } from "../../src/types/messages"
+
 interface Item {
   id: string
   worktreeId?: string | null
@@ -26,7 +29,7 @@ export function createSessionBusy(opts: {
     const blocked = new Set([...opts.permissions(), ...opts.questions()].map((item) => item.sessionID))
     return ids.some((id) => {
       const status = statuses[id]
-      return !!status && status.type !== "idle" && !blocked.has(id)
+      return (status?.type === "busy" || status?.type === "retry") && !blocked.has(id)
     })
   }
   const agent = (id: string) =>
@@ -42,4 +45,26 @@ export function createSessionBusy(opts: {
     return any((opts.projects()[id] ?? []).filter((item) => item.worktreeId === worktreeId).map((item) => item.id))
   }
   return { any, agent, local, project, session: (id: string) => any([id]) }
+}
+
+export function createWorktreeBusy(
+  opts: Parameters<typeof createSessionBusy>[0] & {
+    worktrees: (project?: string) => { id: string; path: string }[]
+    subscribe: (callback: (message: ExtensionMessage) => void) => () => void
+  },
+) {
+  const busy = createSessionBusy(opts)
+  const [active, setActive] = createSignal(new Set<string>())
+  onCleanup(
+    opts.subscribe((message) => {
+      if (message.type === "agentManager.worktreeActivity") setActive(new Set(message.active))
+    }),
+  )
+  const working = (id: string, project?: string) =>
+    active().has(opts.worktrees(project).find((worktree) => worktree.id === id)?.path ?? "")
+  return {
+    ...busy,
+    agent: (id: string) => busy.agent(id) || working(id),
+    project: (project: string, id: string | null) => busy.project(project, id) || (id !== null && working(id, project)),
+  }
 }

--- a/packages/kilo-vscode/webview-ui/agent-manager/project/session-busy.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/project/session-busy.ts
@@ -12,6 +12,7 @@ interface Status {
 
 interface Prompt {
   sessionID: string
+  blocking?: boolean
 }
 
 export function createSessionBusy(opts: {
@@ -26,7 +27,11 @@ export function createSessionBusy(opts: {
   const any = (ids: string[]) => {
     if (ids.length === 0) return false
     const statuses = opts.statuses()
-    const blocked = new Set([...opts.permissions(), ...opts.questions()].map((item) => item.sessionID))
+    const blocked = new Set(
+      [...opts.permissions(), ...opts.questions().filter((item) => item.blocking !== false)].map(
+        (item) => item.sessionID,
+      ),
+    )
     return ids.some((id) => {
       const status = statuses[id]
       return (status?.type === "busy" || status?.type === "retry") && !blocked.has(id)

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -808,6 +808,11 @@ export interface AgentManagerSessionForkedMessage {
   worktreeId?: string
 }
 
+export interface AgentManagerWorktreeActivityMessage {
+  type: "agentManager.worktreeActivity"
+  active: string[]
+}
+
 export interface AgentManagerSessionClosedMessage {
   type: "agentManager.sessionClosed"
   projectId?: string
@@ -1504,6 +1509,7 @@ export type ExtensionMessage =
   | AgentManagerSessionAddedMessage
   | AgentManagerSessionForkedMessage
   | AgentManagerSessionClosedMessage
+  | AgentManagerWorktreeActivityMessage
   | AgentManagerStateMessage
   | AgentManagerProjectsMessage
   | AgentManagerSelectionActivatedMessage


### PR DESCRIPTION
## What Problem This Solves

Agent Manager can show a worktree as idle after its main agent finishes, even while a background agent still works in that directory. Looking only at managed parent sessions also misses running children after the webview reloads.

## Why This Change Was Made

Track worktree activity separately from the selected transcript and the root-session inventory. Read directory-scoped session statuses and pending prompts when worktrees are first loaded or the view reconnects, then keep the cache current with existing SSE events. This avoids loading child histories or adding a background-job polling loop.

## User Impact

- Keep the worktree spinner while any session in its directory is busy or retrying, including background and nested agents.
- Keep activity visible when another worktree is selected and after a webview reload.
- Do not count sessions that are offline, waiting for permission, or waiting for a blocking question. Other running sessions can still keep the worktree active.
- Leave the parent session's actual status and prompt controls unchanged.

## Evidence

- Passed extension typecheck, lint, build, Knip, Kilo-owned code guard, and all 4,256 unit tests.
- Added regression coverage for snapshot/event ordering, failed-read recovery, partial loads, cancellation, deletion, offline state, pending prompts, and directory isolation.
- Exercised real CLI background tasks in isolated VS Code with a deterministic local model fixture. Confirmed the idle parent's worktree keeps spinning, Local stays idle, switching and webview reload preserve activity, and completion or cancellation clears the spinner. Confirmed a pending permission stops the spinner with its prompt visible in the child inspector.
- Rebuilt and repeated the inactive-worktree reload and completion flow after the recovery fix. No real credentials or existing worktrees were used for these tests.

Main agent finished, background agent still running:

<img width="700" alt="Worktree spinner remains active after the main agent finishes while one background agent runs" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260827-agent-manager-background-running-ash-column.png" />

After selecting Local and reloading the webview:

<img width="700" alt="Inactive worktree retains its spinner after webview reload while Local remains idle" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260827-agent-manager-background-reload-ash-column.png" />
