### PR TITLE
chore(deps-dev): bump @babel/core from 7.28.4 to 7.29.6 in /packages/opencode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -681,7 +681,7 @@
         "zod": "catalog:",
       },
       "devDependencies": {
-        "@babel/core": "7.28.4",
+        "@babel/core": "7.29.6",
         "@effect/language-service": "0.84.2",
         "@octokit/webhooks-types": "7.6.1",
         "@opencode-ai/core": "workspace:*",
@@ -1324,7 +1324,7 @@
 
     "@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
 
-    "@babel/core": ["@babel/core@7.28.4", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.3", "@babel/helper-compilation-targets": "^7.27.2", "@babel/helper-module-transforms": "^7.28.3", "@babel/helpers": "^7.28.4", "@babel/parser": "^7.28.4", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.4", "@babel/types": "^7.28.4", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA=="],
+    "@babel/core": ["@babel/core@7.29.6", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.6", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.29.2", "@babel/parser": "^7.29.3", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-QdxmAo/ikZqqRGA8s43ww8lcql6naWRvEz0FFrl6MIlc7Gi6TroXnSdWa5U/kq6fzcpqpHesicQxFZIieZbyIA=="],
 
     "@babel/generator": ["@babel/generator@7.29.8", "", { "dependencies": { "@babel/parser": "^7.29.8", "@babel/types": "^7.29.8", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -62,7 +62,7 @@
     "why-is-node-running": "3.2.2",
     "@types/npmcli__arborist": "6.3.3",
     "@opencode-ai/http-recorder": "workspace:*",
-    "@babel/core": "7.28.4",
+    "@babel/core": "7.29.6",
     "@standard-schema/spec": "1.0.0",
     "@types/babel__core": "7.20.5"
   },


### PR DESCRIPTION
Follow-up to https://github.com/Kilo-Org/kilocode/pull/11273.

Dependabot still flags `@babel/core` in `/packages/opencode` as a low-risk update, so this replicates that bump on top of the current `main`:

- `@babel/core` `7.28.4` → `7.29.6` in `packages/opencode/package.json`
- `bun.lock` updated to match

Tests: `bun test` in `packages/opencode` — 245 passed / 3 failed. The 3 failures (`indexing-worktree`, `lazy-completion`, `instance-vcs-watcher`) reproduce on base `main` without this change and are unrelated to the `@babel/core` bump.
