### PR TITLE
docs: Use `Array.prototype.at(index)` instead of out-of-bounds accesses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ Examples: `fix(tui): simplify thinking toggle styling`, `docs: update contributi
 
 - Keep things in one function unless composable or reusable
 - Avoid unnecessary destructuring. Instead of `const { a, b } = obj`, use `obj.a` and `obj.b` to preserve context
+- Avoid possibly out-of-bounds array access. Instead of `array[index] ?? {}`, use `array.at(index) ?? {}`. Instead of `array[array.length - 1]`, use `array.at(-1)`
 - Avoid `try`/`catch` where possible
 - Avoid using the `any` type
 - Prefer single word variable names where possible


### PR DESCRIPTION
## Issue

In more than one occasion I've reviewed new code that keeps accessing possible *out-of-bounds* indexes which is usually discouraged at the JS core level (it can make arrays dirty or deopt).

## Context

This bullet point in AGENTS.md should hint that whenever the reference is known to be an array, using [.at(index)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at) instead of just `[index]` should be the way to write code.
