### PR TITLE
fix(vscode): show consistent session activity indicators

### DIFF
--- a/.changeset/session-tab-attention.md
+++ b/.changeset/session-tab-attention.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show consistent running, completion, and input-required indicators across session tabs and Agent Manager worktrees.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/session-tab-activity-states-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/session-tab-activity-states-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d55567442d6b3d627e64b583e7d4f49a522685efd8455013b17c4c4f0a84d84
+size 8753

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/worktree-activity-states-active-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/worktree-activity-states-active-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d4601147436962bb2fb3db3eede146e2f83a6d88d50f5d7dce016c34817062d
+size 18551

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/worktree-activity-states-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/worktree-activity-states-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f86a360b9c84e63f8614898edf4fd64e0ce41a570e306326f80868ce99483720
+size 18265

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/session-tabs/activity-states-1280-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/session-tabs/activity-states-1280-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c071338a92316478623abbe23cdb262c366917266511a599f405ccdd7e399225
+size 5710

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/session-tabs/activity-states-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/session-tabs/activity-states-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e275e0ec4ce304fc29c71eaac017872a6828d52fa73a504acce4b779fa389228
+size 7407

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/session-tabs/multiple-sessions-200-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/session-tabs/multiple-sessions-200-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f924b317c2eafaf5112229cc31404591d7526a7e0fba8c1d46cd97597c3a4392
+size 1778

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/session-tabs/multiple-sessions-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/session-tabs/multiple-sessions-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:268efbc7a6121b9fa3c2c843308b70f41a2235d2b9447e61ef6ac5c38b23c5b5
+size 3729

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/session-tabs/switcher-open-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/session-tabs/switcher-open-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:273c76976df0e83fa404ae2af2d561f8c38458e3ef1b32f4f5b1990a5906a195
-size 14239
+oid sha256:f62edc4cf5786ca40fececbec0ae08e20096f0bc2bc08258de42c8a524a2366e
+size 20730

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -142,6 +142,7 @@ import {
 } from "./kilo-provider/handlers/question"
 import { fetchAndSendPendingSuggestions } from "./kilo-provider/handlers/suggestion"
 import { nativeTitle } from "./kilo-provider/native-tab-title"
+import { isActivity, type Activity } from "../webview-ui/src/utils/session-activity"
 import { parseReview, reviewMetadata, type ReviewMessageData } from "./shared/review-comments"
 import { completesWithoutStatus } from "./kilo-provider/command-completion"
 import { KiloProviderMemory } from "./kilo-provider/memory"
@@ -391,6 +392,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private readonly refreshes = new Map<string, number>()
   private readonly anacondaDesktop = new AnacondaDesktopBridge()
   private sessionStatusMap = new Map<string, SessionStatus["type"]>() // Latest status used for destructive config warnings.
+  private activity: Activity = "idle"
+  private caption: string | undefined
   private readonly epochs = new Map<string, Map<string, number>>()
   private readonly requests = new Map<string, number>()
   private epoch = 0
@@ -508,7 +511,15 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       if (id) this.refreshes.set(id, (this.refreshes.get(id) ?? 0) + 1)
     }
     this.currentSession = session
