### PR TITLE
fix: reduce offscreen animation and transcript memory overhead

### DIFF
--- a/.changeset/quiet-parallel-agents.md
+++ b/.changeset/quiet-parallel-agents.md
@@ -1,0 +1,7 @@
+---
+"kilo-code": patch
+"@kilocode/kilo-ui": patch
+"@opencode-ai/ui": patch
+---
+
+Stop offscreen loading animations while preserving their original appearance, and release obsolete transcript pages from memory.

--- a/packages/kilo-ui/src/components/spinner.css
+++ b/packages/kilo-ui/src/components/spinner.css
@@ -1,0 +1,5 @@
+@media (prefers-reduced-motion: reduce) {
+  [data-component="spinner"] > rect {
+    animation: none !important;
+  }
+}

--- a/packages/kilo-ui/src/stories/spinner.stories.tsx
+++ b/packages/kilo-ui/src/stories/spinner.stories.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource solid-js */
 import type { Meta, StoryObj } from "storybook-solidjs-vite"
-import { Spinner } from "@opencode-ai/ui/spinner"
+import { Spinner } from "@kilocode/kilo-ui/spinner"
 
 const meta: Meta<typeof Spinner> = {
   title: "Components/Spinner",
@@ -18,6 +18,16 @@ export const Small: Story = {
 
 export const Large: Story = {
   render: () => <Spinner style={{ width: "48px", height: "48px" }} />,
+}
+
+export const Parallel: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: "8px", "flex-wrap": "wrap" }}>
+      {Array.from({ length: 24 }, () => (
+        <Spinner style={{ width: "16px", height: "16px" }} />
+      ))}
+    </div>
+  ),
 }
 
 export const Colored: Story = {

--- a/packages/kilo-ui/src/styles/index.css
+++ b/packages/kilo-ui/src/styles/index.css
@@ -35,6 +35,7 @@
 @import "../components/select.css";
 @import "../components/session.css";
 @import "../components/settings-sidebar.css";
+@import "../components/spinner.css";
 @import "../components/status-indicator.css";
 @import "../components/switch.css";
 @import "../components/tabs.css";

--- a/packages/kilo-vscode/tests/fixtures/session-tab-switcher.tsx
+++ b/packages/kilo-vscode/tests/fixtures/session-tab-switcher.tsx
@@ -14,6 +14,7 @@ Object.assign(globalThis, {
   HTMLTextAreaElement: window.HTMLTextAreaElement,
   SVGElement: window.SVGElement,
   MutationObserver: window.MutationObserver,
+  IntersectionObserver: window.IntersectionObserver,
   ResizeObserver: window.ResizeObserver,
   CustomEvent: window.CustomEvent,
   Event: window.Event,

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -1453,19 +1453,17 @@ export const SessionProvider: ParentComponent = (props) => {
       if (mode === "replace") {
         const keep = new Set(merged.map((message) => message.id))
         const removed = current.filter((message) => !keep.has(message.id)).map((message) => message.id)
-        if (removed.length > 0) {
-          for (const id of removed) {
-            stash.remove(id)
-            optimisticParts.delete(id)
-          }
-          clearHiddenErrors(removed)
-          setStore(
-            "parts",
-            produce((parts) => {
-              for (const id of removed) delete parts[id]
-            }),
-          )
-        }
+        clearHiddenErrors(removed)
+        setStore(
+          "parts",
+          produce((parts) => {
+            for (const id of removed) {
+              stash.remove(id)
+              optimisticParts.delete(id)
+              delete parts[id]
+            }
+          }),
+        )
         setStore("messages", sessionID, merged)
       } else {
         setStore("messages", sessionID, reconcile(merged, { key: "id" }))

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -1451,6 +1451,21 @@ export const SessionProvider: ParentComponent = (props) => {
       // proxy creation for each message object dominated the trace (~900ms).
       // "prepend" / "reconcile": reconcile to preserve existing proxies.
       if (mode === "replace") {
+        const keep = new Set(merged.map((message) => message.id))
+        const removed = current.filter((message) => !keep.has(message.id)).map((message) => message.id)
+        if (removed.length > 0) {
+          for (const id of removed) {
+            stash.remove(id)
+            optimisticParts.delete(id)
+          }
+          clearHiddenErrors(removed)
+          setStore(
+            "parts",
+            produce((parts) => {
+              for (const id of removed) delete parts[id]
+            }),
+          )
+        }
         setStore("messages", sessionID, merged)
       } else {
         setStore("messages", sessionID, reconcile(merged, { key: "id" }))

--- a/packages/ui/src/components/spinner.css
+++ b/packages/ui/src/components/spinner.css
@@ -4,3 +4,9 @@
   width: 18px;
   aspect-ratio: 1;
 }
+
+/* kilocode_change start */
+[data-component="spinner"][data-paused] > rect {
+  animation: none !important;
+}
+/* kilocode_change end */

--- a/packages/ui/src/components/spinner.tsx
+++ b/packages/ui/src/components/spinner.tsx
@@ -1,4 +1,5 @@
 import { ComponentProps, For } from "solid-js"
+import { observe } from "../kilocode/spinner" // kilocode_change
 
 const outerIndices = new Set([1, 2, 4, 7, 8, 11, 13, 14])
 const cornerIndices = new Set([0, 3, 12, 15])
@@ -19,6 +20,7 @@ export function Spinner(props: {
 }) {
   return (
     <svg
+      ref={observe /* kilocode_change */}
       {...props}
       viewBox="0 0 15 15"
       data-component="spinner"
@@ -37,7 +39,7 @@ export function Spinner(props: {
             height="3"
             rx="1"
             style={{
-              opacity: square.corner ? 0 : undefined,
+              opacity: square.corner ? 0 : square.outer ? 0.15 : 0.4, // kilocode_change
               animation: square.corner
                 ? undefined
                 : `${square.outer ? "pulse-opacity-dim" : "pulse-opacity"} ${square.duration}s ease-in-out infinite`,

--- a/packages/ui/src/kilocode/spinner.ts
+++ b/packages/ui/src/kilocode/spinner.ts
@@ -1,0 +1,41 @@
+import { onCleanup, onMount } from "solid-js"
+
+const roots = new Map<Element, boolean>()
+let observer: IntersectionObserver | undefined
+
+function update(root: Element, visible: boolean) {
+  root.toggleAttribute("data-paused", !visible || document.visibilityState === "hidden")
+}
+
+function refresh() {
+  for (const [root, visible] of roots) update(root, visible)
+}
+
+export function observe(root: SVGSVGElement) {
+  onMount(() => {
+    if (typeof IntersectionObserver === "undefined") return
+    if (!observer) {
+      observer = new IntersectionObserver((entries) => {
+        for (const entry of entries) {
+          if (!roots.has(entry.target)) continue
+          const visible = entry.isIntersecting && entry.intersectionRatio > 0
+          roots.set(entry.target, visible)
+          update(entry.target, visible)
+        }
+      })
+      document.addEventListener("visibilitychange", refresh)
+    }
+    roots.set(root, false)
+    update(root, false)
+    observer.observe(root)
+    onCleanup(() => {
+      observer?.unobserve(root)
+      roots.delete(root)
+      root.removeAttribute("data-paused")
+      if (roots.size > 0) return
+      observer?.disconnect()
+      observer = undefined
+      document.removeEventListener("visibilitychange", refresh)
+    })
+  })
+}

--- a/packages/ui/src/kilocode/spinner.ts
+++ b/packages/ui/src/kilocode/spinner.ts
@@ -13,7 +13,6 @@ function refresh() {
 
 export function observe(root: SVGSVGElement) {
   onMount(() => {
-    if (typeof IntersectionObserver === "undefined") return
     if (!observer) {
       observer = new IntersectionObserver((entries) => {
         for (const entry of entries) {


### PR DESCRIPTION
## What Problem This Solves

Parallel sessions add UI overhead even when most worktree cards are outside the viewport. Each shared grid spinner runs twelve independent square animations, so unseen cards continue to contribute animation work. Replacing a transcript page also leaves the removed messages' parts reachable in the reactive part store and the offscreen part stash.

## Why This Change Was Made

Stop work that cannot affect the visible UI rather than simplify or slow down the loading animation. One shared intersection observer tracks mounted spinners, and one document-visibility listener handles background documents. Offscreen instances have their animations removed; visible instances keep the original SVG geometry, per-square delays, duration, easing, and brightness. Observer registrations are released when components unmount, and reduced-motion mode uses the first-frame appearance.

For authoritative transcript replacements, discard parts belonging to messages that are no longer in the merged page. Overlapping messages, queued prompts, other sessions, and prepend/reconcile history loads remain intact.

## User Impact

- Loading indicators look the same, while the animation workload scales with visible cards instead of every mounted card. This applies to the shared grid spinner throughout the extension and web console, not just Agent Manager.
- Repeated transcript reloads no longer retain obsolete page bodies indefinitely.
- Model execution, builds, tests, Git polling, and backend resource lifetimes are not changed. These results are not whole-device or backend CPU savings.

## Evidence

Controlled local replays on a 48 GiB Mac with 14 logical cores, captured on August 27 using the VS Code self-test profiler. CPU is measured as a percentage of one logical core, not the whole machine.

| Replay | Metric | Before | After | Reduction |
|---|---|---|---|---|
| 24 busy cards, 15 visible | Renderer CPU | 13.00% | 10.37% | 20% |
| 100 busy cards, 15 visible | Renderer CPU | 49.01% | 13.37% | 73% |
| 100 busy cards, 15 visible | Main-thread work over approximately 10 seconds, excluding profiler commands | 2,744.94 ms | 176.82 ms | 94% |
| 100 busy cards, 15 visible | Running square animations | 1,200 | 180 | 85% |
| 100 transcript-page replacements | Additional settled JS heap | 125.01 MiB | 13.35 MiB | 89% |
| 100 transcript-page replacements | Stashed message records | 6,500 | 650 | 90% |

**CPU method:** Same compiled instance, exact Agent Manager frame, Local selected, settled Git/PR state, and no model calls or user tools. The baseline temporarily restores the original inline animations on every card; the optimized capture restores normal styles and enables offscreen suspension. Running-animation counts were checked before each capture. Each sample lasts approximately ten seconds.

**Memory method:** Ten background sessions, ten replacement pages per session, 80 messages per page, and 16 KiB of deterministic unique text per message. The replay uses the real webview message handler and waits ten seconds before sampling. Heap numbers depend on garbage collection; the retained-record count is the stronger structural check. This does not bound all legitimately cached inactive transcripts.

**Appearance and behavior:** Original and optimized square opacities matched exactly at six timestamps from 0 to 2,750 ms. Scrolling from the first to the last card stopped animations on the offscreen card and started all twelve original animations on the newly visible card. Scroll-back behavior, observer cleanup, and reduced-motion behavior were also checked. A retained VS Code editor iframe can remain logically visible when CSS-hidden; no additional hidden-editor CPU saving is claimed.

<img width="430" alt="Original and optimized loading spinners retain identical per-square animation" src="https://marius-kilocode.github.io/pr-assets/20260828-preserved-spinner-pr13529-6e440878-3db73.gif" />

**Validation on the rebased branch:** 4,352 existing extension unit tests and 160 shared UI tests passed, along with extension/shared-UI typechecks, lint, Knip, ownership/annotation checks, and the full extension/console build. No new fixture harness is included.

**Manual test:** Run several sessions, scroll busy worktree cards out of view and back, and confirm the original animation returns. Switch sessions and reopen history; confirm queued prompt text and retained history remain available.
