### PR TITLE
fix(jetbrains): skip git and gh probes for removed worktrees

### DIFF
--- a/.changeset/worktree-probe-missing-dir.md
+++ b/.changeset/worktree-probe-missing-dir.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-jetbrains": patch
+---
+
+Stop showing a false "Git is not installed" warning for worktrees that were deleted from disk

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImpl.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImpl.kt
@@ -189,11 +189,17 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
         val now = System.currentTimeMillis()
         prs[directory]?.takeIf { now - it.time < PR_TTL }?.let { return@withContext it.value }
         val root = Path.of(directory).normalize()
-        // Sync the worktree list before any git/gh probe so a worktree that was added and then
-        // deleted on disk is pruned instead of probed from a directory that no longer exists.
-        val all = sync(root) ?: return@withContext WorktreePrListDto().also { prs[directory] = Timed(now, it) }
+        // A gone directory reports nothing and is not cached, so a real availability problem found
+        // from a live directory still reaches the UI.
+        if (!Files.isDirectory(root)) {
+            LOG.info("pr status skipped, directory does not exist: $root")
+            return@withContext WorktreePrListDto()
+        }
         val available = ghAvailable(root)
         if (available != GhAvailability.OK) return@withContext WorktreePrListDto(available).also { prs[directory] = Timed(now, it) }