-    this.opts.tabTitle?.(nativeTitle(session))
+    this.updateTitle()
+  }
+
+  private updateTitle(): void {
+    if (!this.opts.tabTitle) return
+    const title = nativeTitle(this.currentSession, this.activity, this.opts.tabLabel)
+    if (this.caption === title) return
+    this.caption = title
+    this.opts.tabTitle(title)
   }
 
   private checkpoint(sid: string, run: () => Promise<void>): void {
@@ -1035,6 +1046,11 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           exportTranscript: (sessionID) => this.handleExportSessionTranscript(sessionID),
           copy: (text) => vscode.env.clipboard.writeText(text),
           openSessions: (ids) => this.trackOpenSessions(ids),
+          activity: (state) => {
+            if (!isActivity(state)) return
+            this.activity = state
+            this.updateTitle()
+          },
           speechToTextModels: () => this.fetchAndSendSpeechToTextModels(),
           modelUsage: (msg) => handleModelUsageMessage(msg, this.extensionContext, (value) => this.postMessage(value)),
           backgroundJobs: (sessionID, requestID) => this.fetchAndSendBackgroundJobs(sessionID, requestID),

--- a/packages/kilo-vscode/src/SubAgentViewerProvider.ts
+++ b/packages/kilo-vscode/src/SubAgentViewerProvider.ts
@@ -42,7 +42,13 @@ export class SubAgentViewerProvider implements vscode.Disposable {
       dark: vscode.Uri.joinPath(this.extensionUri, "assets", "icons", "kilo-dark.svg"),
     }
 
-    const provider = new KiloProvider(this.extensionUri, this.connectionService, this.context, { hideTopBar: true })
+    const provider = new KiloProvider(this.extensionUri, this.connectionService, this.context, {
+      hideTopBar: true,
+      tabTitle: (title) => {
+        panel.title = title
+      },
+      tabLabel: label,
+    })
     if (directory) provider.setSessionDirectory(sessionID, directory)
     // Start accepting this session's SSE events as soon as the panel subscribes.
     // Reasoning deltas are not persisted until the reasoning part finishes.

--- a/packages/kilo-vscode/src/agent-manager/vscode-host.ts
+++ b/packages/kilo-vscode/src/agent-manager/vscode-host.ts
@@ -104,6 +104,10 @@ export class VscodeHost implements Host {
     })
 
     const provider = new KiloProvider(this.extensionUri, this.connectionService, this.context, {
+      tabTitle: (title) => {
+        panel.title = title
+      },
+      tabLabel: "Agent Manager",
       platform: PLATFORM,
       snapshotInitialization: SNAPSHOT_INITIALIZATION,
       slimEditMetadata: true,

--- a/packages/kilo-vscode/src/kilo-provider-utils.ts
+++ b/packages/kilo-vscode/src/kilo-provider-utils.ts
@@ -411,7 +411,12 @@ export type WebviewMessage =
       message: Record<string, unknown>
     }
   | { type: "sessionStatus"; sessionID: string; status: string; attempt?: number; message?: string; next?: number }
-  | { type: "sessionTurnClosed"; sessionID: string; reason: "completed" | "error" | "interrupted" | "superseded" }
+  | {
+      type: "sessionTurnClosed"
+      sessionID: string
+      reason: "completed" | "error" | "interrupted" | "superseded"
+      parentID?: string
+    }
   | {
       type: "permissionRequest"
       permission: {
@@ -556,6 +561,7 @@ export function mapSSEEventToWebviewMessage(event: StreamEvent, sessionID: strin
         type: "sessionTurnClosed",
         sessionID: event.properties.sessionID,
         reason: event.properties.reason,
+        ...(event.properties.parentID ? { parentID: event.properties.parentID } : {}),
       }
     case "permission.asked":
       return {

--- a/packages/kilo-vscode/src/kilo-provider/early-message.ts
+++ b/packages/kilo-vscode/src/kilo-provider/early-message.ts
@@ -19,6 +19,7 @@ type Ctx = {
   exportTranscript: (sessionID: string) => Promise<void>
   copy: (text: string) => PromiseLike<void>
   openSessions: (ids: string[]) => void
+  activity: (state: unknown) => void
   speechToTextModels: () => Promise<void>
   modelUsage: (message: ModelUsageMessage) => Promise<void>
   backgroundJobs: (sessionID: string, requestID: string) => Promise<void>
@@ -56,7 +57,7 @@ async function routeBackgroundMessage(
 }
 
 export async function routeEarlyMessage(
-  message: { type: string; id?: unknown; text?: unknown },
+  message: { type: string; id?: unknown; text?: unknown; state?: unknown },
   ctx: Ctx,
 ): Promise<boolean> {
   if (message.type === "copyToClipboard") {
@@ -86,6 +87,10 @@ export async function routeEarlyMessage(
   if (message.type === "exportSessionTranscript") {
     const input = message as { sessionID?: unknown }
     if (typeof input.sessionID === "string") await ctx.exportTranscript(input.sessionID)
+    return true
+  }
+  if (message.type === "sessionActivity") {
+    ctx.activity(message.state)
     return true
   }
   if (message.type === "sidebar.openSessions") {

--- a/packages/kilo-vscode/src/kilo-provider/native-tab-title.ts
+++ b/packages/kilo-vscode/src/kilo-provider/native-tab-title.ts
@@ -1,12 +1,21 @@
 import type { Session } from "@kilocode/sdk/v2/client"
+import type { Activity } from "../../webview-ui/src/utils/session-activity"
 import { EXTENSION_DISPLAY_NAME } from "../constants"
 
 const DEFAULT_SESSION_TITLE = /^(New session|Child session) - \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
 const TITLE_LIMIT = 19
+const icons: Record<Activity, string> = {
+  idle: "",
+  busy: "◔",
+  retry: "◔",
+  waiting: "⚠",
+  error: "⚠",
+  done: "✓",
+}
 
-export const nativeTitle = (session: Session | null) => {
-  const title = session?.title?.trim()
-  if (!title || DEFAULT_SESSION_TITLE.test(title)) return EXTENSION_DISPLAY_NAME
-  if (title.length <= TITLE_LIMIT) return title
-  return `${title.slice(0, TITLE_LIMIT)}...`
+export const nativeTitle = (session: Session | null, state: Activity = "idle", label?: string) => {
+  const value = session?.title?.trim()
+  const title = label ?? (!value || DEFAULT_SESSION_TITLE.test(value) ? EXTENSION_DISPLAY_NAME : value)
+  const text = label || title.length <= TITLE_LIMIT ? title : `${title.slice(0, TITLE_LIMIT)}...`
+  return icons[state] ? `${icons[state]} ${text}` : text
 }

--- a/packages/kilo-vscode/src/kilo-provider/options.ts
+++ b/packages/kilo-vscode/src/kilo-provider/options.ts
@@ -17,6 +17,7 @@ export type KiloProviderOptions = {
   snapshotInitialization?: "wait"
   slimEditMetadata?: boolean
   tabTitle?: (title: string) => void
+  tabLabel?: string
   worktreeDirectories?: () => string[]
   /**
    * Dynamic root directory override. When present, it replaces the

--- a/packages/kilo-vscode/tests/fixtures/session-provider-activity.tsx
+++ b/packages/kilo-vscode/tests/fixtures/session-provider-activity.tsx
@@ -1,0 +1,393 @@
+import assert from "node:assert/strict"
+import { Window } from "happy-dom"
+
+const window = new Window({ url: "http://localhost" })
+const sent: unknown[] = []
+const api = {
+  postMessage: (message: unknown) => sent.push(message),
+  getState: () => undefined,
+  setState: () => {},
+}
+
+Object.assign(globalThis, {
+  window,
+  document: window.document,
+  navigator: window.navigator,
+  Node: window.Node,
+  Element: window.Element,
+  HTMLElement: window.HTMLElement,
+  HTMLInputElement: window.HTMLInputElement,
+  HTMLTextAreaElement: window.HTMLTextAreaElement,
+  SVGElement: window.SVGElement,
+  MutationObserver: window.MutationObserver,
+  ResizeObserver: window.ResizeObserver,
+  CustomEvent: window.CustomEvent,
+  Event: window.Event,
+  MessageEvent: window.MessageEvent,
+  requestAnimationFrame: window.requestAnimationFrame.bind(window),
+  cancelAnimationFrame: window.cancelAnimationFrame.bind(window),
+  getComputedStyle: window.getComputedStyle.bind(window),
+  acquireVsCodeApi: () => api,
+})
+
+const { render } = await import("solid-js/web")
+const { For } = await import("solid-js")
+const { DragDropProvider, SortableProvider } = await import("@thisbeyond/solid-dnd")
+const { renderTab } = await import("../../webview-ui/agent-manager/tab-rendering")
+const { VSCodeProvider } = await import("../../webview-ui/src/context/vscode")
+const { ServerProvider } = await import("../../webview-ui/src/context/server")
+const { ConfigContext } = await import("../../webview-ui/src/context/config")
+const { LanguageContext } = await import("../../webview-ui/src/context/language")
+const { ProviderContext } = await import("../../webview-ui/src/context/provider")
+const { SessionProvider, useSession } = await import("../../webview-ui/src/context/session")
+
+const provider = {
+  providers: () => ({}),
+  connected: () => [],
+  defaults: () => ({}),
+  defaultSelection: () => ({ providerID: "kilocode", modelID: "auto" }),
+  models: () => [],
+  findModel: () => undefined,
+  authMethods: () => ({}),
+  authStates: () => ({}),
+  isModelValid: () => true,
+}
+const config = {
+  config: () => ({}),
+  globalConfig: () => ({}),
+  globalDraft: () => ({}),
+  projectConfig: () => ({}),
+  collections: () => ({}),
+  settings: () => ({}),
+  features: () => ({ indexing: false, sandboxControls: false, backgroundSubagents: false }),
+  loading: () => false,
+  isDirty: () => false,
+  saving: () => false,
+  saveError: () => null,
+  updateConfig: () => {},
+  updateGlobalConfig: () => {},
+  updateProjectConfig: () => {},
+  updateSetting: () => {},
+  applySetting: () => {},
+  saveConfig: () => {},
+  discardConfig: () => {},
+}
+const language = {
+  locale: () => "en",
+  setLocale: () => {},
+  userOverride: () => "",
+  t: (key: string) => key,
+}
+
+const ref = { value: undefined as ReturnType<typeof useSession> | undefined }
+const Probe = () => {
+  const session = useSession()
+  ref.value = session
+  const ids = ["root", "background"]
+  const deps = {
+    terms: { activeId: () => undefined },
+    REVIEW_TAB_ID: "review",
+    tabIds: () => ids,
+    kb: () => ({}),
+    reviewActive: () => false,
+    currentSessionID: session.currentSessionID,
+    visibleTabId: session.currentSessionID,
+    activePendingId: () => undefined,
+    isPending: () => false,
+    activityFor: session.activityFor,
+    stateLabel: (state: string) => state,
+    tabLookup: () => new Map(ids.map((id) => [id, { id, title: id }])),
+    adjacentHint: () => "",
+  } as Parameters<typeof renderTab>[1]
+  return (
+    <DragDropProvider>
+      <SortableProvider ids={ids}>
+        <For each={ids}>{(id) => renderTab(id, deps)}</For>
+      </SortableProvider>
+    </DragDropProvider>
+  )
+}
+const host = document.createElement("div")
+document.body.append(host)
+const step = { value: 0 }
+const failures: string[] = []
+
+const dispose = render(
+  () => (
+    <VSCodeProvider>
+      <ServerProvider>
+        <ProviderContext.Provider value={provider as never}>
+          <ConfigContext.Provider value={config as never}>
+            <LanguageContext.Provider value={language as never}>
+              <SessionProvider>
+                <Probe />
+              </SessionProvider>
+            </LanguageContext.Provider>
+          </ConfigContext.Provider>
+        </ProviderContext.Provider>
+      </ServerProvider>
+    </VSCodeProvider>
+  ),
+  host,
+)
+
+const settle = async () => {
+  await Promise.resolve()
+  await window.happyDOM.waitUntilComplete()
+}
+const emit = async (data: unknown) => {
+  window.dispatchEvent(new MessageEvent("message", { data }))
+  await settle()
+}
+const state = (id: string) => {
+  const value = ref.value
+  assert(value)
+  return value.activityFor(id)
+}
+const check = async (id: string, expected: string) => {
+  await settle()
+  step.value += 1
+  const value = ref.value
+  assert(value)
+  const actual = state(id)
+  const tab = host.querySelector(`[data-tab-id="${id}"] [data-activity]`)
+  if (id === "root" || id === "background") assert(tab, `Missing rendered tab for ${id}`)
+  if (tab && tab.getAttribute("data-activity") !== expected) {
+    failures.push(
+      `step ${step.value} ${id}: rendered tab expected ${expected}, got ${tab.getAttribute("data-activity")}`,
+    )
+  }
+  if (actual !== expected) {
+    failures.push(
+      `step ${step.value} ${id}: expected ${expected}, got ${actual}, status=${value.status()}, close=${value.closeReason() ?? "none"}`,
+    )
+  }
+}
+const info = (id: string, parentID?: string) => ({
+  id,
+  ...(parentID ? { parentID } : {}),
+  title: id,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+})
+const task = (id: string, parentID: string, childID: string, nested: boolean) => ({
+  type: "partUpdated",
+  sessionID: parentID,
+  messageID: `${parentID}-part-message`,
+  part: {
+    type: "tool",
+    id,
+    sessionID: parentID,
+    messageID: `${parentID}-part-message`,
+    tool: "task",
+    state: { status: "running", input: {}, ...(nested ? { metadata: { sessionId: childID } } : {}) },
+    ...(!nested ? { metadata: { sessionId: childID } } : {}),
+  },
+})
+
+try {
+  await settle()
+  await emit({ type: "ready", serverInfo: { port: 1 } })
+  await emit({
+    type: "sessionsLoaded",
+    sessions: [info("root"), info("background"), info("durable-child", "root"), info("durable-grand", "durable-child")],
+  })
+
+  const value = ref.value
+  assert(value)
+  value.setCurrentSessionID("root")
+  await check("root", "idle")
+  await check("background", "idle")
+
+  await emit({ type: "sessionStatus", sessionID: "background", status: "busy" })
+  await check("background", "busy")
+  await check("root", "idle")
+  await emit({ type: "sessionStatus", sessionID: "background", status: "idle" })
+
+  await emit(task("root-task", "root", "task-child", false))
+  await emit(task("child-task", "task-child", "task-grand", true))
+  await emit({ type: "sessionStatus", sessionID: "durable-grand", status: "busy" })
+  await check("root", "busy")
+  await check("durable-child", "busy")
+  await check("durable-grand", "busy")
+  await emit({ type: "sessionStatus", sessionID: "durable-grand", status: "idle" })
+
+  await emit({ type: "sessionStatus", sessionID: "task-child", status: "busy" })
+  await check("root", "busy")
+  await check("task-child", "busy")
+  await emit({ type: "sessionStatus", sessionID: "task-child", status: "retry", attempt: 1, message: "retry", next: 1 })
+  await check("root", "retry")
+  await check("task-child", "retry")
+  await emit({ type: "sessionStatus", sessionID: "task-child", status: "idle" })
+  await emit({ type: "sessionStatus", sessionID: "task-grand", status: "busy" })
+  await check("root", "busy")
+  await check("task-child", "busy")
+  await check("task-grand", "busy")
+  await emit({ type: "sessionStatus", sessionID: "task-grand", status: "offline" })
+  await check("root", "error")
+  await check("task-child", "error")
+  await check("task-grand", "error")
+  await emit({ type: "sessionStatus", sessionID: "task-grand", status: "idle" })
+  await check("root", "idle")
+
+  await emit({
+    type: "permissionRequest",
+    permission: { id: "permission", sessionID: "task-grand", toolName: "bash", patterns: [], always: [], args: {} },
+  })
+  await check("root", "waiting")
+  await check("task-child", "waiting")
+  await check("task-grand", "waiting")
+  await emit({ type: "permissionError", permissionID: "permission", stale: true })
+  await check("root", "idle")
+  assert.equal(value.permissions().length, 0)
+  await emit({
+    type: "permissionRequest",
+    permission: { id: "permission", sessionID: "durable-grand", toolName: "bash", patterns: [], always: [], args: {} },
+  })
+  await check("root", "waiting")
+  await emit({ type: "permissionResolved", permissionID: "permission", sessionID: "durable-grand", response: "once" })
+  await check("root", "idle")
+  assert.equal(value.permissions().length, 0)
+
+  await emit({
+    type: "questionRequest",
+    question: {
+      id: "question",
+      sessionID: "task-child",
+      questions: [{ question: "Continue?", header: "Confirm", options: [] }],
+    },
+  })
+  await check("root", "waiting")
+  await emit({ type: "questionResolved", requestID: "question" })
+  await check("root", "idle")
+  assert.equal(value.questions().length, 0)
+
+  await emit({
+    type: "suggestionRequest",
+    suggestion: { id: "suggestion", sessionID: "task-grand", text: "Try this", actions: [] },
+  })
+  await check("root", "waiting")
+  await emit({ type: "suggestionResolved", requestID: "suggestion" })
+  await check("root", "idle")
+  assert.equal(value.suggestions().length, 0)
+
+  await emit({ type: "sessionTurnClosed", sessionID: "task-child", reason: "completed", parentID: "root" })
+  await check("task-child", "done")
+  await check("root", "idle")
+  await emit({ type: "sessionTurnClosed", sessionID: "task-child", reason: "error", parentID: "root" })
+  await check("task-child", "error")
+  await check("root", "idle")
+  await emit({ type: "sessionStatus", sessionID: "root", status: "busy" })
+  await check("root", "busy")
+  await emit({ type: "sessionStatus", sessionID: "root", status: "idle" })
+  await check("root", "idle")
+
+  await emit({ type: "sessionTurnClosed", sessionID: "root", reason: "completed" })
+  await check("root", "done")
+  await emit({ type: "sessionStatus", sessionID: "root", status: "busy" })
+  await check("root", "busy")
+  await emit({ type: "sessionStatus", sessionID: "root", status: "idle" })
+  await check("root", "idle")
+
+  await emit({ type: "sessionTurnClosed", sessionID: "root", reason: "completed" })
+  await check("root", "done")
+  await emit({
+    type: "sessionUpdated",
+    session: { ...info("root"), revert: { messageID: "root-message" } },
+  })
+  await check("root", "idle")
+  await emit({ type: "sessionUpdated", session: { ...info("root"), revert: null } })
+  await check("root", "idle")
+
+  await emit({ type: "sessionTurnClosed", sessionID: "root", reason: "completed" })
+  await check("root", "done")
+  value.sendMessage("next turn")
+  await settle()
+  await check("root", "busy")
+  await emit({ type: "sessionStatus", sessionID: "root", status: "busy" })
+  await check("root", "busy")
+  await emit({ type: "sessionStatus", sessionID: "root", status: "idle" })
+  await check("root", "idle")
+
+  value.setCurrentSessionID("background")
+  await emit({ type: "sessionStatus", sessionID: "background", status: "busy" })
+  await check("background", "busy")
+  await emit({ type: "sessionError", eventID: "background-aborted", error: { name: "MessageAbortedError" } })
+  await check("background", "busy")
+  await emit({ type: "connectionState", state: "disconnected", error: "offline" })
+  await check("background", "error")
+  await emit({ type: "connectionState", state: "connecting" })
+  await check("background", "error")
+  await emit({ type: "connectionState", state: "connected" })
+  await check("background", "busy")
+
+  await emit({
+    type: "questionRequest",
+    question: {
+      id: "connection-question",
+      sessionID: "background",
+      questions: [{ question: "Reconnect?", header: "Confirm", options: [] }],
+    },
+  })
+  await check("background", "waiting")
+  await emit({ type: "connectionState", state: "error", error: "failed" })
+  await check("background", "error")
+  await emit({ type: "connectionState", state: "connecting" })
+  await check("background", "error")
+  await emit({ type: "connectionState", state: "connected" })
+  await check("background", "waiting")
+  await emit({ type: "questionResolved", requestID: "connection-question" })
+  await check("background", "busy")
+  await emit({ type: "sessionStatus", sessionID: "background", status: "idle" })
+  await check("background", "idle")
+
+  value.setCurrentSessionID("root")
+  await emit({ type: "sessionError", eventID: "aborted", error: { name: "MessageAbortedError" } })
+  await check("root", "idle")
+  await emit({ type: "sessionError", eventID: "root-error", error: { name: "ProviderError" } })
+  await check("root", "error")
+  await emit({ type: "sessionTurnClosed", sessionID: "root", reason: "completed" })
+  await check("root", "error")
+
+  await emit({ type: "sessionStatus", sessionID: "root", status: "busy" })
+  await check("root", "busy")
+  await emit({ type: "sessionStatus", sessionID: "root", status: "idle" })
+  await check("root", "idle")
+
+  await emit({
+    type: "questionRequest",
+    question: {
+      id: "deleted-question",
+      sessionID: "root",
+      questions: [{ question: "Delete?", header: "Confirm", options: [] }],
+    },
+  })
+  await check("root", "waiting")
+  await emit({ type: "sessionDeleted", sessionID: "root" })
+  await check("root", "idle")
+  assert.equal(value.currentSessionID(), undefined)
+  assert.equal(
+    value.sessions().some((item) => item.id === "root"),
+    false,
+  )
+  assert.equal(
+    value.questions().some((item) => item.sessionID === "root"),
+    false,
+  )
+  assert.equal(
+    sent.some((item) => (item as { type?: string }).type === "sendMessage"),
+    true,
+  )
+  assert.deepEqual(failures, [])
+} finally {
+  const before = state("background")
+  dispose()
+  window.dispatchEvent(
+    new MessageEvent("message", { data: { type: "sessionStatus", sessionID: "background", status: "retry" } }),
+  )
+  assert.equal(state("background"), before)
+  await window.happyDOM.cancelAsync()
+  await window.happyDOM.close()
+}
+
+process.exit(0)

--- a/packages/kilo-vscode/tests/setup/vscode-mock.ts
+++ b/packages/kilo-vscode/tests/setup/vscode-mock.ts
@@ -40,6 +40,7 @@ const mockVscode = {
     language: "en",
     machineId: "test-machine",
     isTelemetryEnabled: false,
+    onDidChangeTelemetryEnabled: () => ({ dispose: noop }),
     shell: "/bin/bash",
     openExternal: noop,
   },
@@ -171,6 +172,9 @@ const mockVscode = {
   },
   Disposable: class {
     constructor(private callback: () => void = noop) {}
+    static from(...items: { dispose: () => void }[]) {
+      return { dispose: () => items.forEach((item) => item.dispose()) }
+    }
     dispose() {
       this.callback()
     }

--- a/packages/kilo-vscode/tests/unit/early-message.test.ts
+++ b/packages/kilo-vscode/tests/unit/early-message.test.ts
@@ -43,6 +43,17 @@ describe("routeEarlyMessage clipboard handling", () => {
   })
 })
 
+describe("routeEarlyMessage activity", () => {
+  it("forwards authoritative webview presentation state without interpreting session events", async () => {
+    const calls: unknown[] = []
+    const ctx = { activity: (state: unknown) => calls.push(state) } as Ctx
+    for (const state of ["busy", "waiting", "done", "error", "idle"]) {
+      expect(await routeEarlyMessage({ type: "sessionActivity", state }, ctx)).toBe(true)
+    }
+    expect(calls).toEqual(["busy", "waiting", "done", "error", "idle"])
+  })
+})
+
 describe("routeEarlyMessage background jobs", () => {
   it("forwards list request correlation", async () => {
     const calls: unknown[] = []

--- a/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-utils.test.ts
@@ -376,6 +376,21 @@ describe("mapSSEEventToWebviewMessage", () => {
     expect(msg).toEqual({ type: "sessionTurnClosed", sessionID: "sess-1", reason: "interrupted" })
   })
 
+  it("forwards the parent session ID when a child turn closes", () => {
+    const event: EventSessionTurnClose = {
+      id: "evt-child-turn",
+      type: "session.turn.close",
+      properties: { sessionID: "child", parentID: "parent", reason: "completed" },
+    }
+
+    expect(mapSSEEventToWebviewMessage(event, "child")).toEqual({
+      type: "sessionTurnClosed",
+      sessionID: "child",
+      reason: "completed",
+      parentID: "parent",
+    })
+  })
+
   it("maps session errors with their event identity and message", () => {
     const event: EventSessionError = {
       id: "evt-error",

--- a/packages/kilo-vscode/tests/unit/native-tab-title.test.ts
+++ b/packages/kilo-vscode/tests/unit/native-tab-title.test.ts
@@ -18,4 +18,38 @@ describe("nativeTitle", () => {
   it("truncates long session titles", () => {
     expect(nativeTitle(session("Dynamic VS Code tab titles for Kilo sessions"))).toBe("Dynamic VS Code tab...")
   })
+
+  it("updates the native panel only from valid webview activity reports", async () => {
+    const { KiloProvider } = await import("../../src/KiloProvider")
+    const titles: string[] = []
+    const listener: { current?: (message: { type: string; state: unknown }) => Promise<void> } = {}
+    const provider = new KiloProvider(
+      { fsPath: "/extension" } as never,
+      { unregisterVisible: () => {}, unregisterAttached: () => {} } as never,
+      undefined,
+      { tabTitle: (title) => titles.push(title) },
+    )
+    const internal = provider as unknown as { setupWebviewMessageHandler: (webview: unknown) => void }
+    internal.setupWebviewMessageHandler({
+      onDidReceiveMessage: (handler: NonNullable<typeof listener.current>) => {
+        listener.current = handler
+        return { dispose: () => {} }
+      },
+    })
+    for (const state of ["busy", "waiting", "done", "error", "idle", "idle", "invalid", null]) {
+      await listener.current?.({ type: "sessionActivity", state })
+    }
+    expect(titles).toEqual(["◔ Kilo Code", "⚠ Kilo Code", "✓ Kilo Code", "⚠ Kilo Code", "Kilo Code"])
+    provider.dispose()
+  })
+
+  it("renders the same activity values used by webview tabs and worktrees", () => {
+    expect(nativeTitle(session("Greeting"), "busy")).toBe("◔ Greeting")
+    expect(nativeTitle(session("Greeting"), "retry")).toBe("◔ Greeting")
+    expect(nativeTitle(session("Greeting"), "waiting")).toBe("⚠ Greeting")
+    expect(nativeTitle(session("Greeting"), "error")).toBe("⚠ Greeting")
+    expect(nativeTitle(session("Greeting"), "done")).toBe("✓ Greeting")
+    expect(nativeTitle(session("Greeting"), "idle")).toBe("Greeting")
+    expect(nativeTitle(session("Greeting"), "waiting", "Agent Manager")).toBe("⚠ Agent Manager")
+  })
 })

--- a/packages/kilo-vscode/tests/unit/project-session-busy.test.ts
+++ b/packages/kilo-vscode/tests/unit/project-session-busy.test.ts
@@ -1,31 +1,61 @@
 import { describe, expect, it } from "bun:test"
-import { createSessionBusy } from "../../webview-ui/agent-manager/project/session-busy"
+import { createSessionActivity } from "../../webview-ui/agent-manager/project/session-busy"
 
-const busy = (statuses: Record<string, { type: string }>) =>
-  createSessionBusy({
-    statuses: () => statuses,
-    permissions: () => [],
-    questions: () => [],
+const activity = (values: Record<string, "waiting" | "error" | "retry" | "busy" | "done" | "idle">) =>
+  createSessionActivity({
     managed: () => [
-      { id: "unknown", worktreeId: "wt-unknown" },
-      { id: "idle", worktreeId: "wt-idle" },
-      { id: "working", worktreeId: "wt-working" },
+      { id: "current-wt", worktreeId: "wt-current" },
+      { id: "current-other", worktreeId: "wt-other" },
+      { id: "priority-busy", worktreeId: "wt-priority" },
+      { id: "priority-waiting", worktreeId: "wt-priority" },
     ],
-    local: () => [],
-    projects: () => ({ background: [{ id: "unknown", worktreeId: "wt-unknown" }] }),
-    active: () => "project-a",
+    local: () => ["current-local"],
+    projects: () => ({
+      background: [
+        { id: "background-local", worktreeId: null },
+        { id: "background-wt", worktreeId: "wt-background" },
+      ],
+    }),
+    active: () => "current",
+    activityFor: (id) => values[id] ?? "idle",
   })
 
-describe("createSessionBusy", () => {
-  it("does not mark stopped or unknown sessions as busy", () => {
-    const state = busy({ idle: { type: "idle" } })
+describe("createSessionActivity", () => {
+  it("returns idle for groups without sessions", () => {
+    const state = activity({})
 
-    expect(state.agent("wt-unknown")).toBe(false)
-    expect(state.agent("wt-idle")).toBe(false)
-    expect(state.project("background", "wt-unknown")).toBe(false)
+    expect(state.agent("wt-missing")).toBe("idle")
+    expect(state.project("background", "wt-missing")).toBe("idle")
   })
 
-  it("marks sessions with an active status as busy", () => {
-    expect(busy({ working: { type: "busy" } }).agent("wt-working")).toBe(true)
+  it("scopes local, current, and background project activity", () => {
+    const state = activity({
+      "current-local": "done",
+      "current-wt": "busy",
+      "current-other": "error",
+      "background-local": "retry",
+      "background-wt": "error",
+    })
+
+    expect(state.local()).toBe("done")
+    expect(state.project("current", null)).toBe("done")
+    expect(state.project("current", "wt-current")).toBe("busy")
+    expect(state.project("background", null)).toBe("retry")
+    expect(state.project("background", "wt-background")).toBe("error")
+  })
+
+  it("prioritizes attention over errors and work in a group", () => {
+    const state = activity({
+      "current-wt": "busy",
+      "current-other": "waiting",
+      "priority-busy": "busy",
+      "priority-waiting": "waiting",
+      "background-local": "error",
+      "background-wt": "waiting",
+    })
+
+    expect(state.agent("wt-priority")).toBe("waiting")
+    expect(state.project("current", "wt-other")).toBe("waiting")
+    expect(state.project("background", "wt-background")).toBe("waiting")
   })
 })

--- a/packages/kilo-vscode/tests/unit/session-activity.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-activity.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "bun:test"
+import {
+  activities,
+  activity,
+  isActivity,
+  label,
+  running,
+  strongest,
+  type Activity,
+} from "../../webview-ui/src/utils/session-activity"
+import { ancestry } from "../../webview-ui/src/context/session-utils"
+
+describe("activity", () => {
+  it("maps backend states", () => {
+    expect(activity({})).toBe("idle")
+    expect(activity({ status: "busy" })).toBe("busy")
+    expect(activity({ status: "retry" })).toBe("retry")
+    expect(activity({ status: "offline" })).toBe("error")
+  })
+
+  it("prioritizes waiting over terminal and running states", () => {
+    expect(activity({ status: "busy", blocked: true, errored: true, finished: true })).toBe("waiting")
+  })
+
+  it("prioritizes errors over running and completed states", () => {
+    expect(activity({ status: "retry", errored: true, finished: true })).toBe("error")
+  })
+
+  it("only reports done while idle", () => {
+    expect(activity({ status: "busy", finished: true })).toBe("busy")
+    expect(activity({ finished: true })).toBe("done")
+  })
+})
+
+describe("activities", () => {
+  const parents = new Map([
+    ["child", "root"],
+    ["nested", "child"],
+  ])
+
+  it("derives nested requests and active work without reading transcript pages", () => {
+    const result = activities({
+      parents,
+      statuses: { root: { type: "idle" }, child: { type: "retry" }, other: { type: "busy" } },
+      outcomes: {},
+      blocked: ["nested"],
+      disconnected: false,
+    })
+    expect(result).toEqual({ root: "waiting", child: "waiting", nested: "waiting", other: "busy" })
+  })
+
+  it("rolls up child work but leaves terminal outcomes with their owning sessions", () => {
+    const input = {
+      parents,
+      statuses: {},
+      outcomes: { child: { reason: "error" }, nested: { reason: "completed" } },
+      blocked: [],
+      disconnected: false,
+    }
+    expect(activities(input)).toEqual({ child: "error", nested: "done" })
+    expect(activities({ ...input, submitting: ["nested"] })).toEqual({
+      root: "busy",
+      child: "error",
+      nested: "busy",
+    })
+    expect(activities({ ...input, outcomes: { ...input.outcomes, root: { reason: "completed" } } }).root).toBe("done")
+  })
+
+  it("shows disconnected active sessions as errors without changing idle or completed sessions", () => {
+    const input = {
+      parents,
+      statuses: { root: { type: "busy" as const }, other: { type: "idle" as const } },
+      outcomes: { complete: { reason: "completed" } },
+      blocked: ["nested"],
+      disconnected: true,
+    }
+    expect(activities(input)).toEqual({
+      root: "error",
+      child: "error",
+      nested: "error",
+      other: "idle",
+      complete: "done",
+    })
+    expect(activities({ ...input, disconnected: false }).root).toBe("waiting")
+  })
+
+  it("does not leak a parent request into child or sibling session indicators", () => {
+    expect(
+      activities({
+        parents,
+        statuses: { child: { type: "busy" }, nested: { type: "idle" } },
+        outcomes: {},
+        blocked: ["root"],
+        disconnected: false,
+      }),
+    ).toEqual({ root: "waiting", child: "busy", nested: "idle" })
+  })
+
+  it("guards cycles and does not mutate its source state", () => {
+    const parents = new Map([
+      ["first", "second"],
+      ["second", "first"],
+    ])
+    const statuses = { first: { type: "busy" as const } }
+    const input = { parents, statuses, outcomes: {}, blocked: [], disconnected: false }
+    expect(activities(input)).toEqual({ first: "busy", second: "busy" })
+    expect(activities({ ...input, statuses: {} })).toEqual({})
+    expect(statuses).toEqual({ first: { type: "busy" } })
+  })
+})
+
+describe("ancestry", () => {
+  it("prefers durable session metadata over task and close-event fallbacks", () => {
+    const result = ancestry(
+      { child: { parentID: "root" }, root: { parentID: null } },
+      {
+        other: [
+          { type: "tool", tool: "task", metadata: { sessionId: "child" } },
+          { type: "tool", tool: "task", state: { metadata: { sessionId: "fallback" } } },
+        ],
+      },
+      { child: { parentID: "stale" }, missing: { parentID: "root" } },
+    )
+    expect(Object.fromEntries(result.parents)).toEqual({ child: "root", fallback: "other", missing: "root" })
+    expect(result.children.get("root")).toEqual(["child", "missing"])
+  })
+})
+
+describe("isActivity", () => {
+  it("accepts only known presentation states", () => {
+    expect(isActivity("waiting")).toBe(true)
+    expect(isActivity("done")).toBe(true)
+    expect(isActivity("unknown")).toBe(false)
+    expect(isActivity({ state: "waiting" })).toBe(false)
+    expect(isActivity(undefined)).toBe(false)
+  })
+})
+
+describe("running", () => {
+  it("matches spinner states", () => {
+    expect(running("busy")).toBe(true)
+    expect(running("retry")).toBe(true)
+    expect(running("waiting")).toBe(false)
+    expect(running("done")).toBe(false)
+  })
+})
+
+describe("strongest", () => {
+  it("returns the highest priority state", () => {
+    expect(strongest(["busy", "waiting", "idle"])).toBe("waiting")
+    expect(strongest(["done", "error", "retry"])).toBe("error")
+    expect(strongest(["done", "busy"])).toBe("busy")
+    expect(strongest([])).toBe("idle")
+  })
+})
+
+describe("label", () => {
+  it("returns existing translation keys", () => {
+    const states: Activity[] = ["waiting", "error", "retry", "busy", "done", "idle"]
+    expect(states.map(label)).toEqual([
+      "task.backgroundAgents.needsInput",
+      "task.backgroundAgents.status.error",
+      "session.status.retry",
+      "session.tabs.switcher.busy",
+      "task.backgroundAgents.status.completed",
+      "session.current",
+    ])
+  })
+})

--- a/packages/kilo-vscode/tests/unit/session-activity.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-activity.test.ts
@@ -5,6 +5,7 @@ import {
   isActivity,
   label,
   running,
+  score,
   strongest,
   type Activity,
 } from "../../webview-ui/src/utils/session-activity"
@@ -130,6 +131,7 @@ describe("isActivity", () => {
   it("accepts only known presentation states", () => {
     expect(isActivity("waiting")).toBe(true)
     expect(isActivity("done")).toBe(true)
+    expect(isActivity("idle")).toBe(true)
     expect(isActivity("unknown")).toBe(false)
     expect(isActivity({ state: "waiting" })).toBe(false)
     expect(isActivity(undefined)).toBe(false)
@@ -142,6 +144,19 @@ describe("running", () => {
     expect(running("retry")).toBe(true)
     expect(running("waiting")).toBe(false)
     expect(running("done")).toBe(false)
+  })
+})
+
+describe("score", () => {
+  it("preserves every activity priority with idle scoring zero", () => {
+    const states: Activity[] = ["idle", "done", "busy", "retry", "error", "waiting"]
+    expect(states.map(score)).toEqual([0, 1, 2, 3, 4, 5])
+    for (const [index, state] of states.entries()) {
+      for (const lower of states.slice(0, index + 1)) {
+        expect(strongest([state, lower])).toBe(state)
+        expect(strongest([lower, state])).toBe(state)
+      }
+    }
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/session-provider-activity.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-provider-activity.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test"
+import { unlinkSync } from "node:fs"
+import path from "node:path"
+import { build } from "esbuild"
+import { solidPlugin } from "esbuild-plugin-solid"
+
+const root = path.resolve(import.meta.dir, "../..")
+const webview = path.join(root, "webview-ui")
+const fixture = path.join(root, "tests/fixtures/session-provider-activity.tsx")
+
+describe("SessionProvider activity", () => {
+  it("covers real session activity lifecycle messages", async () => {
+    const solid = path.dirname(Bun.resolveSync("solid-js/package.json", webview))
+    const aliases: Record<string, string> = {
+      "solid-js": path.join(solid, "dist/solid.js"),
+      "solid-js/web": path.join(solid, "web/dist/web.js"),
+      "solid-js/store": path.join(solid, "store/dist/store.js"),
+    }
+    const dedupe = {
+      name: "solid-dedupe",
+      setup(ctx: Parameters<NonNullable<Parameters<typeof build>[0]["plugins"]>[number]["setup"]>[0]) {
+        ctx.onResolve({ filter: /^solid-js(\/web|\/store)?$/ }, (args) => ({ path: aliases[args.path] }))
+      },
+    }
+    const result = await build({
+      entryPoints: [fixture],
+      bundle: true,
+      conditions: ["browser"],
+      external: ["happy-dom"],
+      format: "esm",
+      logLevel: "silent",
+      loader: { ".css": "empty" },
+      platform: "node",
+      plugins: [dedupe, solidPlugin()],
+      target: "es2022",
+      write: false,
+    })
+    const file = path.join(root, `.session-provider-activity-${crypto.randomUUID()}.mjs`)
+    await Bun.write(file, result.outputFiles[0]!.contents)
+    try {
+      const child = Bun.spawnSync(["bun", file], { cwd: webview, stdout: "pipe", stderr: "pipe" })
+      const output = child.stdout.toString() + child.stderr.toString()
+      expect(child.exitCode, output).toBe(0)
+    } finally {
+      unlinkSync(file)
+    }
+  })
+})

--- a/packages/kilo-vscode/tests/unit/sidebar-search.test.ts
+++ b/packages/kilo-vscode/tests/unit/sidebar-search.test.ts
@@ -51,9 +51,8 @@ const build = (overrides?: Partial<Parameters<typeof buildSidebarSearch>[0]>) =>
     localBranch: "main",
     untitled: "Untitled",
     pending: (id) => id.startsWith("pending:"),
-    status: (id) => (id === "busy-session" ? "busy" : "idle"),
+    activityFor: (id) => (id === "busy-session" ? "busy" : "idle"),
     busy: () => false,
-    localBusy: false,
     ...overrides,
   })
 
@@ -104,6 +103,24 @@ describe("buildSidebarSearch", () => {
     expect(items[4]).toMatchObject({ state: "busy", updatedAt: "2026-06-03T00:00:00.000Z" })
   })
 
+  it("uses the strongest session activity for context rows", () => {
+    const items = build({
+      activityFor: (id) => (id === "busy-session" ? "busy" : id === "recent-session" ? "waiting" : "idle"),
+    })
+
+    expect(items.find((item) => item.key === "session:recent-session")).toMatchObject({ state: "waiting" })
+    expect(items.find((item) => item.key === "worktree:wt-search")).toMatchObject({ state: "waiting" })
+  })
+
+  it("keeps operation busy separate from session activity", () => {
+    const items = build({
+      activityFor: () => "idle",
+      busy: () => true,
+    })
+
+    expect(items.find((item) => item.key === "worktree:wt-search")).toMatchObject({ state: "idle", busy: true })
+  })
+
   it("uses expanded sidebar visibility before recency as a tie-breaker", () => {
     const items = build({
       worktrees: [
@@ -119,7 +136,7 @@ describe("buildSidebarSearch", () => {
         },
       ],
       local: [],
-      status: () => "idle",
+      activityFor: () => "idle",
     })
 
     expect(items.filter((item) => item.kind === "session").map((item) => item.sessionId)).toEqual(["visible", "hidden"])

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -91,7 +91,7 @@ import { createProjectRegistry, type PersistedProjectTabs } from "./project/regi
 import type { WorktreeBusyState } from "./project/store"
 import { rememberTarget, restoreProjectTarget } from "./project/restore"
 import { createProjectStateRouter } from "./project/state"
-import { createSessionBusy } from "./project/session-busy"
+import { createSessionActivity } from "./project/session-busy"
 import { switchProject } from "./project/switch"
 import { createProjectStateHandlers } from "./project/state-handlers"
 import { ownsParent as ownsParentSession, isCurrent } from "./project/message-ownership"
@@ -116,6 +116,7 @@ import { DataBridge } from "../src/App"
 import { LanguageBridge } from "../src/context/language-bridge"
 import { useLanguage } from "../src/context/language"
 import { createTabFocus } from "../src/utils/tab-navigation"
+import { label, strongest } from "../src/utils/session-activity"
 import {
   canOpenRootSession,
   isKnownRootSession,
@@ -123,6 +124,7 @@ import {
   adjacentHint,
   focusChatSearch,
   LOCAL,
+  remoteSessions,
 } from "./navigate"
 import { buildProjectNavEntries, createProjectNav } from "./project-nav"
 import {
@@ -898,22 +900,26 @@ const AgentManagerContent: Component = () => {
     return label !== wt.branch ? wt.branch : undefined
   }
 
-  const isStaleWorktree = (worktreeId: string): boolean => staleWorktreeIds().has(worktreeId)
-
-  const busy = createSessionBusy({
-    statuses: session.allStatusMap,
-    permissions: session.permissions,
-    questions: session.questions,
+  const activity = createSessionActivity({
     managed: managedSessions,
     local: localSessionIDs,
     projects: projectSessionsLive,
     active: activeProjectId,
+    activityFor: session.activityFor,
   })
-  const isAgentBusy = busy.agent
-  const isLocalBusy = busy.local
-  const projectBusy = busy.project
-  const isSessionBusy = busy.session
-
+  const sessionActivity = createMemo(() =>
+    strongest(
+      multiProject()
+        ? projectList()
+            .filter((project) => projectStates()[project.id])
+            .flatMap((project) => [
+              activity.project(project.id, null),
+              ...projectStates()[project.id]!.worktrees.map((worktree) => activity.project(project.id, worktree.id)),
+            ])
+        : remoteSessions(localSessionIDs(), managedSessions(), isPending).map(session.activityFor),
+    ),
+  )
+  createEffect(() => vscode.postMessage({ type: "sessionActivity", state: sessionActivity() }))
   /** Worktrees sorted so that grouped items are always adjacent, respecting custom order if set. */
   const sortedWorktrees = createMemo(() => sortWorktrees(worktrees(), sidebarWorktreeOrder()))
 
@@ -1050,14 +1056,11 @@ const AgentManagerContent: Component = () => {
     localBranch: repoBranch,
     selection,
     sessionId: session.currentSessionID,
-    statuses: session.allStatusMap,
-    permissions: session.permissions,
-    questions: session.questions,
+    activityFor: session.activityFor,
     label: worktreeLabel,
     sessions: sessionsForWorktree,
     pending: isPending,
     busy: (id) => busyWorktrees().has(id) || (runStatuses()[id]?.state ?? "idle") !== "idle",
-    localBusy: isLocalBusy,
     t,
   })
   const focusSidebarSearchItem = (item: SidebarSearchItem) => {
@@ -2255,7 +2258,8 @@ const AgentManagerContent: Component = () => {
       activePendingId,
       visibleTabId,
       isPending,
-      isBusy: isSessionBusy,
+      activityFor: (id) => session.activityFor(id),
+      stateLabel: (state) => t(label(state)),
       tabLookup,
       adjacentHint,
       activateTerminal: termHandlers.activate,
@@ -2319,8 +2323,6 @@ const AgentManagerContent: Component = () => {
             states={projectStates()}
             store={(id) => registry.ensure(id)}
             busy={(projectId, id) => registry.ensure(projectId).busy().has(id)}
-            working={(projectId, id) => projectBusy(projectId, id)}
-            localBusy={(projectId) => projectBusy(projectId, null)}
             stats={projectLive.stats()}
             local={projectLive.local()}
             prs={projectLive.prs()}
@@ -2337,6 +2339,8 @@ const AgentManagerContent: Component = () => {
             onShortcuts={handleShowKeyboardShortcuts}
             onHistory={openHistory}
             shortcutMap={projectShortcutMap}
+            activityFor={activity.project}
+            sessionActivity={session.activityFor}
           />
         </Show>
         <Show when={!multiProject()}>
@@ -2346,7 +2350,7 @@ const AgentManagerContent: Component = () => {
             currentSessionID={session.currentSessionID}
             selectLocal={selectLocal}
             selectWorktree={selectWorktree}
-            isLocalBusy={isLocalBusy}
+            activityFor={(id) => (id === null ? activity.local() : activity.agent(id))}
             repoBranch={repoBranch}
             localStats={localStats}
             search={{ items: sidebarSearch.items, current: sidebarSearch.current }}
@@ -2384,8 +2388,7 @@ const AgentManagerContent: Component = () => {
             worktreeSubtitle={worktreeSubtitle}
             pendingDelete={pendingDelete}
             busy={(id) => busyWorktrees().has(id)}
-            isAgentBusy={isAgentBusy}
-            isStaleWorktree={isStaleWorktree}
+            isStaleWorktree={(id) => staleWorktreeIds().has(id)}
             shortcutMap={shortcutMap}
             worktreeStats={worktreeStats}
             prStatuses={prStatuses}

--- a/packages/kilo-vscode/webview-ui/agent-manager/ProjectList.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ProjectList.tsx
@@ -7,6 +7,7 @@ import type {
   LocalGitStats,
   PRStatus,
   ProjectSessionInfo,
+  RunStatus,
   WorktreeGitStats,
 } from "../src/types/messages"
 import type { LanguageContextValue } from "../src/context/language"
@@ -16,6 +17,7 @@ import { ProjectsSection } from "./ProjectsSection"
 import { ProjectSidebarBody } from "./ProjectSidebarBody"
 import { SidebarSearchMenu, type SidebarSearchMenuRef } from "./SidebarSearchMenu"
 import type { SidebarSearchItem } from "./sidebar-search"
+import { label, type Activity } from "../src/utils/session-activity"
 import { LOCAL } from "./navigate"
 import { NewWorktreeDialog } from "./NewWorktreeDialog"
 import type { ProjectStore } from "./project/store"
@@ -25,6 +27,10 @@ const place = (state: AgentManagerStateMessage, session: ProjectSessionInfo, loc
   const wt = state.worktrees.find((item) => item.id === session.worktreeId)
   return wt?.label || wt?.branch || local
 }
+
+const activeRun = (status: RunStatus | undefined) => status?.state === "running" || status?.state === "stopping"
+const operationBusy = (store: ProjectStore | undefined, id: string) =>
+  store?.busy().has(id) || activeRun(store?.runStatuses()[id])
 
 interface Props {
   projects: AgentProjectSnapshot[]
@@ -40,9 +46,9 @@ interface Props {
   mode: ModeRouter
   defaultBase?: (projectId: string) => string | undefined
   onCreate?: (projectId: string) => void
-  busy?: (projectId: string, id: string) => boolean
-  working?: (projectId: string, id: string) => boolean
-  localBusy?: (projectId: string) => boolean
+  busy: (projectId: string, id: string) => boolean
+  activityFor: (projectId: string, worktreeId: string | null) => Activity
+  sessionActivity: (id: string) => Activity
   bindings: Record<string, string>
   t: LanguageContextValue["t"]
   onSearchRef: (ref: SidebarSearchMenuRef) => void
@@ -61,6 +67,7 @@ export const ProjectList: Component<Props> = (props) => {
     for (const project of props.projects) {
       const state = props.states[project.id]
       if (!state) continue
+      const store = props.store?.(project.id)
       const local = props.sessions[project.id]?.filter((session) => session.worktreeId === null) ?? []
       items.push({
         key: `${project.id}:local`,
@@ -73,7 +80,7 @@ export const ProjectList: Component<Props> = (props) => {
           .filter(Boolean)
           .join(" "),
         updatedAt: local.reduce((latest, session) => (session.updatedAt > latest ? session.updatedAt : latest), ""),
-        state: "idle",
+        state: props.activityFor(project.id, null),
         visible: project.expanded,
         count: local.length,
       })
@@ -88,10 +95,11 @@ export const ProjectList: Component<Props> = (props) => {
           meta: [project.label, worktree.branch],
           search: [project.label, worktree.label, worktree.branch, worktree.id].filter(Boolean).join(" "),
           updatedAt: worktree.createdAt,
-          state: "idle",
+          state: props.activityFor(project.id, worktree.id),
           visible: project.expanded,
           worktreeId: worktree.id,
           count: sessions.length,
+          busy: props.busy(project.id, worktree.id) || operationBusy(store, worktree.id),
         })
       }
       for (const session of props.sessions[project.id] ?? []) {
@@ -106,7 +114,7 @@ export const ProjectList: Component<Props> = (props) => {
           meta: [project.label, where],
           search: [project.label, where, wt?.branch, session.title, session.id].filter(Boolean).join(" "),
           updatedAt: session.updatedAt,
-          state: "idle",
+          state: props.sessionActivity(session.id),
           visible: project.expanded,
           sessionId: session.id,
           location: session.worktreeId ? "worktree" : "local",
@@ -172,8 +180,7 @@ export const ProjectList: Component<Props> = (props) => {
               scope: props.t("agentManager.sidebarSearch.scope"),
               sessions: props.t("agentManager.section.sessions"),
               contexts: props.t("agentManager.sidebarSearch.contexts"),
-              waiting: props.t("agentManager.tabsMenu.status.waiting"),
-              retry: props.t("agentManager.tabsMenu.status.retry"),
+              state: (value) => props.t(label(value)),
             }}
             onSelect={selectSearch}
           />
@@ -216,9 +223,8 @@ export const ProjectList: Component<Props> = (props) => {
           project={project}
           state={props.states[project.id]}
           store={props.store?.(project.id)}
-          busy={(id) => props.busy?.(project.id, id) ?? false}
-          working={(id) => props.working?.(project.id, id) ?? false}
-          localBusy={() => props.localBusy?.(project.id) ?? false}
+          busy={(id) => props.busy(project.id, id)}
+          activityFor={(id) => props.activityFor(project.id, id)}
           stats={props.stats[project.id]}
           local={props.local[project.id]}
           prs={props.prs[project.id]}

--- a/packages/kilo-vscode/webview-ui/agent-manager/ProjectSidebarBody.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ProjectSidebarBody.tsx
@@ -1,6 +1,5 @@
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, type Component } from "solid-js"
 import { Icon } from "@kilocode/kilo-ui/icon"
-import { Spinner } from "@kilocode/kilo-ui/spinner"
 import {
   DragDropProvider,
   DragDropSensors,
@@ -19,6 +18,8 @@ import type {
   WorktreeGitStats,
 } from "../src/types/messages"
 import type { LanguageContextValue } from "../src/context/language"
+import { ActivityIcon } from "../src/components/shared/ActivityIcon"
+import { label, type Activity } from "../src/utils/session-activity"
 import { useVSCode } from "../src/context/vscode"
 import SectionHeader from "./SectionHeader"
 import { SidebarSectionHeader } from "./SidebarSectionHeader"
@@ -40,9 +41,8 @@ interface Props {
   project: AgentProjectSnapshot
   state?: AgentManagerStateMessage
   store?: ProjectStore
-  busy?: (id: string) => boolean
-  working?: (id: string) => boolean
-  localBusy?: () => boolean
+  busy: (id: string) => boolean
+  activityFor: (worktreeId: string | null) => Activity
   stats?: Record<string, WorktreeGitStats>
   local?: LocalGitStats
   prs?: Record<string, PRStatus | null>
@@ -105,6 +105,7 @@ export const ProjectSidebarBody: Component<Props> = (props) => {
   const sidebarOrder = createMemo(() => projectSidebarOrder(top(), sorted(), sections(), members))
   const post = (message: Record<string, unknown>) =>
     vscode.postMessage({ ...message, projectId: props.project.id } as never)
+  const localState = () => props.activityFor(null)
 
   const row = (id: string) =>
     projectWorktreeRow({
@@ -236,8 +237,8 @@ export const ProjectSidebarBody: Component<Props> = (props) => {
           subtitle={worktree.label ? (worktree.label !== worktree.branch ? worktree.branch : undefined) : subtitle()}
           active={active() && props.selection === worktree.id}
           pendingDelete={pending() === worktree.id}
-          busy={props.busy?.(worktree.id) ?? false}
-          working={props.working?.(worktree.id) || runs()[worktree.id]?.state === "running"}
+          busy={props.busy(worktree.id)}
+          activity={props.activityFor(worktree.id)}
           stale={state()?.staleWorktreeIds?.includes(worktree.id) === true}
           stats={props.stats?.[worktree.id]}
           shortcut={values().shortcut}
@@ -294,13 +295,18 @@ export const ProjectSidebarBody: Component<Props> = (props) => {
         data-sidebar-id={`${props.project.id}:local`}
         onClick={() => props.onSelectLocal(props.project.id)}
       >
-        <Show when={!props.localBusy?.()} fallback={<Spinner class="am-worktree-spinner" />}>
-          <svg class="am-local-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <rect x="2.5" y="3.5" width="15" height="10" rx="1" stroke="currentColor" />
-            <path d="M6 16.5H14" stroke="currentColor" stroke-linecap="square" />
-            <path d="M10 13.5V16.5" stroke="currentColor" />
-          </svg>
-        </Show>
+        <span class="am-local-status" data-activity={localState()} aria-label={props.t(label(localState()))}>
+          <ActivityIcon
+            state={localState()}
+            idle={
+              <svg class="am-local-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <rect x="2.5" y="3.5" width="15" height="10" rx="1" stroke="currentColor" />
+                <path d="M6 16.5H14" stroke="currentColor" stroke-linecap="square" />
+                <path d="M10 13.5V16.5" stroke="currentColor" />
+              </svg>
+            }
+          />
+        </span>
         <div class="am-local-text">
           <span class="am-local-label">{props.t("agentManager.local")}</span>
           <Show when={props.local === undefined}>

--- a/packages/kilo-vscode/webview-ui/agent-manager/SidebarBody.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/SidebarBody.tsx
@@ -1,6 +1,5 @@
 import { For, Show, createMemo, createSignal, type Component } from "solid-js"
 import { Icon } from "@kilocode/kilo-ui/icon"
-import { Spinner } from "@kilocode/kilo-ui/spinner"
 import {
   DragDropProvider,
   DragDropSensors,
@@ -32,6 +31,8 @@ import { WorktreeItem } from "./WorktreeItem"
 import { WorktreeSectionActions } from "./WorktreeSectionActions"
 import { StatsSkeleton, WorktreeSkeleton } from "./Skeleton"
 import type { SidebarSearchMenuRef } from "./SidebarSearchMenu"
+import { ActivityIcon } from "../src/components/shared/ActivityIcon"
+import { label, type Activity } from "../src/utils/session-activity"
 
 const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent)
 
@@ -43,7 +44,7 @@ export interface SidebarBodyProps {
   currentSessionID: () => string | undefined
   selectLocal: () => void
   selectWorktree: (id: string) => void
-  isLocalBusy: () => boolean
+  activityFor: (id: string | null) => Activity
   repoBranch: () => string | undefined
   localStats: () => LocalGitStats | undefined
   search: { items: () => SidebarSearchItem[]; current: () => SidebarSearchItem | undefined }
@@ -80,7 +81,6 @@ export interface SidebarBodyProps {
   worktreeSubtitle: (wt: WorktreeState) => string | undefined
   pendingDelete: () => string | null
   busy: (id: string) => boolean
-  isAgentBusy: (id: string) => boolean
   isStaleWorktree: (id: string) => boolean
   shortcutMap: () => Map<string, number>
   worktreeStats: () => Record<string, WorktreeGitStats>
@@ -95,6 +95,7 @@ export interface SidebarBodyProps {
 /** Legacy single-project sidebar body: local repo, worktrees, unassigned sessions. */
 export const SidebarBody: Component<SidebarBodyProps> = (props) => {
   const vscode = useVSCode()
+  const localState = () => props.activityFor(null)
 
   return (
     <>
@@ -104,13 +105,18 @@ export const SidebarBody: Component<SidebarBodyProps> = (props) => {
         data-sidebar-id="local"
         onClick={() => props.selectLocal()}
       >
-        <Show when={!props.isLocalBusy()} fallback={<Spinner class="am-worktree-spinner" />}>
-          <svg class="am-local-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <rect x="2.5" y="3.5" width="15" height="10" rx="1" stroke="currentColor" />
-            <path d="M6 16.5H14" stroke="currentColor" stroke-linecap="square" />
-            <path d="M10 13.5V16.5" stroke="currentColor" />
-          </svg>
-        </Show>
+        <span class="am-local-status" data-activity={localState()} aria-label={props.t(label(localState()))}>
+          <ActivityIcon
+            state={localState()}
+            idle={
+              <svg class="am-local-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <rect x="2.5" y="3.5" width="15" height="10" rx="1" stroke="currentColor" />
+                <path d="M6 16.5H14" stroke="currentColor" stroke-linecap="square" />
+                <path d="M10 13.5V16.5" stroke="currentColor" />
+              </svg>
+            }
+          />
+        </span>
         <div class="am-local-text">
           <span class="am-local-label">{props.t("agentManager.local")}</span>
           <Show when={props.repoBranch()}>
@@ -314,7 +320,7 @@ export const SidebarBody: Component<SidebarBodyProps> = (props) => {
                                 active={props.selection() === wt.id}
                                 pendingDelete={props.pendingDelete() === wt.id}
                                 busy={props.busy(wt.id)}
-                                working={props.isAgentBusy(wt.id)}
+                                activity={props.activityFor(wt.id)}
                                 stale={props.isStaleWorktree(wt.id)}
                                 shortcut={props.shortcutMap().get(wt.id)}
                                 stats={props.worktreeStats()[wt.id]}

--- a/packages/kilo-vscode/webview-ui/agent-manager/SidebarSearchMenu.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/SidebarSearchMenu.tsx
@@ -9,6 +9,8 @@ import type { ListRef } from "@kilocode/kilo-ui/list"
 import { Popover } from "@kilocode/kilo-ui/popover"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
 import { TooltipKeybind } from "@kilocode/kilo-ui/tooltip"
+import { ActivityIcon } from "../src/components/shared/ActivityIcon"
+import type { Activity } from "../src/utils/session-activity"
 import { formatRelativeDate } from "../src/utils/date"
 import { colorCss } from "./section-colors"
 import type { SidebarSearchItem } from "./sidebar-search"
@@ -20,7 +22,13 @@ export interface SidebarSearchMenuRef {
 interface SidebarSearchMenuProps {
   items: Accessor<SidebarSearchItem[]>
   current: Accessor<SidebarSearchItem | undefined>
-  labels: { search: string; scope: string; contexts: string; sessions: string; waiting: string; retry: string }
+  labels: {
+    search: string
+    scope: string
+    contexts: string
+    sessions: string
+    state: (value: Activity) => string
+  }
   keybind: string
   ref?: (value: SidebarSearchMenuRef) => void
   onSelect: (item: SidebarSearchItem) => void
@@ -104,7 +112,7 @@ export const SidebarSearchMenu: Component<SidebarSearchMenuProps> = (props) => {
             }}
           >
             {(item) => {
-              const working = item.state === "busy" || item.state === "retry"
+              const stateLabel = () => props.labels.state(item.state)
               return (
                 <span
                   class="search-menu-row"
@@ -114,19 +122,30 @@ export const SidebarSearchMenu: Component<SidebarSearchMenuProps> = (props) => {
                   data-session-id={item.kind === "session" ? item.sessionId : undefined}
                   data-worktree-id={item.kind === "worktree" ? item.worktreeId : undefined}
                 >
-                  <span class="search-menu-icon">
-                    <Show when={!working} fallback={<Spinner class="search-menu-spinner" />}>
-                      <Show
-                        when={item.kind !== "local"}
-                        fallback={
-                          <svg class="am-local-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true">
-                            <rect x="2.5" y="3.5" width="15" height="10" rx="1" stroke="currentColor" />
-                            <path d="M6 16.5H14M10 13.5V16.5" stroke="currentColor" />
-                          </svg>
-                        }
-                      >
-                        <Icon name={item.kind === "worktree" ? "branch" : "speech-bubble"} size="small" />
-                      </Show>
+                  <span class="search-menu-icon" data-activity={item.state}>
+                    <Show
+                      when={item.busy}
+                      fallback={
+                        <ActivityIcon
+                          state={item.state}
+                          spinner="search-menu-spinner"
+                          idle={
+                            <Show
+                              when={item.kind !== "local"}
+                              fallback={
+                                <svg class="am-local-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+                                  <rect x="2.5" y="3.5" width="15" height="10" rx="1" stroke="currentColor" />
+                                  <path d="M6 16.5H14M10 13.5V16.5" stroke="currentColor" />
+                                </svg>
+                              }
+                            >
+                              <Icon name={item.kind === "worktree" ? "branch" : "speech-bubble"} size="small" />
+                            </Show>
+                          }
+                        />
+                      }
+                    >
+                      <Spinner class="search-menu-spinner" />
                     </Show>
                   </span>
                   <span class="search-menu-copy">
@@ -143,13 +162,12 @@ export const SidebarSearchMenu: Component<SidebarSearchMenuProps> = (props) => {
                       <span>{item.meta.join(" · ")}</span>
                     </span>
                   </span>
-                  <Show when={item.state === "waiting"}>
-                    <span class="search-menu-status am-sidebar-search-status">{props.labels.waiting}</span>
+                  <Show when={item.state !== "idle" && item.state !== "busy"}>
+                    <span class="search-menu-status am-sidebar-search-status" data-activity={item.state}>
+                      {stateLabel()}
+                    </span>
                   </Show>
-                  <Show when={item.state === "retry"}>
-                    <span class="search-menu-status am-sidebar-search-status">{props.labels.retry}</span>
-                  </Show>
-                  <Show when={item.kind !== "session" && item.state === "idle"}>
+                  <Show when={item.kind !== "session" && item.state === "idle" && !item.busy}>
                     <span class="search-menu-status am-sidebar-search-count">
                       {item.kind !== "session" ? item.count : ""}
                     </span>

--- a/packages/kilo-vscode/webview-ui/agent-manager/SidebarSearchMenu.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/SidebarSearchMenu.tsx
@@ -122,7 +122,7 @@ export const SidebarSearchMenu: Component<SidebarSearchMenuProps> = (props) => {
                   data-session-id={item.kind === "session" ? item.sessionId : undefined}
                   data-worktree-id={item.kind === "worktree" ? item.worktreeId : undefined}
                 >
-                  <span class="search-menu-icon" data-activity={item.state}>
+                  <span class="search-menu-icon am-sidebar-search-icon" data-activity={item.state}>
                     <Show
                       when={item.busy}
                       fallback={

--- a/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
@@ -12,6 +12,8 @@ import { ContextMenu } from "@kilocode/kilo-ui/context-menu"
 import { Button } from "@kilocode/kilo-ui/button"
 import type { WorktreeState, WorktreeGitStats, SectionState, RunStatus } from "../src/types/messages"
 import type { PRStatus } from "../src/types/messages"
+import { ActivityIcon } from "../src/components/shared/ActivityIcon"
+import { label, type Activity } from "../src/utils/session-activity"
 import { colorCss } from "./section-colors"
 import { useLanguage } from "../src/context/language"
 import { formatRelativeDate } from "../src/utils/date"
@@ -31,8 +33,7 @@ interface WorktreeItemProps {
   active: boolean
   pendingDelete: boolean
   busy: boolean
-  /** Whether an agent session on this worktree is actively working (shows spinner instead of branch icon). */
-  working: boolean
+  activity: Activity
   stale: boolean
   /** 1-indexed shortcut number shown as ⌘2, ⌘3, etc. Pass 0, >9, or undefined to hide. */
   shortcut?: number
@@ -155,6 +156,7 @@ export const WorktreeItem: Component<WorktreeItemProps> = (props) => {
   const { t } = useLanguage()
   const [hovered, setHovered] = createSignal(false)
   const [overClose, setOverClose] = createSignal(false)
+  const state = () => props.activity
 
   const handleOpenPR = (e: MouseEvent) => {
     e.stopPropagation()
@@ -199,9 +201,12 @@ export const WorktreeItem: Component<WorktreeItemProps> = (props) => {
                 data-sidebar-id={props.sidebarId ?? props.worktree.id}
                 onClick={() => props.onClick()}
               >
-                <div class="am-wt-icon">
-                  <Show when={!props.busy && !props.working} fallback={<Spinner class="am-worktree-spinner" />}>
-                    <Icon name="branch" size="small" />
+                <div class="am-wt-icon" data-activity={state()} aria-label={t(label(state()))}>
+                  <Show
+                    when={!props.busy && props.runStatus?.state !== "running"}
+                    fallback={<Spinner class="am-worktree-spinner" />}
+                  >
+                    <ActivityIcon state={state()} idle={<Icon name="branch" size="small" />} />
                   </Show>
                 </div>
                 <div class="am-wt-content">

--- a/packages/kilo-vscode/webview-ui/agent-manager/WorktreeSectionActions.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/WorktreeSectionActions.tsx
@@ -10,6 +10,7 @@ import type { LanguageContextValue } from "../src/context/language"
 import { parseBindingTokens } from "./keybind-tokens"
 import { SidebarSearchMenu, type SidebarSearchMenuRef } from "./SidebarSearchMenu"
 import type { SidebarSearchItem } from "./sidebar-search"
+import { label } from "../src/utils/session-activity"
 
 interface WorktreeSectionActionsProps {
   items: Accessor<SidebarSearchItem[]>
@@ -41,8 +42,7 @@ export const WorktreeSectionActions: Component<WorktreeSectionActionsProps> = (p
         scope: props.t("agentManager.sidebarSearch.scope"),
         sessions: props.t("agentManager.section.sessions"),
         contexts: props.t("agentManager.sidebarSearch.contexts"),
-        waiting: props.t("agentManager.tabsMenu.status.waiting"),
-        retry: props.t("agentManager.tabsMenu.status.retry"),
+        state: (value) => props.t(label(value)),
       }}
       onSelect={props.onSelect}
     />

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -164,26 +164,38 @@ html[data-theme="kilo-vscode"]
   .am-tab-icon,
   .am-wt-icon,
   .am-local-status,
-  .search-menu-icon,
+  .am-sidebar-search-icon,
   .am-sidebar-search-status
 )[data-activity="waiting"] {
-  --icon-base: var(--icon-warning-base, var(--vscode-notificationsWarningIcon-foreground, #d9a13a));
-  color: var(--icon-base);
+  --am-activity-color: var(--icon-warning-base, var(--vscode-notificationsWarningIcon-foreground, #d9a13a));
+  color: var(--am-activity-color);
 }
 
-:is(.am-tab-icon, .am-wt-icon, .am-local-status, .search-menu-icon, .am-sidebar-search-status)[data-activity="error"] {
-  --icon-base: var(--icon-critical-base, var(--vscode-errorForeground, #f14c4c));
-  color: var(--icon-base);
+:is(
+  .am-tab-icon,
+  .am-wt-icon,
+  .am-local-status,
+  .am-sidebar-search-icon,
+  .am-sidebar-search-status
+)[data-activity="error"] {
+  --am-activity-color: var(--icon-critical-base, var(--vscode-errorForeground, #f14c4c));
+  color: var(--am-activity-color);
 }
 
-:is(.am-tab-icon, .am-wt-icon, .am-local-status, .search-menu-icon, .am-sidebar-search-status)[data-activity="done"] {
-  --icon-base: var(--icon-success-base, var(--vscode-testing-iconPassed, #73c991));
-  color: var(--icon-base);
+:is(
+  .am-tab-icon,
+  .am-wt-icon,
+  .am-local-status,
+  .am-sidebar-search-icon,
+  .am-sidebar-search-status
+)[data-activity="done"] {
+  --am-activity-color: var(--icon-success-base, var(--vscode-testing-iconPassed, #73c991));
+  color: var(--am-activity-color);
 }
 
-:is(.am-tab-icon, .am-wt-icon, .am-local-status, .search-menu-icon)[data-activity]:not([data-activity="idle"])
+:is(.am-tab-icon, .am-wt-icon, .am-local-status, .am-sidebar-search-icon)[data-activity]:not([data-activity="idle"])
   [data-component="icon"] {
-  color: var(--icon-base);
+  color: var(--am-activity-color);
 }
 
 .am-local-text {

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -160,22 +160,30 @@ html[data-theme="kilo-vscode"]
   flex-shrink: 0;
 }
 
-[data-activity="waiting"] [data-component="icon"],
-[data-activity="waiting"] [data-slot="icon-svg"],
-.am-sidebar-search-status[data-activity="waiting"] {
-  color: var(--icon-warning-base, var(--vscode-notificationsWarningIcon-foreground, #d9a13a));
+:is(
+  .am-tab-icon,
+  .am-wt-icon,
+  .am-local-status,
+  .search-menu-icon,
+  .am-sidebar-search-status
+)[data-activity="waiting"] {
+  --icon-base: var(--icon-warning-base, var(--vscode-notificationsWarningIcon-foreground, #d9a13a));
+  color: var(--icon-base);
 }
 
-[data-activity="error"] [data-component="icon"],
-[data-activity="error"] [data-slot="icon-svg"],
-.am-sidebar-search-status[data-activity="error"] {
-  color: var(--icon-critical-base, var(--vscode-errorForeground, #f14c4c));
+:is(.am-tab-icon, .am-wt-icon, .am-local-status, .search-menu-icon, .am-sidebar-search-status)[data-activity="error"] {
+  --icon-base: var(--icon-critical-base, var(--vscode-errorForeground, #f14c4c));
+  color: var(--icon-base);
 }
 
-[data-activity="done"] [data-component="icon"],
-[data-activity="done"] [data-slot="icon-svg"],
-.am-sidebar-search-status[data-activity="done"] {
-  color: var(--icon-success-base, var(--vscode-testing-iconPassed, #73c991));
+:is(.am-tab-icon, .am-wt-icon, .am-local-status, .search-menu-icon, .am-sidebar-search-status)[data-activity="done"] {
+  --icon-base: var(--icon-success-base, var(--vscode-testing-iconPassed, #73c991));
+  color: var(--icon-base);
+}
+
+:is(.am-tab-icon, .am-wt-icon, .am-local-status, .search-menu-icon)[data-activity]:not([data-activity="idle"])
+  [data-component="icon"] {
+  color: var(--icon-base);
 }
 
 .am-local-text {

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -151,6 +151,33 @@ html[data-theme="kilo-vscode"]
   color: var(--text-weak);
 }
 
+.am-local-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+[data-activity="waiting"] [data-component="icon"],
+[data-activity="waiting"] [data-slot="icon-svg"],
+.am-sidebar-search-status[data-activity="waiting"] {
+  color: var(--icon-warning-base, var(--vscode-notificationsWarningIcon-foreground, #d9a13a));
+}
+
+[data-activity="error"] [data-component="icon"],
+[data-activity="error"] [data-slot="icon-svg"],
+.am-sidebar-search-status[data-activity="error"] {
+  color: var(--icon-critical-base, var(--vscode-errorForeground, #f14c4c));
+}
+
+[data-activity="done"] [data-component="icon"],
+[data-activity="done"] [data-slot="icon-svg"],
+.am-sidebar-search-status[data-activity="done"] {
+  color: var(--icon-success-base, var(--vscode-testing-iconPassed, #73c991));
+}
+
 .am-local-text {
   display: flex;
   flex-direction: column;

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -62,8 +62,6 @@ export const dict = {
   "agentManager.tab.terminal": "الطرفية",
   "agentManager.tab.openTerminal": "فتح الطرفية",
   "agentManager.tab.newOptions": "المزيد من خيارات علامات التبويب الجديدة",
-  "agentManager.tabsMenu.status.waiting": "انتظار",
-  "agentManager.tabsMenu.status.retry": "إعادة",
   "agentManager.sidebarSearch.label": "البحث في Worktrees والجلسات",
   "agentManager.sidebarSearch.scope": "يبحث في مساحة العمل المحلية والجلسات المحلية وWorktrees وجلساتها",
   "agentManager.sidebarSearch.contexts": "محلي & WORKTREES",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -63,8 +63,6 @@ export const dict = {
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Abrir Terminal",
   "agentManager.tab.newOptions": "Mais opções de nova aba",
-  "agentManager.tabsMenu.status.waiting": "Espera",
-  "agentManager.tabsMenu.status.retry": "Repetir",
   "agentManager.sidebarSearch.label": "Pesquisar Worktrees e sessões",
   "agentManager.sidebarSearch.scope":
     "Pesquisa o espaço de trabalho local, as sessões locais, os Worktrees e suas sessões",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -62,8 +62,6 @@ export const dict = {
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Otvori Terminal",
   "agentManager.tab.newOptions": "Više opcija nove kartice",
-  "agentManager.tabsMenu.status.waiting": "Čeka",
-  "agentManager.tabsMenu.status.retry": "Pokušaj",
   "agentManager.sidebarSearch.label": "Pretraži Worktree-ove i sesije",
   "agentManager.sidebarSearch.scope": "Pretražuje lokalni radni prostor, lokalne sesije, Worktree-ove i njihove sesije",
   "agentManager.sidebarSearch.contexts": "LOKALNO & WORKTREES",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -63,8 +63,6 @@ export const dict = {
   "agentManager.tab.openTerminal": "Åbn Terminal",
   "agentManager.tab.newOptions": "Flere nye faneindstillinger",
 
-  "agentManager.tabsMenu.status.waiting": "Venter",
-  "agentManager.tabsMenu.status.retry": "Igen",
   "agentManager.sidebarSearch.label": "Søg i Worktrees og sessioner",
   "agentManager.sidebarSearch.scope":
     "Søger i det lokale arbejdsområde, lokale sessioner, Worktrees og deres sessioner",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -64,8 +64,6 @@ export const dict = {
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Terminal öffnen",
   "agentManager.tab.newOptions": "Weitere Tab-Optionen",
-  "agentManager.tabsMenu.status.waiting": "Warten",
-  "agentManager.tabsMenu.status.retry": "Erneut",
   "agentManager.sidebarSearch.label": "Worktrees und Sitzungen durchsuchen",
   "agentManager.sidebarSearch.scope":
     "Durchsucht den lokalen Arbeitsbereich, lokale Sitzungen, Worktrees und deren Sitzungen",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -66,8 +66,6 @@ export const dict = {
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Open Terminal",
   "agentManager.tab.newOptions": "More new-tab options",
-  "agentManager.tabsMenu.status.waiting": "Wait",
-  "agentManager.tabsMenu.status.retry": "Retry",
   "agentManager.sidebarSearch.label": "Search worktrees and sessions",
   "agentManager.sidebarSearch.scope": "Searches the local workspace, local sessions, worktrees, and their sessions",
   "agentManager.sidebarSearch.contexts": "LOCAL & WORKTREES",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -63,8 +63,6 @@ export const dict = {
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Abrir Terminal",
   "agentManager.tab.newOptions": "Más opciones de nueva pestaña",
-  "agentManager.tabsMenu.status.waiting": "Espera",
-  "agentManager.tabsMenu.status.retry": "Reintento",
   "agentManager.sidebarSearch.label": "Buscar Worktrees y sesiones",
   "agentManager.sidebarSearch.scope":
     "Busca en el espacio de trabajo local, las sesiones locales, los Worktrees y sus sesiones",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
@@ -67,8 +67,6 @@ export const dict = {
   "agentManager.tab.terminal": "ترمینال",
   "agentManager.tab.openTerminal": "باز کردن ترمینال",
   "agentManager.tab.newOptions": "گزینه‌های بیشتر برای تب جدید",
-  "agentManager.tabsMenu.status.waiting": "انتظار",
-  "agentManager.tabsMenu.status.retry": "تلاش مجدد",
   "agentManager.sidebarSearch.label": "جستجوی worktree‌ها و جلسات",
   "agentManager.sidebarSearch.scope": "جستجو در فضای کاری محلی، جلسات محلی، worktree‌ها و جلسات آن‌ها",
   "agentManager.sidebarSearch.contexts": "محلی و WORKTREE‌ها",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -64,8 +64,6 @@ export const dict = {
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Ouvrir le Terminal",
   "agentManager.tab.newOptions": "Plus d'options de nouvel onglet",
-  "agentManager.tabsMenu.status.waiting": "Attente",
-  "agentManager.tabsMenu.status.retry": "Réessai",
   "agentManager.sidebarSearch.label": "Rechercher des Worktrees et des sessions",
   "agentManager.sidebarSearch.scope":
     "Recherche dans l'espace de travail local, les sessions locales, les Worktrees et leurs sessions",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
@@ -68,8 +68,6 @@ export const dict = {
   "agentManager.tab.terminal": "Terminale",
   "agentManager.tab.openTerminal": "Apri terminale",
   "agentManager.tab.newOptions": "Altre opzioni nuova scheda",
-  "agentManager.tabsMenu.status.waiting": "Attendi",
-  "agentManager.tabsMenu.status.retry": "Riprova",
   "agentManager.sidebarSearch.label": "Cerca Worktree e sessioni",
   "agentManager.sidebarSearch.scope":
     "Cerca nell'area di lavoro locale, nelle sessioni locali, nei Worktree e nelle relative sessioni",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -62,8 +62,6 @@ export const dict = {
   "agentManager.tab.terminal": "ターミナル",
   "agentManager.tab.openTerminal": "ターミナルを開く",
   "agentManager.tab.newOptions": "新しいタブのその他のオプション",
-  "agentManager.tabsMenu.status.waiting": "待機",
-  "agentManager.tabsMenu.status.retry": "再試行",
   "agentManager.sidebarSearch.label": "Worktreeとセッションを検索",
   "agentManager.sidebarSearch.scope":
     "ローカルワークスペース、ローカルセッション、Worktree、および各Worktreeのセッションを検索",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -62,8 +62,6 @@ export const dict = {
   "agentManager.tab.terminal": "터미널",
   "agentManager.tab.openTerminal": "터미널 열기",
   "agentManager.tab.newOptions": "더 많은 새 탭 옵션",
-  "agentManager.tabsMenu.status.waiting": "대기",
-  "agentManager.tabsMenu.status.retry": "재시도",
   "agentManager.sidebarSearch.label": "Worktree 및 세션 검색",
   "agentManager.sidebarSearch.scope": "로컬 워크스페이스, 로컬 세션, Worktree 및 각 Worktree의 세션 검색",
   "agentManager.sidebarSearch.contexts": "로컬 & WORKTREES",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
@@ -67,8 +67,6 @@ export const dict = {
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Terminal openen",
   "agentManager.tab.newOptions": "Meer opties voor nieuwe tabblad",
-  "agentManager.tabsMenu.status.waiting": "Wacht",
-  "agentManager.tabsMenu.status.retry": "Opnieuw",
   "agentManager.sidebarSearch.label": "Worktrees en sessies doorzoeken",
   "agentManager.sidebarSearch.scope": "Doorzoekt de lokale werkruimte, lokale sessies, Worktrees en hun sessies",
   "agentManager.sidebarSearch.contexts": "LOKAAL & WORKTREES",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -62,8 +62,6 @@ export const dict = {
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Åpne Terminal",
   "agentManager.tab.newOptions": "Flere alternativer for ny fane",
-  "agentManager.tabsMenu.status.waiting": "Venter",
-  "agentManager.tabsMenu.status.retry": "Igjen",
   "agentManager.sidebarSearch.label": "Søk i Worktrees og økter",
   "agentManager.sidebarSearch.scope": "Søker i det lokale arbeidsområdet, lokale økter, Worktrees og øktene deres",
   "agentManager.sidebarSearch.contexts": "LOKAL & WORKTREES",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -62,8 +62,6 @@ export const dict = {
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Otwórz Terminal",
   "agentManager.tab.newOptions": "Więcej opcji nowej karty",
-  "agentManager.tabsMenu.status.waiting": "Czeka",
-  "agentManager.tabsMenu.status.retry": "Ponów",
   "agentManager.sidebarSearch.label": "Wyszukaj Worktree i sesje",
   "agentManager.sidebarSearch.scope":
     "Przeszukuje lokalny obszar roboczy, lokalne sesje, Worktree i przypisane do nich sesje",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -63,8 +63,6 @@ export const dict = {
   "agentManager.tab.terminal": "Терминал",
   "agentManager.tab.openTerminal": "Открыть терминал",
   "agentManager.tab.newOptions": "Другие параметры новой вкладки",
-  "agentManager.tabsMenu.status.waiting": "Ожидание",
-  "agentManager.tabsMenu.status.retry": "Повтор",
   "agentManager.sidebarSearch.label": "Поиск по Worktree и сессиям",
   "agentManager.sidebarSearch.scope":
     "Поиск локального рабочего пространства, локальных сессий, Worktree и связанных с ними сессий",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -62,8 +62,6 @@ export const dict = {
   "agentManager.tab.terminal": "เทอร์มินัล",
   "agentManager.tab.openTerminal": "เปิดเทอร์มินัล",
   "agentManager.tab.newOptions": "ตัวเลือกแท็บใหม่เพิ่มเติม",
-  "agentManager.tabsMenu.status.waiting": "รอ",
-  "agentManager.tabsMenu.status.retry": "ลองใหม่",
   "agentManager.sidebarSearch.label": "ค้นหา Worktree และเซสชัน",
   "agentManager.sidebarSearch.scope": "ค้นหาพื้นที่ทำงานในเครื่อง เซสชันในเครื่อง Worktree และเซสชันของ Worktree",
   "agentManager.sidebarSearch.contexts": "ในเครื่อง & WORKTREES",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
@@ -67,8 +67,6 @@ export const dict = {
   "agentManager.tab.terminal": "Terminal",
   "agentManager.tab.openTerminal": "Terminali Aç",
   "agentManager.tab.newOptions": "Daha fazla yeni sekme seçeneği",
-  "agentManager.tabsMenu.status.waiting": "Bekliyor",
-  "agentManager.tabsMenu.status.retry": "Yeniden",
   "agentManager.sidebarSearch.label": "Worktree'leri ve oturumları ara",
   "agentManager.sidebarSearch.scope":
     "Yerel çalışma alanını, yerel oturumları, Worktree'leri ve bunların oturumlarını arar",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
@@ -67,8 +67,6 @@ export const dict = {
   "agentManager.tab.terminal": "Термінал",
   "agentManager.tab.openTerminal": "Відкрити термінал",
   "agentManager.tab.newOptions": "Інші параметри нової вкладки",
-  "agentManager.tabsMenu.status.waiting": "Очікує",
-  "agentManager.tabsMenu.status.retry": "Повтор",
   "agentManager.sidebarSearch.label": "Пошук робочих дерев і сесій",
   "agentManager.sidebarSearch.scope":
     "Пошук локального робочого простору, локальних сесій, робочих дерев і призначених їм сесій",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -62,8 +62,6 @@ export const dict = {
   "agentManager.tab.terminal": "终端",
   "agentManager.tab.openTerminal": "打开终端",
   "agentManager.tab.newOptions": "更多新建标签页选项",
-  "agentManager.tabsMenu.status.waiting": "等待",
-  "agentManager.tabsMenu.status.retry": "重试",
   "agentManager.sidebarSearch.label": "搜索 Worktree 和会话",
   "agentManager.sidebarSearch.scope": "搜索本地工作区、本地会话、Worktree 及其会话",
   "agentManager.sidebarSearch.contexts": "本地 & WORKTREES",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -62,8 +62,6 @@ export const dict = {
   "agentManager.tab.terminal": "終端機",
   "agentManager.tab.openTerminal": "開啟終端機",
   "agentManager.tab.newOptions": "更多新增分頁選項",
-  "agentManager.tabsMenu.status.waiting": "等待",
-  "agentManager.tabsMenu.status.retry": "重試",
   "agentManager.sidebarSearch.label": "搜尋 Worktree 與工作階段",
   "agentManager.sidebarSearch.scope": "搜尋本機工作區、本機工作階段、Worktree 及其工作階段",
   "agentManager.sidebarSearch.contexts": "本機 & WORKTREES",

--- a/packages/kilo-vscode/webview-ui/agent-manager/project/session-busy.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/project/session-busy.ts
@@ -1,45 +1,41 @@
+import { createMemo } from "solid-js"
+import { strongest, type Activity } from "../../src/utils/session-activity"
+
 interface Item {
   id: string
   worktreeId?: string | null
 }
 
-interface Status {
-  type: string
-}
-
-interface Prompt {
-  sessionID: string
-}
-
-export function createSessionBusy(opts: {
-  statuses: () => Record<string, Status>
-  permissions: () => Prompt[]
-  questions: () => Prompt[]
+export function createSessionActivity(opts: {
   managed: () => Item[]
   local: () => string[]
   projects: () => Record<string, Item[]>
   active: () => string | undefined
+  activityFor: (id: string) => Activity
 }) {
-  const any = (ids: string[]) => {
-    if (ids.length === 0) return false
-    const statuses = opts.statuses()
-    const blocked = new Set([...opts.permissions(), ...opts.questions()].map((item) => item.sessionID))
-    return ids.some((id) => {
-      const status = statuses[id]
-      return !!status && status.type !== "idle" && !blocked.has(id)
-    })
+  const group = (items: Item[]) => {
+    const states = new Map<string | null, Activity[]>()
+    for (const item of items) {
+      const id = item.worktreeId ?? null
+      const values = states.get(id) ?? []
+      values.push(opts.activityFor(item.id))
+      states.set(id, values)
+    }
+    return new Map([...states].map(([id, values]) => [id, strongest(values)]))
   }
-  const agent = (id: string) =>
-    any(
-      opts
-        .managed()
-        .filter((item) => item.worktreeId === id)
-        .map((item) => item.id),
-    )
-  const local = () => any(opts.local())
-  const project = (id: string, worktreeId: string | null) => {
-    if (id === opts.active()) return worktreeId === null ? local() : agent(worktreeId)
-    return any((opts.projects()[id] ?? []).filter((item) => item.worktreeId === worktreeId).map((item) => item.id))
+  const local = createMemo(() => strongest(opts.local().map(opts.activityFor)))
+  const managed = createMemo(() => group(opts.managed()))
+  const projects = createMemo(() => {
+    const values = new Map<string, Map<string | null, Activity>>()
+    for (const [id, items] of Object.entries(opts.projects())) values.set(id, group(items))
+    return values
+  })
+  return {
+    local: () => local(),
+    agent: (id: string) => managed().get(id) ?? "idle",
+    project: (id: string, worktree: string | null): Activity => {
+      if (id === opts.active()) return worktree === null ? local() : (managed().get(worktree) ?? "idle")
+      return projects().get(id)?.get(worktree) ?? "idle"
+    },
   }
-  return { any, agent, local, project, session: (id: string) => any([id]) }
 }

--- a/packages/kilo-vscode/webview-ui/agent-manager/sidebar-search.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/sidebar-search.ts
@@ -1,7 +1,7 @@
 import { createMemo } from "solid-js"
 import type { Accessor } from "solid-js"
 import type { SectionState, SessionInfo, WorktreeState } from "../src/types/messages"
-import { strongest, type Activity } from "../src/utils/session-activity"
+import { score, strongest, type Activity } from "../src/utils/session-activity"
 import { LOCAL } from "./navigate"
 
 export type SidebarSearchState = Activity
@@ -59,18 +59,6 @@ interface SidebarSearchInput {
 
 const root = (item: SessionInfo) => !item.parentID
 const same = (a: string, b: string) => a.trim().toLowerCase() === b.trim().toLowerCase()
-const score = (state: SidebarSearchState) =>
-  state === "waiting"
-    ? 5
-    : state === "error"
-      ? 4
-      : state === "retry"
-        ? 3
-        : state === "busy"
-          ? 2
-          : state === "done"
-            ? 1
-            : 0
 const newest = (items: SessionInfo[], fallback: string) =>
   items.reduce((latest, item) => (item.updatedAt > latest ? item.updatedAt : latest), fallback)
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/sidebar-search.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/sidebar-search.ts
@@ -1,16 +1,10 @@
 import { createMemo } from "solid-js"
 import type { Accessor } from "solid-js"
-import type {
-  PermissionRequest,
-  QuestionRequest,
-  SectionState,
-  SessionInfo,
-  SessionStatusInfo,
-  WorktreeState,
-} from "../src/types/messages"
+import type { SectionState, SessionInfo, WorktreeState } from "../src/types/messages"
+import { strongest, type Activity } from "../src/utils/session-activity"
 import { LOCAL } from "./navigate"
 
-export type SidebarSearchState = "idle" | "busy" | "retry" | "waiting"
+export type SidebarSearchState = Activity
 
 type SearchItem = {
   key: string
@@ -20,6 +14,7 @@ type SearchItem = {
   search: string
   updatedAt: string
   state: SidebarSearchState
+  busy?: boolean
   visible: boolean
   section?: SectionState
 }
@@ -58,14 +53,24 @@ interface SidebarSearchInput {
   localBranch?: string
   untitled: string
   pending: (id: string) => boolean
-  status: (id: string) => SidebarSearchState
+  activityFor: (id: string) => Activity
   busy: (id: string) => boolean
-  localBusy: boolean
 }
 
 const root = (item: SessionInfo) => !item.parentID
 const same = (a: string, b: string) => a.trim().toLowerCase() === b.trim().toLowerCase()
-const score = (state: SidebarSearchState) => (state === "waiting" ? 3 : state === "idle" ? 0 : 2)
+const score = (state: SidebarSearchState) =>
+  state === "waiting"
+    ? 5
+    : state === "error"
+      ? 4
+      : state === "retry"
+        ? 3
+        : state === "busy"
+          ? 2
+          : state === "done"
+            ? 1
+            : 0
 const newest = (items: SessionInfo[], fallback: string) =>
   items.reduce((latest, item) => (item.updatedAt > latest ? item.updatedAt : latest), fallback)
 
@@ -79,6 +84,7 @@ export function sortSidebarSearch(a: SidebarSearchItem, b: SidebarSearchItem) {
 }
 
 export function buildSidebarSearch(input: SidebarSearchInput): SidebarSearchItem[] {
+  const state = input.activityFor
   const sections = new Map(input.sections.map((item) => [item.id, item]))
   const owned = new Set(input.worktrees.flatMap((item) => item.sessions.map((session) => session.id)))
   const local = input.local.filter((session) => root(session) && !input.pending(session.id) && !owned.has(session.id))
@@ -92,10 +98,10 @@ export function buildSidebarSearch(input: SidebarSearchInput): SidebarSearchItem
     sessionId: session.id,
     location: "local" as const,
     updatedAt: session.updatedAt,
-    state: input.status(session.id),
+    state: state(session.id),
     visible: true,
   }))
-  const localState = local.map((session) => input.status(session.id)).sort((a, b) => score(b) - score(a))[0] ?? "idle"
+  const localState = strongest(local.map((session) => state(session.id)))
   const contexts: SidebarSearchItem[] = [
     {
       key: LOCAL,
@@ -105,7 +111,7 @@ export function buildSidebarSearch(input: SidebarSearchInput): SidebarSearchItem
       meta: input.localBranch ? [input.localBranch] : [],
       search: [input.localLabel, input.localBranch].filter(Boolean).join(" "),
       updatedAt: newest(local, ""),
-      state: input.localBusy && localState === "idle" ? "busy" : localState,
+      state: localState,
       visible: true,
       count: local.length,
     },
@@ -132,13 +138,13 @@ export function buildSidebarSearch(input: SidebarSearchInput): SidebarSearchItem
         location: "worktree",
         worktreeId: wt.id,
         updatedAt: session.updatedAt,
-        state: input.status(session.id),
+        state: state(session.id),
         visible: !section?.collapsed,
         section,
       })
     }
 
-    const state = roots.map((session) => input.status(session.id)).sort((a, b) => score(b) - score(a))[0] ?? "idle"
+    const context = strongest(roots.map((session) => state(session.id)))
     contexts.push({
       key: `worktree:${wt.id}`,
       kind: "worktree",
@@ -150,7 +156,8 @@ export function buildSidebarSearch(input: SidebarSearchInput): SidebarSearchItem
         .join(" "),
       worktreeId: wt.id,
       updatedAt: newest(roots, wt.createdAt),
-      state: input.busy(wt.id) && state === "idle" ? "busy" : state,
+      state: context,
+      busy: input.busy(wt.id),
       visible: !section?.collapsed,
       section,
       count: roots.length,
@@ -168,24 +175,16 @@ interface SidebarSearchDeps {
   localBranch: Accessor<string | undefined>
   selection: Accessor<string | null>
   sessionId: Accessor<string | undefined>
-  statuses: Accessor<Record<string, SessionStatusInfo>>
-  permissions: Accessor<PermissionRequest[]>
-  questions: Accessor<QuestionRequest[]>
+  activityFor: (id: string) => Activity
   label: (worktree: WorktreeState) => string
   sessions: (id: string) => SessionInfo[]
   pending: (id: string) => boolean
   busy: (id: string) => boolean
-  localBusy: Accessor<boolean>
   t: (key: string) => string
 }
 
 export function createSidebarSearch(deps: SidebarSearchDeps) {
   const items = createMemo(() => {
-    const statuses = deps.statuses()
-    const blocked = new Set([
-      ...deps.permissions().map((item) => item.sessionID),
-      ...deps.questions().map((item) => item.sessionID),
-    ])
     return buildSidebarSearch({
       worktrees: deps.worktrees().map((worktree) => ({
         worktree,
@@ -198,13 +197,8 @@ export function createSidebarSearch(deps: SidebarSearchDeps) {
       localBranch: deps.localBranch(),
       untitled: deps.t("agentManager.session.untitled"),
       pending: deps.pending,
-      status: (id) => {
-        if (blocked.has(id)) return "waiting"
-        const status = statuses[id]?.type
-        return status === "busy" || status === "retry" ? status : "idle"
-      },
+      activityFor: deps.activityFor,
       busy: deps.busy,
-      localBusy: deps.localBusy(),
     })
   })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/sortable-tab.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/sortable-tab.tsx
@@ -12,13 +12,15 @@ import { useLanguage } from "../src/context/language"
 import { SessionTab } from "../src/components/chat/SessionTab"
 import { SessionTabMenu } from "../src/components/chat/SessionTabMenu"
 import { SortableTabContainer } from "../src/components/chat/TabDnd"
+import type { Activity } from "../src/utils/session-activity"
 import { parseBindingTokens } from "./keybind-tokens"
 
 /** Individual sortable tab wrapper using the `use:sortable` directive. */
 export const SortableTab: Component<{
   tab: SessionInfo
   active: boolean
-  busy: boolean
+  state: Activity
+  stateLabel: string
   keybind?: string
   closeKeybind?: string
   onSelect: () => void
@@ -52,7 +54,8 @@ export const SortableTab: Component<{
         <SessionTab
           title={props.tab.title || t("agentManager.session.untitled")}
           active={props.active}
-          busy={props.busy}
+          state={props.state}
+          stateLabel={props.stateLabel}
           keybind={props.keybind}
           closeKeybind={props.closeKeybind}
           closeTabIndex={props.active ? 0 : -1}

--- a/packages/kilo-vscode/webview-ui/agent-manager/tab-rendering.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/tab-rendering.tsx
@@ -7,7 +7,7 @@
  * and content area.
  */
 
-import { Show } from "solid-js"
+import { Show, createMemo } from "solid-js"
 import type { Accessor, JSX } from "solid-js"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { DropdownMenu } from "@kilocode/kilo-ui/dropdown-menu"
@@ -17,6 +17,7 @@ import { SortableTab, SortableReviewTab } from "./sortable-tab"
 import type { TerminalStateControls } from "./terminal"
 import { isTerminalTabId, renderTerminalTab } from "./terminal"
 import type { SessionInfo } from "../src/types/messages"
+import type { Activity } from "../src/utils/session-activity"
 import { parseBindingTokens } from "./keybind-tokens"
 
 interface FocusTabDeps {
@@ -72,7 +73,8 @@ export interface TabRenderDeps {
    *  getter so Solid tracks its reactivity inside rendered JSX. */
   visibleTabId: () => string | undefined
   isPending: (id: string) => boolean
-  isBusy: (id: string) => boolean
+  activityFor: (id: string) => Activity
+  stateLabel: (state: Activity) => string
   tabLookup: () => Map<string, SessionInfo>
   adjacentHint: (id: string, activeId: string, ids: string[], prev: string, next: string) => string
   // Handlers
@@ -164,6 +166,7 @@ function renderReviewTab(deps: TabRenderDeps): JSX.Element {
 
 function renderSessionTab(s: SessionInfo, deps: TabRenderDeps): JSX.Element {
   const pending = deps.isPending(s.id)
+  const state = createMemo(() => deps.activityFor(s.id))
   const active = () =>
     !deps.terms.activeId() &&
     (pending ? s.id === deps.activePendingId() && !deps.currentSessionID() : s.id === deps.currentSessionID())
@@ -181,7 +184,8 @@ function renderSessionTab(s: SessionInfo, deps: TabRenderDeps): JSX.Element {
     <SortableTab
       tab={s}
       active={active() && !deps.reviewActive()}
-      busy={deps.isBusy(s.id)}
+      state={state()}
+      stateLabel={deps.stateLabel(state())}
       role="tab"
       selected={deps.visibleTabId() === s.id}
       tabIndex={deps.visibleTabId() === s.id ? 0 : -1}

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { Component, createSignal, createMemo, Switch, Match, Show, onMount, onCleanup } from "solid-js"
+import { Component, createSignal, createMemo, createEffect, Switch, Match, Show, onMount, onCleanup } from "solid-js"
 import { DataProvider } from "@kilocode/kilo-ui/context/data"
 import Settings from "./components/settings/Settings"
 import ProfileView from "./components/profile/ProfileView"
@@ -17,6 +17,7 @@ import { registerVscodeToolOverrides } from "./components/chat/VscodeToolOverrid
 import { useWorktreeMode } from "./context/worktree-mode"
 import { useDiffStyle } from "./context/diff-style"
 import { dispatchAgentManagerEditPreview } from "./utils/agent-manager-events"
+import { strongest } from "./utils/session-activity"
 import type { PermissionFileDiff } from "./types/messages"
 
 // Override the upstream "task" tool renderer with the fully-expanded version
@@ -229,6 +230,10 @@ const AppContent: Component = () => {
   const tabs = useLocalTabs()
   const server = useServer()
   const vscode = useVSCode()
+  const activity = createMemo(() =>
+    strongest([session.currentSessionID(), ...(tabs?.ids() ?? [])].map(session.activityFor)),
+  )
+  createEffect(() => vscode.postMessage({ type: "sessionActivity", state: activity() }))
 
   const handleViewAction = (action: string) => {
     switch (action) {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/SessionTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/SessionTab.tsx
@@ -1,12 +1,14 @@
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
-import { Spinner } from "@kilocode/kilo-ui/spinner"
 import { TooltipKeybind } from "@kilocode/kilo-ui/tooltip"
 import { Show, type Component, type JSX } from "solid-js"
+import { ActivityIcon } from "../shared/ActivityIcon"
+import type { Activity } from "../../utils/session-activity"
 
 export const SessionTab: Component<{
   title: string
   active: boolean
-  busy: boolean
+  state: Activity
+  stateLabel: string
   closeTitle: string
   closeLabel: string
   keybind?: string
@@ -21,7 +23,7 @@ export const SessionTab: Component<{
   onKeyDown?: JSX.EventHandlerUnion<HTMLDivElement, KeyboardEvent>
   onClose: () => void
 }> = (props) => (
-  <div class={`am-tab ${props.active ? "am-tab-active" : ""}`}>
+  <div class={`am-tab ${props.active ? "am-tab-active" : ""}`} data-activity={props.state}>
     <div
       class="am-tab-target"
       role={props.role}
@@ -41,9 +43,9 @@ export const SessionTab: Component<{
         openDelay={0}
       >
         <span class="am-tab-title">
-          <Show when={props.busy}>
-            <span class="am-tab-icon">
-              <Spinner class="am-worktree-spinner" />
+          <Show when={props.state !== "idle"}>
+            <span class="am-tab-icon" data-activity={props.state} aria-label={props.stateLabel}>
+              <ActivityIcon state={props.state} />
             </span>
           </Show>
           <span class="am-tab-label">{props.title}</span>

--- a/packages/kilo-vscode/webview-ui/src/components/chat/SessionTabStrip.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/SessionTabStrip.tsx
@@ -8,6 +8,7 @@ import { isPendingTab } from "../../utils/local-tabs"
 import { useTabScroll } from "../../utils/tab-scroll"
 import { focusPrompt, focusSelectedTab, focusTabElement, handleTabKey } from "../../utils/tab-navigation"
 import { setTabWidths } from "../../utils/tab-widths"
+import { label, running } from "../../utils/session-activity"
 import { useVSCode } from "../../context/vscode"
 import { SessionTab } from "./SessionTab"
 import { SessionTabMenu } from "./SessionTabMenu"
@@ -28,10 +29,8 @@ export const SessionTabStrip: Component = () => {
     if (isPendingTab(id)) return language.t("sidebar.session.newSession")
     return items().get(id)?.title || language.t("session.untitled")
   }
-  const working = (id: string) => {
-    const status = session.allStatusMap()[id]
-    return status?.type === "busy" || status?.type === "retry"
-  }
+  const state = (id: string) => (isPendingTab(id) ? "idle" : session.activityFor(id))
+  const working = (id: string) => running(state(id))
   const middle = (id: string, event: MouseEvent) => {
     if (event.button !== 1) return
     event.preventDefault()
@@ -62,7 +61,8 @@ export const SessionTabStrip: Component = () => {
       id,
       title: title(id),
       active: tabs.active() === id,
-      busy: working(id),
+      state: state(id),
+      stateLabel: language.t(label(state(id))),
       pending: isPendingTab(id),
     })),
   )
@@ -140,7 +140,8 @@ export const SessionTabStrip: Component = () => {
                         <SessionTab
                           title={title(id)}
                           active={tabs.active() === id}
-                          busy={working(id)}
+                          state={state(id)}
+                          stateLabel={language.t(label(state(id)))}
                           closeTitle={language.t("common.closeTab")}
                           closeLabel={language.t("common.closeTab")}
                           role="tab"
@@ -171,7 +172,6 @@ export const SessionTabStrip: Component = () => {
               close: language.t("common.closeTab"),
               current: language.t("session.tabs.switcher.current"),
               pending: language.t("session.tabs.switcher.pending"),
-              busy: language.t("session.tabs.switcher.busy"),
             }}
             onSelect={tabs.select}
             onRestore={focusPrompt}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/SessionTabSwitcher.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/SessionTabSwitcher.tsx
@@ -1,17 +1,18 @@
-import { Icon } from "@kilocode/kilo-ui/icon"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { List } from "@kilocode/kilo-ui/list"
 import type { ListRef } from "@kilocode/kilo-ui/list"
 import { Popover } from "@kilocode/kilo-ui/popover"
-import { Spinner } from "@kilocode/kilo-ui/spinner"
 import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { Show, createEffect, createMemo, createSignal, type Component, type JSX } from "solid-js"
+import { ActivityIcon } from "../shared/ActivityIcon"
+import type { Activity } from "../../utils/session-activity"
 
 interface SessionTabSwitcherItem {
   id: string
   title: string
   active: boolean
-  busy: boolean
+  state: Activity
+  stateLabel: string
   pending: boolean
 }
 
@@ -23,7 +24,6 @@ interface SessionTabSwitcherProps {
     close: string
     current: string
     pending: string
-    busy: string
   }
   onSelect: (id: string) => void
   onRestore: () => void
@@ -144,19 +144,17 @@ export const SessionTabSwitcher: Component<SessionTabSwitcherProps> = (props) =>
           >
             {(item) => (
               <span class="search-menu-row">
-                <span class="search-menu-icon">
-                  <Show when={!item.busy} fallback={<Spinner class="search-menu-spinner" />}>
-                    <Icon name="speech-bubble" size="small" />
-                  </Show>
+                <span class="search-menu-icon" data-activity={item.state} aria-label={item.stateLabel}>
+                  <ActivityIcon state={item.state} spinner="search-menu-spinner" />
                 </span>
                 <span class="search-menu-copy">
                   <span class="search-menu-title" dir="auto">
                     {item.title}
                   </span>
-                  <Show when={item.busy || item.pending}>
-                    <span class="search-menu-meta session-tab-switcher-meta">
-                      <Show when={item.busy} fallback={props.labels.pending}>
-                        {props.labels.busy}
+                  <Show when={item.state !== "idle" || item.pending}>
+                    <span class="search-menu-meta session-tab-switcher-meta" data-activity={item.state}>
+                      <Show when={item.state !== "idle"} fallback={props.labels.pending}>
+                        {item.stateLabel}
                       </Show>
                     </span>
                   </Show>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ActivityIcon.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ActivityIcon.tsx
@@ -1,0 +1,22 @@
+import { Icon } from "@kilocode/kilo-ui/icon"
+import { Spinner } from "@kilocode/kilo-ui/spinner"
+import { Match, Switch, type Component, type JSX } from "solid-js"
+import { running, type Activity } from "../../utils/session-activity"
+
+export const ActivityIcon: Component<{
+  state: Activity
+  idle?: JSX.Element
+  spinner?: string
+}> = (props) => (
+  <Switch fallback={props.idle ?? <Icon name="speech-bubble" size="small" />}>
+    <Match when={running(props.state)}>
+      <Spinner class={props.spinner ?? "am-worktree-spinner"} />
+    </Match>
+    <Match when={props.state === "waiting" || props.state === "error"}>
+      <Icon name="warning" size="small" />
+    </Match>
+    <Match when={props.state === "done"}>
+      <Icon name="circle-check" size="small" />
+    </Match>
+  </Switch>
+)

--- a/packages/kilo-vscode/webview-ui/src/context/session-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-utils.ts
@@ -117,6 +117,34 @@ export function childID(part: TaskPart): string | undefined {
   return part.metadata?.sessionId ?? part.state?.metadata?.sessionId
 }
 
+export function ancestry(
+  sessions: Record<string, ParentSession>,
+  tools: Record<string, readonly TaskPart[]>,
+  outcomes: Record<string, ParentSession | undefined>,
+) {
+  const parents = new Map<string, string>()
+  for (const [id, parts] of Object.entries(tools)) {
+    for (const part of parts) {
+      const child = childID(part)
+      if (child) parents.set(child, id)
+    }
+  }
+  for (const [id, close] of Object.entries(outcomes)) {
+    if (close?.parentID) parents.set(id, close.parentID)
+  }
+  for (const [id, session] of Object.entries(sessions)) {
+    if (session.parentID === null) parents.delete(id)
+    if (session.parentID) parents.set(id, session.parentID)
+  }
+  const children = new Map<string, string[]>()
+  for (const [child, parent] of parents) {
+    const ids = children.get(parent) ?? []
+    ids.push(child)
+    children.set(parent, ids)
+  }
+  return { parents, children }
+}
+
 export function latestTaskPart(partID: string | undefined, child: string | undefined, parts: readonly TaskPart[]) {
   if (!partID || !child) return false
   return parts.findLast((part) => childID(part) === child)?.id === partID

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -9,6 +9,7 @@ import {
   useContext,
   createSignal,
   createMemo,
+  createComputed,
   createEffect,
   on,
   onMount,
@@ -62,6 +63,7 @@ import {
   buildCostBreakdown,
   buildSessionToolParts,
   childID,
+  ancestry,
   dropSet,
   emptyPageState,
   messageParts,
@@ -93,6 +95,7 @@ import { clearIfOn, createCloudPrune } from "./session-cloud-prune"
 import { isSameSessionTree } from "./model-usage"
 import { createDraftAgentSeed, resolvePromptAgent } from "./session-agent"
 import { createModelSelector } from "./session-model-selector"
+import { activities, type Activity } from "../utils/session-activity"
 
 const RECENT_LIMIT = 5
 const MESSAGE_PAGE_LIMIT = 80
@@ -112,6 +115,11 @@ interface SessionStore {
   favoriteModels: ModelSelection[]
   modelUsageHistory: ModelUsageMap
   modelUsage: Record<string, { requestID: string; data?: SessionModelUsage }>
+}
+
+interface CloseState {
+  reason: SessionCloseReason
+  parentID?: string
 }
 
 interface SessionContextValue {
@@ -153,6 +161,8 @@ interface SessionContextValue {
 
   // All session statuses keyed by sessionID (for DataBridge)
   allStatusMap: () => Record<string, SessionStatusInfo>
+
+  activityFor: (sessionID: string | undefined) => Activity
 
   // Parts for a specific message
   getParts: (messageID: string) => Part[]
@@ -323,7 +333,7 @@ export const SessionProvider: ParentComponent = (props) => {
 
   // Per-session status map — keyed by sessionID
   const [statusMap, setStatusMap] = createStore<Record<string, SessionStatusInfo>>({})
-  const [closeMap, setCloseMap] = createStore<Record<string, SessionCloseReason | undefined>>({})
+  const [closeMap, setCloseMap] = createStore<Record<string, CloseState | undefined>>({})
   const [busySinceMap, setBusySinceMap] = createStore<Record<string, number>>({})
   const [submissionMap, setSubmissionMap] = createStore<Record<string, number>>({})
   const pendingSubmissions = new Map<string, string>()
@@ -339,7 +349,7 @@ export const SessionProvider: ParentComponent = (props) => {
   const status = () => statusInfo().type as SessionStatus
   const closeReason = () => {
     const id = currentSessionID()
-    return id ? closeMap[id] : undefined
+    return id ? closeMap[id]?.reason : undefined
   }
   const clearClose = (id: string) =>
     setCloseMap(
@@ -990,6 +1000,15 @@ export const SessionProvider: ParentComponent = (props) => {
     if (message.sessionID) patchPage(message.sessionID, { loadingInitial: false, loadingOlder: false })
   }
 
+  function closed(message: Extract<ExtensionMessage, { type: "sessionTurnClosed" }>) {
+    if (message.reason === "completed" && closeMap[message.sessionID]?.reason === "error") return
+    setCloseMap(message.sessionID, { reason: message.reason, parentID: message.parentID })
+  }
+
+  function failed(id: string) {
+    setCloseMap(id, { reason: "error", parentID: store.sessions[id]?.parentID ?? undefined })
+  }
+
   function toggleFavorite(providerID: string, modelID: string) {
     const key = `${providerID}/${modelID}`
     const idx = store.favoriteModels.findIndex((f) => `${f.providerID}/${f.modelID}` === key)
@@ -1089,7 +1108,7 @@ export const SessionProvider: ParentComponent = (props) => {
         break
 
       case "sessionTurnClosed":
-        setCloseMap(message.sessionID, message.reason)
+        closed(message)
         break
 
       case "todoUpdated":
@@ -1137,6 +1156,7 @@ export const SessionProvider: ParentComponent = (props) => {
         if (!message.error || message.error.name === "MessageAbortedError") break
         const sid = message.sessionID ?? currentSessionID()
         if (!sid) break
+        failed(sid)
         // Find the last user message in this session to use as parentID
         const msgs = store.messages[sid] ?? []
         const parent = [...msgs].reverse().find((m) => m.role === "user")
@@ -1656,7 +1676,7 @@ export const SessionProvider: ParentComponent = (props) => {
   ) {
     const shouldAbort = aborts.update(sessionID, newStatus)
     confirmSubmissions(sessionID)
-    const prev = statusMap[sessionID] ?? { type: "idle" }
+    const prev = statusMap[sessionID]?.type ?? "idle"
     const info: SessionStatusInfo =
       newStatus === "retry"
         ? { type: "retry", attempt: attempt ?? 0, message: message ?? "", next: next ?? 0 }
@@ -1665,7 +1685,7 @@ export const SessionProvider: ParentComponent = (props) => {
           : { type: newStatus }
     setStatusMap(sessionID, info)
     // Track busy start time and discard the previous turn's terminal state.
-    if (prev.type === "idle" && newStatus !== "idle") {
+    if (prev === "idle" && newStatus !== "idle") {
       clearClose(sessionID)
       if (!busySinceMap[sessionID]) setBusySinceMap(sessionID, Date.now())
     }
@@ -1866,8 +1886,14 @@ export const SessionProvider: ParentComponent = (props) => {
     return ids
   }
 
+  const lineage = createMemo(() => ancestry(store.sessions, store.toolParts, closeMap))
+
   function sessionFamily(rootID: string): Set<string> {
-    return sessionIDs(rootID, (sid) => store.messages[sid] ?? [])
+    const ids = new Set([rootID])
+    for (const id of ids) {
+      for (const child of lineage().children.get(id) ?? []) ids.add(child)
+    }
+    return ids
   }
 
   function modelUsageRelated(sessionID: string, parentID?: string | null): boolean {
@@ -1908,6 +1934,24 @@ export const SessionProvider: ParentComponent = (props) => {
     const family = sessionFamily(sessionID)
     return suggestions().filter((item) => family.has(item.sessionID))
   }
+
+  const [activityMap, setActivityMap] = createStore<Record<string, Activity>>({})
+  createComputed(() => {
+    const connection = server.connectionState()
+    setActivityMap(
+      reconcile(
+        activities({
+          parents: lineage().parents,
+          statuses: statusMap,
+          outcomes: closeMap,
+          blocked: [...permissions(), ...questions(), ...suggestions()].map((item) => item.sessionID),
+          submitting: Object.keys(submissionMap),
+          disconnected: connection !== "connected",
+        }),
+      ),
+    )
+  })
+  const activityFor = (id: string | undefined): Activity => (id ? (activityMap[id] ?? "idle") : "idle")
 
   function handleTodoUpdated(sessionID: string, items: TodoItem[]) {
     setStore("todos", sessionID, items)
@@ -2986,6 +3030,7 @@ export const SessionProvider: ParentComponent = (props) => {
     allMessages,
     allParts,
     allStatusMap,
+    activityFor,
     recentModels: () => store.recentModels,
     modelUsageHistory: () => store.modelUsageHistory,
     favoriteModels: () => store.favoriteModels,

--- a/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
@@ -29,7 +29,7 @@ import { ThinkingSelectorBase } from "../components/shared/ThinkingSelector"
 import { DeferredPopover } from "../components/shared/DeferredPopover"
 import { ProjectSelect } from "../../agent-manager/ProjectSelect"
 import { PRComments } from "../../agent-manager/pr/PRComments"
-import { createSignal, onCleanup, onMount, type JSX } from "solid-js"
+import { For, createSignal, onCleanup, onMount, type JSX } from "solid-js"
 import type {
   AgentProjectSnapshot,
   WorktreeFileDiff,
@@ -539,7 +539,7 @@ const defaultProps = {
   active: false,
   pendingDelete: false,
   busy: false,
-  working: false,
+  activity: "idle" as const,
   stale: false,
   shortcut: 2,
   sessions: 1,
@@ -565,6 +565,46 @@ const defaultProps = {
 // ---------------------------------------------------------------------------
 // WorktreeItem stories
 // ---------------------------------------------------------------------------
+
+export const WorktreeActivityStates: Story = {
+  name: "Worktree cards - all activity states",
+  render: () => (
+    <StoryProviders noPadding>
+      <div data-activity-story style={{ padding: "12px", background: "var(--surface-base)" }}>
+        <style>{'[data-activity-story] [data-component="spinner"] rect { animation: none !important; }'}</style>
+        <For
+          each={
+            [
+              ["busy", "Running"],
+              ["waiting", "Needs input"],
+              ["done", "Completed"],
+              ["retry", "Retrying"],
+              ["error", "Error"],
+              ["idle", "Idle"],
+            ] as const
+          }
+        >
+          {([state, title]) => (
+            <WorktreeItem
+              {...defaultProps}
+              worktree={{
+                ...baseWorktree,
+                id: `wt-${state}`,
+                branch: `feature/${state}`,
+                createdAt: "2026-01-01T00:00:00.000Z",
+              }}
+              label={title}
+              subtitle={`feature/${state}`}
+              activity={state}
+              stats={{ ...baseStats, worktreeId: `wt-${state}` }}
+              shortcut={0}
+            />
+          )}
+        </For>
+      </div>
+    </StoryProviders>
+  ),
+}
 
 export const WorktreeItemDefault: Story = {
   name: "WorktreeItem — default",
@@ -1377,8 +1417,7 @@ export const SidebarSearchOpen: Story = {
                   scope: "Searches the local workspace, local sessions, worktrees, and their sessions",
                   contexts: "LOCAL & WORKTREES",
                   sessions: "SESSIONS",
-                  waiting: "Wait",
-                  retry: "Retry",
+                  state: (value) => value,
                 }}
                 onSelect={(item) => setSelected(item.key)}
                 defaultOpen
@@ -1537,6 +1576,7 @@ export const MultiProjectSidebar: Story = {
               [projectB.id]: storyLocal("master", 0, 0, 0, 2),
             }}
             prs={{ [projectA.id]: {}, [projectB.id]: {} }}
+            busy={() => false}
             sessions={{
               [projectA.id]: [
                 projectSession("ses-a1", null, "Refine project accordion layout", "2026-07-24T08:30:00Z"),
@@ -1546,6 +1586,8 @@ export const MultiProjectSidebar: Story = {
             }}
             selectedProject={projectA.id}
             selection="local"
+            activityFor={() => "idle"}
+            sessionActivity={() => "idle"}
             bindings={{ search: "⌘F", showShortcuts: "⌘⇧/", newWorktree: "⌘N", quickWorktree: "⌘⇧N" }}
             t={t}
             onSearchRef={() => {}}

--- a/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
@@ -10,6 +10,7 @@ import { FileTree } from "../../diff-viewer/FileTree"
 import { DiffPanel } from "../../agent-manager/DiffPanel"
 import { FullScreenDiffView } from "../../diff-viewer/FullScreenDiffView"
 import { WorktreeItem } from "../../agent-manager/WorktreeItem"
+import { SessionTab } from "../components/chat/SessionTab"
 import { ChatView } from "../components/chat/ChatView"
 import { registerVscodeToolOverrides } from "../components/chat/VscodeToolOverrides"
 import { SessionContext } from "../context/session"
@@ -566,24 +567,22 @@ const defaultProps = {
 // WorktreeItem stories
 // ---------------------------------------------------------------------------
 
+const activityStates = [
+  ["busy", "Running"],
+  ["waiting", "Needs input"],
+  ["done", "Completed"],
+  ["retry", "Retrying"],
+  ["error", "Error"],
+  ["idle", "Idle"],
+] as const
+
 export const WorktreeActivityStates: Story = {
   name: "Worktree cards - all activity states",
-  render: () => (
+  render: (args: { active?: boolean }) => (
     <StoryProviders noPadding>
       <div data-activity-story style={{ padding: "12px", background: "var(--surface-base)" }}>
         <style>{'[data-activity-story] [data-component="spinner"] rect { animation: none !important; }'}</style>
-        <For
-          each={
-            [
-              ["busy", "Running"],
-              ["waiting", "Needs input"],
-              ["done", "Completed"],
-              ["retry", "Retrying"],
-              ["error", "Error"],
-              ["idle", "Idle"],
-            ] as const
-          }
-        >
+        <For each={activityStates}>
           {([state, title]) => (
             <WorktreeItem
               {...defaultProps}
@@ -595,10 +594,47 @@ export const WorktreeActivityStates: Story = {
               }}
               label={title}
               subtitle={`feature/${state}`}
+              active={args.active === true}
               activity={state}
               stats={{ ...baseStats, worktreeId: `wt-${state}` }}
               shortcut={0}
             />
+          )}
+        </For>
+      </div>
+    </StoryProviders>
+  ),
+}
+
+export const WorktreeActivityStatesActive: Story = {
+  ...WorktreeActivityStates,
+  name: "Worktree cards - selected activity states",
+  args: { active: true },
+}
+
+export const SessionTabActivityStates: Story = {
+  name: "Agent Manager session tabs - activity states",
+  render: () => (
+    <StoryProviders noPadding>
+      <div data-activity-story style={{ padding: "12px", background: "var(--surface-base)" }}>
+        <style>{'[data-activity-story] [data-component="spinner"] rect { animation: none !important; }'}</style>
+        <For each={activityStates}>
+          {([state, title]) => (
+            <div class="am-tab-bar" role="tablist" aria-label={title}>
+              <SessionTab
+                title={title}
+                active
+                state={state}
+                stateLabel={title}
+                closeTitle="Close tab"
+                closeLabel="Close tab"
+                role="tab"
+                selected
+                onSelect={noop}
+                onMiddleClick={noop}
+                onClose={noop}
+              />
+            </div>
           )}
         </For>
       </div>

--- a/packages/kilo-vscode/webview-ui/src/stories/section-header.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/section-header.stories.tsx
@@ -58,7 +58,7 @@ const wtProps = {
   active: false,
   pendingDelete: false,
   busy: false,
-  working: false,
+  activity: "idle" as const,
   stale: false,
   sessions: 1,
   grouped: false,
@@ -402,7 +402,7 @@ export const WithBusyWorktree: Story = {
         <DndWrap>
           <SectionHeader section={sec("s1", 0, { name: "Running", color: "Yellow" })} count={2} {...sectionProps}>
             <div class="am-section-group-body">
-              <WorktreeItem {...wtProps} worktree={wt("wt-1", "feat/generate")} label="feat/generate" working />
+              <WorktreeItem {...wtProps} worktree={wt("wt-1", "feat/generate")} label="feat/generate" activity="busy" />
               <WorktreeItem
                 {...wtProps}
                 worktree={wt("wt-2", "feat/refactor")}
@@ -517,7 +517,7 @@ export const DenseSidebar: Story = {
 
           <SectionHeader section={sec("s3", 2, { name: "Infra", color: "Orange" })} count={1} {...sectionProps}>
             <div class="am-section-group-body">
-              <WorktreeItem {...wtProps} worktree={wt("wt-i1", "chore/docker")} label="chore/docker" working />
+              <WorktreeItem {...wtProps} worktree={wt("wt-i1", "chore/docker")} label="chore/docker" activity="busy" />
             </div>
           </SectionHeader>
 

--- a/packages/kilo-vscode/webview-ui/src/stories/session-tabs.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/session-tabs.stories.tsx
@@ -1,14 +1,45 @@
 /** @jsxImportSource solid-js */
 
 import type { Meta, StoryObj } from "storybook-solidjs-vite"
+import { For } from "solid-js"
+import { SessionTab } from "../components/chat/SessionTab"
 import { SessionTabSwitcher } from "../components/chat/SessionTabSwitcher"
+import type { Activity } from "../utils/session-activity"
 import { StoryProviders } from "./StoryProviders"
 
 const rows = [
-  { id: "refactor", title: "Refactor shared search menu styles", active: false, busy: false, pending: false },
-  { id: "current", title: "Run the extension test suite", active: true, busy: true, pending: false },
-  { id: "pending", title: "Untitled session", active: false, busy: false, pending: true },
-  { id: "idle", title: "Review keyboard navigation behavior", active: false, busy: false, pending: false },
+  {
+    id: "refactor",
+    title: "Refactor shared search menu styles",
+    active: false,
+    state: "done" as const,
+    stateLabel: "Done",
+    pending: false,
+  },
+  {
+    id: "current",
+    title: "Run the extension test suite",
+    active: true,
+    state: "busy" as const,
+    stateLabel: "Running",
+    pending: false,
+  },
+  {
+    id: "pending",
+    title: "Untitled session",
+    active: false,
+    state: "idle" as const,
+    stateLabel: "Current session",
+    pending: true,
+  },
+  {
+    id: "idle",
+    title: "Review keyboard navigation behavior",
+    active: false,
+    state: "idle" as const,
+    stateLabel: "Current session",
+    pending: false,
+  },
 ]
 
 const noop = () => {}
@@ -20,6 +51,71 @@ const meta: Meta = {
 
 export default meta
 type Story = StoryObj
+
+const states: { state: Activity; title: string }[] = [
+  { state: "busy", title: "Running" },
+  { state: "waiting", title: "Needs input" },
+  { state: "done", title: "Completed" },
+  { state: "retry", title: "Retrying" },
+  { state: "error", title: "Error" },
+  { state: "idle", title: "Idle" },
+]
+
+const tabs = (items: typeof states) => (
+  <div class="session-tab-bar">
+    <div class="am-tab-list" role="tablist" aria-label="Session states" style={{ "--tab-count": items.length }}>
+      <For each={items}>
+        {(item) => (
+          <div class="am-tab-sortable">
+            <SessionTab
+              title={item.title}
+              active={false}
+              state={item.state}
+              stateLabel={item.title}
+              closeTitle="Close tab"
+              closeLabel="Close tab"
+              role="tab"
+              selected={false}
+              tabIndex={0}
+              onSelect={noop}
+              onMiddleClick={noop}
+              onClose={noop}
+            />
+          </div>
+        )}
+      </For>
+    </div>
+  </div>
+)
+
+const gallery = (groups: (typeof states)[]) => (
+  <StoryProviders noPadding>
+    <div data-activity-story style={{ padding: "12px", background: "var(--surface-base)" }}>
+      <style>{'[data-activity-story] [data-component="spinner"] rect { animation: none !important; }'}</style>
+      <For each={groups}>{tabs}</For>
+    </div>
+  </StoryProviders>
+)
+
+export const ActivityStates: Story = {
+  name: "Session tabs - all activity states",
+  render: () => gallery(states.map((item) => [item])),
+}
+
+export const ActivityStates1280: Story = {
+  name: "Session tabs - all activity states - 1280px",
+  render: () => gallery([states]),
+}
+
+export const MultipleSessions: Story = {
+  name: "Sidebar session tabs - multiple sessions",
+  render: () => gallery([states.slice(0, 3)]),
+}
+
+export const MultipleSessions200: Story = {
+  name: "Sidebar session tabs - multiple sessions - 200px",
+  render: () => gallery([states.slice(0, 3)]),
+}
 
 export const SwitcherOpen: Story = {
   name: "Session tab switcher — open",
@@ -45,7 +141,6 @@ export const SwitcherOpen: Story = {
               close: "Close tab",
               current: "Current",
               pending: "New",
-              busy: "Working",
             }}
             onSelect={noop}
             onRestore={focus}

--- a/packages/kilo-vscode/webview-ui/src/stories/session-tabs.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/session-tabs.stories.tsx
@@ -25,6 +25,22 @@ const rows = [
     pending: false,
   },
   {
+    id: "waiting",
+    title: "Approve a pending command",
+    active: false,
+    state: "waiting" as const,
+    stateLabel: "Needs input",
+    pending: false,
+  },
+  {
+    id: "error",
+    title: "Review the failed session",
+    active: false,
+    state: "error" as const,
+    stateLabel: "Error",
+    pending: false,
+  },
+  {
     id: "pending",
     title: "Untitled session",
     active: false,
@@ -124,7 +140,7 @@ export const SwitcherOpen: Story = {
       <div
         style={{
           display: "flex",
-          "min-height": "420px",
+          "min-height": "560px",
           "justify-content": "flex-end",
           "align-items": "flex-start",
           padding: "16px",
@@ -146,7 +162,6 @@ export const SwitcherOpen: Story = {
             onRestore={focus}
             onClose={noop}
             defaultOpen
-            portal={false}
           />
         </div>
       </div>

--- a/packages/kilo-vscode/webview-ui/src/styles/session-tabs.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/session-tabs.css
@@ -178,22 +178,22 @@
 }
 
 .session-tab-bar .am-tab-icon[data-activity="waiting"],
-.session-tab-bar .search-menu-icon[data-activity="waiting"],
-.session-tab-bar .session-tab-switcher-meta[data-activity="waiting"] {
+.session-tab-switcher-popover .search-menu-icon[data-activity="waiting"],
+.session-tab-switcher-popover .session-tab-switcher-meta[data-activity="waiting"] {
   --icon-base: var(--icon-warning-base);
   color: var(--icon-warning-base);
 }
 
 .session-tab-bar .am-tab-icon[data-activity="error"],
-.session-tab-bar .search-menu-icon[data-activity="error"],
-.session-tab-bar .session-tab-switcher-meta[data-activity="error"] {
+.session-tab-switcher-popover .search-menu-icon[data-activity="error"],
+.session-tab-switcher-popover .session-tab-switcher-meta[data-activity="error"] {
   --icon-base: var(--icon-critical-base);
   color: var(--icon-critical-base);
 }
 
 .session-tab-bar .am-tab-icon[data-activity="done"],
-.session-tab-bar .search-menu-icon[data-activity="done"],
-.session-tab-bar .session-tab-switcher-meta[data-activity="done"] {
+.session-tab-switcher-popover .search-menu-icon[data-activity="done"],
+.session-tab-switcher-popover .session-tab-switcher-meta[data-activity="done"] {
   --icon-base: var(--icon-success-base);
   color: var(--icon-success-base);
 }

--- a/packages/kilo-vscode/webview-ui/src/styles/session-tabs.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/session-tabs.css
@@ -177,6 +177,27 @@
   flex-shrink: 0;
 }
 
+.session-tab-bar .am-tab-icon[data-activity="waiting"],
+.session-tab-bar .search-menu-icon[data-activity="waiting"],
+.session-tab-bar .session-tab-switcher-meta[data-activity="waiting"] {
+  --icon-base: var(--icon-warning-base);
+  color: var(--icon-warning-base);
+}
+
+.session-tab-bar .am-tab-icon[data-activity="error"],
+.session-tab-bar .search-menu-icon[data-activity="error"],
+.session-tab-bar .session-tab-switcher-meta[data-activity="error"] {
+  --icon-base: var(--icon-critical-base);
+  color: var(--icon-critical-base);
+}
+
+.session-tab-bar .am-tab-icon[data-activity="done"],
+.session-tab-bar .search-menu-icon[data-activity="done"],
+.session-tab-bar .session-tab-switcher-meta[data-activity="done"] {
+  --icon-base: var(--icon-success-base);
+  color: var(--icon-success-base);
+}
+
 .session-tab-bar .am-worktree-spinner {
   width: 16px;
   height: 16px;

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -168,6 +168,7 @@ export interface SessionTurnClosedMessage {
   type: "sessionTurnClosed"
   sessionID: string
   reason: SessionCloseReason
+  parentID?: string
 }
 
 export interface SessionErrorMessage {

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -17,6 +17,7 @@ import type {
   StartMigrationMessage,
 } from "./migration"
 import type { MemoryShowMessage, MemoryOperationMessage, RequestMemoryMessage } from "./memory"
+import type { Activity } from "../../utils/session-activity"
 
 // ============================================
 // Messages FROM webview TO extension
@@ -1490,6 +1491,7 @@ export interface DismissAgentMigrationBannerMessage {
 }
 
 export type WebviewMessage =
+  | { type: "sessionActivity"; state: Activity }
   | DocumentRequestMessage
   | DocumentOpenFileMessage
   | DocumentCloseMessage

--- a/packages/kilo-vscode/webview-ui/src/utils/session-activity.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/session-activity.ts
@@ -58,17 +58,18 @@ export function running(state: Activity): boolean {
   return state === "busy" || state === "retry"
 }
 
-const ORDER: Activity[] = ["waiting", "error", "retry", "busy", "done", "idle"]
+const STATES: Activity[] = ["done", "busy", "retry", "error", "waiting"]
+
+export function score(state: Activity): number {
+  return STATES.indexOf(state) + 1
+}
 
 export function isActivity(value: unknown): value is Activity {
-  return typeof value === "string" && ORDER.includes(value as Activity)
+  return value === "idle" || (typeof value === "string" && STATES.includes(value as Activity))
 }
 
 export function strongest(states: Activity[]): Activity {
-  for (const state of ORDER) {
-    if (states.includes(state)) return state
-  }
-  return "idle"
+  return states.reduce((best, state) => (score(state) > score(best) ? state : best), "idle")
 }
 
 const LABELS: Record<Activity, string> = {

--- a/packages/kilo-vscode/webview-ui/src/utils/session-activity.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/session-activity.ts
@@ -1,0 +1,85 @@
+export type Activity = "waiting" | "error" | "retry" | "busy" | "done" | "idle"
+
+export type Status = "idle" | "busy" | "retry" | "offline"
+
+export interface ActivityInput {
+  status?: Status
+  blocked?: boolean
+  errored?: boolean
+  finished?: boolean
+  disconnected?: boolean
+}
+
+export function activity(input: ActivityInput): Activity {
+  if (input.disconnected && (input.blocked || input.status === "busy" || input.status === "retry")) return "error"
+  if (input.blocked) return "waiting"
+  if (input.errored || input.status === "offline") return "error"
+  if (input.status === "retry") return "retry"
+  if (input.status === "busy") return "busy"
+  if (input.finished) return "done"
+  return "idle"
+}
+
+export function activities(input: {
+  parents: ReadonlyMap<string, string>
+  statuses: Record<string, { type: Status }>
+  outcomes: Record<string, { reason: string } | undefined>
+  blocked: Iterable<string>
+  submitting?: Iterable<string>
+  disconnected: boolean
+}): Record<string, Activity> {
+  const blocked = new Set(input.blocked)
+  const submitting = new Set(input.submitting)
+  const ids = new Set([...Object.keys(input.statuses), ...Object.keys(input.outcomes), ...blocked, ...submitting])
+  const result: Record<string, Activity> = {}
+  for (const id of ids) {
+    const status = submitting.has(id) ? "busy" : input.statuses[id]?.type
+    const close = input.outcomes[id]?.reason
+    const active = activity({ status, blocked: blocked.has(id), disconnected: input.disconnected })
+    const own = activity({
+      status,
+      blocked: blocked.has(id),
+      disconnected: input.disconnected,
+      errored: close === "error",
+      finished: close === "completed",
+    })
+    result[id] = strongest([result[id] ?? "idle", own])
+    if (active === "idle") continue
+    const seen = new Set([id])
+    for (let parent = input.parents.get(id); parent && !seen.has(parent); parent = input.parents.get(parent)) {
+      seen.add(parent)
+      result[parent] = strongest([result[parent] ?? "idle", active])
+    }
+  }
+  return result
+}
+
+export function running(state: Activity): boolean {
+  return state === "busy" || state === "retry"
+}
+
+const ORDER: Activity[] = ["waiting", "error", "retry", "busy", "done", "idle"]
+
+export function isActivity(value: unknown): value is Activity {
+  return typeof value === "string" && ORDER.includes(value as Activity)
+}
+
+export function strongest(states: Activity[]): Activity {
+  for (const state of ORDER) {
+    if (states.includes(state)) return state
+  }
+  return "idle"
+}
+
+const LABELS: Record<Activity, string> = {
+  waiting: "task.backgroundAgents.needsInput",
+  error: "task.backgroundAgents.status.error",
+  retry: "session.status.retry",
+  busy: "session.tabs.switcher.busy",
+  done: "task.backgroundAgents.status.completed",
+  idle: "session.current",
+}
+
+export function label(state: Activity): string {
+  return LABELS[state]
+}


### PR DESCRIPTION
## What Problem This Solves

When several sessions are open, a loading indicator alone does not show which session needs an answer or permission. Stopped, completed, and failed sessions also look too similar across the sidebar, native editor tabs, and Agent Manager.

## Why This Change Was Made

Use one cached session-activity calculation for every presentation surface. Native editor tabs receive the derived state instead of maintaining a second backend-event state machine. Session ancestry comes from session metadata and task metadata, so a child request remains visible even when its originating task is outside the loaded transcript page.

The existing prompt-recovery path is preserved. There are no new polling loops or notification settings.

## User Impact

| Session state | Sidebar tabs, Agent Manager tabs, and worktree cards | Native editor tab |
|---|---|---|
| Running or retrying | Loading indicator | `◔` |
| Needs input or permission | Amber warning | `⚠` |
| Completed | Green check | `✓` |
| Failed or disconnected while active | Red warning | `⚠` |
| Idle | Normal tab or worktree appearance | No status prefix |

- Covers the sidebar's multiple-session tab strip and switcher, Open in Tab, standalone sub-agent tabs, Agent Manager session tabs, local/worktree cards, and session search.
- Pending child questions, permissions, and suggestions take precedence over ongoing work in their parent context. A child's terminal outcome does not overwrite a recovered parent's outcome.
- Answering a request, starting a new turn, or reverting clears the relevant old state. Removed worktrees and unrelated session history do not keep the native Agent Manager tab marked for attention.
- Status colors use theme tokens and work without depending on Agent Manager styles being loaded into the sidebar.

## Evidence

**Automated checks**

- `bun run compile`: passed, including extension/webview typechecks, lint, and bundles.
- `bun run test:unit`: 4,319 passed, 0 failed after resolving conflicts with current `main`.
- `bun run knip`, `bun run check-kilocode-change`, package formatting, and diff whitespace checks passed.
- The new mounted-provider regression drives real VS Code message transport through `SessionProvider` and renders actual Agent Manager tabs. It covers nested requests without loaded transcript pages, resolution, stale permissions, retry/offline states, completion/error ownership, next-turn and revert resets, reconnection, deletion, and disposal.

**Screenshot tests**

Added seven stories to the existing automatically discovered Playwright screenshot suite:

- All session-tab states at the default sidebar width.
- All session-tab states at 1280px.
- Multiple sidebar sessions at 420px and 200px.
- All worktree-card activity states, including selected worktrees.
- Agent Manager session-tab states with its actual tab-bar styles.

The existing switcher story now uses a real portal and includes waiting and error states.

The original five stories and the three focused review-regression scenarios were rendered locally in dark and light themes. Repeated captures were byte-identical, and warning, success, and error colors were distinct. Spinner animation is frozen only in the screenshot fixtures. Linux baseline generation and pixel comparison run in CI; the repository intentionally skips baseline comparison on macOS.

**VS Code self-test**

Verified the sidebar's multiple-session tabs, native editor tabs, Agent Manager tabs, and worktree cards in isolated VS Code. Checked input-required priority, stale-permission recovery, completion, new-turn reset, failure, revert, reconnect, and removal/history scoping. These checks used controlled session events, not a live model round trip.

**Native editor tabs**

<img width="600" alt="Native VS Code tabs showing a completed Agent Manager context and a Kilo session that needs attention" src="https://marius-kilocode.github.io/pr-assets/20260827-session-status-native-rotated-raft.png" />

**Multiple sessions in the sidebar**

<img width="420" alt="Sidebar session tabs showing running, input-required, and completed sessions" src="https://marius-kilocode.github.io/pr-assets/20260827-session-status-sidebar-rotated-raft.png" />

**All tab states, dark and light themes**

<img width="360" alt="Dark theme session-tab states: running, needs input, completed, retrying, error, and idle" src="https://marius-kilocode.github.io/pr-assets/20260827-session-status-tabs-dark-rotated-raft.png" />
<img width="360" alt="Light theme session-tab states: running, needs input, completed, retrying, error, and idle" src="https://marius-kilocode.github.io/pr-assets/20260827-session-status-tabs-light-rotated-raft.png" />

**Worktree cards**

<img width="420" alt="Agent Manager worktree cards showing all six activity states with consistent icons and colors" src="https://marius-kilocode.github.io/pr-assets/20260827-session-status-worktrees-rotated-raft.png" />

**Manual test**

Run two sessions in the sidebar or Agent Manager. Trigger a question or permission in one while the other runs, answer the request, then complete a session and start its next turn. Confirm that both the session tab and its native/context indicator update and that old attention or completion states clear.



**Review regression checks in VS Code**

Verified that the selected worktree retains its warning color and that the real portalled sidebar switcher retains warning, completion, and error colors.

<img width="420" alt="Selected worktree retains its amber attention indicator" src="https://marius-kilocode.github.io/pr-assets/20260827-session-status-selected-fix.png" />
<img width="360" alt="Portalled sidebar switcher retains warning, completion, and error colors" src="https://marius-kilocode.github.io/pr-assets/20260827-session-status-switcher-fix.png" />



