### PR TITLE
feat(browser-task): define negotiated job contracts

### DIFF
--- a/packages/opencode/src/kilo-sessions/remote-protocol.ts
+++ b/packages/opencode/src/kilo-sessions/remote-protocol.ts
@@ -53,6 +53,8 @@ export namespace RemoteProtocol {
       // wire form omits sessionClone; remove the mobile fail-closed check
       // when every shipped CLI advertises it.
       sessionClone: z.boolean().optional(),
+      // Old heartbeats omit browserJobsV1: normalize to unsupported until all old clients retire.
+      browserJobsV1: z.boolean().optional(),
     })
     .optional()
   export const Heartbeat = z.object({
@@ -116,6 +118,8 @@ export namespace RemoteProtocol {
 
   export const HeartbeatAck = z.object({
     type: z.literal("heartbeat_ack"),
+    // Old acknowledgements omit capabilities: normalize to unsupported until all old relays retire.
+    capabilities: z.object({ browserJobsV1: z.boolean().optional() }).optional(),
   })
   export type HeartbeatAck = z.infer<typeof HeartbeatAck>
 
@@ -124,4 +128,444 @@ export namespace RemoteProtocol {
 
   /** Lightweight schema for diagnostic logging before full parse. */
   export const Preview = z.object({ type: z.string(), id: z.string().optional() })
+
+  // --- Negotiated browser jobs v1 ---
+  // Match services/session-ingest/src/types/user-connection-protocol.ts and
+  // packages/cloud-agent-sdk/src/schemas.ts. Legacy parsers above stay narrow.
+
+  export const BROWSER_GOAL_MAX_BYTES = 16 * 1024
+  export const BROWSER_RESULT_MAX_BYTES = 64 * 1024
+  export const BROWSER_FRAME_MAX_BYTES = 128 * 1024
+  export const BROWSER_PAGE_SIZE = 25
+
+  export const BrowserCapabilities = z.object({ browserJobsV1: z.boolean().optional() })
+  export const NormalizedBrowserCapabilities = BrowserCapabilities.optional()
+    // Old peers omit capabilities or browserJobsV1. Keep this fallback until all old peers retire.
+    .transform((capabilities) => ({ browserJobsV1: capabilities?.browserJobsV1 ?? false }))
+  export type BrowserCapabilities = z.infer<typeof NormalizedBrowserCapabilities>
+
+  export const Ping = z.object({
+    type: z.literal("ping"),
+    nonce: z.string(),
+    // Old web peers omit capabilities: normalize to unsupported until all old peers retire.
+    capabilities: BrowserCapabilities.optional(),
+  })
+  export const Pong = z.object({
+    type: z.literal("pong"),
+    nonce: z.string(),
+    // Old web peers omit capabilities: normalize to unsupported until all old peers retire.
+    capabilities: BrowserCapabilities.optional(),
+  })
+  export const WebOutbound = z.discriminatedUnion("type", [
+    Subscribe,
+    Unsubscribe,
+    Command.extend({
+      data: z.unknown().optional(),
+      connectionId: z.string().optional(),
+      mutationId: z.string().max(128).optional(),
+    }),
+    Ping,
+  ])
+  export type WebOutbound = z.infer<typeof WebOutbound>
+  export const WebInbound = z.discriminatedUnion("type", [Event, System, Response, Pong])
+  export type WebInbound = z.infer<typeof WebInbound>
+
+  function text(limit: number) {
+    return z
+      .string()
+      .max(limit)
+      .refine((value) => new TextEncoder().encode(value).byteLength <= limit, {
+        message: "Text exceeds the UTF-8 byte limit",
+      })
+  }
+
+  // Do not propagate Zod issues from proof-bearing inputs: even unknown key names
+  // can contain secrets. Consumers must not enable Zod's reportInput option.
+  function boundary<T extends z.ZodType>(schema: T) {
+    return z.unknown().transform((input, context): z.output<T> => {
+      const parsed = schema.safeParse(input)
+      if (
+        parsed.success &&
+        new TextEncoder().encode(JSON.stringify(parsed.data)).byteLength < BROWSER_FRAME_MAX_BYTES
+      ) {
+        return parsed.data
+      }
+      context.addIssue({ code: "custom", message: "Invalid browser message" })
+      return z.NEVER
+    })
+  }
+
+  export const BrowserProviderId = z.templateLiteral(["bp_", z.uuid()])
+  export const BrowserTaskId = z.templateLiteral(["bt_", z.uuid()])
+  export const BrowserJobId = z.templateLiteral(["bj_", z.uuid()])
+  export const BrowserInvocationId = z
+    .string()
+    .regex(/^b1\.[1-9][0-9]{0,15}\.[a-f0-9]{64}$/)
+    .refine(
+      (value) => {
+        const created = Number(value.split(".").at(1))
+        return Number.isSafeInteger(created) && created <= 8_640_000_000_000_000
+      },
+      { message: "Invalid invocation timestamp" },
+    )
+  const correlation = z.uuid()
+  const timestamp = z.iso.datetime({ precision: 3 })
+  const fingerprint = z.string().regex(/^[a-f0-9]{64}$/)
+  const proof = z.string().regex(/^[a-f0-9]{64}$/)
+  const goal = text(BROWSER_GOAL_MAX_BYTES).min(1)
+  const generation = z.number().int().positive().max(Number.MAX_SAFE_INTEGER)
+  const tab = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER)
+  const owner = z.strictObject({
+    parentSessionId: text(128).regex(/^ses_[A-Za-z0-9_-]+$/),
+    parentProof: proof,
+  })
+
+  export const BrowserJobStatus = z.enum([
+    "queued",
+    "awaiting_approval",
+    "running",
+    "succeeded",
+    "failed",
+    "cancelled",
+    "interrupted",
+    "timed_out",
+  ])
+  export const BrowserTerminalStatus = BrowserJobStatus.exclude(["queued", "awaiting_approval", "running"])
+  export const BrowserFailureReason = z.enum([
+    "approval_denied",
+    "permission_denied",
+    "invocation_expired",
+    "invocation_conflict",
+    "conversation_busy",
+    "capacity_exceeded",
+    "tab_lost",
+    "provider_lost",
+    "provider_unavailable",
+    "queue_timeout",
+    "approval_timeout",
+    "execution_timeout",
+    "lease_expired",
+    "effects_uncertain",
+    "cancelled",
+    "runner_failed",
+    "unsupported",
+    "invalid_request",
+    "owner_mismatch",
+    "not_found",
+  ])
+  export const BrowserReasonCode = z.enum(["completed", ...BrowserFailureReason.options])
+
+  const handle = {
+    providerId: BrowserProviderId,
+    browserTaskId: BrowserTaskId,
+    jobId: BrowserJobId,
+    invocationId: BrowserInvocationId,
+  }
+  export const BrowserJobHandle = z.strictObject(handle)
+  export type BrowserJobHandle = z.infer<typeof BrowserJobHandle>
+  const binding = { providerId: BrowserProviderId, generation }
+  const bound = { ...handle, generation }
+
+  export const BrowserApprovedTab = z.strictObject({
+    tabId: tab,
+    title: text(1024),
+    url: text(8192).url(),
+    effectiveMode: z.enum(["safe", "dangerous"]),
+  })
+  export const BrowserDeadlines = z.strictObject({
+    queue: timestamp,
+    approval: timestamp.optional(),
+    execution: timestamp.optional(),
+    lease: timestamp.optional(),
+  })
+  const metadata = {
+    ...bound,
+    payloadFingerprint: fingerprint,
+    createdAt: timestamp,
+    expiresAt: timestamp,
+    deadlines: BrowserDeadlines,
+  }
+  const evidence = z
+    .strictObject({
+      text: text(8192).min(1).optional(),
+      title: text(1024).min(1).optional(),
+      url: text(8192).url().optional(),
+    })
+    .refine((evidence) => Object.keys(evidence).length > 0, {
+      message: "Evidence must contain an observation",
+    })
+  const outcome = {
+    ...handle,
+    summary: text(32 * 1024).min(1),
+    evidence: z.array(evidence).max(32),
+  }
+  export const BrowserResult = z
+    .discriminatedUnion("status", [
+      z.strictObject({
+        ...outcome,
+        status: z.literal("succeeded"),
+        reason: z.literal("completed"),
+        effectsUncertain: z.literal(false),
+      }),
+      z.strictObject({
+        ...outcome,
+        status: BrowserTerminalStatus.exclude(["succeeded"]),
+        reason: BrowserFailureReason,
+        effectsUncertain: z.boolean(),
+      }),
+    ])
+    .refine((result) => new TextEncoder().encode(JSON.stringify(result)).byteLength <= BROWSER_RESULT_MAX_BYTES, {
+      message: "Result exceeds the serialized UTF-8 byte limit",
+    })
+  export type BrowserResult = z.infer<typeof BrowserResult>
+
+  function same(left: BrowserJobHandle, right: BrowserJobHandle) {
+    return (
+      left.providerId === right.providerId &&
+      left.browserTaskId === right.browserTaskId &&
+      left.jobId === right.jobId &&
+      left.invocationId === right.invocationId
+    )
+  }
+
+  export const BrowserJobSnapshot = z
+    .strictObject({
+      ...metadata,
+      status: BrowserJobStatus,
+      approvedTab: BrowserApprovedTab.optional(),
+      result: BrowserResult.optional(),
+    })
+    .superRefine((job, context) => {
+      const terminal = BrowserTerminalStatus.safeParse(job.status).success
+      if (
+        terminal !== (job.result !== undefined) ||
+        (job.result && (job.status !== job.result.status || !same(job, job.result)))
+      ) {
+        context.addIssue({ code: "custom", message: "Result must match the terminal job" })
+      }
+      if (
+        (job.status === "running" && !job.approvedTab) ||
+        ((job.status === "queued" || job.status === "awaiting_approval") && job.approvedTab)
+      ) {
+        context.addIssue({ code: "custom", message: "Tab approval must match the job phase" })
+      }
+      const created = Date.parse(job.createdAt)
+      const expires = Date.parse(job.expiresAt)
+      if (
+        created > expires ||
+        Object.values(job.deadlines).some(
+          (deadline) => deadline !== undefined && (Date.parse(deadline) < created || Date.parse(deadline) > expires),
+        )
+      ) {
+        context.addIssue({ code: "custom", message: "Deadlines must stay within job retention" })
+      }
+    })
+  export type BrowserJobSnapshot = z.infer<typeof BrowserJobSnapshot>
+
+  // Model arguments never select parent, invocation, proof, user, or socket authority.
+  export const BrowserTaskArguments = boundary(
+    z.discriminatedUnion("operation", [
+      z.strictObject({ operation: z.literal("list") }),
+      z.strictObject({
+        operation: z.literal("run"),
+        provider_id: BrowserProviderId,
+        goal,
+        browser_task_id: BrowserTaskId.optional(),
+      }),
+      z.strictObject({
+        operation: z.literal("status"),
+        browser_task_id: BrowserTaskId,
+        job_id: BrowserJobId.optional(),
+      }),
+      z.strictObject({
+        operation: z.literal("cancel"),
+        browser_task_id: BrowserTaskId,
+        job_id: BrowserJobId.optional(),
+      }),
+      z.strictObject({ operation: z.literal("recover") }),
+    ]),
+  )
+  export type BrowserTaskArguments = z.infer<typeof BrowserTaskArguments>
+
+  const request = { type: z.literal("browser_request"), requestId: correlation }
+  // An absent jobId selects only this conversation's latest job, after owner verification.
+  const lookup = { owner, browserTaskId: BrowserTaskId, jobId: BrowserJobId.optional() }
+  // Only authenticated, negotiated CLI sockets can submit these requests. Recover
+  // looks up a persisted invocation; it cannot carry a new goal or choose a provider.
+  export const BrowserRequest = boundary(
+    z.discriminatedUnion("operation", [
+      z.strictObject({ ...request, operation: z.literal("list"), cursor: BrowserProviderId.optional() }),
+      z.strictObject({
+        ...request,
+        operation: z.literal("invoke"),
+        owner,
+        providerId: BrowserProviderId,
+        browserTaskId: BrowserTaskId.optional(),
+        invocationId: BrowserInvocationId,
+        goal,
+      }),
+      z.strictObject({ ...request, operation: z.literal("status"), ...lookup }),
+      z.strictObject({ ...request, operation: z.literal("cancel"), ...lookup }),
+      z.strictObject({ ...request, operation: z.literal("recover"), owner, invocationId: BrowserInvocationId }),
+    ]),
+  )
+  export type BrowserRequest = z.infer<typeof BrowserRequest>
+
+  export const BrowserProviderDescriptor = z.strictObject({
+    providerId: BrowserProviderId,
+    label: text(128).min(1),
+    availability: z.enum(["available", "busy", "unavailable"]),
+    queueDepth: z.number().int().min(0).max(100),
+  })
+  export const BrowserResponse = boundary(
+    z.strictObject({
+      type: z.literal("browser_response"),
+      requestId: correlation,
+      response: z.discriminatedUnion("kind", [
+        z.strictObject({
+          kind: z.literal("providers"),
+          providers: z.array(BrowserProviderDescriptor).max(BROWSER_PAGE_SIZE),
+          nextCursor: BrowserProviderId.optional(),
+        }),
+        // An acknowledgement is not progress or a terminal result, including cancel.
+        z.strictObject({ kind: z.literal("ack"), operation: z.enum(["invoke", "cancel"]), ...handle }),
+        z.strictObject({ kind: z.literal("status"), job: BrowserJobSnapshot }),
+        z.strictObject({ kind: z.literal("recovered"), job: BrowserJobSnapshot }),
+        z.strictObject({ kind: z.literal("not_found"), invocationId: BrowserInvocationId }),
+        z.strictObject({
+          kind: z.literal("error"),
+          code: BrowserFailureReason,
+          message: text(1024).min(1),
+          retryable: z.boolean(),
+        }),
+      ]),
+    }),
+  )
+  export type BrowserResponse = z.infer<typeof BrowserResponse>
+  export const BrowserEvent = boundary(
+    z.discriminatedUnion("event", [
+      z.strictObject({
+        type: z.literal("browser_event"),
+        requestId: correlation,
+        event: z.literal("progress"),
+        job: BrowserJobSnapshot.refine((job) => !BrowserTerminalStatus.safeParse(job.status).success, {
+          message: "Progress cannot contain a terminal result",
+        }),
+      }),
+      z.strictObject({
+        type: z.literal("browser_event"),
+        requestId: correlation,
+        event: z.literal("result"),
+        result: BrowserResult,
+      }),
+    ]),
+  )
+  export type BrowserEvent = z.infer<typeof BrowserEvent>
+  export const BrowserCLIInbound = z.union([BrowserResponse, BrowserEvent])
+
+  // The registration proof stays on the authenticated provider-to-relay boundary.
+  // Generation zero means first registration; other values name the last grant.
+  // The relay allocates the next generation and binds it to the actual socket.
+  export const BrowserProviderOutbound = boundary(
+    z
+      .discriminatedUnion("type", [
+        z.strictObject({
+          type: z.literal("provider_register"),
+          requestId: correlation,
+          providerId: BrowserProviderId,
+          generation: z.number().int().min(0).max(Number.MAX_SAFE_INTEGER),
+          providerProof: proof,
+          label: text(128).min(1),
+          enabled: z.literal(true),
+          recovery: z
+            .strictObject({
+              invocationId: BrowserInvocationId,
+              tabId: tab,
+              tabClosed: z.literal(true),
+              locksDrained: z.literal(true),
+            })
+            .optional(),
+        }),
+        z.strictObject({
+          type: z.literal("provider_heartbeat"),
+          requestId: correlation,
+          ...binding,
+          cursor: BrowserJobId.optional(),
+        }),
+        z.strictObject({
+          type: z.literal("provider_approval"),
+          ...bound,
+          approval: z.discriminatedUnion("decision", [
+            z.strictObject({ decision: z.literal("approved"), tab: BrowserApprovedTab }),
+            z.strictObject({ decision: z.literal("denied"), reason: z.literal("approval_denied") }),
+          ]),
+        }),
+        z.strictObject({
+          type: z.literal("provider_result"),
+          ...bound,
+          tab: BrowserApprovedTab,
+          result: BrowserResult,
+        }),
+        z.strictObject({ type: z.literal("provider_quiesced"), ...bound, tabId: tab }),
+        z.strictObject({
+          type: z.literal("provider_unavailable"),
+          ...binding,
+          reason: BrowserFailureReason,
+          effectsUncertain: z.boolean(),
+        }),
+        // Provider Stop targets this profile's exact job, not a client-selected parent.
+        z.strictObject({ type: z.literal("provider_cancel"), ...bound }),
+      ])
+      .refine((message) => message.type !== "provider_result" || same(message, message.result), {
+        message: "Provider result must match the job",
+      }),
+  )
+  export type BrowserProviderOutbound = z.infer<typeof BrowserProviderOutbound>
+
+  // These frames target only the registered provider socket, never ordinary web
+  // subscribers. A snapshot is reconciliation data, not permission to execute.
+  export const BrowserProviderInbound = boundary(
+    z
+      .discriminatedUnion("type", [
+        z.strictObject({
+          type: z.literal("provider_job"),
+          job: BrowserJobSnapshot.refine((job) => job.status === "awaiting_approval", {
+            message: "Dispatch requires tab approval",
+          }),
+          goal,
+          ownerLabel: text(128).min(1),
+        }),
+        z.strictObject({ type: z.literal("provider_job_cancel"), ...bound, reason: BrowserFailureReason }),
+        z.strictObject({
+          type: z.literal("provider_snapshot"),
+          ...binding,
+          requestId: correlation.optional(),
+          jobs: z.array(BrowserJobSnapshot).max(BROWSER_PAGE_SIZE),
+          nextCursor: BrowserJobId.optional(),
+        }),
+        z.strictObject({
+          type: z.literal("provider_lease_ack"),
+          ...binding,
+          requestId: correlation,
+          leaseExpiresAt: timestamp,
+        }),
+      ])
+      .refine(
+        (message) =>
+          message.type !== "provider_snapshot" ||
+          message.jobs.every((job) => job.providerId === message.providerId && job.generation === message.generation),
+        { message: "Snapshot must match the registered provider" },
+      ),
+  )
+  export type BrowserProviderInbound = z.infer<typeof BrowserProviderInbound>
+
+  // Opt-in consumers adopt these separately; the legacy parser exports never widen.
+  export const OutboundWithBrowser = z.union([Outbound, BrowserRequest])
+  export type OutboundWithBrowser = z.infer<typeof OutboundWithBrowser>
+  export const InboundWithBrowser = z.union([Inbound, BrowserCLIInbound])
+  export type InboundWithBrowser = z.infer<typeof InboundWithBrowser>
+  export const WebOutboundWithBrowser = z.union([WebOutbound, BrowserProviderOutbound])
+  export type WebOutboundWithBrowser = z.infer<typeof WebOutboundWithBrowser>
+  export const WebInboundWithBrowser = z.union([WebInbound, BrowserProviderInbound])
+  export type WebInboundWithBrowser = z.infer<typeof WebInboundWithBrowser>
 }

--- a/packages/opencode/src/kilo-sessions/remote-protocol.ts
+++ b/packages/opencode/src/kilo-sessions/remote-protocol.ts
@@ -514,7 +514,7 @@ export namespace RemoteProtocol {
           tab: BrowserApprovedTab,
           result: BrowserResult,
         }),
-        z.strictObject({ type: z.literal("provider_quiesced"), ...bound, tabId: tab }),
+        z.strictObject({ type: z.literal("provider_quiesced"), ...bound, tabId: tab.optional() }),
         z.strictObject({
           type: z.literal("provider_unavailable"),
           ...binding,

--- a/packages/opencode/src/kilo-sessions/remote-protocol.ts
+++ b/packages/opencode/src/kilo-sessions/remote-protocol.ts
@@ -561,6 +561,13 @@ export namespace RemoteProtocol {
             type: z.literal("provider_status_result"),
             requestId: correlation,
             providerId: BrowserProviderId,
+            // Old responses omit this field; retained identities can outlive job history.
+            unresolvedFence: z
+              .strictObject({
+                invocationId: BrowserInvocationId,
+                tabId: tab.optional(),
+              })
+              .optional(),
             jobs: z.array(BrowserJobSnapshot).max(BROWSER_PAGE_SIZE),
             nextCursor: BrowserJobId.optional(),
           })

--- a/packages/opencode/src/kilo-sessions/remote-protocol.ts
+++ b/packages/opencode/src/kilo-sessions/remote-protocol.ts
@@ -332,10 +332,16 @@ export namespace RemoteProtocol {
     .strictObject({
       ...metadata,
       status: BrowserJobStatus,
+      // Optional display metadata; legacy snapshots omit it.
+      ownerLabel: text(128).min(1).optional(),
+      queuePosition: z.number().int().min(1).max(100).optional(),
       approvedTab: BrowserApprovedTab.optional(),
       result: BrowserResult.optional(),
     })
     .superRefine((job, context) => {
+      if (job.queuePosition !== undefined && job.status !== "queued") {
+        context.addIssue({ code: "custom", message: "Queue position requires a queued job" })
+      }
       const terminal = BrowserTerminalStatus.safeParse(job.status).success
       if (
         terminal !== (job.result !== undefined) ||

--- a/packages/opencode/src/kilo-sessions/remote-protocol.ts
+++ b/packages/opencode/src/kilo-sessions/remote-protocol.ts
@@ -486,6 +486,14 @@ export namespace RemoteProtocol {
             })
             .optional(),
         }),
+        // Read-only history requires proof, not registration or a generation grant.
+        z.strictObject({
+          type: z.literal("provider_status"),
+          requestId: correlation,
+          providerId: BrowserProviderId,
+          providerProof: proof,
+          cursor: BrowserJobId.optional(),
+        }),
         z.strictObject({
           type: z.literal("provider_heartbeat"),
           requestId: correlation,
@@ -522,8 +530,9 @@ export namespace RemoteProtocol {
   )
   export type BrowserProviderOutbound = z.infer<typeof BrowserProviderOutbound>
 
-  // These frames target only the registered provider socket, never ordinary web
-  // subscribers. A snapshot is reconciliation data, not permission to execute.
+  // Provider frames never target ordinary web subscribers. Execution frames require
+  // a registered socket; status results require a proof-authorized request.
+  // A snapshot is reconciliation data, not permission to execute.
   export const BrowserProviderInbound = boundary(
     z
       .discriminatedUnion("type", [
@@ -543,6 +552,18 @@ export namespace RemoteProtocol {
           jobs: z.array(BrowserJobSnapshot).max(BROWSER_PAGE_SIZE),
           nextCursor: BrowserJobId.optional(),
         }),
+        // History grants no execution, lease, approval, or recovery authority.
+        z
+          .strictObject({
+            type: z.literal("provider_status_result"),
+            requestId: correlation,
+            providerId: BrowserProviderId,
+            jobs: z.array(BrowserJobSnapshot).max(BROWSER_PAGE_SIZE),
+            nextCursor: BrowserJobId.optional(),
+          })
+          .refine((message) => message.jobs.every((job) => job.providerId === message.providerId), {
+            message: "History must match the requested provider",
+          }),
         z.strictObject({
           type: z.literal("provider_lease_ack"),
           ...binding,

--- a/packages/opencode/src/kilo-sessions/remote-protocol.ts
+++ b/packages/opencode/src/kilo-sessions/remote-protocol.ts
@@ -480,7 +480,7 @@ export namespace RemoteProtocol {
           recovery: z
             .strictObject({
               invocationId: BrowserInvocationId,
-              tabId: tab,
+              tabId: tab.optional(),
               tabClosed: z.literal(true),
               locksDrained: z.literal(true),
             })

--- a/packages/opencode/src/kilo-sessions/remote-protocol.ts
+++ b/packages/opencode/src/kilo-sessions/remote-protocol.ts
@@ -543,6 +543,9 @@ export namespace RemoteProtocol {
           }),
           goal,
           ownerLabel: text(128).min(1),
+          // Old dispatches omit intent. Consumers must treat absence as unknown
+          // and reject execution, never infer permission to start a new conversation.
+          conversationMode: z.enum(["new", "continue"]).optional(),
         }),
         z.strictObject({ type: z.literal("provider_job_cancel"), ...bound, reason: BrowserFailureReason }),
         z.strictObject({

--- a/packages/opencode/test/kilocode/sessions/remote-protocol.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-protocol.test.ts
@@ -704,6 +704,14 @@ describe("RemoteProtocol browser jobs v1", () => {
     ],
     nextCursor: interrupted.jobId,
   } satisfies RemoteProtocol.BrowserProviderInbound
+  const fence = { invocationId: interrupted.invocationId, tabId: tab.tabId }
+  const expired = `b1.1.${"f".repeat(64)}`
+  const empty = {
+    type: "provider_status_result",
+    requestId,
+    providerId: handle.providerId,
+    jobs: [],
+  } satisfies RemoteProtocol.BrowserProviderInbound
   const sent = [
     status,
     { ...status, cursor: handle.jobId },
@@ -733,7 +741,9 @@ describe("RemoteProtocol browser jobs v1", () => {
     { type: "provider_snapshot", ...binding, jobs: [] },
     { type: "provider_lease_ack", requestId, ...binding, leaseExpiresAt: "2026-08-28T00:00:15.000Z" },
     history,
-    { type: "provider_status_result", requestId, providerId: handle.providerId, jobs: [] },
+    empty,
+    { ...history, unresolvedFence: fence },
+    { ...empty, unresolvedFence: { invocationId: expired } },
   ] satisfies RemoteProtocol.BrowserProviderInbound[]
 
   describe.each([
@@ -770,6 +780,92 @@ describe("RemoteProtocol browser jobs v1", () => {
   })
 
   describe("read-only provider status", () => {
+    test("keeps absent fences omitted from old status frames", () => {
+      for (const frame of [history, empty]) {
+        expect(RemoteProtocol.BrowserProviderInbound.parse(frame)).toStrictEqual(frame)
+        expect(RemoteProtocol.WebInboundWithBrowser.parse(frame)).toStrictEqual(frame)
+      }
+    })
+
+    test.each([
+      { invocationId: handle.invocationId },
+      fence,
+      { ...fence, tabId: 0 },
+      { ...fence, tabId: Number.MAX_SAFE_INTEGER },
+      { invocationId: expired },
+      { ...fence, invocationId: expired },
+    ])("preserves a compact fence without retained jobs: %j", (value) => {
+      const frame = { ...empty, unresolvedFence: value } satisfies RemoteProtocol.BrowserProviderInbound
+      expect(RemoteProtocol.BrowserProviderInbound.parse(frame)).toStrictEqual(frame)
+      expect(RemoteProtocol.WebInboundWithBrowser.parse(frame)).toStrictEqual(frame)
+    })
+
+    test.each([
+      { unresolvedFence: null },
+      { unresolvedFence: false },
+      { unresolvedFence: 0 },
+      { unresolvedFence: "fence" },
+      { unresolvedFence: [] },
+      { unresolvedFence: {} },
+      { unresolvedFence: { tabId: tab.tabId } },
+    ])("rejects malformed fence objects: %j", (fields) => {
+      const frame = { ...history, ...fields }
+      expect(RemoteProtocol.BrowserProviderInbound.safeParse(frame).success).toBe(false)
+      expect(RemoteProtocol.WebInboundWithBrowser.safeParse(frame).success).toBe(false)
+    })
+
+    test.each([
+      { invocationId: undefined },
+      { invocationId: null },
+      { invocationId: 7 },
+      { invocationId: "" },
+      { invocationId: handle.jobId },
+      { invocationId: `b1.0.${"a".repeat(64)}` },
+      { invocationId: `b1.01.${"a".repeat(64)}` },
+      { invocationId: `b1.8640000000000001.${"a".repeat(64)}` },
+      { invocationId: `b1.9007199254740992.${"a".repeat(64)}` },
+      { invocationId: `b1.1787875200000.${"A".repeat(64)}` },
+      { invocationId: `b1.1787875200000.${"a".repeat(63)}` },
+      { tabId: null },
+      { tabId: -1 },
+      { tabId: 1.5 },
+      { tabId: Number.MAX_SAFE_INTEGER + 1 },
+      { tabId: "7" },
+      { tabId: true },
+    ])("rejects invalid fence fields: %j", (fields) => {
+      const frame = { ...history, unresolvedFence: { ...fence, ...fields } }
+      expect(RemoteProtocol.BrowserProviderInbound.safeParse(frame).success).toBe(false)
+      expect(RemoteProtocol.WebInboundWithBrowser.safeParse(frame).success).toBe(false)
+    })
+
+    test.each([
+      { parentSessionId: owner.parentSessionId },
+      { parentProof: owner.parentProof },
+      { providerProof: registration.providerProof },
+      { connectionId: "private-route" },
+      { generation: 1 },
+      { goal: invoke.goal },
+      { result: completed },
+      { tabClosed: true },
+      { locksDrained: true },
+      { extra: true },
+    ])("rejects private or unknown fence fields: %j", (fields) => {
+      const frame = { ...history, unresolvedFence: { ...fence, ...fields } }
+      expect(RemoteProtocol.BrowserProviderInbound.safeParse(frame).success).toBe(false)
+      expect(RemoteProtocol.WebInboundWithBrowser.safeParse(frame).success).toBe(false)
+    })
+
+    test("keeps fence discovery out of execution frames and job snapshots", () => {
+      for (const frame of received) {
+        if (frame.type === "provider_status_result") continue
+        expect(RemoteProtocol.BrowserProviderInbound.safeParse({ ...frame, unresolvedFence: fence }).success).toBe(
+          false,
+        )
+        expect(RemoteProtocol.WebInboundWithBrowser.safeParse({ ...frame, unresolvedFence: fence }).success).toBe(false)
+      }
+      expect(RemoteProtocol.BrowserJobSnapshot.safeParse({ ...job, unresolvedFence: fence }).success).toBe(false)
+    })
+
     test("keeps historical generations separate from execution snapshots", () => {
       expect(RemoteProtocol.BrowserProviderInbound.parse(history)).toEqual(history)
       for (const generation of [1, 2]) {
@@ -862,8 +958,12 @@ describe("RemoteProtocol browser jobs v1", () => {
       }
     })
 
-    test("accepts 25 historical jobs but rejects a 26th job", () => {
-      const page = { ...history, jobs: Array.from({ length: 25 }, () => job) }
+    test("accepts 25 historical jobs with a fence but rejects a 26th job", () => {
+      const page = {
+        ...history,
+        unresolvedFence: fence,
+        jobs: Array.from({ length: 25 }, () => job),
+      } satisfies RemoteProtocol.BrowserProviderInbound
       expect(RemoteProtocol.BrowserProviderInbound.parse(page)).toEqual(page)
       expect(RemoteProtocol.BrowserProviderInbound.safeParse({ ...page, jobs: [...page.jobs, job] }).success).toBe(
         false,
@@ -877,6 +977,24 @@ describe("RemoteProtocol browser jobs v1", () => {
       expect(RemoteProtocol.BrowserProviderInbound.safeParse({ ...page, jobs: [...page.jobs, large] }).success).toBe(
         false,
       )
+    })
+
+    test("counts compact fences in the existing frame byte limit", () => {
+      const large = { ...finished, result: { ...completed, summary: "\u00e9".repeat(16384) } }
+      for (const schema of [RemoteProtocol.BrowserProviderInbound, RemoteProtocol.WebInboundWithBrowser]) {
+        const last = { ...finished, result: { ...completed, summary: "" } }
+        const page = {
+          ...history,
+          unresolvedFence: fence,
+          jobs: [large, large, large, last],
+        } satisfies RemoteProtocol.BrowserProviderInbound
+        last.result.summary = "x".repeat(128 * 1024 - 1 - Buffer.byteLength(JSON.stringify(page), "utf8"))
+        expect(schema.parse(page)).toEqual(page)
+        last.result.summary += "x"
+        expect(schema.safeParse(page).success).toBe(false)
+        const unfenced = { ...history, jobs: page.jobs }
+        expect(schema.parse(unfenced)).toEqual(unfenced)
+      }
     })
   })
 

--- a/packages/opencode/test/kilocode/sessions/remote-protocol.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-protocol.test.ts
@@ -712,15 +712,13 @@ describe("RemoteProtocol browser jobs v1", () => {
     providerId: handle.providerId,
     jobs: [],
   } satisfies RemoteProtocol.BrowserProviderInbound
+  const recovery = { invocationId: handle.invocationId, tabClosed: true, locksDrained: true } as const
   const sent = [
     status,
     { ...status, cursor: handle.jobId },
     registration,
-    {
-      ...registration,
-      generation: 1,
-      recovery: { invocationId: handle.invocationId, tabId: tab.tabId, tabClosed: true, locksDrained: true },
-    },
+    { ...registration, generation: 1, recovery },
+    { ...registration, generation: 1, recovery: { ...recovery, tabId: tab.tabId } },
     { type: "provider_heartbeat", requestId, ...binding, cursor: handle.jobId },
     { type: "provider_approval", ...bound, approval: { decision: "approved", tab } },
     { type: "provider_approval", ...bound, approval: { decision: "denied", reason: "approval_denied" } },
@@ -1387,26 +1385,68 @@ describe("RemoteProtocol browser jobs v1", () => {
     }
   })
 
-  test("requires closed tabs and drained locks on provider recovery registration", () => {
-    const recovery = { invocationId: handle.invocationId, tabId: tab.tabId, tabClosed: true, locksDrained: true }
-    for (const fields of [
+  describe("provider recovery registration", () => {
+    test.each([
+      recovery,
+      { ...recovery, tabId: tab.tabId },
+      { ...recovery, tabId: 0 },
+      { ...recovery, tabId: Number.MAX_SAFE_INTEGER },
+      { ...recovery, invocationId: expired },
+      { ...recovery, invocationId: expired, tabId: tab.tabId },
+    ])("preserves recovery identity and tab omission: %j", (recovery) => {
+      const frame = { ...registration, generation: 1, recovery }
+      expect(RemoteProtocol.BrowserProviderOutbound.parse(frame)).toStrictEqual(frame)
+      expect(RemoteProtocol.WebOutboundWithBrowser.parse(frame)).toStrictEqual(frame)
+    })
+
+    test.each([
+      { tabClosed: undefined },
       { tabClosed: false },
+      { tabClosed: "true" },
+      { tabClosed: 1 },
+      { locksDrained: undefined },
       { locksDrained: false },
-      { tabId: undefined },
+      { locksDrained: "true" },
+      { locksDrained: 1 },
       { invocationId: undefined },
+      { invocationId: null },
+      { invocationId: 7 },
+      { invocationId: "" },
+      { invocationId: handle.jobId },
+      { invocationId: `b1.0.${"a".repeat(64)}` },
+      { invocationId: `b1.01.${"a".repeat(64)}` },
+      { invocationId: `b1.8640000000000001.${"a".repeat(64)}` },
+      { invocationId: `b1.9007199254740992.${"a".repeat(64)}` },
+      { invocationId: `b1.1787875200000.${"A".repeat(64)}` },
+      { invocationId: `b1.1787875200000.${"a".repeat(63)}` },
       { owner },
-    ]) {
-      expect(
-        RemoteProtocol.BrowserProviderOutbound.safeParse({
-          ...registration,
-          generation: 1,
-          recovery: { ...recovery, ...fields },
-        }).success,
-      ).toBe(false)
-    }
-    for (const generation of [-1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
-      expect(RemoteProtocol.BrowserProviderOutbound.safeParse({ ...registration, generation }).success).toBe(false)
-    }
+      { extra: true },
+    ])("rejects unsafe or malformed recovery with and without a tab: %j", (fields) => {
+      for (const value of [{}, { tabId: tab.tabId }]) {
+        const frame = { ...registration, generation: 1, recovery: { ...recovery, ...value, ...fields } }
+        expect(RemoteProtocol.BrowserProviderOutbound.safeParse(frame).success).toBe(false)
+        expect(RemoteProtocol.WebOutboundWithBrowser.safeParse(frame).success).toBe(false)
+      }
+    })
+
+    test.each([
+      { tabId: null },
+      { tabId: -1 },
+      { tabId: 1.5 },
+      { tabId: Number.MAX_SAFE_INTEGER + 1 },
+      { tabId: "7" },
+      { tabId: true },
+      { tabId: [] },
+      { tabId: {} },
+    ])("rejects invalid supplied recovery tabs: %j", (fields) => {
+      const frame = { ...registration, generation: 1, recovery: { ...recovery, ...fields } }
+      expect(RemoteProtocol.BrowserProviderOutbound.safeParse(frame).success).toBe(false)
+      expect(RemoteProtocol.WebOutboundWithBrowser.safeParse(frame).success).toBe(false)
+    })
+  })
+
+  test.each([-1, 1.5, Number.MAX_SAFE_INTEGER + 1])("rejects invalid registration generation %s", (generation) => {
+    expect(RemoteProtocol.BrowserProviderOutbound.safeParse({ ...registration, generation }).success).toBe(false)
   })
 
   test.each([

--- a/packages/opencode/test/kilocode/sessions/remote-protocol.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-protocol.test.ts
@@ -671,7 +671,42 @@ describe("RemoteProtocol browser jobs v1", () => {
     { type: "browser_event", requestId, event: "progress", job },
     { type: "browser_event", requestId, event: "result", result: completed },
   ] satisfies RemoteProtocol.BrowserEvent[]
+  const status = {
+    type: "provider_status",
+    requestId,
+    providerId: handle.providerId,
+    providerProof: registration.providerProof,
+  } as const
+  const interrupted = {
+    ...handle,
+    jobId: "bj_00000000-0000-4000-8000-000000000005",
+    invocationId: `b1.1787875200000.${"e".repeat(64)}`,
+  } as const
+  const history = {
+    type: "provider_status_result",
+    requestId,
+    providerId: handle.providerId,
+    jobs: [
+      finished,
+      {
+        ...finished,
+        ...interrupted,
+        generation: 2,
+        status: "interrupted",
+        result: {
+          ...completed,
+          ...interrupted,
+          status: "interrupted",
+          reason: "effects_uncertain",
+          effectsUncertain: true,
+        },
+      },
+    ],
+    nextCursor: interrupted.jobId,
+  } satisfies RemoteProtocol.BrowserProviderInbound
   const sent = [
+    status,
+    { ...status, cursor: handle.jobId },
     registration,
     {
       ...registration,
@@ -692,7 +727,121 @@ describe("RemoteProtocol browser jobs v1", () => {
     { type: "provider_snapshot", requestId, ...binding, jobs: [job, finished], nextCursor: handle.jobId },
     { type: "provider_snapshot", ...binding, jobs: [] },
     { type: "provider_lease_ack", requestId, ...binding, leaseExpiresAt: "2026-08-28T00:00:15.000Z" },
+    history,
+    { type: "provider_status_result", requestId, providerId: handle.providerId, jobs: [] },
   ] satisfies RemoteProtocol.BrowserProviderInbound[]
+
+  describe("read-only provider status", () => {
+    test("keeps historical generations separate from execution snapshots", () => {
+      expect(RemoteProtocol.BrowserProviderInbound.parse(history)).toEqual(history)
+      for (const generation of [1, 2]) {
+        expect(
+          RemoteProtocol.BrowserProviderInbound.safeParse({
+            ...history,
+            type: "provider_snapshot",
+            generation,
+          }).success,
+        ).toBe(false)
+      }
+    })
+
+    test.each([
+      { requestId: undefined },
+      { requestId: "invalid" },
+      { providerId: undefined },
+      { providerId: handle.jobId },
+      { providerProof: undefined },
+      { providerProof: "d".repeat(63) },
+      { providerProof: "D".repeat(64) },
+      { cursor: handle.providerId },
+      { cursor: "" },
+    ])("rejects malformed status requests: %j", (fields) => {
+      expect(RemoteProtocol.BrowserProviderOutbound.safeParse({ ...status, ...fields }).success).toBe(false)
+    })
+
+    test.each([
+      { requestId: undefined },
+      { requestId: "invalid" },
+      { providerId: undefined },
+      { providerId: handle.jobId },
+      { jobs: undefined },
+      { jobs: null },
+      { jobs: [{ ...job, generation: undefined }] },
+      { jobs: [{ ...job, generation: 0 }] },
+      { jobs: [{ ...finished, result: undefined }] },
+      { jobs: [{ ...finished, result: { ...completed, jobId: interrupted.jobId } }] },
+      { nextCursor: handle.providerId },
+      { nextCursor: "" },
+    ])("rejects malformed provider history: %j", (fields) => {
+      expect(RemoteProtocol.BrowserProviderInbound.safeParse({ ...history, ...fields }).success).toBe(false)
+    })
+
+    test.each([
+      { generation: 1 },
+      { enabled: true },
+      { leaseExpiresAt: "2026-08-28T00:00:15.000Z" },
+      { approval: { decision: "approved", tab } },
+      {
+        recovery: {
+          invocationId: handle.invocationId,
+          tabId: tab.tabId,
+          tabClosed: true,
+          locksDrained: true,
+        },
+      },
+    ])("rejects authority fields on status frames: %j", (fields) => {
+      expect(RemoteProtocol.BrowserProviderOutbound.safeParse({ ...status, ...fields }).success).toBe(false)
+      expect(RemoteProtocol.BrowserProviderInbound.safeParse({ ...history, ...fields }).success).toBe(false)
+    })
+
+    test("rejects otherwise valid history from another provider", () => {
+      const provider = "bp_00000000-0000-4000-8000-000000000006"
+      const foreign = {
+        ...finished,
+        providerId: provider,
+        result: { ...completed, providerId: provider },
+      } satisfies RemoteProtocol.BrowserJobSnapshot
+      expect(RemoteProtocol.BrowserJobSnapshot.parse(foreign)).toEqual(foreign)
+      expect(
+        RemoteProtocol.BrowserProviderInbound.safeParse({ ...history, jobs: [...history.jobs, foreign] }).success,
+      ).toBe(false)
+    })
+
+    test("redacts status proofs and attacker-controlled keys from parse errors", () => {
+      const secret = "private-status-proof-must-not-appear"
+      const cases = [
+        { schema: RemoteProtocol.BrowserProviderOutbound, frame: { ...status, providerProof: secret } },
+        { schema: RemoteProtocol.WebOutboundWithBrowser, frame: { ...status, [secret]: true } },
+        { schema: RemoteProtocol.BrowserProviderInbound, frame: { ...history, [secret]: true } },
+        { schema: RemoteProtocol.WebInboundWithBrowser, frame: { ...history, providerProof: secret } },
+      ]
+      for (const { schema, frame } of cases) {
+        const parsed = schema.safeParse(frame)
+        expect(parsed.success).toBe(false)
+        if (parsed.success) throw new Error("Invalid status frame was accepted")
+        expect(parsed.error.message).not.toContain(secret)
+        expect(JSON.stringify(parsed.error)).not.toContain(secret)
+      }
+    })
+
+    test("accepts 25 historical jobs but rejects a 26th job", () => {
+      const page = { ...history, jobs: Array.from({ length: 25 }, () => job) }
+      expect(RemoteProtocol.BrowserProviderInbound.parse(page)).toEqual(page)
+      expect(RemoteProtocol.BrowserProviderInbound.safeParse({ ...page, jobs: [...page.jobs, job] }).success).toBe(
+        false,
+      )
+    })
+
+    test("bounds historical pages by serialized UTF-8 bytes", () => {
+      const large = { ...finished, result: { ...completed, summary: "\u00e9".repeat(16384) } }
+      const page = { ...history, jobs: Array.from({ length: 3 }, () => large) }
+      expect(RemoteProtocol.BrowserProviderInbound.parse(page)).toEqual(page)
+      expect(RemoteProtocol.BrowserProviderInbound.safeParse({ ...page, jobs: [...page.jobs, large] }).success).toBe(
+        false,
+      )
+    })
+  })
+
   const operations = [
     { operation: "list" },
     { operation: "run", provider_id: handle.providerId, goal: invoke.goal },
@@ -823,13 +972,15 @@ describe("RemoteProtocol browser jobs v1", () => {
     }
   })
 
-  test("keeps private proofs only on owned requests and provider registration", () => {
+  test("keeps proofs on owned requests, registration, and provider status", () => {
     for (const direction of directions) {
       for (const frame of direction.frames) {
         for (const extra of [
           { parentProof: owner.parentProof },
           ...(frame.type === "browser_request" ? [] : [{ owner }]),
-          ...(frame.type === "provider_register" ? [] : [{ providerProof: registration.providerProof }]),
+          ...(frame.type === "provider_register" || frame.type === "provider_status"
+            ? []
+            : [{ providerProof: registration.providerProof }]),
         ]) {
           expect(direction.schema.safeParse({ ...frame, ...extra }).success).toBe(false)
         }

--- a/packages/opencode/test/kilocode/sessions/remote-protocol.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-protocol.test.ts
@@ -723,6 +723,7 @@ describe("RemoteProtocol browser jobs v1", () => {
     { type: "provider_approval", ...bound, approval: { decision: "approved", tab } },
     { type: "provider_approval", ...bound, approval: { decision: "denied", reason: "approval_denied" } },
     { type: "provider_result", ...bound, tab, result: completed },
+    { type: "provider_quiesced", ...bound },
     { type: "provider_quiesced", ...bound, tabId: tab.tabId },
     { type: "provider_unavailable", ...binding, reason: "provider_lost", effectsUncertain: true },
     { type: "provider_cancel", ...bound },
@@ -743,6 +744,82 @@ describe("RemoteProtocol browser jobs v1", () => {
     { ...history, unresolvedFence: fence },
     { ...empty, unresolvedFence: { invocationId: expired } },
   ] satisfies RemoteProtocol.BrowserProviderInbound[]
+
+  describe("provider quiescence", () => {
+    const quiesced = { type: "provider_quiesced", ...bound } as const
+
+    test.each([{}, { tabId: tab.tabId }, { tabId: 0 }, { tabId: Number.MAX_SAFE_INTEGER }])(
+      "preserves the exact binding and supplied or omitted tab: %j",
+      (fields) => {
+        const frame = { ...quiesced, ...fields }
+        expect(RemoteProtocol.BrowserProviderOutbound.parse(frame)).toStrictEqual(frame)
+        expect(RemoteProtocol.WebOutboundWithBrowser.parse(frame)).toStrictEqual(frame)
+      },
+    )
+
+    test.each([
+      { tabId: null },
+      { tabId: -1 },
+      { tabId: 1.5 },
+      { tabId: Number.MAX_SAFE_INTEGER + 1 },
+      { tabId: "7" },
+      { tabId: true },
+      { tabId: [] },
+      { tabId: {} },
+    ])("rejects invalid supplied quiescence tabs: %j", (fields) => {
+      const frame = { ...quiesced, ...fields }
+      expect(RemoteProtocol.BrowserProviderOutbound.safeParse(frame).success).toBe(false)
+      expect(RemoteProtocol.WebOutboundWithBrowser.safeParse(frame).success).toBe(false)
+    })
+
+    test.each([
+      { providerId: undefined },
+      { providerId: handle.jobId },
+      { browserTaskId: undefined },
+      { browserTaskId: handle.jobId },
+      { jobId: undefined },
+      { jobId: handle.providerId },
+      { invocationId: undefined },
+      { invocationId: handle.jobId },
+      { generation: undefined },
+      { generation: null },
+      { generation: 0 },
+      { generation: -1 },
+      { generation: 1.5 },
+      { generation: Number.MAX_SAFE_INTEGER + 1 },
+      { generation: "1" },
+    ])("rejects invalid or missing quiescence bindings: %j", (fields) => {
+      for (const value of [{}, { tabId: tab.tabId }]) {
+        const frame = JSON.parse(JSON.stringify({ ...quiesced, ...value, ...fields }))
+        expect(RemoteProtocol.BrowserProviderOutbound.safeParse(frame).success).toBe(false)
+        expect(RemoteProtocol.WebOutboundWithBrowser.safeParse(frame).success).toBe(false)
+      }
+    })
+
+    test.each([{ connectionId: "foreign-socket" }, { recovery }, { tabClosed: true }, { locksDrained: true }])(
+      "rejects socket or recovery authority on quiescence: %j",
+      (fields) => {
+        for (const value of [{}, { tabId: tab.tabId }]) {
+          const frame = { ...quiesced, ...value, ...fields }
+          expect(RemoteProtocol.BrowserProviderOutbound.safeParse(frame).success).toBe(false)
+          expect(RemoteProtocol.WebOutboundWithBrowser.safeParse(frame).success).toBe(false)
+        }
+      },
+    )
+
+    test.each([{ tab: undefined }, { tab: { ...tab, tabId: undefined } }])(
+      "keeps approved tabs required outside quiescence: %j",
+      (fields) => {
+        for (const frame of [
+          { type: "provider_approval", ...bound, approval: { decision: "approved", tab: fields.tab } },
+          { type: "provider_result", ...bound, tab: fields.tab, result: completed },
+        ]) {
+          expect(RemoteProtocol.BrowserProviderOutbound.safeParse(frame).success).toBe(false)
+          expect(RemoteProtocol.WebOutboundWithBrowser.safeParse(frame).success).toBe(false)
+        }
+      },
+    )
+  })
 
   describe.each([
     { name: "provider", schema: RemoteProtocol.BrowserProviderInbound },

--- a/packages/opencode/test/kilocode/sessions/remote-protocol.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-protocol.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { entries } from "remeda"
 import { RemoteProtocol } from "../../../src/kilo-sessions/remote-protocol"
 
 describe("RemoteProtocol", () => {
@@ -560,5 +561,762 @@ describe("RemoteProtocol", () => {
         prNumber: 7,
       })
     }
+  })
+})
+
+// Canonical v1 examples match the relay and SDK schema tests.
+describe("RemoteProtocol browser jobs v1", () => {
+  const requestId = "00000000-0000-4000-8000-000000000001"
+  const handle = {
+    providerId: "bp_00000000-0000-4000-8000-000000000002",
+    browserTaskId: "bt_00000000-0000-4000-8000-000000000003",
+    jobId: "bj_00000000-0000-4000-8000-000000000004",
+    invocationId: `b1.1787875200000.${"a".repeat(64)}`,
+  } as const
+  const owner = { parentSessionId: "ses_parent", parentProof: "b".repeat(64) }
+  const binding = { providerId: handle.providerId, generation: 1 }
+  const bound = { ...handle, generation: 1 }
+  const tab = { tabId: 7, title: "Example", url: "https://example.com/", effectiveMode: "safe" } as const
+  const job = {
+    ...bound,
+    payloadFingerprint: "c".repeat(64),
+    createdAt: "2026-08-28T00:00:00.000Z",
+    expiresAt: "2026-09-04T00:00:00.000Z",
+    deadlines: { queue: "2026-08-28T00:10:00.000Z", approval: "2026-08-28T00:02:00.000Z" },
+    status: "awaiting_approval",
+  } as const
+  const completed = {
+    ...handle,
+    status: "succeeded",
+    reason: "completed",
+    effectsUncertain: false,
+    summary: "Read the example page",
+    evidence: [{ text: "Example Domain", title: tab.title, url: tab.url }],
+  } satisfies RemoteProtocol.BrowserResult
+  const finished = { ...job, status: "succeeded", approvedTab: tab, result: completed } as const
+  const invoke = {
+    type: "browser_request",
+    requestId,
+    operation: "invoke",
+    owner,
+    providerId: handle.providerId,
+    invocationId: handle.invocationId,
+    goal: "Read the example page",
+  } as const
+  const registration = {
+    type: "provider_register",
+    requestId,
+    providerId: handle.providerId,
+    generation: 0,
+    providerProof: "d".repeat(64),
+    label: "Work browser",
+    enabled: true,
+  } as const
+  const provider = {
+    providerId: handle.providerId,
+    label: registration.label,
+    availability: "available",
+    queueDepth: 0,
+  } as const
+  const requests = [
+    { type: "browser_request", requestId, operation: "list" },
+    { type: "browser_request", requestId, operation: "list", cursor: handle.providerId },
+    invoke,
+    { ...invoke, browserTaskId: handle.browserTaskId },
+    ...(["status", "cancel"] as const).flatMap<RemoteProtocol.BrowserRequest>((operation) => [
+      { type: "browser_request", requestId, operation, owner, browserTaskId: handle.browserTaskId },
+      {
+        type: "browser_request",
+        requestId,
+        operation,
+        owner,
+        browserTaskId: handle.browserTaskId,
+        jobId: handle.jobId,
+      },
+    ]),
+    { type: "browser_request", requestId, operation: "recover", owner, invocationId: handle.invocationId },
+  ] satisfies RemoteProtocol.BrowserRequest[]
+  const responses = [
+    { type: "browser_response", requestId, response: { kind: "providers", providers: [] } },
+    {
+      type: "browser_response",
+      requestId,
+      response: { kind: "providers", providers: [provider], nextCursor: handle.providerId },
+    },
+    ...(["invoke", "cancel"] as const).map<RemoteProtocol.BrowserResponse>((operation) => ({
+      type: "browser_response",
+      requestId,
+      response: { kind: "ack", operation, ...handle },
+    })),
+    { type: "browser_response", requestId, response: { kind: "status", job } },
+    { type: "browser_response", requestId, response: { kind: "recovered", job: finished } },
+    { type: "browser_response", requestId, response: { kind: "not_found", invocationId: handle.invocationId } },
+    {
+      type: "browser_response",
+      requestId,
+      response: { kind: "error", code: "provider_unavailable", message: "Open the browser panel", retryable: true },
+    },
+    {
+      type: "browser_response",
+      requestId,
+      response: {
+        kind: "error",
+        code: "owner_mismatch",
+        message: "This parent does not own the job",
+        retryable: false,
+      },
+    },
+  ] satisfies RemoteProtocol.BrowserResponse[]
+  const events = [
+    { type: "browser_event", requestId, event: "progress", job },
+    { type: "browser_event", requestId, event: "result", result: completed },
+  ] satisfies RemoteProtocol.BrowserEvent[]
+  const sent = [
+    registration,
+    {
+      ...registration,
+      generation: 1,
+      recovery: { invocationId: handle.invocationId, tabId: tab.tabId, tabClosed: true, locksDrained: true },
+    },
+    { type: "provider_heartbeat", requestId, ...binding, cursor: handle.jobId },
+    { type: "provider_approval", ...bound, approval: { decision: "approved", tab } },
+    { type: "provider_approval", ...bound, approval: { decision: "denied", reason: "approval_denied" } },
+    { type: "provider_result", ...bound, tab, result: completed },
+    { type: "provider_quiesced", ...bound, tabId: tab.tabId },
+    { type: "provider_unavailable", ...binding, reason: "provider_lost", effectsUncertain: true },
+    { type: "provider_cancel", ...bound },
+  ] satisfies RemoteProtocol.BrowserProviderOutbound[]
+  const received = [
+    { type: "provider_job", job, goal: invoke.goal, ownerLabel: "Parent chat" },
+    { type: "provider_job_cancel", ...bound, reason: "cancelled" },
+    { type: "provider_snapshot", requestId, ...binding, jobs: [job, finished], nextCursor: handle.jobId },
+    { type: "provider_snapshot", ...binding, jobs: [] },
+    { type: "provider_lease_ack", requestId, ...binding, leaseExpiresAt: "2026-08-28T00:00:15.000Z" },
+  ] satisfies RemoteProtocol.BrowserProviderInbound[]
+  const operations = [
+    { operation: "list" },
+    { operation: "run", provider_id: handle.providerId, goal: invoke.goal },
+    { operation: "run", provider_id: handle.providerId, goal: invoke.goal, browser_task_id: handle.browserTaskId },
+    ...(["status", "cancel"] as const).flatMap<RemoteProtocol.BrowserTaskArguments>((operation) => [
+      { operation, browser_task_id: handle.browserTaskId },
+      { operation, browser_task_id: handle.browserTaskId, job_id: handle.jobId },
+    ]),
+    { operation: "recover" },
+  ] satisfies RemoteProtocol.BrowserTaskArguments[]
+  const directions = [
+    {
+      name: "CLI requests",
+      schema: RemoteProtocol.BrowserRequest,
+      composite: RemoteProtocol.OutboundWithBrowser,
+      frames: requests,
+    },
+    {
+      name: "CLI replies",
+      schema: RemoteProtocol.BrowserCLIInbound,
+      composite: RemoteProtocol.InboundWithBrowser,
+      frames: [...responses, ...events],
+    },
+    {
+      name: "provider outbound",
+      schema: RemoteProtocol.BrowserProviderOutbound,
+      composite: RemoteProtocol.WebOutboundWithBrowser,
+      frames: sent,
+    },
+    {
+      name: "provider inbound",
+      schema: RemoteProtocol.BrowserProviderInbound,
+      composite: RemoteProtocol.WebInboundWithBrowser,
+      frames: received,
+    },
+  ]
+
+  test.each(directions)("round-trips canonical $name only in its opt-in direction", ({ schema, composite, frames }) => {
+    for (const frame of frames) {
+      const wire = JSON.parse(JSON.stringify(frame))
+      expect(schema.parse(wire)).toEqual(frame)
+      expect(composite.parse(wire)).toEqual(frame)
+      expect(schema.safeParse({ ...frame, extra: true }).success).toBe(false)
+      expect(composite.safeParse({ ...frame, extra: true }).success).toBe(false)
+      for (const other of directions) {
+        if (other.schema === schema) continue
+        expect(other.schema.safeParse(wire).success).toBe(false)
+        expect(other.composite.safeParse(wire).success).toBe(false)
+      }
+      for (const legacy of [
+        RemoteProtocol.Outbound,
+        RemoteProtocol.Inbound,
+        RemoteProtocol.WebOutbound,
+        RemoteProtocol.WebInbound,
+      ]) {
+        expect(legacy.safeParse(wire).success).toBe(false)
+      }
+    }
+  })
+
+  test("enforces the model operation matrix without model-selected authority", () => {
+    for (const args of operations) {
+      expect(RemoteProtocol.BrowserTaskArguments.parse(args)).toEqual(args)
+      for (const field of [
+        "owner",
+        "parentSessionId",
+        "parentProof",
+        "providerProof",
+        "userId",
+        "connectionId",
+        "invocationId",
+        "sessionID",
+        "messageID",
+        "callID",
+        "extra",
+      ]) {
+        expect(RemoteProtocol.BrowserTaskArguments.safeParse({ ...args, [field]: "untrusted" }).success).toBe(false)
+      }
+    }
+    for (const args of [
+      { operation: "run", goal: invoke.goal },
+      { operation: "run", provider_id: handle.providerId },
+      { operation: "invoke", provider_id: handle.providerId, goal: invoke.goal },
+      { operation: "list", provider_id: handle.providerId },
+    ]) {
+      expect(RemoteProtocol.BrowserTaskArguments.safeParse(args).success).toBe(false)
+    }
+  })
+
+  test("requires a conversation for status and cancel, even with an exact job ID", () => {
+    for (const operation of ["status", "cancel"]) {
+      expect(RemoteProtocol.BrowserTaskArguments.safeParse({ operation, job_id: handle.jobId }).success).toBe(false)
+      const frame = { type: "browser_request", requestId, operation, owner, jobId: handle.jobId }
+      expect(RemoteProtocol.BrowserRequest.safeParse(frame).success).toBe(false)
+      expect(RemoteProtocol.BrowserRequest.safeParse({ ...frame, browserTaskId: handle.jobId }).success).toBe(false)
+      expect(
+        RemoteProtocol.BrowserRequest.safeParse({ ...frame, browserTaskId: handle.browserTaskId, owner: undefined })
+          .success,
+      ).toBe(false)
+    }
+  })
+
+  test("keeps recovery lookup-only with trusted parent and invocation", () => {
+    const recover = {
+      type: "browser_request",
+      requestId,
+      operation: "recover",
+      owner,
+      invocationId: handle.invocationId,
+    }
+    for (const extra of [
+      { goal: invoke.goal },
+      { providerId: handle.providerId },
+      { jobId: handle.jobId },
+      { browserTaskId: handle.browserTaskId },
+      { owner: undefined },
+      { invocationId: undefined },
+    ]) {
+      expect(RemoteProtocol.BrowserRequest.safeParse({ ...recover, ...extra }).success).toBe(false)
+    }
+    for (const extra of [
+      { goal: invoke.goal },
+      { provider_id: handle.providerId },
+      { browser_task_id: handle.browserTaskId },
+      { job_id: handle.jobId },
+    ]) {
+      expect(RemoteProtocol.BrowserTaskArguments.safeParse({ operation: "recover", ...extra }).success).toBe(false)
+    }
+  })
+
+  test("keeps private proofs only on owned requests and provider registration", () => {
+    for (const direction of directions) {
+      for (const frame of direction.frames) {
+        for (const extra of [
+          { parentProof: owner.parentProof },
+          ...(frame.type === "browser_request" ? [] : [{ owner }]),
+          ...(frame.type === "provider_register" ? [] : [{ providerProof: registration.providerProof }]),
+        ]) {
+          expect(direction.schema.safeParse({ ...frame, ...extra }).success).toBe(false)
+        }
+      }
+    }
+    expect(
+      RemoteProtocol.BrowserRequest.safeParse({ type: "browser_request", requestId, operation: "list", owner }).success,
+    ).toBe(false)
+    expect(
+      RemoteProtocol.BrowserRequest.safeParse({ ...invoke, owner: { parentSessionId: owner.parentSessionId } }).success,
+    ).toBe(false)
+    expect(
+      RemoteProtocol.BrowserProviderOutbound.safeParse({ ...registration, providerProof: undefined }).success,
+    ).toBe(false)
+    expect(
+      RemoteProtocol.BrowserResponse.safeParse({
+        type: "browser_response",
+        requestId,
+        response: { kind: "providers", providers: [{ ...provider, providerProof: registration.providerProof }] },
+      }).success,
+    ).toBe(false)
+    expect(
+      RemoteProtocol.BrowserProviderInbound.safeParse({
+        type: "provider_job",
+        job: { ...job, owner },
+        goal: invoke.goal,
+        ownerLabel: "Parent chat",
+      }).success,
+    ).toBe(false)
+    expect(
+      RemoteProtocol.BrowserEvent.safeParse({
+        type: "browser_event",
+        requestId,
+        event: "result",
+        result: { ...completed, parentProof: owner.parentProof },
+      }).success,
+    ).toBe(false)
+  })
+
+  test("redacts proof values and attacker-controlled key names from errors and previews", () => {
+    const secret = "private-proof-must-not-appear"
+    for (const { schema, composite, frames } of directions) {
+      for (const frame of frames) {
+        const input = {
+          ...frame,
+          [secret]: true,
+          owner: { ...owner, parentProof: secret, [secret]: true },
+          providerProof: secret,
+        }
+        for (const parser of [schema, composite]) {
+          const parsed = parser.safeParse(input)
+          expect(parsed.success).toBe(false)
+          if (parsed.success) throw new Error("Invalid proof-bearing input was accepted")
+          expect(parsed.error.message).not.toContain(secret)
+          expect(JSON.stringify(parsed.error)).not.toContain(secret)
+        }
+        expect(RemoteProtocol.Preview.parse(input)).toEqual({ type: frame.type })
+      }
+    }
+    const parsed = RemoteProtocol.BrowserTaskArguments.safeParse({ operation: "recover", [secret]: true })
+    expect(parsed.success).toBe(false)
+    if (parsed.success) throw new Error("Model-selected proof was accepted")
+    expect(parsed.error.message).not.toContain(secret)
+    expect(JSON.stringify(parsed.error)).not.toContain(secret)
+  })
+
+  test.each([
+    { requestId: "request-1" },
+    { requestId: "" },
+    { providerId: handle.browserTaskId },
+    { browserTaskId: handle.jobId },
+    { providerId: "bp_not-a-uuid" },
+    { invocationId: `b1.0.${"a".repeat(64)}` },
+    { invocationId: `b1.01787875200000.${"a".repeat(64)}` },
+    { invocationId: `b1.8640000000000001.${"a".repeat(64)}` },
+    { invocationId: `b1.9007199254740992.${"a".repeat(64)}` },
+    { invocationId: `b1.1787875200000.${"A".repeat(64)}` },
+    { owner: { ...owner, parentSessionId: "parent" } },
+    { owner: { ...owner, connectionId: "untrusted" } },
+  ])("rejects malformed request identities: %j", (fields) => {
+    expect(RemoteProtocol.BrowserRequest.safeParse({ ...invoke, ...fields }).success).toBe(false)
+  })
+
+  test("requires correlation IDs and separates acknowledgement, progress, and results", () => {
+    for (const frame of requests) {
+      expect(RemoteProtocol.BrowserRequest.safeParse({ ...frame, requestId: undefined }).success).toBe(false)
+    }
+    for (const frame of [...responses, ...events]) {
+      expect(RemoteProtocol.BrowserCLIInbound.safeParse({ ...frame, requestId: undefined }).success).toBe(false)
+    }
+    expect(
+      RemoteProtocol.BrowserResponse.safeParse({
+        type: "browser_response",
+        requestId,
+        response: { kind: "ack", operation: "cancel", ...handle, result: completed },
+      }).success,
+    ).toBe(false)
+    expect(
+      RemoteProtocol.BrowserEvent.safeParse({ type: "browser_event", requestId, event: "progress", job: finished })
+        .success,
+    ).toBe(false)
+    expect(
+      RemoteProtocol.BrowserEvent.safeParse({
+        type: "browser_event",
+        requestId,
+        event: "result",
+        result: { ...completed, status: "running" },
+      }).success,
+    ).toBe(false)
+  })
+
+  const statuses = {
+    queued: null,
+    awaiting_approval: null,
+    running: null,
+    succeeded: completed,
+    failed: { ...completed, status: "failed", reason: "runner_failed", effectsUncertain: false },
+    cancelled: { ...completed, status: "cancelled", reason: "cancelled", effectsUncertain: false },
+    interrupted: { ...completed, status: "interrupted", reason: "effects_uncertain", effectsUncertain: true },
+    timed_out: { ...completed, status: "timed_out", reason: "execution_timeout", effectsUncertain: true },
+  } satisfies Record<RemoteProtocol.BrowserJobSnapshot["status"], RemoteProtocol.BrowserResult | null>
+
+  test.each(entries(statuses))("enforces the observable result contract for %s", (status, result) => {
+    const snapshot = {
+      ...job,
+      status,
+      ...(status === "running" ? { approvedTab: tab } : {}),
+      ...(result ? { result } : {}),
+    }
+    expect(RemoteProtocol.BrowserJobSnapshot.parse(snapshot)).toEqual(snapshot)
+    if (result) {
+      const frame = { type: "browser_event", requestId, event: "result", result } satisfies RemoteProtocol.BrowserEvent
+      expect(RemoteProtocol.BrowserEvent.parse(frame)).toEqual(frame)
+      expect(RemoteProtocol.BrowserJobSnapshot.safeParse({ ...snapshot, result: undefined }).success).toBe(false)
+      return
+    }
+    const frame = {
+      type: "browser_event",
+      requestId,
+      event: "progress",
+      job: snapshot,
+    } satisfies RemoteProtocol.BrowserEvent
+    expect(RemoteProtocol.BrowserEvent.parse(frame)).toEqual(frame)
+    expect(RemoteProtocol.BrowserJobSnapshot.safeParse({ ...snapshot, result: completed }).success).toBe(false)
+  })
+
+  test("rejects false success, unknown states, empty evidence, and mismatched results", () => {
+    expect(RemoteProtocol.BrowserJobSnapshot.safeParse({ ...job, status: "idle" }).success).toBe(false)
+    for (const fields of [
+      { effectsUncertain: true },
+      { reason: "runner_failed" },
+      { status: "failed" },
+      { summary: "" },
+      { evidence: [{}] },
+      { evidence: [{ text: "Observed", screenshot: "data:image/png;base64,AAAA" }] },
+    ]) {
+      expect(RemoteProtocol.BrowserResult.safeParse({ ...completed, ...fields }).success).toBe(false)
+    }
+    for (const field of ["providerId", "browserTaskId", "jobId", "invocationId"] as const) {
+      const result = { ...completed, [field]: handle[field].replace(/.$/, "5") }
+      expect(RemoteProtocol.BrowserJobSnapshot.safeParse({ ...finished, result }).success).toBe(false)
+      expect(
+        RemoteProtocol.BrowserProviderOutbound.safeParse({ type: "provider_result", ...bound, tab, result }).success,
+      ).toBe(false)
+    }
+    expect(RemoteProtocol.BrowserJobSnapshot.safeParse({ ...finished, status: "failed" }).success).toBe(false)
+  })
+
+  test.each([
+    "approval_denied",
+    "permission_denied",
+    "invocation_expired",
+    "invocation_conflict",
+    "conversation_busy",
+    "capacity_exceeded",
+    "tab_lost",
+    "provider_lost",
+    "provider_unavailable",
+    "queue_timeout",
+    "approval_timeout",
+    "execution_timeout",
+    "lease_expired",
+    "effects_uncertain",
+    "cancelled",
+    "runner_failed",
+    "unsupported",
+    "invalid_request",
+    "owner_mismatch",
+    "not_found",
+  ])("retains finite error reason %s", (code) => {
+    const frame = {
+      type: "browser_response",
+      requestId,
+      response: { kind: "error", code, message: "Browser request rejected", retryable: false },
+    } satisfies RemoteProtocol.BrowserResponse
+    expect(RemoteProtocol.BrowserResponse.parse(frame)).toEqual(frame)
+    expect(
+      RemoteProtocol.BrowserResponse.safeParse({ ...frame, response: { ...frame.response, code: `${code}_unknown` } })
+        .success,
+    ).toBe(false)
+  })
+
+  test("binds approval and cancellation to an invocation and generation, not parent authority", () => {
+    const approval = { type: "provider_approval", ...bound, approval: { decision: "approved", tab } }
+    const cancel = { type: "provider_cancel", ...bound }
+    for (const frame of [approval, cancel]) {
+      for (const field of Object.keys(bound)) {
+        expect(RemoteProtocol.BrowserProviderOutbound.safeParse({ ...frame, [field]: undefined }).success).toBe(false)
+      }
+      expect(RemoteProtocol.BrowserProviderOutbound.safeParse({ ...frame, generation: 0 }).success).toBe(false)
+      expect(RemoteProtocol.BrowserProviderOutbound.safeParse({ ...frame, owner }).success).toBe(false)
+    }
+    for (const fields of [
+      { tabId: -1 },
+      { tabId: 1.5 },
+      { title: undefined },
+      { url: "not-a-url" },
+      { effectiveMode: "automatic" },
+      { extra: true },
+    ]) {
+      expect(
+        RemoteProtocol.BrowserProviderOutbound.safeParse({
+          ...approval,
+          approval: { decision: "approved", tab: { ...tab, ...fields } },
+        }).success,
+      ).toBe(false)
+    }
+    expect(RemoteProtocol.BrowserJobSnapshot.safeParse({ ...job, status: "running" }).success).toBe(false)
+    for (const status of ["queued", "awaiting_approval"]) {
+      expect(RemoteProtocol.BrowserJobSnapshot.safeParse({ ...job, status, approvedTab: tab }).success).toBe(false)
+    }
+    expect(
+      RemoteProtocol.BrowserProviderInbound.safeParse({
+        type: "provider_job",
+        job: { ...job, status: "running", approvedTab: tab },
+        goal: invoke.goal,
+        ownerLabel: "Parent chat",
+      }).success,
+    ).toBe(false)
+    for (const fields of [{ generation: 2 }, { providerId: handle.providerId.replace(/.$/, "5") }]) {
+      expect(
+        RemoteProtocol.BrowserProviderInbound.safeParse({
+          type: "provider_snapshot",
+          ...binding,
+          jobs: [{ ...job, ...fields }],
+        }).success,
+      ).toBe(false)
+    }
+  })
+
+  test("requires closed tabs and drained locks on provider recovery registration", () => {
+    const recovery = { invocationId: handle.invocationId, tabId: tab.tabId, tabClosed: true, locksDrained: true }
+    for (const fields of [
+      { tabClosed: false },
+      { locksDrained: false },
+      { tabId: undefined },
+      { invocationId: undefined },
+      { owner },
+    ]) {
+      expect(
+        RemoteProtocol.BrowserProviderOutbound.safeParse({
+          ...registration,
+          generation: 1,
+          recovery: { ...recovery, ...fields },
+        }).success,
+      ).toBe(false)
+    }
+    for (const generation of [-1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+      expect(RemoteProtocol.BrowserProviderOutbound.safeParse({ ...registration, generation }).success).toBe(false)
+    }
+  })
+
+  test.each([
+    { createdAt: "2026-08-28" },
+    { createdAt: "2026-08-28T00:00:00Z" },
+    { createdAt: "2026-02-30T00:00:00.000Z" },
+    { createdAt: "2026-08-28T00:00:00.000+01:00" },
+    { expiresAt: "2026-08-27T00:00:00.000Z" },
+    { payloadFingerprint: "not-a-digest" },
+    { deadlines: { queue: "2026-08-27T00:00:00.000Z" } },
+    { deadlines: { queue: "2026-09-04T00:00:00.001Z" } },
+    { deadlines: { ...job.deadlines, execution: "2026-09-04T00:00:00.001Z" } },
+    { deadlines: { ...job.deadlines, lease: "invalid" } },
+    { deadlines: { ...job.deadlines, extra: true } },
+  ])("rejects malformed metadata and out-of-retention deadlines: %j", (fields) => {
+    expect(RemoteProtocol.BrowserJobSnapshot.safeParse({ ...job, ...fields }).success).toBe(false)
+  })
+
+  test("applies UTF-8 byte limits instead of JavaScript string lengths", () => {
+    const goal = "\u00e9".repeat(8192)
+    const args = {
+      operation: "run",
+      provider_id: handle.providerId,
+      goal,
+    } satisfies RemoteProtocol.BrowserTaskArguments
+    expect(RemoteProtocol.BrowserRequest.parse({ ...invoke, goal })).toMatchObject({ goal })
+    expect(RemoteProtocol.BrowserTaskArguments.parse(args)).toEqual(args)
+    expect(RemoteProtocol.BrowserRequest.safeParse({ ...invoke, goal: `${goal}a` }).success).toBe(false)
+    expect(RemoteProtocol.BrowserTaskArguments.safeParse({ ...args, goal: `${goal}a` }).success).toBe(false)
+    expect(RemoteProtocol.BrowserRequest.safeParse({ ...invoke, goal: "" }).success).toBe(false)
+    expect(
+      RemoteProtocol.BrowserProviderOutbound.safeParse({ ...registration, label: "\u00e9".repeat(65) }).success,
+    ).toBe(false)
+    for (const fields of [
+      { summary: "\u00e9".repeat(16385) },
+      { evidence: [{ text: "\u00e9".repeat(4097) }] },
+      { evidence: [{ title: "\u00e9".repeat(513) }] },
+      { evidence: [{ url: `https://example.com/${"\u00e9".repeat(4096)}` }] },
+    ]) {
+      expect(RemoteProtocol.BrowserResult.safeParse({ ...completed, ...fields }).success).toBe(false)
+    }
+    expect(
+      RemoteProtocol.BrowserResponse.safeParse({
+        type: "browser_response",
+        requestId,
+        response: { kind: "error", code: "invalid_request", message: "\u00e9".repeat(513), retryable: false },
+      }).success,
+    ).toBe(false)
+  })
+
+  test("bounds serialized results at 64 KiB and complete frames below 128 KiB", () => {
+    const padding = { text: "" }
+    const evidence = [...Array.from({ length: 3 }, () => ({ text: "x".repeat(8192) })), padding]
+    const result = { ...completed, summary: "x".repeat(32768), evidence }
+    padding.text = "x".repeat(65536 - Buffer.byteLength(JSON.stringify(result), "utf8"))
+    expect(RemoteProtocol.BrowserResult.parse(result)).toEqual(result)
+    expect(
+      RemoteProtocol.BrowserResult.safeParse({ ...result, summary: `${result.summary.slice(1)}\u00e9` }).success,
+    ).toBe(false)
+    const snapshot = { ...finished, result }
+    const frame = {
+      type: "provider_snapshot",
+      ...binding,
+      jobs: [snapshot],
+    } satisfies RemoteProtocol.BrowserProviderInbound
+    expect(RemoteProtocol.BrowserProviderInbound.parse(frame)).toEqual(frame)
+    expect(RemoteProtocol.BrowserProviderInbound.safeParse({ ...frame, jobs: [snapshot, snapshot] }).success).toBe(
+      false,
+    )
+    expect(
+      RemoteProtocol.BrowserResult.safeParse({
+        ...completed,
+        evidence: Array.from({ length: 33 }, () => ({ text: "Observed" })),
+      }).success,
+    ).toBe(false)
+  })
+
+  test("bounds discovery pages, snapshot pages, and queue depth", () => {
+    const frame = {
+      type: "browser_response",
+      requestId,
+      response: { kind: "providers", providers: Array.from({ length: 25 }, () => provider) },
+    } satisfies RemoteProtocol.BrowserResponse
+    expect(RemoteProtocol.BrowserResponse.parse(frame)).toEqual(frame)
+    expect(
+      RemoteProtocol.BrowserResponse.safeParse({
+        ...frame,
+        response: { ...frame.response, providers: [...frame.response.providers, provider] },
+      }).success,
+    ).toBe(false)
+    expect(
+      RemoteProtocol.BrowserResponse.safeParse({
+        ...frame,
+        response: { ...frame.response, providers: [{ ...provider, queueDepth: 101 }] },
+      }).success,
+    ).toBe(false)
+    expect(
+      RemoteProtocol.BrowserProviderInbound.safeParse({
+        type: "provider_snapshot",
+        ...binding,
+        jobs: Array.from({ length: 26 }, () => job),
+      }).success,
+    ).toBe(false)
+  })
+
+  test.each([
+    { capabilities: undefined, supported: false },
+    { capabilities: {}, supported: false },
+    { capabilities: { browserJobsV1: false }, supported: false },
+    { capabilities: { browserJobsV1: true }, supported: true },
+  ])("normalizes negotiation without changing legacy envelopes: %j", ({ capabilities, supported }) => {
+    const cases = [
+      { schema: RemoteProtocol.Outbound, frame: { type: "heartbeat" as const, sessions: [] } },
+      { schema: RemoteProtocol.Inbound, frame: { type: "heartbeat_ack" as const } },
+      { schema: RemoteProtocol.WebOutbound, frame: { type: "ping" as const, nonce: "legacy-nonce" } },
+      { schema: RemoteProtocol.WebInbound, frame: { type: "pong" as const, nonce: "legacy-nonce" } },
+    ]
+    for (const { schema, frame } of cases) {
+      const input = { ...frame, ...(capabilities === undefined ? {} : { capabilities }) }
+      const parsed = schema.parse(input)
+      expect(parsed).toEqual(input)
+      const advertised = "capabilities" in parsed ? parsed.capabilities : undefined
+      expect(RemoteProtocol.NormalizedBrowserCapabilities.parse(advertised)).toEqual({ browserJobsV1: supported })
+      expect(schema.safeParse({ ...frame, capabilities: { browserJobsV1: "yes" } }).success).toBe(false)
+    }
+  })
+
+  // Frozen pre-browser callbacks must remain assignable to the legacy parser output.
+  type LegacyInbound =
+    | { type: "subscribe" | "unsubscribe"; sessionId: string }
+    | { type: "command"; id: string; command: string; sessionId?: string; data: unknown }
+    | { type: "system"; event: string; data: unknown }
+    | { type: "heartbeat_ack" }
+  type LegacyWebInbound =
+    | { type: "event"; sessionId: string; event: string; data: unknown }
+    | { type: "system"; event: string; data: unknown }
+    | { type: "response"; id: string; result?: unknown; error?: unknown }
+    | { type: "pong"; nonce: string }
+  const cli: (message: RemoteProtocol.Inbound) => string = (message: LegacyInbound) => {
+    switch (message.type) {
+      case "subscribe":
+      case "unsubscribe":
+        return `${message.type}:${message.sessionId}`
+      case "command":
+        return `${message.command}:${message.id}`
+      case "system":
+        return message.event
+      case "heartbeat_ack":
+        return "alive"
+    }
+    throw new Error("Unexpected legacy CLI message")
+  }
+  const web: (message: RemoteProtocol.WebInbound) => unknown = (message: LegacyWebInbound) => {
+    switch (message.type) {
+      case "event":
+        return `${message.sessionId}:${message.event}`
+      case "system":
+        return message.event
+      case "response":
+        return message.error ?? message.result
+      case "pong":
+        return message.nonce
+    }
+    throw new Error("Unexpected legacy web message")
+  }
+
+  test("preserves legacy callback types and delivered values", () => {
+    const cliExamples = [
+      { frame: { type: "subscribe", sessionId: "legacy-session" }, value: "subscribe:legacy-session" },
+      { frame: { type: "unsubscribe", sessionId: "legacy-session" }, value: "unsubscribe:legacy-session" },
+      {
+        frame: { type: "command", id: "legacy-request", command: "list_sessions", data: null },
+        value: "list_sessions:legacy-request",
+      },
+      { frame: { type: "system", event: "web.connected", data: {} }, value: "web.connected" },
+      { frame: { type: "heartbeat_ack" }, value: "alive" },
+    ] satisfies { frame: RemoteProtocol.Inbound; value: string }[]
+    const webExamples = [
+      {
+        frame: { type: "event", sessionId: "legacy-session", event: "message.updated", data: {} },
+        value: "legacy-session:message.updated",
+      },
+      { frame: { type: "system", event: "cli.connected", data: {} }, value: "cli.connected" },
+      { frame: { type: "response", id: "legacy-request", result: { ok: true } }, value: { ok: true } },
+      { frame: { type: "response", id: "legacy-request", error: "not found" }, value: "not found" },
+      { frame: { type: "pong", nonce: "legacy-nonce" }, value: "legacy-nonce" },
+    ] satisfies { frame: RemoteProtocol.WebInbound; value: unknown }[]
+    for (const { frame, value } of cliExamples) {
+      expect(cli(RemoteProtocol.Inbound.parse(frame))).toEqual(value)
+      expect(RemoteProtocol.InboundWithBrowser.parse(frame)).toEqual(frame)
+    }
+    for (const { frame, value } of webExamples) {
+      expect(web(RemoteProtocol.WebInbound.parse(frame))).toEqual(value)
+      expect(RemoteProtocol.WebInboundWithBrowser.parse(frame)).toEqual(frame)
+    }
+    for (const frame of [
+      { type: "heartbeat", sessions: [] },
+      { type: "event", sessionId: "legacy-session", event: "message.updated", data: {} },
+      { type: "response", id: "legacy-request", error: { arbitrary: ["legacy"] } },
+    ] satisfies RemoteProtocol.Outbound[]) {
+      expect(RemoteProtocol.OutboundWithBrowser.parse(frame)).toEqual(frame)
+    }
+    for (const frame of [
+      { type: "subscribe", sessionId: "legacy-session" },
+      { type: "unsubscribe", sessionId: "legacy-session" },
+      { type: "command", id: "legacy-request", command: "list_sessions" },
+      { type: "ping", nonce: "legacy-nonce" },
+    ] satisfies RemoteProtocol.WebOutbound[]) {
+      expect(RemoteProtocol.WebOutboundWithBrowser.parse(frame)).toEqual(frame)
+    }
+    expect(RemoteProtocol.Inbound.parse({ type: "subscribe", sessionId: "legacy-session", extra: true })).toEqual({
+      type: "subscribe",
+      sessionId: "legacy-session",
+    })
+    expect(RemoteProtocol.WebOutbound.parse({ type: "subscribe", sessionId: "legacy-session", extra: true })).toEqual({
+      type: "subscribe",
+      sessionId: "legacy-session",
+    })
   })
 })

--- a/packages/opencode/test/kilocode/sessions/remote-protocol.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-protocol.test.ts
@@ -1334,6 +1334,190 @@ describe("RemoteProtocol browser jobs v1", () => {
     timed_out: { ...completed, status: "timed_out", reason: "execution_timeout", effectsUncertain: true },
   } satisfies Record<RemoteProtocol.BrowserJobSnapshot["status"], RemoteProtocol.BrowserResult | null>
 
+  // Canonical queue fixtures match both Cloud schema suites.
+  describe("queue metadata", () => {
+    const queued = { ...job, status: "queued" } as const
+
+    test.each([
+      {},
+      { ownerLabel: owner.parentSessionId },
+      { queuePosition: 1 },
+      { queuePosition: 100 },
+      { ownerLabel: owner.parentSessionId, queuePosition: 50 },
+    ])("preserves optional metadata through negotiated frames only: %j", (fields) => {
+      const snapshot = { ...queued, ...fields }
+      expect(RemoteProtocol.BrowserJobSnapshot.parse(snapshot)).toStrictEqual(snapshot)
+      for (const frame of [
+        { type: "provider_snapshot", ...binding, jobs: [snapshot] },
+        { ...empty, jobs: [snapshot] },
+      ] satisfies RemoteProtocol.BrowserProviderInbound[]) {
+        const wire = JSON.parse(JSON.stringify(frame))
+        expect(RemoteProtocol.BrowserProviderInbound.parse(wire)).toStrictEqual(frame)
+        expect(RemoteProtocol.WebInboundWithBrowser.parse(wire)).toStrictEqual(frame)
+        expect(RemoteProtocol.WebInbound.safeParse(wire).success).toBe(false)
+      }
+      for (const frame of [
+        { type: "browser_response", requestId, response: { kind: "status", job: snapshot } },
+        { type: "browser_response", requestId, response: { kind: "recovered", job: snapshot } },
+        { type: "browser_event", requestId, event: "progress", job: snapshot },
+      ] satisfies (RemoteProtocol.BrowserResponse | RemoteProtocol.BrowserEvent)[]) {
+        const wire = JSON.parse(JSON.stringify(frame))
+        expect(RemoteProtocol.BrowserCLIInbound.parse(wire)).toStrictEqual(frame)
+        expect(RemoteProtocol.InboundWithBrowser.parse(wire)).toStrictEqual(frame)
+        expect(RemoteProtocol.Inbound.safeParse(wire).success).toBe(false)
+      }
+    })
+
+    test.each([
+      { queuePosition: 0 },
+      { queuePosition: -1 },
+      { queuePosition: 101 },
+      { queuePosition: 1.5 },
+      { queuePosition: "1" },
+      { queuePosition: null },
+      { queuePosition: true },
+      { queuePosition: [] },
+      { queuePosition: {} },
+      { queuePosition: NaN },
+      { queuePosition: Infinity },
+    ])("rejects malformed queue positions: %j", (fields) => {
+      expect(RemoteProtocol.BrowserJobSnapshot.safeParse({ ...queued, ...fields }).success).toBe(false)
+    })
+
+    test.each([
+      { ownerLabel: "x", accepted: true },
+      { ownerLabel: "x".repeat(128), accepted: true },
+      { ownerLabel: "\u00e9".repeat(64), accepted: true },
+      { ownerLabel: "", accepted: false },
+      { ownerLabel: "x".repeat(129), accepted: false },
+      { ownerLabel: "\u00e9".repeat(65), accepted: false },
+      { ownerLabel: null, accepted: false },
+      { ownerLabel: 1, accepted: false },
+      { ownerLabel: false, accepted: false },
+      { ownerLabel: [], accepted: false },
+      { ownerLabel: {}, accepted: false },
+    ])("matches the existing dispatch owner-label bounds: %j", ({ ownerLabel, accepted }) => {
+      expect(RemoteProtocol.BrowserJobSnapshot.safeParse({ ...queued, ownerLabel }).success).toBe(accepted)
+      expect(RemoteProtocol.BrowserProviderInbound.safeParse({ ...dispatch, ownerLabel }).success).toBe(accepted)
+    })
+
+    test.each(entries(statuses).filter(([status]) => status !== "queued"))(
+      "preserves legacy %s snapshots and labels but rejects stale queue positions",
+      (status, result) => {
+        const snapshot = {
+          ...job,
+          status,
+          ...(status === "running" ? { approvedTab: tab } : {}),
+          ...(result ? { result } : {}),
+        }
+        expect(RemoteProtocol.BrowserJobSnapshot.parse(snapshot)).toStrictEqual(snapshot)
+        const labeled = { ...snapshot, ownerLabel: owner.parentSessionId }
+        expect(RemoteProtocol.BrowserJobSnapshot.parse(labeled)).toStrictEqual(labeled)
+        expect(RemoteProtocol.BrowserJobSnapshot.safeParse({ ...labeled, queuePosition: 1 }).success).toBe(false)
+      },
+    )
+
+    test.each([
+      { queuePosition: 0 },
+      { queuePosition: 101 },
+      { queuePosition: 1.5 },
+      { queuePosition: "1" },
+      { queuePosition: null },
+      { ownerLabel: "" },
+      { ownerLabel: "\u00e9".repeat(65) },
+      { ownerLabel: null },
+      { status: "awaiting_approval" },
+      { status: "running", approvedTab: tab },
+      finished,
+      { approvedTab: tab },
+      { result: completed },
+      { deadlines: { queue: "2026-09-04T00:00:00.001Z" } },
+    ])("rejects malformed metadata and invalid phases through negotiated parsers: %j", (fields) => {
+      const snapshot = { ...queued, ownerLabel: owner.parentSessionId, queuePosition: 1, ...fields }
+      for (const frame of [
+        { type: "provider_snapshot", ...binding, jobs: [snapshot] },
+        { ...empty, jobs: [snapshot] },
+      ]) {
+        expect(RemoteProtocol.BrowserProviderInbound.safeParse(frame).success).toBe(false)
+        expect(RemoteProtocol.WebInboundWithBrowser.safeParse(frame).success).toBe(false)
+      }
+      for (const frame of [
+        { type: "browser_response", requestId, response: { kind: "status", job: snapshot } },
+        { type: "browser_response", requestId, response: { kind: "recovered", job: snapshot } },
+        { type: "browser_event", requestId, event: "progress", job: snapshot },
+      ]) {
+        expect(RemoteProtocol.BrowserCLIInbound.safeParse(frame).success).toBe(false)
+        expect(RemoteProtocol.InboundWithBrowser.safeParse(frame).success).toBe(false)
+      }
+    })
+
+    test.each([
+      { owner },
+      { parentSessionId: owner.parentSessionId },
+      { parentProof: owner.parentProof },
+      { providerProof: registration.providerProof },
+      { connectionId: "private-route" },
+      { capabilities: { browserJobsV1: true } },
+      { goal: invoke.goal },
+      { recovery },
+      { leaseExpiresAt: "2026-08-28T00:00:15.000Z" },
+    ])("keeps private data and authority out of labeled snapshots: %j", (fields) => {
+      expect(
+        RemoteProtocol.BrowserJobSnapshot.safeParse({
+          ...queued,
+          ownerLabel: owner.parentSessionId,
+          queuePosition: 1,
+          ...fields,
+        }).success,
+      ).toBe(false)
+    })
+
+    test.each([{ ownerLabel: owner.parentSessionId }, { queuePosition: 1 }])(
+      "keeps projection metadata out of requests and immutable results: %j",
+      (fields) => {
+        for (const args of operations) {
+          expect(RemoteProtocol.BrowserTaskArguments.safeParse({ ...args, ...fields }).success).toBe(false)
+        }
+        for (const frame of requests) {
+          expect(RemoteProtocol.BrowserRequest.safeParse({ ...frame, ...fields }).success).toBe(false)
+        }
+        for (const frame of sent) {
+          expect(RemoteProtocol.BrowserProviderOutbound.safeParse({ ...frame, ...fields }).success).toBe(false)
+        }
+        expect(RemoteProtocol.BrowserResult.safeParse({ ...completed, ...fields }).success).toBe(false)
+      },
+    )
+
+    test("does not turn queued metadata into dispatch authority", () => {
+      const snapshot = { ...queued, ownerLabel: owner.parentSessionId, queuePosition: 1 }
+      expect(RemoteProtocol.BrowserJobSnapshot.parse(snapshot)).toStrictEqual(snapshot)
+      const frame = { ...dispatch, job: snapshot, conversationMode: "new" }
+      expect(RemoteProtocol.BrowserProviderInbound.safeParse(frame).success).toBe(false)
+      expect(RemoteProtocol.WebInboundWithBrowser.safeParse(frame).success).toBe(false)
+    })
+
+    test("counts queue metadata in the unchanged serialized frame limit", () => {
+      const large = { ...finished, result: { ...completed, summary: "\u00e9".repeat(16384) } }
+      const last = { ...finished, result: { ...completed, summary: "" } }
+      const snapshot = { ...queued, ownerLabel: "\u00e9".repeat(64), queuePosition: 100 }
+      const page = {
+        type: "provider_snapshot",
+        ...binding,
+        jobs: [snapshot, large, large, large, last],
+      } satisfies RemoteProtocol.BrowserProviderInbound
+      last.result.summary = "x".repeat(128 * 1024 - 1 - Buffer.byteLength(JSON.stringify(page), "utf8"))
+      for (const schema of [RemoteProtocol.BrowserProviderInbound, RemoteProtocol.WebInboundWithBrowser]) {
+        expect(schema.parse(page)).toStrictEqual(page)
+      }
+      last.result.summary += "x"
+      const legacy = { ...page, jobs: [queued, ...page.jobs.slice(1)] }
+      for (const schema of [RemoteProtocol.BrowserProviderInbound, RemoteProtocol.WebInboundWithBrowser]) {
+        expect(schema.safeParse(page).success).toBe(false)
+        expect(schema.parse(legacy)).toStrictEqual(legacy)
+      }
+    })
+  })
+
   test.each(entries(statuses))("enforces the observable result contract for %s", (status, result) => {
     const snapshot = {
       ...job,

--- a/packages/opencode/test/kilocode/sessions/remote-protocol.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-protocol.test.ts
@@ -721,8 +721,13 @@ describe("RemoteProtocol browser jobs v1", () => {
     { type: "provider_unavailable", ...binding, reason: "provider_lost", effectsUncertain: true },
     { type: "provider_cancel", ...bound },
   ] satisfies RemoteProtocol.BrowserProviderOutbound[]
+  const dispatch = { type: "provider_job", job, goal: invoke.goal, ownerLabel: "Parent chat" } as const
   const received = [
-    { type: "provider_job", job, goal: invoke.goal, ownerLabel: "Parent chat" },
+    dispatch,
+    ...(["new", "continue"] as const).map<RemoteProtocol.BrowserProviderInbound>((mode) => ({
+      ...dispatch,
+      conversationMode: mode,
+    })),
     { type: "provider_job_cancel", ...bound, reason: "cancelled" },
     { type: "provider_snapshot", requestId, ...binding, jobs: [job, finished], nextCursor: handle.jobId },
     { type: "provider_snapshot", ...binding, jobs: [] },
@@ -730,6 +735,39 @@ describe("RemoteProtocol browser jobs v1", () => {
     history,
     { type: "provider_status_result", requestId, providerId: handle.providerId, jobs: [] },
   ] satisfies RemoteProtocol.BrowserProviderInbound[]
+
+  describe.each([
+    { name: "provider", schema: RemoteProtocol.BrowserProviderInbound },
+    { name: "negotiated web", schema: RemoteProtocol.WebInboundWithBrowser },
+  ])("provider conversation intent: $name", (contract) => {
+    test("keeps legacy jobs parseable without inventing conversation intent", () => {
+      const parsed = contract.schema.parse(dispatch)
+      expect(parsed).toStrictEqual(dispatch)
+      expect(parsed).not.toHaveProperty("conversationMode")
+    })
+
+    test.each(["new", "continue"] as const)("preserves explicit %s intent and rejects unknown fields", (mode) => {
+      const frame = { ...dispatch, conversationMode: mode }
+      expect(contract.schema.parse(frame)).toStrictEqual(frame)
+      expect(contract.schema.safeParse({ ...frame, extra: true }).success).toBe(false)
+      expect(contract.schema.safeParse({ ...frame, job: { ...job, conversationMode: mode } }).success).toBe(false)
+    })
+
+    test.each([
+      { conversationMode: "" },
+      { conversationMode: "unknown" },
+      { conversationMode: "NEW" },
+      { conversationMode: "CONTINUE" },
+      { conversationMode: "new " },
+      { conversationMode: null },
+      { conversationMode: false },
+      { conversationMode: 0 },
+      { conversationMode: [] },
+      { conversationMode: {} },
+    ])("rejects invalid conversation modes: %j", (fields) => {
+      expect(contract.schema.safeParse({ ...dispatch, ...fields }).success).toBe(false)
+    })
+  })
 
   describe("read-only provider status", () => {
     test("keeps historical generations separate from execution snapshots", () => {


### PR DESCRIPTION
No new behavior — this change does not enable browser delegation.

---

## Context

`RemoteProtocol` adds dormant C1 schemas matching the relay and software development kit (SDK): `BrowserTaskArguments`, `BrowserRequest`, `BrowserResponse`, `BrowserEvent`, `BrowserCLIInbound`, `BrowserJobHandle`, `BrowserJobSnapshot`, `BrowserResult`, `BrowserProviderOutbound`, and `BrowserProviderInbound`.
`browserJobsV1` remains optional; `NormalizedBrowserCapabilities` treats missing support as false, while `OutboundWithBrowser`, `InboundWithBrowser`, `WebOutboundWithBrowser`, and `WebInboundWithBrowser` preserve the legacy parser unions.
The schemas bound data and protect proofs; maintainers must keep the copies aligned, and this level neither registers `browser_task` nor connects runtime consumers.

## Implementation

<details>
<summary>Files</summary>

- `packages/opencode/src/kilo-sessions/remote-protocol.ts` — M (modified); Source; 444 lines added, none removed. Extends `Capabilities` and `HeartbeatAck` with optional advertisements; adds `BrowserCapabilities`, `Ping`, `Pong`, `WebOutbound`, and `WebInbound`. Web commands accept optional data and connection IDs; mutation IDs allow 128 characters. The four browser unions require explicit adoption; existing inbound and outbound parsers still reject browser frames. `BrowserProviderId`, `BrowserTaskId`, and `BrowserJobId` use `bp_`, `bt_`, and `bj_` prefixes with universally unique identifiers (UUIDs). `BrowserInvocationId` uses `b1.<timestamp>.<digest>` with a safe-range timestamp; proofs, fingerprints, and invocation digests require 64 lowercase hexadecimal characters. Request IDs use UUIDs; generations and tab IDs use bounded integers, and `BrowserDeadlines` requires millisecond timestamps. Model arguments support list, run, status, cancel, and recover without parent, invocation, proof, user, or socket authority. Requests add paginated discovery and owned invoke, status, cancel, and recover operations. Status and cancel require a conversation ID; omitted job IDs designate its latest job after owner verification. Recovery only looks up a persisted invocation and cannot supply a new goal or provider. Responses distinguish provider pages, acknowledgments, status, recovered or missing invocations, and errors with retryability. Invoke and cancel acknowledgments do not represent progress or completion; events separate nonterminal progress from results. `BrowserProviderDescriptor` bounds labels, availability, and queue depth from zero through 100. `BrowserJobStatus` covers queued, awaiting approval, running, succeeded, failed, cancelled, interrupted, and timed out; `BrowserTerminalStatus` excludes the three active states. `BrowserFailureReason` and `BrowserReasonCode` define finite failure and completion codes. Terminal snapshots require results with matching identities and status; success requires `completed` and `effectsUncertain: false`. Running snapshots require `BrowserApprovedTab`; queued and awaiting-approval snapshots reject it, and all deadlines stay within retention. Approved tabs include the ID, bounded title, valid address, and `safe` or `dangerous` mode. Provider contracts cover registration, heartbeat, approval, results, quiescence, unavailability, exact-job cancellation, dispatch, snapshots, and lease acknowledgments. Registration requires `enabled: true`; generation zero denotes first registration, while later messages require positive generations. Registration recovery requires `tabClosed: true` and `locksDrained: true`; provider results must match the job identity. Dispatch accepts only jobs awaiting approval; snapshots match the provider and generation, reconcile state, and do not grant permission to execute. Text bounds count bytes in 8-bit Unicode Transformation Format (UTF-8). `BROWSER_GOAL_MAX_BYTES` allows 16,384-byte goals; `BROWSER_RESULT_MAX_BYTES` allows 65,536-byte serialized results; `BROWSER_FRAME_MAX_BYTES` requires serialized boundary frames below 131,072 bytes. `BROWSER_PAGE_SIZE` limits provider lists and snapshots to 25 entries; results allow 32 bounded evidence items and 32,768-byte summaries. Evidence contains text, a title, or a valid address; labels, titles, addresses, parent IDs, and error messages also have byte limits. Parent proofs belong only to owned requests; provider proofs belong only to registration, never discovery or results. Strict browser boundaries reject unknown fields and replace validation details with `Invalid browser message`, hiding proof values and unknown key names. Consumers must not enable Zod's `reportInput`.

</details>

Canonical and legacy fixtures check C1 compatibility, invalid messages, directionality, and unchanged callback types.
Checked literal fixtures retain discriminants, so strict TypeScript validation needs no unsafe casts or changes to the assertions.

<details>
<summary>Files</summary>

- `packages/opencode/test/kilocode/sessions/remote-protocol.test.ts` — M (modified); Test; 758 lines added, none removed. Adds canonical browser frames, legacy envelopes, capability absence, authority rejection, malformed identities, status exhaustiveness, byte limits, proof redaction, and opt-in parser checks. Preserves frozen callback types and uses checked `satisfies` declarations for literal fixtures.

</details>

Tests: 1 file modified — `remote-protocol.test.ts`; 758 lines added, none removed.
Generated: 0 files changed.

---

## Issue

No issue number was supplied. This PR contains level 1 of the browser-job contracts for the command-line interface (CLI).

Matching relay and software development kit (SDK) contract level: [Kilo-Org/cloud#5638](https://github.com/Kilo-Org/cloud/pull/5638).
Both schema levels remain dormant and independently buildable; neither enables browser delegation.

### Repository scope

- `Kilo-Org/kilocode`: `/Users/igor/Projects/.worktrees/browser-task-0787-kilocode`; branch `browser-task-0787`; base `origin/main`. This PR modifies two files, with 1,202 added lines and no deletions.
- `Kilo-Org/cloud`: `/Users/igor/Projects/.worktrees/browser-task-0787`; branch `browser-task-0787`; base `origin/main`. Its matching relay and SDK contracts belong to the separate Cloud PR, not this CLI description.

## Screenshots / Video

Visual Changes: N/A

## How to Test

### Verification

Runtime verification waits for the stack tips because this level adds dormant schemas and does not enable browser delegation.
The handoff includes no end-to-end report.

### Manual/local verification

The reviewer agent ran these scoped checks and recorded passing results:

- Strict TypeScript validation for the changed source and test files.
- The targeted Bun suite: 120 tests passed, with 1,283 assertions.
- Oxlint for both changed files.
- Prettier for both changed files.

The handoff records no human runtime verification for this level.

### Reviewer test steps

1. In `packages/opencode/`, run the scoped TypeScript check:

```sh
../../node_modules/.bin/tsgo --ignoreConfig --noEmit --strict --skipLibCheck --target ESNext --module Preserve --moduleResolution Bundler --types bun src/kilo-sessions/remote-protocol.ts test/kilocode/sessions/remote-protocol.test.ts
```

2. From the CLI repository root, run these checks in order:

```sh
npx --yes bun@1.3.14 test --cwd packages/opencode --no-env-file ./test/kilocode/sessions/remote-protocol.test.ts
./node_modules/.bin/oxlint --config .oxlintrc.json packages/opencode/src/kilo-sessions/remote-protocol.ts packages/opencode/test/kilocode/sessions/remote-protocol.test.ts
./node_modules/.bin/prettier --check packages/opencode/src/kilo-sessions/remote-protocol.ts packages/opencode/test/kilocode/sessions/remote-protocol.test.ts
```

### Blocked checks and substitute verification

No scoped check remains blocked. Schema and compatibility checks provide local verification while runtime integration remains outside this level.
These results do not establish live verification, continuous integration (CI), or a passing full-section gate.

## Human steps

- **before merge:** Confirm the personal-review checklist item as the PR author.
- **before merge:** After every PR receives human-ready, merge each repository's levels from bottom to top.
- This level requires no new environment values, secrets, migrations, flag changes, or deployment order.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes — none required because this level changes no user-facing behavior.
- [ ] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

No contact handle was supplied.

## Notes

Runtime verification remains pending on the stack tips. This level adds dormant schemas and does not enable browser delegation.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `browser-task-0787` — #13535 ← this PR
5. `browser-task-0787-s5` — #13561
6. `browser-task-0787-s6` — #13567 (tip)
