### PR TITLE
fix(vscode): prevent empty queued messages

### DIFF
--- a/.changeset/fix-empty-queued-messages.md
+++ b/.changeset/fix-empty-queued-messages.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep queued prompt text visible while attachment context loads, and hide empty queued placeholders and internal messages.

--- a/packages/kilo-vscode/tests/unit/prompt-rail.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-rail.test.ts
@@ -111,9 +111,25 @@ describe("promptItems", () => {
   it("marks queued rows", () => {
     const u1 = user("u1")
     const u2 = user("u2")
-    const rows = transcriptRows(messageTurns([u1, u2]), lookup({}), { queued: new Set(["u2"]) })
+    const parts = { u1: [text("up1", "u1", "Start")], u2: [text("up2", "u2", "Follow up")] }
+    const rows = transcriptRows(messageTurns([u1, u2]), lookup(parts), { queued: new Set(["u2"]) })
 
     expect(promptItems(rows).map((item) => item.queued)).toEqual([false, true])
+  })
+
+  it("omits empty and internal queued prompt markers", () => {
+    const messages = [user("u1"), user("u2"), user("u3"), user("u4")]
+    const parts = {
+      u1: [text("up1", "u1", "Start")],
+      u3: [text("context", "u3", "Internal context", { synthetic: true })],
+      u4: [text("up4", "u4", "Follow up")],
+    }
+    const rows = transcriptRows(messageTurns(messages), lookup(parts), { queued: new Set(["u2", "u3", "u4"]) })
+
+    expect(promptItems(rows).map((item) => ({ turn: item.turn, queued: item.queued, prompt: item.prompt }))).toEqual([
+      { turn: "u1", queued: false, prompt: "Start" },
+      { turn: "u4", queued: true, prompt: "Follow up" },
+    ])
   })
 
   it("truncates long prompts and answers", () => {

--- a/packages/kilo-vscode/tests/unit/session-parts.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-parts.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "bun:test"
 import { createStore, produce } from "solid-js/store"
-import { isolate, mergeOptimisticPart, mergeParts, sameParts } from "../../webview-ui/src/context/session-parts"
+import {
+  isolate,
+  mergeOptimisticPart,
+  mergeOptimisticParts,
+  mergeParts,
+  sameParts,
+} from "../../webview-ui/src/context/session-parts"
 import type { Part } from "../../webview-ui/src/types/messages"
 
 function text(id: string, value: string, time: { start?: number; end?: number } = {}): Part {
@@ -153,6 +159,83 @@ describe("mergeOptimisticPart", () => {
 
     expect(result.parts.map((part) => part.id)).toEqual(["client-text", "server-file"])
     expect(result.replaced).toBe("client-file")
+  })
+
+  it("keeps queued text when synthetic attachment context arrives first", () => {
+    const current = [text("client-text", "queued prompt"), file("client-file")]
+    const ids = new Set(current.map((part) => part.id))
+    const part: Part = {
+      id: "context",
+      messageID: "m1",
+      type: "text",
+      text: "Attachment context",
+      synthetic: true,
+    }
+    const context = mergeOptimisticPart(current, ids, part)
+
+    expect(context.parts).toEqual([...current, part])
+    expect(context.replaced).toBeUndefined()
+    expect(value(context.parts, "client-text")).toBe("queued prompt")
+
+    const body = { ...part, id: "contents", text: "Attachment contents" }
+    const contents = mergeOptimisticPart(context.parts, ids, body)
+    expect(contents.replaced).toBeUndefined()
+    expect(value(contents.parts, "client-text")).toBe("queued prompt")
+
+    const attachment = mergeOptimisticPart(contents.parts, ids, file("server-file"))
+    expect(attachment.replaced).toBe("client-file")
+    expect(value(attachment.parts, "client-text")).toBe("queued prompt")
+
+    const result = mergeOptimisticPart(attachment.parts, ids, text("server-text", "queued prompt"))
+
+    expect(result.parts).toEqual([text("server-text", "queued prompt"), file("server-file"), part, body])
+    expect(result.replaced).toBe("client-text")
+    expect(current).toEqual([text("client-text", "queued prompt"), file("client-file")])
+  })
+
+  it("preserves unresolved optimistic parts across partial snapshots", () => {
+    const current = [text("client-text", "queued prompt"), file("client-file")]
+    const ids = new Set(current.map((part) => part.id))
+    const context: Part = {
+      id: "context",
+      messageID: "m1",
+      type: "text",
+      text: "Attachment context",
+      synthetic: true,
+    }
+
+    const partial = mergeOptimisticParts(current, ids, [context])
+    expect(partial.parts.map((part) => part.id)).toEqual(["client-text", "client-file", "context"])
+    expect(partial.pending).toEqual(ids)
+    const repeated = mergeOptimisticParts(partial.parts, partial.pending, [context])
+    expect(repeated).toEqual(partial)
+
+    const complete = mergeOptimisticParts(partial.parts, partial.pending, [text("server-text", "queued prompt")])
+    expect(complete.parts.map((part) => part.id)).toEqual(["server-text", "client-file", "context"])
+    expect(complete.pending).toEqual(new Set(["client-file"]))
+
+    const resolved = mergeOptimisticParts(complete.parts, complete.pending, [
+      text("server-text", "queued prompt"),
+      file("server-file"),
+    ])
+    expect(resolved.parts.map((part) => part.id)).toEqual(["server-text", "server-file", "context"])
+    expect(resolved.pending).toEqual(new Set())
+  })
+
+  it("retains confirmed text when a stale prefix resolves the last optimistic attachment", () => {
+    const current = [text("server-text", "queued prompt"), file("client-file")]
+    const result = mergeOptimisticParts(current, new Set(["client-file"]), [file("server-file")])
+
+    expect(result.parts).toEqual([text("server-text", "queued prompt"), file("server-file")])
+    expect(result.pending).toEqual(new Set())
+  })
+
+  it("uses a resolved snapshot as authoritative after optimism retires", () => {
+    const current = [text("client-text", "queued prompt"), file("client-file")]
+    const result = mergeOptimisticParts(current, new Set(), [text("server-text", "server prompt")])
+
+    expect(result.parts).toEqual([text("server-text", "server prompt")])
+    expect(result.pending).toEqual(new Set())
   })
 
   it("keeps streamed deltas independent across session stores", () => {

--- a/packages/kilo-vscode/tests/unit/transcript-rows-reactivity.test.ts
+++ b/packages/kilo-vscode/tests/unit/transcript-rows-reactivity.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test"
+import path from "node:path"
+
+const WEBVIEW = path.resolve(import.meta.dir, "../../webview-ui")
+const PASS = "TRANSCRIPT_ROWS_REACTIVITY_PASS"
+const FAIL = "TRANSCRIPT_ROWS_REACTIVITY_FAIL:"
+
+const SCRIPT = `
+  const { createMemo } = await import("solid-js")
+  const { createStore } = await import("solid-js/store")
+  const { PartStash } = await import("./src/context/part-stash.ts")
+  const { messageTurns } = await import("./src/context/session-queue.ts")
+  const { transcriptRows } = await import("./src/context/transcript-rows.ts")
+
+  const fail = (reason) => {
+    console.log("${FAIL}" + reason)
+    process.exit(2)
+  }
+  const user = { id: "u1", sessionID: "session", role: "user", createdAt: "2026-01-01T00:00:00.000Z" }
+  const turns = messageTurns([user])
+  const stash = new PartStash()
+  stash.put("u1", [{ id: "context", messageID: "u1", type: "text", text: "Attachment context", synthetic: true }])
+  const [store, setStore] = createStore({ parts: {} })
+  const get = (id) => stash.read(id, store.parts)
+  const rows = createMemo(() => transcriptRows(turns, get, { queued: new Set(["u1"]) }))
+
+  if (rows().length !== 0) fail("synthetic context created a queued row")
+  stash.remove("u1")
+  setStore("parts", "u1", [{ id: "prompt", messageID: "u1", type: "text", text: "Visible prompt" }])
+  if (rows().length !== 1 || rows()[0]?.type !== "user") fail("canonical part did not invalidate rows")
+  console.log("${PASS}")
+`
+
+describe("transcript rows reactivity", () => {
+  it("invalidates a memo when a stashed synthetic prefix is promoted", () => {
+    const result = Bun.spawnSync([process.execPath, "--conditions=browser", "-e", SCRIPT], {
+      cwd: WEBVIEW,
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const output = result.stdout.toString() + result.stderr.toString()
+
+    if (result.exitCode === 0 && output.includes(PASS)) return
+    const index = output.indexOf(FAIL)
+    if (index !== -1) {
+      expect.unreachable(
+        output
+          .slice(index + FAIL.length)
+          .split("\n")[0]
+          ?.trim(),
+      )
+    }
+    expect.unreachable(`transcript rows reactivity test exited ${result.exitCode}: ${output.trim()}`)
+  })
+})

--- a/packages/kilo-vscode/tests/unit/transcript-rows.test.ts
+++ b/packages/kilo-vscode/tests/unit/transcript-rows.test.ts
@@ -73,6 +73,81 @@ describe("transcriptRows", () => {
     expect(rows[0]).toMatchObject({ type: "assistant", turn: "u1", partial: true, queued: true, live: true })
   })
 
+  it("omits queued user rows without visible content", () => {
+    const cases: Part[][] = [
+      [],
+      [{ ...part("context", "u1"), synthetic: true }],
+      [{ ...part("blank", "u1"), text: " \n\t" }],
+      [{ id: "compact", messageID: "u1", type: "compaction", auto: true }],
+      [{ id: "file", messageID: "u1", type: "file", mime: "text/plain", url: "data:,context" }],
+    ]
+
+    for (const parts of cases) {
+      const rows = transcriptRows(messageTurns([user("u1")]), lookup({ u1: parts }), {
+        queued: new Set(["u1"]),
+      })
+
+      expect(rows).toEqual([])
+    }
+  })
+
+  it("shows a queued message when its visible text arrives after metadata and context", () => {
+    const turns = messageTurns([user("u1")])
+    const opts = { queued: new Set(["u1"]) }
+    const parts: Record<string, Part[]> = {}
+    const get = lookup(parts)
+    const empty = transcriptRows(turns, get, opts)
+    expect(empty).toEqual([])
+
+    parts.u1 = [{ ...part("context", "u1"), synthetic: true }]
+    const hidden = transcriptRows(turns, get, opts, empty)
+    expect(hidden).toEqual([])
+
+    parts.u1 = [...parts.u1, part("prompt", "u1")]
+    const ready = transcriptRows(turns, get, opts, hidden)
+    expect(ready).toHaveLength(1)
+    expect(ready[0]).toMatchObject({ type: "user", key: "u1:user", queued: true, parts: parts.u1 })
+    expect(turns[0]?.user.id).toBe("u1")
+  })
+
+  it("keeps queued image and PDF attachments visible without prompt text", () => {
+    for (const mime of ["image/png", "application/pdf"]) {
+      const parts: Part[] = [
+        { ...part("context", "u1"), synthetic: true },
+        { id: "file", messageID: "u1", type: "file", mime, url: "data:,attachment" },
+      ]
+      const rows = transcriptRows(messageTurns([user("u1")]), lookup({ u1: parts }), {
+        queued: new Set(["u1"]),
+      })
+
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toMatchObject({ type: "user", queued: true, parts })
+    }
+  })
+
+  it("preserves assistant, diff, and error rows when an internal queued user row is hidden", () => {
+    const u1 = user("u1", { summary: { diffs: [{ file: "a.ts" }] } })
+    const a1 = assistant("a1", "u1", { error: { name: "ProviderError" } })
+    const rows = transcriptRows(
+      messageTurns([u1, a1]),
+      lookup({ u1: [{ ...part("context", "u1"), synthetic: true }], a1: [part("reply", "a1")] }),
+      { queued: new Set(["u1"]) },
+    )
+
+    expect(rows.map((row) => `${row.turn}:${row.type}`)).toEqual(["u1:assistant", "u1:diff", "u1:error"])
+    expect(rows[0]?.message).toBe(a1)
+  })
+
+  it("does not show a blank queued row when only a later text part has content", () => {
+    const rows = transcriptRows(
+      messageTurns([user("u1")]),
+      lookup({ u1: [{ ...part("first", "u1"), text: "" }, part("later", "u1")] }),
+      { queued: new Set(["u1"]) },
+    )
+
+    expect(rows).toEqual([])
+  })
+
   it("places only the first visible non-abort error after diffs", () => {
     const u1 = user("u1", { summary: { diffs: [{ file: "a.ts" }] } })
     const a1 = assistant("a1", "u1", { error: { name: "MessageAbortedError" } })
@@ -252,7 +327,8 @@ describe("partitionRows", () => {
     const u1 = user("u1")
     const a1 = assistant("a1", "u1")
     const u2 = user("u2")
-    const first = transcriptRows(messageTurns([u1, a1, u2]), lookup({ a1: [part("p1", "a1")] }), {
+    const parts = { a1: [part("p1", "a1")], u2: [part("up2", "u2")] }
+    const first = transcriptRows(messageTurns([u1, a1, u2]), lookup(parts), {
       live: new Set(["u1"]),
       queued: new Set(["u2"]),
     })
@@ -261,7 +337,7 @@ describe("partitionRows", () => {
     expect(active.direct.map((row) => row.turn)).toEqual(["u1"])
     expect(active.queued.map((row) => row.turn)).toEqual(["u2"])
 
-    const second = transcriptRows(messageTurns([u1, a1, u2]), lookup({ a1: [part("p1", "a1")] }), {
+    const second = transcriptRows(messageTurns([u1, a1, u2]), lookup(parts), {
       live: new Set(["u2"]),
     })
     const handed = partitionRows(second, new Set(["u2"]))
@@ -297,10 +373,14 @@ describe("partitionRows", () => {
     const u1 = user("u1")
     const a1 = assistant("a1", "u1")
     const u2 = user("u2")
-    const rows = transcriptRows(messageTurns([u1, a1, u2]), lookup({ a1: [part("p1", "a1")] }), {
-      live: new Set(["u1"]),
-      queued: new Set(["u2"]),
-    })
+    const rows = transcriptRows(
+      messageTurns([u1, a1, u2]),
+      lookup({ a1: [part("p1", "a1")], u2: [part("up2", "u2")] }),
+      {
+        live: new Set(["u1"]),
+        queued: new Set(["u2"]),
+      },
+    )
     const result = partitionRows(rows, new Set(["u1"]))
 
     expect(result.virtual.map((row) => row.type)).toEqual(["user"])

--- a/packages/kilo-vscode/webview-ui/src/context/part-stash.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/part-stash.ts
@@ -24,6 +24,11 @@ export class PartStash {
     return this.map.get(messageID)
   }
 
+  read(messageID: string, parts: Record<string, Part[]>): Part[] {
+    const live = parts[messageID]
+    return this.peek(messageID) ?? live ?? []
+  }
+
   /**
    * Invalidate any stashed parts for a message. Callers MUST invoke this in
    * every path that removes a message from state (messageRemoved,

--- a/packages/kilo-vscode/webview-ui/src/context/session-parts.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-parts.ts
@@ -30,13 +30,36 @@ export function sameParts(local: Part[] = [], snapshot: Part[] = []): boolean {
 }
 
 export function mergeOptimisticPart(current: Part[], ids: ReadonlySet<string>, part: Part) {
-  const index = current.findIndex((item) => ids.has(item.id) && item.type === part.type)
+  const index =
+    part.type === "text" && part.synthetic
+      ? -1
+      : current.findIndex((item) => ids.has(item.id) && item.type === part.type)
   const copy = isolate(part)
   if (index < 0) return { parts: [...current, copy] }
   const old = current[index]!
   const next = current.slice()
   next[index] = copy
   return { parts: next, replaced: old.id }
+}
+
+export function mergeOptimisticParts(current: Part[], ids: ReadonlySet<string>, snapshot: Part[]) {
+  if (ids.size === 0) return { parts: snapshot.map(isolate), pending: new Set<string>() }
+  const pending = new Set(ids)
+  let parts = current
+  for (const part of snapshot) {
+    const index = parts.findIndex((item) => item.id === part.id)
+    if (index >= 0) {
+      const next = parts.slice()
+      next[index] = isolate(part)
+      parts = next
+      pending.delete(part.id)
+      continue
+    }
+    const merged = mergeOptimisticPart(parts, pending, part)
+    parts = merged.parts
+    if (merged.replaced) pending.delete(merged.replaced)
+  }
+  return { parts, pending }
 }
 
 /**

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -79,7 +79,7 @@ import { getAgentModel } from "./session-model-store"
 import { resolveMessagePrefs } from "./session-preferences"
 import { errorIDs, preserveSessionErrors, withoutResolvedSessionErrors } from "./session-errors"
 import { PartStash } from "./part-stash"
-import { isolate, mergeOptimisticPart, mergeParts } from "./session-parts"
+import { isolate, mergeOptimisticPart, mergeOptimisticParts, mergeParts } from "./session-parts"
 import { mergeMessages, sameReconcileShape } from "./session-merge"
 import { state as todoState } from "./todo-revert"
 import { sessionVariantKeys, transferVariants, variantKey } from "./session-variant-store"
@@ -1465,13 +1465,18 @@ export const SessionProvider: ParentComponent = (props) => {
           continue
         }
         if (parts.length > 0) {
-          optimisticParts.delete(msg.id)
-          loadedParts[msg.id] = parts
+          const pending = optimisticParts.get(msg.id)
+          const next = pending
+            ? mergeOptimisticParts(store.parts[msg.id] ?? stash.peek(msg.id) ?? [], pending, parts)
+            : { parts, pending: undefined }
+          if (next.pending?.size) optimisticParts.set(msg.id, next.pending)
+          if (next.pending?.size === 0) optimisticParts.delete(msg.id)
+          loadedParts[msg.id] = next.parts
           if (i >= cutoff) {
-            setStore("parts", msg.id, parts)
+            setStore("parts", msg.id, next.parts)
             stash.remove(msg.id)
           } else {
-            stash.put(msg.id, parts)
+            stash.put(msg.id, next.parts)
           }
           continue
         }
@@ -2723,7 +2728,7 @@ export const SessionProvider: ParentComponent = (props) => {
 
   // Keep off-screen history in the non-reactive stash, but track live parts so
   // newly streamed messages invalidate the transcript.
-  const getParts = (messageID: string) => stash.peek(messageID) ?? store.parts[messageID] ?? []
+  const getParts = (messageID: string) => stash.read(messageID, store.parts)
 
   const getSessionToolParts = (sessionID: string) => store.toolParts[sessionID] ?? []
 

--- a/packages/kilo-vscode/webview-ui/src/context/transcript-rows.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/transcript-rows.ts
@@ -108,6 +108,14 @@ function diffs(msg: Message) {
   return msg.summary.diffs ?? []
 }
 
+function content(parts: Part[]) {
+  const text = parts.find((part) => part.type === "text" && !part.synthetic)
+  if (text?.type === "text" && text.text.trim()) return true
+  return parts.some(
+    (part) => part.type === "file" && (part.mime.startsWith("image/") || part.mime === "application/pdf"),
+  )
+}
+
 function copy(messages: Message[], getParts: (id: string) => Part[], live: boolean) {
   // While the session streams, the last non-empty text part changes at every
   // part boundary and the copy/feedback row would hop between parts (mount/
@@ -143,14 +151,15 @@ export function transcriptRows(
       live: opts.live?.has(turn.id) === true,
     }
     const copied = copy(turn.assistant, parts, meta.live)
+    const user = turn.partial ? [] : parts(turn.user.id)
 
-    if (!turn.partial) {
+    if (!turn.partial && (!meta.queued || content(user))) {
       rows.push({
         ...meta,
         type: "user",
         key: `${turn.id}:user`,
         message: turn.user,
-        parts: parts(turn.user.id),
+        parts: user,
         interrupted: turn.assistant.some((msg) => terminal(msg) && msg.error?.name === "MessageAbortedError"),
         answered: turn.assistant.length > 0,
       })


### PR DESCRIPTION
## What Problem This Solves

Queued follow-ups can show only a “Queued” label and a remove button, with no prompt text. The earlier fix in #13176 preserved text through metadata-only confirmation, but synthetic attachment context and partial message snapshots could still replace it.

## Why This Change Was Made

Attachments are expanded into synthetic text before the visible prompt part arrives. Matching only by part type mistakes this internal context for confirmation of the user’s text. A snapshot can also observe only the first persisted parts.

Preserve unresolved optimistic parts through both event and snapshot reconciliation. Do not discard already-confirmed text when a stale prefix resolves the last pending attachment. Keep snapshots authoritative once optimism has retired.

Empty and internal queued user rows are omitted without deleting their messages or changing assistant-parent grouping. Reads still subscribe to reactive parts when a cached value exists, so hidden rows can appear when their visible text arrives.

## User Impact

- Queued text remains visible while attachment context loads.
- Empty placeholders and internal messages no longer create blank queue rows or prompt-navigation markers.
- Image/PDF-only queued messages remain visible, and late text appears without a session switch.

## Evidence

Reported behavior before the fix:

<img width="1000" alt="Before the fix: two empty queued rows show only the Queued label and remove controls" src="https://marius-kilocode.github.io/pr-assets/20260828-empty-queued-messages-before-0615.png" />

- Full extension unit suite: **4,266 passed** with `bun run test:unit --timeout 30000`. The initial run hit two existing five-second timeouts during a concurrent local build; no test timeout settings were changed in the code.
- Typecheck, lint, webview bundle, Knip, formatting, and merge-marker guard passed.
- Controlled VS Code replay verified attachment-context ordering, empty/internal rows, late text, and image/PDF-only messages in the initial implementation pass. The subsequent snapshot and lazy-loading corrections have automated regression coverage, including a browser-condition Solid memo test using the production part accessor, rather than a new end-to-end IDE run.

Manual verification: while a reply runs, queue a follow-up with an `@file` reference. Confirm its text stays visible, then switch away and back and confirm it is still present without duplicate or empty queue rows.
