### PR TITLE
refactor(agent-manager): extract project-scoped diff/review routing

### DIFF
--- a/packages/kilo-vscode/tests/unit/agent-manager-review-routing.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-review-routing.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "bun:test"
+import { createRoot } from "solid-js"
+import { createDiffReviewScope } from "../../webview-ui/agent-manager/diff-review-scope"
+import { routeReview } from "../../webview-ui/agent-manager/project/review-routing"
+import { applyProjectSelection } from "../../webview-ui/agent-manager/project/selection"
+import type { ExtensionMessage } from "../../webview-ui/src/types/messages"
+
+const messages = {
+  diff: { type: "agentManager.worktreeDiff", sessionId: "shared#branch", diffs: [] },
+  file: { type: "agentManager.worktreeDiffFile", sessionId: "shared#branch", file: "file.ts", diff: null },
+  loading: { type: "agentManager.worktreeDiffLoading", sessionId: "shared#branch", loading: true },
+  notice: { type: "agentManager.worktreeDiffNotice", sessionId: "shared#branch", notice: "deleted" },
+  branches: {
+    type: "agentManager.diffBranches",
+    sessionId: "shared#branch",
+    branches: [],
+    defaultBranch: "main",
+    isAuto: true,
+  },
+  apply: { type: "agentManager.applyWorktreeDiffResult", worktreeId: "shared", status: "success", message: "Applied" },
+  revert: {
+    type: "agentManager.revertWorktreeFileResult",
+    sessionId: "shared#branch",
+    file: "file.ts",
+    status: "success",
+    message: "Reverted",
+  },
+} satisfies Record<string, ExtensionMessage>
+
+function recorder() {
+  const calls: { route: string; msg: ExtensionMessage }[] = []
+  const record = (route: string) => (msg: ExtensionMessage) => calls.push({ route, msg })
+  return {
+    calls,
+    handlers: {
+      diff: record("diff"),
+      file: record("file"),
+      loading: record("loading"),
+      notice: record("notice"),
+      branches: record("branches"),
+      apply: record("apply"),
+      revert: record("revert"),
+    },
+  }
+}
+
+describe("project review routing", () => {
+  it.each(Object.entries(messages))("routes %s by applied state throughout a project switch", (route, msg) => {
+    const result = recorder()
+    const active = "b"
+    let applied: string | undefined
+    const current = () => applied
+    const previous = { ...msg, projectId: "a" }
+    const next = { ...msg, projectId: active }
+
+    expect(routeReview(next, current, result.handlers)).toBe("stale")
+    applied = "a"
+    expect(routeReview(next, current, result.handlers)).toBe("stale")
+    expect(result.calls).toEqual([])
+    expect(routeReview(previous, current, result.handlers)).toBe("handled")
+    expect(result.calls).toEqual([{ route, msg: previous }])
+    expect(result.calls.at(0)?.msg).toBe(previous)
+
+    applied = active
+    expect(routeReview(next, current, result.handlers)).toBe("handled")
+    expect(routeReview(previous, current, result.handlers)).toBe("stale")
+    expect(result.calls).toEqual([
+      { route, msg: previous },
+      { route, msg: next },
+    ])
+    expect(result.calls.at(1)?.msg).toBe(next)
+  })
+
+  it.each([undefined, "a"])("keeps legacy unqualified messages with applied project %j", (project) => {
+    for (const [route, msg] of Object.entries(messages)) {
+      const result = recorder()
+      const empty = { ...msg, projectId: "" }
+      expect(routeReview(msg, () => project, result.handlers)).toBe("handled")
+      expect(routeReview(empty, () => project, result.handlers)).toBe("handled")
+      expect(result.calls).toEqual([
+        { route, msg },
+        { route, msg: empty },
+      ])
+    }
+  })
+
+  it("leaves unrelated messages for the existing selection and project handlers", () => {
+    const result = recorder()
+    const selection: ExtensionMessage = {
+      type: "agentManager.selectionActivated",
+      target: { projectId: "b", kind: "worktree", worktreeId: "shared" },
+    }
+    const current = () => {
+      throw new Error("Unrelated messages must not read the current project")
+    }
+    const events: ExtensionMessage[] = [
+      selection,
+      { type: "agentManager.prError", projectId: "a", error: "gh_missing" },
+      { type: "agentManager.worktreeStats", projectId: "a", stats: [] },
+      { type: "agentManager.keybindings", bindings: {} },
+    ]
+    for (const msg of events) expect(routeReview(msg, current, result.handlers)).toBe("unhandled")
+    expect(result.calls).toEqual([])
+
+    const calls: string[] = []
+    expect(
+      applyProjectSelection(selection, {
+        active: (id) => id === "b",
+        applied: (id) => id === "b",
+        managed: () => [],
+        local: (id) => calls.push(`local:${id}`),
+        worktree: (id, worktree) => calls.push(`${id}:${worktree}`),
+        focusLocal: (id) => calls.push(`session:${id}`),
+        managedSession: (worktree, id) => calls.push(`${worktree}:${id}`),
+      }),
+    ).toBe(true)
+    expect(calls).toEqual(["b:shared"])
+  })
+
+  it("keeps review content for identical worktree IDs isolated and preserves context filtering", () => {
+    createRoot((dispose) => {
+      let applied = "a"
+      const current = () => applied
+      const sent: unknown[] = []
+      const review = createDiffReviewScope({
+        ctx: () => "shared",
+        session: () => undefined,
+        panelOpen: () => false,
+        reviewActive: () => false,
+        vscode: { postMessage: (msg) => sent.push(msg) },
+        project: current,
+      })
+      const handlers = { ...recorder().handlers, branches: review.onBranches }
+      const previous = { ...messages.branches, projectId: "a", currentBranch: "branch-a" }
+      const next = { ...messages.branches, projectId: "b", currentBranch: "branch-b" }
+
+      expect(routeReview(previous, current, handlers)).toBe("handled")
+      expect(review.currentBranch()).toBe("branch-a")
+      expect(routeReview(next, current, handlers)).toBe("stale")
+      expect(review.currentBranch()).toBe("branch-a")
+      applied = "b"
+      expect(routeReview(next, current, handlers)).toBe("handled")
+      expect(routeReview(previous, current, handlers)).toBe("stale")
+      expect(routeReview({ ...next, sessionId: "other#branch", currentBranch: "other" }, current, handlers)).toBe(
+        "handled",
+      )
+      expect(review.currentBranch()).toBe("branch-b")
+      expect(sent).toEqual([])
+      dispose()
+    })
+  })
+})

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -23,12 +23,6 @@ import type {
   AgentManagerKeybindingsMessage,
   AgentManagerMultiVersionProgressMessage,
   AgentManagerSendInitialMessage,
-  AgentManagerWorktreeDiffMessage,
-  AgentManagerWorktreeDiffFileMessage,
-  AgentManagerWorktreeDiffLoadingMessage,
-  AgentManagerWorktreeDiffNoticeMessage,
-  AgentManagerDiffBranchesMessage,
-  AgentManagerApplyWorktreeDiffResultMessage,
   AgentManagerWorktreeStatsMessage,
   AgentManagerLocalStatsMessage,
   WorktreeFileDiff,
@@ -97,6 +91,7 @@ import { createWorktreeActivity } from "./project/session-busy"
 import { switchProject } from "./project/switch"
 import { createProjectStateHandlers } from "./project/state-handlers"
 import { ownsParent as ownsParentSession, isCurrent } from "./project/message-ownership"
+import { routeReview } from "./project/review-routing"
 import {
   reviewComments as readReviewComments,
   reviewOpen as isReviewOpen,
@@ -1527,40 +1522,18 @@ const AgentManagerContent: Component = () => {
         }
       }
 
-      if (msg.type === "agentManager.worktreeDiff") {
-        if (!isCurrent(msg, currentProjectId())) return
-        diffs.onWorktreeDiff(msg as AgentManagerWorktreeDiffMessage)
-      }
-
-      if (msg.type === "agentManager.worktreeDiffFile") {
-        if (!isCurrent(msg, currentProjectId())) return
-        diffs.onWorktreeDiffFile(msg as AgentManagerWorktreeDiffFileMessage)
-      }
-
-      if (msg.type === "agentManager.worktreeDiffLoading") {
-        if (!isCurrent(msg, currentProjectId())) return
-        diffs.onWorktreeDiffLoading(msg as AgentManagerWorktreeDiffLoadingMessage)
-      }
-
-      if (msg.type === "agentManager.worktreeDiffNotice") {
-        if (!isCurrent(msg, currentProjectId())) return
-        diffs.onWorktreeDiffNotice(msg as AgentManagerWorktreeDiffNoticeMessage)
-      }
-
-      if (msg.type === "agentManager.diffBranches") {
-        if (!isCurrent(msg, currentProjectId())) return
-        review.onBranches(msg as AgentManagerDiffBranchesMessage)
-      }
-
-      if (msg.type === "agentManager.applyWorktreeDiffResult") {
-        if (!isCurrent(msg, currentProjectId())) return
-        apply.onApplyResult(msg as AgentManagerApplyWorktreeDiffResultMessage)
-      }
-
-      if (msg.type === "agentManager.revertWorktreeFileResult") {
-        if (!isCurrent(msg, currentProjectId())) return
-        revertCtl.onResult(msg as never)
-      }
+      if (
+        routeReview(msg, currentProjectId, {
+          diff: diffs.onWorktreeDiff,
+          file: diffs.onWorktreeDiffFile,
+          loading: diffs.onWorktreeDiffLoading,
+          notice: diffs.onWorktreeDiffNotice,
+          branches: review.onBranches,
+          apply: apply.onApplyResult,
+          revert: revertCtl.onResult,
+        }) === "stale"
+      )
+        return
 
       applyProjectSelection(msg, {
         active: (projectId) => activeProjectId() === projectId,

--- a/packages/kilo-vscode/webview-ui/agent-manager/project/review-routing.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/project/review-routing.ts
@@ -1,0 +1,52 @@
+import type {
+  AgentManagerApplyWorktreeDiffResultMessage,
+  AgentManagerDiffBranchesMessage,
+  AgentManagerRevertWorktreeFileResultMessage,
+  AgentManagerWorktreeDiffFileMessage,
+  AgentManagerWorktreeDiffLoadingMessage,
+  AgentManagerWorktreeDiffMessage,
+  AgentManagerWorktreeDiffNoticeMessage,
+  ExtensionMessage,
+} from "../../src/types/messages"
+import { isCurrent } from "./message-ownership"
+
+type Handlers = {
+  diff: (msg: AgentManagerWorktreeDiffMessage) => void
+  file: (msg: AgentManagerWorktreeDiffFileMessage) => void
+  loading: (msg: AgentManagerWorktreeDiffLoadingMessage) => void
+  notice: (msg: AgentManagerWorktreeDiffNoticeMessage) => void
+  branches: (msg: AgentManagerDiffBranchesMessage) => void
+  apply: (msg: AgentManagerApplyWorktreeDiffResultMessage) => void
+  revert: (msg: AgentManagerRevertWorktreeFileResultMessage) => void
+}
+
+export function routeReview(
+  msg: ExtensionMessage,
+  current: () => string | undefined,
+  handlers: Handlers,
+): "handled" | "stale" | "unhandled" {
+  const dispatch = <T extends { projectId?: string }>(value: T, handle: (msg: T) => void): "handled" | "stale" => {
+    if (!isCurrent(value, current())) return "stale"
+    handle(value)
+    return "handled"
+  }
+
+  switch (msg.type) {
+    case "agentManager.worktreeDiff":
+      return dispatch(msg, handlers.diff)
+    case "agentManager.worktreeDiffFile":
+      return dispatch(msg, handlers.file)
+    case "agentManager.worktreeDiffLoading":
+      return dispatch(msg, handlers.loading)
+    case "agentManager.worktreeDiffNotice":
+      return dispatch(msg, handlers.notice)
+    case "agentManager.diffBranches":
+      return dispatch(msg, handlers.branches)
+    case "agentManager.applyWorktreeDiffResult":
+      return dispatch(msg, handlers.apply)
+    case "agentManager.revertWorktreeFileResult":
+      return dispatch(msg, handlers.revert)
+    default:
+      return "unhandled"
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Seven Agent Manager diff/review response routes repeat the same project guard inside the main subscription. This makes the applied-project boundary harder to test in isolation.

## Why This Change Was Made

Extract only these routes into a small typed, runtime-independent helper that uses the existing `isCurrent` check and handlers. Keep `currentProjectId` (the project whose state has been applied), not `activeProjectId`, as the routing boundary. Preserve the subscription, dispatch position, stale-message early return, and accepted/unrelated-message fall-through.

## User Impact

No intended behavior change. Legacy unqualified messages remain accepted. State ownership, session selection, rendering, and protocols are unchanged.

## Evidence

- 11 focused helper tests cover all seven routes, project-switch timing, identical worktree IDs across projects, unrelated messages, legacy messages, and the existing selection/review helpers. The related targeted run passed 204 tests across 12 files.
- Passed from `packages/kilo-vscode`: `bun test tests/unit/agent-manager-review-routing.test.ts`, `bun run lint`, `bun run typecheck`, `bun run knip`, `bun run check-kilocode-change`, and `bun run compile`.
- Passed from the repository root: `bun run script/check-opencode-annotations.ts --worktree` and `git diff --check`.
- Isolated VS Code smoke test: opened inline diff and full-screen review, switched between local and worktree changes with multi-project disabled, then switched between two disposable projects and reopened each review. Content matched the selected source and loading settled. An injected stale branch response from the other project did not change the current review. Screenshots were inspected and the isolated instance was cleaned up. No model requests or apply/revert operations were performed.

<details>
<summary>Isolated smoke-test screenshots</summary>

Multi-project disabled, worktree review:

<img width="700" alt="Legacy Agent Manager review showing the selected Alpha worktree change" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260828-am-review-routing-legacy-f2nzqt.png" />

Two projects, selected Beta project review:

<img width="700" alt="Two-project Agent Manager review showing Beta content after switching projects" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260828-am-review-routing-multi-f2nzqt.png" />

</details>