+        // Sync the worktree list before the per-worktree lookups so a worktree that was added and
+        // then deleted on disk is pruned instead of resolved from a directory that no longer exists.
+        val all = sync(root) ?: return@withContext WorktreePrListDto().also { prs[directory] = Timed(now, it) }
         val items = prTargets(all)
         val base = baseBranch(all)
         var status = GhAvailability.OK

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImpl.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImpl.kt
@@ -152,11 +152,33 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
 
     override suspend fun stats(directory: String): WorktreeStatsListDto = withContext(Dispatchers.IO) {
         val root = Path.of(directory).normalize()
-        val res = runGit(root, "worktree", "list", "--porcelain")
-        if (!res.ok) return@withContext WorktreeStatsListDto()
-        val items = managedWorktrees(parseWorktreeList(res.stdout))
+        val items = sync(root) ?: return@withContext WorktreeStatsListDto()
         val fallback = baseBranch(items) ?: "HEAD"
         WorktreeStatsListDto(parallel(items.filter { !it.main }) { item -> stats(item, fallback) })
+    }
+
+    /**
+     * Lists the managed worktrees of [root] after reconciling git's metadata with the disk: stale
+     * entries are pruned and entries whose checkout is gone are dropped, so callers never probe a
+     * directory that no longer exists. Returns null when [root] itself is gone or git cannot list.
+     */
+    private fun sync(root: Path): List<WorktreeDto>? {
+        if (!Files.isDirectory(root)) {
+            LOG.info("worktree sync skipped, directory does not exist: $root")
+            return null
+        }
+        val res = runGit(root, "worktree", "list", "--porcelain")
+        if (!res.ok) return null
+        val raw = parseWorktreeList(res.stdout)
+        val gone = raw.any { !it.main && (it.prunable || !Files.isDirectory(Path.of(it.path))) }
+        val synced = if (!gone) managedWorktrees(raw) else {
+            val prune = runGit(root, "worktree", "prune")
+            if (!prune.ok) LOG.warn("worktree prune during sync failed: exit=${prune.exit} stderr=${snippet(prune.stderr)}")
+            val again = runGit(root, "worktree", "list", "--porcelain")
+            if (!again.ok) return null
+            managedWorktrees(parseWorktreeList(again.stdout))
+        }
+        return synced.filter { Files.isDirectory(Path.of(it.path)) }
     }
 
     override suspend fun ghStatus(directory: String): GhAvailability = withContext(Dispatchers.IO) {
@@ -167,11 +189,11 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
         val now = System.currentTimeMillis()
         prs[directory]?.takeIf { now - it.time < PR_TTL }?.let { return@withContext it.value }
         val root = Path.of(directory).normalize()
+        // Sync the worktree list before any git/gh probe so a worktree that was added and then
+        // deleted on disk is pruned instead of probed from a directory that no longer exists.
+        val all = sync(root) ?: return@withContext WorktreePrListDto().also { prs[directory] = Timed(now, it) }
         val available = ghAvailable(root)
         if (available != GhAvailability.OK) return@withContext WorktreePrListDto(available).also { prs[directory] = Timed(now, it) }
-        val res = runGit(root, "worktree", "list", "--porcelain")
-        if (!res.ok) return@withContext WorktreePrListDto().also { prs[directory] = Timed(now, it) }
-        val all = managedWorktrees(parseWorktreeList(res.stdout))
         val items = prTargets(all)
         val base = baseBranch(all)
         var status = GhAvailability.OK
@@ -192,6 +214,10 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
         val now = System.currentTimeMillis()
         branches[directory]?.takeIf { now - it.time < PR_TTL }?.let { return@withContext it.value }
         val root = Path.of(directory).normalize()
+        if (!Files.isDirectory(root)) {
+            LOG.info("branch status skipped, directory does not exist: $root")
+            return@withContext BranchStatusDto()
+        }
         val branch = runGit(root, "branch", "--show-current").stdout.trim()
         val worktree = isLinkedWorktree(root)
         val availability = ghAvailable(root)
@@ -603,6 +629,10 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
     }
 
     private fun ghAvailable(root: Path): GhAvailability {
+        if (!Files.isDirectory(root)) {
+            LOG.info("gh availability skipped dir=$root missing=true")
+            return GhAvailability.OK
+        }
         val status = probeGh(root, "availability")
         if (status != GhAvailability.MISSING) return status
         val now = System.currentTimeMillis()
@@ -614,6 +644,13 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
     }
 
     private fun probeGh(root: Path, reason: String): GhAvailability = synchronized(ghLock) {
+        // A stale/removed worktree directory makes the process spawn fail, which would be
+        // misreported as GIT_MISSING. Treat a missing directory as "nothing to report" and
+        // don't cache it, so the next probe on a real directory still runs.
+        if (!Files.isDirectory(root)) {
+            LOG.info("gh probe skipped reason=$reason dir=$root missing=true")
+            return@synchronized GhAvailability.OK
+        }
         val now = System.currentTimeMillis()
         ghCache?.takeIf { now - it.time < GH_STATUS_TTL }?.let {
             LOG.info("gh probe cache hit reason=$reason value=${it.value}")
@@ -623,6 +660,12 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
         LOG.info("gh probe start reason=$reason dir=$root")
         val git = runGit(root, "--version")
         if (!git.ok) {
+            // The directory can disappear between the check above and the spawn; a failed working
+            // directory is not evidence that git is uninstalled, so report nothing in that case.
+            if (badDir(git.stderr)) {
+                LOG.info("gh probe skipped reason=$reason dir=$root badDir=true stderr=${snippet(git.stderr)}")
+                return@synchronized GhAvailability.OK
+            }
             val value = GhAvailability.GIT_MISSING
             ghCache = Timed(System.currentTimeMillis(), value)
             LOG.info("gh probe result reason=$reason value=$value exit=${git.exit} ms=${System.currentTimeMillis() - start} stderr=${snippet(git.stderr)}")
@@ -639,6 +682,12 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
         return text.trim().replace(Regex("\\s+"), " ").take(180)
     }
 
+}
+
+/** True when a process failed because its working directory is gone, not because the tool is absent. */
+internal fun badDir(text: String): Boolean {
+    val msg = text.lowercase()
+    return msg.contains("working directory") && (msg.contains("does not exist") || msg.contains("not a directory"))
 }
 
 internal fun classifyGhError(text: String): GhAvailability {

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImpl.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImpl.kt
@@ -158,9 +158,15 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
     }
 
     /**
-     * Lists the managed worktrees of [root] after reconciling git's metadata with the disk: stale
-     * entries are pruned and entries whose checkout is gone are dropped, so callers never probe a
-     * directory that no longer exists. Returns null when [root] itself is gone or git cannot list.
+     * Lists the managed worktrees of [root] after reconciling git's metadata with the disk, so
+     * callers never probe a directory that no longer exists. Returns null when [root] itself is gone
+     * or git cannot list.
+     *
+     * Dropping gone entries from the result is what makes probing safe; the prune is only metadata
+     * hygiene. So the prune runs exclusively when a Kilo-managed worktree is the stale one, and a
+     * mis-parse can at worst skip it — git re-checks every entry on disk and only ever removes
+     * `$GIT_DIR/worktrees` bookkeeping for a checkout it finds missing, never any files, and never a
+     * locked worktree (the documented guard for worktrees on unmounted volumes).
      */
     private fun sync(root: Path): List<WorktreeDto>? {
         if (!Files.isDirectory(root)) {
@@ -170,10 +176,12 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
         val res = runGit(root, "worktree", "list", "--porcelain")
         if (!res.ok) return null
         val raw = parseWorktreeList(res.stdout)
-        val gone = raw.any { !it.main && (it.prunable || !Files.isDirectory(Path.of(it.path))) }
-        val synced = if (!gone) managedWorktrees(raw) else {
-            val prune = runGit(root, "worktree", "prune")
+        val stale = staleWorktrees(raw)
+        val synced = if (stale.isEmpty()) managedWorktrees(raw) else {
+            LOG.info("worktree sync pruning stale managed worktrees: ${stale.joinToString(", ") { it.path }}")
+            val prune = runGit(root, "worktree", "prune", "-v")
             if (!prune.ok) LOG.warn("worktree prune during sync failed: exit=${prune.exit} stderr=${snippet(prune.stderr)}")
+            if (prune.ok && prune.stdout.isNotBlank()) LOG.info("worktree sync pruned: ${snippet(prune.stdout)}")
             val again = runGit(root, "worktree", "list", "--porcelain")
             if (!again.ok) return null
             managedWorktrees(parseWorktreeList(again.stdout))
@@ -855,6 +863,21 @@ internal fun managedWorktrees(items: List<WorktreeDto>): List<WorktreeDto> {
         if (item.prunable) return@filter false
         val path = Path.of(item.path).normalize()
         path.parent == storage
+    }
+}
+
+/**
+ * Kilo-managed worktrees under `.kilo/worktrees/` whose checkout is gone. This is the only reason
+ * [KiloWorktreeRpcApiImpl.sync] runs a prune, so a stale worktree the user keeps somewhere else is
+ * never a reason for the plugin to touch git's administrative files on a polling loop.
+ */
+internal fun staleWorktrees(items: List<WorktreeDto>): List<WorktreeDto> {
+    val main = items.firstOrNull { it.main } ?: return emptyList()
+    val storage = Path.of(main.path).normalize().resolve(".kilo").resolve("worktrees").normalize()
+    return items.filter { item ->
+        if (item.main) return@filter false
+        if (Path.of(item.path).normalize().parent != storage) return@filter false
+        item.prunable || !Files.isDirectory(Path.of(item.path))
     }
 }
 

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImplTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImplTest.kt
@@ -73,6 +73,36 @@ class KiloWorktreeRpcApiImplTest {
     }
 
     @Test
+    fun `stats leaves a gone worktree outside the kilo storage registered`() = runBlocking {
+        initRepo()
+        val outside = remote.resolve("elsewhere")
+        git(repo, "worktree", "add", "-b", "feature/outside", outside.toString())
+        delete(outside)
+
+        // The gone entry is excluded from the probe targets, but pruning someone else's worktree
+        // metadata is not the plugin's business, so git's bookkeeping is left untouched.
+        assertTrue(api.stats(repo.toString()).items.none { it.path == outside.toString() })
+        val listed = output(repo, "worktree", "list", "--porcelain")
+        assertTrue(listed.contains(outside.toString()), "unmanaged worktree must not be pruned: $listed")
+    }
+
+    @Test
+    fun `staleWorktrees only reports gone worktrees inside the kilo storage`() {
+        val main = WorktreeDto("/repo", "repo", "main", "/repo", main = true)
+        val managed = WorktreeDto(
+            "/repo/.kilo/worktrees/gone",
+            "gone",
+            "feature/gone",
+            "/repo/.kilo/worktrees/gone",
+            prunable = true,
+        )
+        val outside = WorktreeDto("/elsewhere/gone", "gone", "feature/other", "/elsewhere/gone", prunable = true)
+
+        assertEquals(listOf(managed.path), staleWorktrees(listOf(main, managed, outside)).map { it.path })
+        assertTrue(staleWorktrees(listOf(main, outside)).isEmpty())
+    }
+
+    @Test
     fun `badDir detects a missing working directory spawn failure`() {
         assertTrue(badDir("Cannot start a process, the working directory '/tmp/gone' does not exist"))
         assertFalse(badDir("Cannot run program \"git\": error=2, No such file or directory"))

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImplTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImplTest.kt
@@ -48,6 +48,17 @@ class KiloWorktreeRpcApiImplTest {
     }
 
     @Test
+    fun `branch status skips a missing directory without caching the empty result`() = runBlocking {
+        initRepo()
+        val dir = repo.resolve(".kilo").resolve("worktrees").resolve("late")
+        assertEquals("", api.branchStatus(dir.toString()).branch)
+
+        git(repo, "worktree", "add", "-b", "feature/x", dir.toString())
+
+        assertEquals("feature/x", api.branchStatus(dir.toString()).branch)
+    }
+
+    @Test
     fun `stats syncs away a worktree deleted from disk`() = runBlocking {
         initRepo()
         val created = assertNotNull(api.create(repo.toString(), CreateWorktreeRequestDto("feature/x")).worktree)

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImplTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImplTest.kt
@@ -38,6 +38,36 @@ class KiloWorktreeRpcApiImplTest {
     }
 
     @Test
+    fun `ghStatus does not report git missing for a removed directory`() = runBlocking {
+        assertEquals(GhAvailability.OK, api.ghStatus(repo.resolve("missing").toString()))
+    }
+
+    @Test
+    fun `prStatus does not report git missing for a removed directory`() = runBlocking {
+        assertEquals(GhAvailability.OK, api.prStatus(repo.resolve("missing").toString()).availability)
+    }
+
+    @Test
+    fun `stats syncs away a worktree deleted from disk`() = runBlocking {
+        initRepo()
+        val created = assertNotNull(api.create(repo.toString(), CreateWorktreeRequestDto("feature/x")).worktree)
+        assertTrue(api.stats(repo.toString()).items.any { it.path == created.path })
+
+        delete(Path.of(created.path))
+
+        assertTrue(api.stats(repo.toString()).items.none { it.path == created.path })
+        // The stale entry is pruned from git metadata, so later probes never target the gone directory.
+        val listed = output(repo, "worktree", "list", "--porcelain")
+        assertFalse(listed.contains(created.path), "stale worktree should be pruned during sync: $listed")
+    }
+
+    @Test
+    fun `badDir detects a missing working directory spawn failure`() {
+        assertTrue(badDir("Cannot start a process, the working directory '/tmp/gone' does not exist"))
+        assertFalse(badDir("Cannot run program \"git\": error=2, No such file or directory"))
+    }
+
+    @Test
     fun `parseWorktreeList reads porcelain output and flags the main tree`() {
         val raw = """
             worktree /repo


### PR DESCRIPTION
## Issue

No linked issue — reported from a user log where the JetBrains Agent Manager claimed git was not installed on a machine with a working git.

## Context

When a worktree directory no longer exists, the backend still spawned `git`/`gh` with that directory as the working directory. IntelliJ fails the spawn with `Cannot start a process, the working directory '...' does not exist`, and the probe classified that as `GIT_MISSING`:

```
gh probe result reason=availability value=GIT_MISSING exit=-1 ms=0 stderr=Cannot start a process, the working directory '/Users/.../.kilo/worktrees/snappy-hedgehog' does not exist
```

That surfaced a sticky "Git is not installed" notification/banner and pushed the probe loop into its slow 60s backoff, even though nothing was wrong with the environment.

A gone directory is normal: a frame or session can still be rooted at a worktree that was deleted (removal does not close that window), a worktree can be deleted outside the plugin (`rm -rf`, terminal `git worktree remove`), and git keeps the entry in `worktree list` as `prunable` until someone prunes.

## Implementation

All in `KiloWorktreeRpcApiImpl`:

- New `sync(root)` reconciles git metadata with the disk before any probe: bails out when `root` itself is gone, prunes when any listed entry is `prunable` or its checkout is missing, re-lists, and drops entries without a directory. `stats()` and `prStatus()` now source their worktrees from it, and in `prStatus()` the sync runs *before* `ghAvailable()` so a deleted worktree is pruned rather than probed.
- `ghAvailable()` and `probeGh()` check the directory first and return `OK` without caching, so a dead directory reports nothing instead of poisoning the shared `ghCache` for every caller.
- `branchStatus()` returns an empty DTO for a missing directory instead of running git there.
- New `badDir()` covers the residual race where the directory disappears between the check and the spawn: a working-directory spawn failure is no longer evidence that git is uninstalled.

Deliberately not in scope: the frontend still polls `project.basePath` for a project opened on a deleted worktree. This PR makes those probes harmless; stopping them (closing or rerouting such a project/session on removal) is a separate change.

## Screenshots / Video

N/A — no visual changes; the user-visible effect is the absence of a false notification.

## How to Test

### Manual/local verification

- `./gradlew typecheck` from `packages/kilo-jetbrains/` — passed (agent)
- `./gradlew :backend:test` from `packages/kilo-jetbrains/` — passed (agent), including four new tests: `stats` prunes and drops a worktree deleted from disk, `ghStatus`/`prStatus` on a removed directory report `OK`, and `badDir` distinguishes a dead working directory from a missing `git` binary

### Reviewer test steps

1. Open a repo in the IDE and create a worktree from the Agent Manager
2. Open that worktree as its own project, then delete the worktree directory from a terminal (`rm -rf .kilo/worktrees/<name>`)
3. Confirm no "Git is not installed" notification or banner appears in either window, and the idea.log shows `gh probe skipped ... missing=true` / `worktree sync skipped` instead of `value=GIT_MISSING`
4. Back in the main project, confirm `git worktree list --porcelain` no longer lists the deleted worktree after a stats refresh

### Blocked checks and substitute verification

- None

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

N/A
