### PR TITLE
fix(vscode): preserve background agent dismissals

### DIFF
--- a/.changeset/fix-background-agent-dismissals.md
+++ b/.changeset/fix-background-agent-dismissals.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep dismissed background agent statuses hidden when switching between sessions.

--- a/packages/kilo-vscode/tests/unit/background-agent-dismissals.test.ts
+++ b/packages/kilo-vscode/tests/unit/background-agent-dismissals.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test"
+import { showBackgroundAgent, type BackgroundAgent } from "../../webview-ui/src/components/chat/background-agents"
+
+const completed: BackgroundAgent = {
+  id: "child",
+  status: "completed",
+  startedAt: 1,
+  jobID: "job",
+}
+
+describe("background agent dismissals", () => {
+  it("keeps a completed job hidden after switching back to its parent session", () => {
+    const hidden = new Map<string, ReadonlySet<string>>([["parent-a", new Set(["job"])]])
+
+    expect(showBackgroundAgent(completed, hidden, "parent-b")).toBe(true)
+    expect(showBackgroundAgent(completed, hidden, "parent-a")).toBe(false)
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
@@ -30,14 +30,13 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
   const [open, setOpen] = createSignal(false)
   const [jobs, setJobs] = createSignal<BackgroundJobInfo[]>([])
   const [loaded, setLoaded] = createSignal(false)
-  const [hidden, setHidden] = createSignal<Set<string>>(new Set())
+  const [hidden, setHidden] = createSignal<Map<string, ReadonlySet<string>>>(new Map())
   const [mounted, setMounted] = createSignal(false)
   let pending: string | undefined
   let revision = 0
 
   createEffect(
     on(session.currentSessionID, () => {
-      setHidden(new Set<string>())
       setLoaded(false)
       setJobs([])
       pending = undefined
@@ -89,7 +88,11 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
     return fallback()
   })
 
-  const visible = createMemo(() => agents().filter((agent) => showBackgroundAgent(agent, hidden())))
+  const visible = createMemo(() => {
+    const id = session.currentSessionID()
+    if (!id) return agents()
+    return agents().filter((agent) => showBackgroundAgent(agent, hidden(), id))
+  })
   const summary = createMemo(() => {
     const running = visible().filter((agent) => agent.status === "running").length
     const total = visible().length
@@ -130,13 +133,23 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
     vscode.postMessage({ type: "cancelBackgroundJob", jobID: agent.jobID, sessionID: id, requestID: pending })
   }
 
+  const hide = (ids: Iterable<string>) => {
+    const id = session.currentSessionID()
+    if (!id) return
+    setHidden((current) => {
+      const next = new Map(current)
+      const jobs = new Set(next.get(id))
+      for (const jobID of ids) jobs.add(jobID)
+      next.set(id, jobs)
+      return next
+    })
+  }
+
   const hideFinished = () =>
-    setHidden(
-      new Set(
-        agents()
-          .filter((agent) => agent.status !== "running")
-          .map((agent) => agent.jobID),
-      ),
+    hide(
+      agents()
+        .filter((agent) => agent.status !== "running")
+        .map((agent) => agent.jobID),
     )
 
   return (
@@ -241,7 +254,7 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
                       aria-label={`${language.t("task.backgroundAgents.dismiss")}: ${label(agent)}`}
                       onClick={(event: MouseEvent) => {
                         event.stopPropagation()
-                        setHidden((current) => new Set(current).add(agent.jobID))
+                        hide([agent.jobID])
                       }}
                     >
                       <span data-slot="task-header-agent-action-label">

--- a/packages/kilo-vscode/webview-ui/src/components/chat/background-agents.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/background-agents.ts
@@ -37,8 +37,22 @@ export interface BackgroundAgent {
   question?: QuestionRequest
 }
 
-export function showBackgroundAgent(agent: BackgroundAgent, hidden: ReadonlySet<string>): boolean {
-  return agent.status === "running" || !hidden.has(agent.jobID)
+export function showBackgroundAgent(agent: BackgroundAgent, hidden: ReadonlySet<string>): boolean
+export function showBackgroundAgent(
+  agent: BackgroundAgent,
+  hidden: ReadonlyMap<string, ReadonlySet<string>>,
+  sessionID: string,
+): boolean
+export function showBackgroundAgent(
+  agent: BackgroundAgent,
+  hidden: ReadonlySet<string> | ReadonlyMap<string, ReadonlySet<string>>,
+  sessionID?: string,
+): boolean {
+  const jobs =
+    sessionID === undefined
+      ? (hidden as ReadonlySet<string>)
+      : (hidden as ReadonlyMap<string, ReadonlySet<string>>).get(sessionID)
+  return agent.status === "running" || !jobs?.has(agent.jobID)
 }
 
 function text(value: unknown): string | undefined {


### PR DESCRIPTION
## Issue

Fixes #13507

## Context

Dismissed completed background-agent entries reappeared after switching sessions because the component cleared one shared hidden-job set whenever the current session changed.

## Implementation

Store dismissed job IDs by parent session and update only the active parent for row dismissal and clear-finished actions. Running jobs remain visible if they restart. The existing set-based visibility call remains compatible.

## Screenshots / Video

N/A for this Draft: no visual styling changed; the session-switch state transition is covered by a focused regression test.

## How to Test

### Manual/local verification

- `bun test tests/unit/background-agent-dismissals.test.ts` (1 pass)
- `bun run typecheck`
- `bun run lint`
- `bun run test:unit` (4,321 pass)
- `bun run knip`
- `bun run check-kilocode-change`

### Reviewer test steps

1. Dismiss a completed background-agent status in one parent session.
2. Switch to another session, then return to the original parent.
3. Confirm the dismissed status remains hidden.
4. Confirm a restarted running job is visible again.

### Blocked checks and substitute verification

- None for the affected package.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [ ] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

Available through the GitHub discussion on this PR.