### PR TITLE
feat(vscode): add compaction model setting

### DIFF
--- a/.changeset/quiet-compaction-model.md
+++ b/.changeset/quiet-compaction-model.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Choose a separate model for conversation compaction in Context settings.

--- a/packages/kilo-vscode/tests/unit/config-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/config-utils.test.ts
@@ -392,6 +392,27 @@ describe("ConfigState", () => {
     })
   })
 
+  it("sets and clears the compaction model without changing other settings", () => {
+    const s = new ConfigState()
+    const cfg: Config = {
+      model: "kilo/openai/gpt-4.1",
+      agent: { compaction: { prompt: "Keep task details" }, code: { model: "kilo/openai/gpt-4.1" } },
+    }
+    const model = "kilo/anthropic/claude-haiku-4-5"
+    s.handleConfigLoaded(cfg)
+    s.updateConfig({ agent: { compaction: { model } } })
+
+    expect(s.config).toEqual({
+      ...cfg,
+      agent: { ...cfg.agent, compaction: { prompt: "Keep task details", model } },
+    })
+    s.updateConfig({ agent: { compaction: { model: null } } })
+
+    expect(s.config).toEqual(cfg)
+    expect(s.draft.agent?.compaction?.model).toBeNull()
+    expect(configUnsetPaths(s.draft)).toEqual([["agent", "compaction", "model"]])
+  })
+
   describe("agent permission patches", () => {
     it("merges nested per-agent permission patches into existing rules", () => {
       const s = new ConfigState()

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ContextTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ContextTab.tsx
@@ -8,6 +8,8 @@ import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { useConfig } from "../../context/config"
 import { useLanguage } from "../../context/language"
 import { useMemory } from "../../context/memory"
+import { parseModelString } from "../../../../src/shared/provider-model"
+import { ModelSelectorBase } from "../shared/ModelSelector"
 import SettingsRow from "./SettingsRow"
 
 const ContextTab: Component = () => {
@@ -138,6 +140,24 @@ const ContextTab: Component = () => {
           >
             {language.t("settings.context.autoCompaction.title")}
           </Switch>
+        </SettingsRow>
+        <SettingsRow
+          title={language.t("settings.context.compactionModel.title")}
+          description={language.t("settings.context.compactionModel.description")}
+        >
+          <ModelSelectorBase
+            value={parseModelString(config().agent?.compaction?.model ?? undefined)}
+            onSelect={(providerID, modelID) =>
+              updateConfig({
+                agent: { compaction: { model: providerID && modelID ? `${providerID}/${modelID}` : null } },
+              })
+            }
+            placement="bottom-start"
+            allowClear
+            clearLabel={language.t("settings.context.compactionModel.useChatModel")}
+            label={language.t("settings.context.compactionModel.title")}
+            description={language.t("settings.context.compactionModel.description")}
+          />
         </SettingsRow>
         <SettingsRow
           title={language.t("settings.context.compactionLimit.title")}

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1034,6 +1034,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "ضغط تلقائي",
   "settings.context.autoCompaction.description": "ضغط السياق تلقائياً قبل أن يصل إلى الحد",
   "settings.context.compaction.title": "الضغط",
+  "settings.context.compactionModel.title": "نموذج الضغط",
+  "settings.context.compactionModel.description":
+    "النموذج المستخدم للضغط التلقائي واليدوي. اتركه فارغاً لاستخدام نموذج الدردشة. تعتمد التكلفة والسرعة وجودة الملخص على النموذج.",
+  "settings.context.compactionModel.useChatModel": "استخدام نموذج الدردشة",
   "settings.context.compactionLimit.title": "حد الضغط التلقائي",
   "settings.context.compactionLimit.description":
     "اضغط عندما يصل السياق إلى هذه النسبة المئوية من نافذة النموذج. اتركه فارغاً لاستخدام هامش الأمان فقط.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1074,6 +1074,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "Compactação automática",
   "settings.context.autoCompaction.description": "Compactar automaticamente o contexto antes que atinja o limite",
   "settings.context.compaction.title": "Compactação",
+  "settings.context.compactionModel.title": "Modelo de compactação",
+  "settings.context.compactionModel.description":
+    "Modelo usado para compactação automática e manual. Deixe sem definir para usar o modelo de chat. O custo, a velocidade e a qualidade do resumo dependem do modelo.",
+  "settings.context.compactionModel.useChatModel": "Usar modelo de chat",
   "settings.context.compactionLimit.title": "Limite de compactação automática",
   "settings.context.compactionLimit.description":
     "Compacte quando o contexto atingir esta porcentagem da janela do modelo. Deixe em branco para usar apenas a margem de segurança.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1066,6 +1066,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "Automatska kompresija",
   "settings.context.autoCompaction.description": "Automatski komprimiraj kontekst prije nego dostigne limit",
   "settings.context.compaction.title": "Kompresija",
+  "settings.context.compactionModel.title": "Model za kompresiju",
+  "settings.context.compactionModel.description":
+    "Model koji se koristi za automatsku i ručnu kompresiju. Ostavite nepostavljeno da biste koristili model za chat. Trošak, brzina i kvalitet sažetka zavise od modela.",
+  "settings.context.compactionModel.useChatModel": "Koristi model za chat",
   "settings.context.compactionLimit.title": "Limit automatske kompresije",
   "settings.context.compactionLimit.description":
     "Komprimiraj kada kontekst dostigne ovaj procenat prozora modela. Ostavite prazno da koristite samo sigurnosnu rezervu.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1061,6 +1061,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "Automatisk komprimering",
   "settings.context.autoCompaction.description": "Komprimér automatisk kontekst, før den når grænsen",
   "settings.context.compaction.title": "Komprimering",
+  "settings.context.compactionModel.title": "Komprimeringsmodel",
+  "settings.context.compactionModel.description":
+    "Model, der bruges til automatisk og manuel komprimering. Lad feltet være tomt for at bruge chatmodellen. Omkostninger, hastighed og kvaliteten af opsummeringen afhænger af modellen.",
+  "settings.context.compactionModel.useChatModel": "Brug chatmodel",
   "settings.context.compactionLimit.title": "Grænse for automatisk komprimering",
   "settings.context.compactionLimit.description":
     "Komprimér, når konteksten når denne procentdel af modelvinduet. Lad feltet være tomt for kun at bruge sikkerhedsbufferen.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1086,6 +1086,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "Automatische Komprimierung",
   "settings.context.autoCompaction.description": "Kontext automatisch komprimieren, bevor er das Limit erreicht",
   "settings.context.compaction.title": "Komprimierung",
+  "settings.context.compactionModel.title": "Komprimierungsmodell",
+  "settings.context.compactionModel.description":
+    "Modell für die automatische und manuelle Komprimierung. Leer lassen, um das Chatmodell zu verwenden. Kosten, Geschwindigkeit und Zusammenfassungsqualität hängen vom Modell ab.",
+  "settings.context.compactionModel.useChatModel": "Chatmodell verwenden",
   "settings.context.compactionLimit.title": "Limit für automatische Komprimierung",
   "settings.context.compactionLimit.description":
     "Komprimieren, wenn der Kontext diesen Prozentsatz des Modellfensters erreicht. Leer lassen, um nur den Sicherheitspuffer zu verwenden.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1038,6 +1038,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "Auto Compaction",
   "settings.context.autoCompaction.description": "Automatically compact context before it reaches the limit",
   "settings.context.compaction.title": "Compaction",
+  "settings.context.compactionModel.title": "Compaction model",
+  "settings.context.compactionModel.description":
+    "Model used for automatic and manual compaction. Leave unset to use the chat model. Cost, speed, and summary quality depend on the model.",
+  "settings.context.compactionModel.useChatModel": "Use chat model",
   "settings.context.compactionLimit.title": "Auto Compaction Limit",
   "settings.context.compactionLimit.description":
     "Compact when context reaches this percentage of the model window. Leave blank to use the safety buffer only.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1076,6 +1076,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "Compactación automática",
   "settings.context.autoCompaction.description": "Compactar automáticamente el contexto antes de que alcance el límite",
   "settings.context.compaction.title": "Compactación",
+  "settings.context.compactionModel.title": "Modelo de compactación",
+  "settings.context.compactionModel.description":
+    "Modelo utilizado para la compactación automática y manual. Déjalo sin configurar para usar el modelo de chat. El coste, la velocidad y la calidad del resumen dependen del modelo.",
+  "settings.context.compactionModel.useChatModel": "Usar modelo de chat",
   "settings.context.compactionLimit.title": "Límite de compactación automática",
   "settings.context.compactionLimit.description":
     "Compactar cuando el contexto alcance este porcentaje de la ventana del modelo. Déjalo en blanco para usar solo el búfer de seguridad.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
@@ -1048,6 +1048,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "فشرده‌سازی خودکار",
   "settings.context.autoCompaction.description": "قبل از رسیدن به محدودیت، زمینه را به‌طور خودکار فشرده کنید",
   "settings.context.compaction.title": "فشرده‌سازی",
+  "settings.context.compactionModel.title": "مدل فشرده‌سازی",
+  "settings.context.compactionModel.description":
+    "مدل مورد استفاده برای فشرده‌سازی خودکار و دستی. برای استفاده از مدل چت، خالی بگذارید. هزینه، سرعت و کیفیت خلاصه به مدل بستگی دارند.",
+  "settings.context.compactionModel.useChatModel": "استفاده از مدل چت",
   "settings.context.compactionLimit.title": "محدودیت فشرده‌سازی خودکار",
   "settings.context.compactionLimit.description":
     "زمانی فشرده‌سازی انجام شود که زمینه به این درصد از پنجره مدل برسد. برای استفاده تنها از بافر ایمنی، خالی بگذارید.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1093,6 +1093,10 @@ export const dict = {
   "settings.context.autoCompaction.description":
     "Compacter automatiquement le contexte avant qu'il n'atteigne la limite",
   "settings.context.compaction.title": "Compactage",
+  "settings.context.compactionModel.title": "Modèle de compactage",
+  "settings.context.compactionModel.description":
+    "Modèle utilisé pour le compactage automatique et manuel. Laissez ce champ vide pour utiliser le modèle de chat. Le coût, la vitesse et la qualité du résumé dépendent du modèle.",
+  "settings.context.compactionModel.useChatModel": "Utiliser le modèle de chat",
   "settings.context.compactionLimit.title": "Limite de compactage automatique",
   "settings.context.compactionLimit.description":
     "Compacter lorsque le contexte atteint ce pourcentage de la fenêtre du modèle. Laissez vide pour utiliser uniquement la marge de sécurité.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -949,6 +949,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "Compattazione automatica",
   "settings.context.autoCompaction.description": "Compatta automaticamente il contesto quando è pieno",
   "settings.context.compaction.title": "Compattazione",
+  "settings.context.compactionModel.title": "Modello di compattazione",
+  "settings.context.compactionModel.description":
+    "Modello usato per la compattazione automatica e manuale. Lascia non impostato per usare il modello di chat. Costo, velocità e qualità del riepilogo dipendono dal modello.",
+  "settings.context.compactionModel.useChatModel": "Usa il modello di chat",
   "settings.context.prune.title": "Riduci output vecchi",
   "settings.context.prune.description": "Rimuovi output tool vecchi durante la compattazione",
   "settings.context.watcherPatterns": "Pattern ignore file watcher",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1055,6 +1055,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "自動圧縮",
   "settings.context.autoCompaction.description": "コンテキストが上限に達する前に自動的に圧縮",
   "settings.context.compaction.title": "圧縮",
+  "settings.context.compactionModel.title": "圧縮モデル",
+  "settings.context.compactionModel.description":
+    "自動および手動の圧縮に使用するモデル。チャットモデルを使用するには未設定のままにしてください。コスト、速度、要約の品質はモデルによって異なります。",
+  "settings.context.compactionModel.useChatModel": "チャットモデルを使用",
   "settings.context.compactionLimit.title": "自動圧縮の上限",
   "settings.context.compactionLimit.description":
     "コンテキストがモデルウィンドウのこの割合に達したら圧縮します。安全バッファーのみを使用するには空欄のままにしてください。",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1044,6 +1044,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "자동 압축",
   "settings.context.autoCompaction.description": "컨텍스트가 한도에 도달하기 전에 자동으로 압축",
   "settings.context.compaction.title": "압축",
+  "settings.context.compactionModel.title": "압축 모델",
+  "settings.context.compactionModel.description":
+    "자동 및 수동 압축에 사용하는 모델입니다. 채팅 모델을 사용하려면 설정하지 않은 상태로 두세요. 비용, 속도 및 요약 품질은 모델에 따라 달라집니다.",
+  "settings.context.compactionModel.useChatModel": "채팅 모델 사용",
   "settings.context.compactionLimit.title": "자동 압축 한도",
   "settings.context.compactionLimit.description":
     "컨텍스트가 모델 창의 이 비율에 도달하면 압축합니다. 안전 버퍼만 사용하려면 비워 두세요.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1033,6 +1033,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "Automatische Compactie",
   "settings.context.autoCompaction.description": "Context automatisch compacteren voordat deze de limiet bereikt",
   "settings.context.compaction.title": "Compactie",
+  "settings.context.compactionModel.title": "Compactiemodel",
+  "settings.context.compactionModel.description":
+    "Model dat wordt gebruikt voor automatische en handmatige compactie. Laat dit leeg om het chatmodel te gebruiken. Kosten, snelheid en de kwaliteit van de samenvatting hangen af van het model.",
+  "settings.context.compactionModel.useChatModel": "Chatmodel gebruiken",
   "settings.context.compactionLimit.title": "Limiet voor automatisch compacteren",
   "settings.context.compactionLimit.description":
     "Compacteer wanneer de context dit percentage van het modelvenster bereikt. Laat leeg om alleen de veiligheidsbuffer te gebruiken.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1060,6 +1060,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "Automatisk komprimering",
   "settings.context.autoCompaction.description": "Komprimer automatisk kontekst før den når grensen",
   "settings.context.compaction.title": "Komprimering",
+  "settings.context.compactionModel.title": "Komprimeringsmodell",
+  "settings.context.compactionModel.description":
+    "Modell som brukes for automatisk og manuell komprimering. La feltet stå tomt for å bruke chatmodellen. Kostnad, hastighet og kvaliteten på sammendraget avhenger av modellen.",
+  "settings.context.compactionModel.useChatModel": "Bruk chatmodell",
   "settings.context.compactionLimit.title": "Grense for automatisk komprimering",
   "settings.context.compactionLimit.description":
     "Komprimer når konteksten når denne prosentandelen av modellvinduet. La stå tomt for å bare bruke sikkerhetsbufferen.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1066,6 +1066,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "Automatyczna kompakcja",
   "settings.context.autoCompaction.description": "Automatycznie kompaktuj kontekst, zanim osiągnie limit",
   "settings.context.compaction.title": "Kompaktowanie",
+  "settings.context.compactionModel.title": "Model kompakcji",
+  "settings.context.compactionModel.description":
+    "Model używany do automatycznej i ręcznej kompakcji. Pozostaw puste, aby używać modelu czatu. Koszt, szybkość i jakość podsumowania zależą od modelu.",
+  "settings.context.compactionModel.useChatModel": "Użyj modelu czatu",
   "settings.context.compactionLimit.title": "Limit automatycznego kompaktowania",
   "settings.context.compactionLimit.description":
     "Kompaktuj, gdy kontekst osiągnie ten procent okna modelu. Pozostaw puste, aby używać tylko bufora bezpieczeństwa.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1061,6 +1061,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "Автоматическое сжатие",
   "settings.context.autoCompaction.description": "Автоматически сжимать контекст до достижения лимита",
   "settings.context.compaction.title": "Сжатие",
+  "settings.context.compactionModel.title": "Модель сжатия",
+  "settings.context.compactionModel.description":
+    "Модель, используемая для автоматического и ручного сжатия. Оставьте поле пустым, чтобы использовать модель чата. Стоимость, скорость и качество сводки зависят от модели.",
+  "settings.context.compactionModel.useChatModel": "Использовать модель чата",
   "settings.context.compactionLimit.title": "Лимит автоматического сжатия",
   "settings.context.compactionLimit.description":
     "Сжимать, когда контекст достигает этого процента окна модели. Оставьте пустым, чтобы использовать только буфер безопасности.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1041,6 +1041,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "การบีบอัดอัตโนมัติ",
   "settings.context.autoCompaction.description": "บีบอัดบริบทอัตโนมัติก่อนถึงขีดจำกัด",
   "settings.context.compaction.title": "การบีบอัด",
+  "settings.context.compactionModel.title": "โมเดลสำหรับการบีบอัด",
+  "settings.context.compactionModel.description":
+    "โมเดลที่ใช้สำหรับการบีบอัดอัตโนมัติและด้วยตนเอง เว้นว่างไว้เพื่อใช้โมเดลแชท ค่าใช้จ่าย ความเร็ว และคุณภาพของสรุปขึ้นอยู่กับโมเดล",
+  "settings.context.compactionModel.useChatModel": "ใช้โมเดลแชท",
   "settings.context.compactionLimit.title": "ขีดจำกัดการบีบอัดอัตโนมัติ",
   "settings.context.compactionLimit.description":
     "บีบอัดเมื่อบริบทถึงเปอร์เซ็นต์นี้ของหน้าต่างโมเดล เว้นว่างไว้เพื่อใช้เฉพาะบัฟเฟอร์ความปลอดภัย",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1021,6 +1021,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "Otomatik Sıkıştırma",
   "settings.context.autoCompaction.description": "Bağlam sınıra ulaşmadan önce otomatik olarak sıkıştır",
   "settings.context.compaction.title": "Sıkıştırma",
+  "settings.context.compactionModel.title": "Sıkıştırma modeli",
+  "settings.context.compactionModel.description":
+    "Otomatik ve manuel sıkıştırma için kullanılan model. Sohbet modelini kullanmak için boş bırakın. Maliyet, hız ve özet kalitesi modele bağlıdır.",
+  "settings.context.compactionModel.useChatModel": "Sohbet modelini kullan",
   "settings.context.compactionLimit.title": "Otomatik sıkıştırma sınırı",
   "settings.context.compactionLimit.description":
     "Bağlam model penceresinin bu yüzdesine ulaştığında sıkıştır. Yalnızca güvenlik tamponunu kullanmak için boş bırakın.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1020,6 +1020,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "Автоматичне стиснення",
   "settings.context.autoCompaction.description": "Автоматично стискати контекст до досягнення ліміту",
   "settings.context.compaction.title": "Стискання",
+  "settings.context.compactionModel.title": "Модель стискання",
+  "settings.context.compactionModel.description":
+    "Модель, що використовується для автоматичного та ручного стискання. Залиште поле порожнім, щоб використовувати модель чату. Вартість, швидкість і якість підсумку залежать від моделі.",
+  "settings.context.compactionModel.useChatModel": "Використовувати модель чату",
   "settings.context.compactionLimit.title": "Ліміт автоматичного стискання",
   "settings.context.compactionLimit.description":
     "Стискати, коли контекст досягає цього відсотка вікна моделі. Залиште порожнім, щоб використовувати лише буфер безпеки.",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1005,6 +1005,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "自动压缩",
   "settings.context.autoCompaction.description": "在上下文达到限制前自动压缩",
   "settings.context.compaction.title": "压缩",
+  "settings.context.compactionModel.title": "压缩模型",
+  "settings.context.compactionModel.description":
+    "用于自动和手动压缩的模型。留空以使用聊天模型。成本、速度和摘要质量取决于模型。",
+  "settings.context.compactionModel.useChatModel": "使用聊天模型",
   "settings.context.compactionLimit.title": "自动压缩限制",
   "settings.context.compactionLimit.description": "当上下文达到模型窗口的此百分比时进行压缩。留空则仅使用安全缓冲区。",
   "settings.context.prune.title": "修剪旧输出",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -968,6 +968,10 @@ export const dict = {
   "settings.context.autoCompaction.title": "自動壓縮",
   "settings.context.autoCompaction.description": "在上下文達到限制前自動壓縮",
   "settings.context.compaction.title": "壓縮",
+  "settings.context.compactionModel.title": "壓縮模型",
+  "settings.context.compactionModel.description":
+    "用於自動和手動壓縮的模型。留空以使用聊天模型。成本、速度和摘要品質取決於模型。",
+  "settings.context.compactionModel.useChatModel": "使用聊天模型",
   "settings.context.compactionLimit.title": "自動壓縮限制",
   "settings.context.compactionLimit.description": "當上下文達到模型視窗的此百分比時進行壓縮。留空則僅使用安全緩衝區。",
   "settings.context.prune.title": "修剪舊輸出",


### PR DESCRIPTION
## What Problem This Solves

Choosing a separate model for conversation compaction required editing CLI configuration. Kilo settings did not expose this choice.

## Why This Change Was Made

Expose the existing `agent.compaction.model` setting in Context settings. The selector uses the current SDK configuration path, so no backend, SDK, or schema change is needed.

## User Impact

Choose a model for automatic and manual compaction, or clear the selection to use the chat model. Changing the compaction model does not change the chat model. Cost, speed, and summary quality depend on the selected model.

The code diff contains the selector, required translations, one focused set/reset test, and a changeset. No benchmark artifacts or generated files are included.

## Evidence

Typecheck, lint, compile, Knip, and the change-marker check passed. The extension unit suite passed all 4,321 tests.

The isolated VS Code self-test verified model selection, Save, Reload, Discard, clearing an unavailable model, and keyboard reset with auto-compaction disabled. The chat model and other compaction settings stayed unchanged.

Two live compaction attempts used identical synthetic histories. The saved override selected the configured compaction model; clearing it selected the chat model. Both requests returned HTTP 401 before generation, so these attempts do not establish timing, cost, or summary-quality differences.

<img width="700" alt="Compaction settings with a separate model selected and automatic compaction disabled" src="https://marius-kilocode.github.io/pr-assets/20260828-compaction-model-setting-c6c4ec.png" />
