### PR TITLE
fix(agent-manager): restore configured reasoning variant

### DIFF
--- a/.changeset/restore-agent-manager-variant.md
+++ b/.changeset/restore-agent-manager-variant.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Restore each agent's configured reasoning effort when opening a new Agent Manager tab.

--- a/packages/kilo-vscode/tests/unit/session-variant-store.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-variant-store.test.ts
@@ -52,6 +52,15 @@ describe("per-session variant selection", () => {
     expect(getAgentVariant(store, model, { variants: { low: {}, high: {} } }, "ask")).toBe("high")
   })
 
+  it("falls back to the configured mode variant", () => {
+    expect(getAgentVariant({}, model, { variants: { high: {}, max: {} } }, "code", "max")).toBe("max")
+  })
+
+  it("prefers an explicit model default over the configured mode variant", () => {
+    const store = { [variantKey(model, "code")]: "" }
+    expect(getAgentVariant(store, model, { variants: { high: {}, max: {} } }, "code", "max")).toBeUndefined()
+  })
+
   it("uses the model default when no variant is selected", () => {
     expect(getVariant({}, model, variants, "code")).toBeUndefined()
     expect(getVariant({ [variantKey(model, "code")]: "" }, model, variants, "code")).toBeUndefined()

--- a/packages/kilo-vscode/tests/unit/session-variants.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-variants.test.ts
@@ -4,7 +4,7 @@ import type { ExtensionMessage, ModelSelection } from "../../webview-ui/src/type
 
 const model: ModelSelection = { providerID: "anthropic", modelID: "claude-sonnet-4" }
 
-function setup(session?: string) {
+function setup(session?: string, configured?: string) {
   const selections: Record<string, string> = {}
   const messages: Array<{ type: string; key?: string; value?: string }> = []
   const order: string[] = []
@@ -17,7 +17,8 @@ function setup(session?: string) {
     selected: () => model,
     session: () => session,
     agent: () => "code",
-    find: () => ({ variants: { low: {}, high: {} } }),
+    configured: () => configured,
+    find: () => ({ variants: { low: {}, high: {}, max: {} } }),
     post: (message) => {
       order.push("post")
       messages.push(message)
@@ -49,6 +50,19 @@ describe("session variants", () => {
       variants: { "agent/code/anthropic/claude-sonnet-4": "high", "session/old/model": "low" },
     })
     expect(state.selections).toEqual({ "agent/code/anthropic/claude-sonnet-4": "high" })
+  })
+
+  it("uses the configured agent variant when no picker selection exists", () => {
+    const state = setup(undefined, "max")
+    expect(state.variants.agent("code", model)).toBe("max")
+    expect(state.variants.current()).toBe("max")
+  })
+
+  it("lets an explicit model default override the configured agent variant", () => {
+    const state = setup(undefined, "max")
+    state.variants.select(undefined)
+    expect(state.variants.agent("code", model)).toBeUndefined()
+    expect(state.variants.current()).toBeUndefined()
   })
 
   it("persists global selections but keeps session selections local", () => {

--- a/packages/kilo-vscode/webview-ui/src/context/session-variant-store.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-variant-store.ts
@@ -39,11 +39,12 @@ export function getVariant(
   variants: string[],
   agent: string,
   session?: string,
+  configured?: string,
 ) {
   if (variants.length === 0) return undefined
   const key = variantKey(sel, agent, session)
   const fallback = session ? store[variantKey(sel, agent)] : undefined
-  const stored = store[key] ?? fallback ?? store[legacyVariantKey(sel)]
+  const stored = store[key] ?? fallback ?? store[legacyVariantKey(sel)] ?? configured
   if (stored === undefined || stored === DEFAULT_VARIANT) return undefined
   return preserveVariant(stored, variants)
 }
@@ -53,9 +54,10 @@ export function getAgentVariant(
   sel: ModelSelection,
   model: { variants?: Record<string, unknown> } | undefined,
   agent: string,
+  configured?: string,
 ) {
   if (!model?.variants) return undefined
-  return getVariant(store, sel, Object.keys(model.variants), agent)
+  return getVariant(store, sel, Object.keys(model.variants), agent, undefined, configured)
 }
 
 /**

--- a/packages/kilo-vscode/webview-ui/src/context/session-variants.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-variants.ts
@@ -14,6 +14,7 @@ interface Options {
   selected: (sessionID?: string) => ModelSelection | null
   session: Accessor<string | undefined>
   agent: (sessionID?: string) => string
+  configured: (agent: string) => string | undefined
   find: (selection: ModelSelection) => Model | undefined
   post: (message: Message) => void
   listen: (handler: (message: ExtensionMessage) => void) => () => void
@@ -28,7 +29,7 @@ export function createSessionVariants(options: Options) {
 
   const agent = (name: string, selection: ModelSelection | null) => {
     if (!selection) return undefined
-    return getAgentVariant(options.selections(), selection, options.find(selection), name)
+    return getAgentVariant(options.selections(), selection, options.find(selection), name, options.configured(name))
   }
 
   const current = (sessionID?: string) => {
@@ -37,7 +38,8 @@ export function createSessionVariants(options: Options) {
     if (!selection) return undefined
     const variants = list(sid)
     if (variants.length === 0) return undefined
-    return getVariant(options.selections(), selection, variants, options.agent(sid), sid)
+    const name = options.agent(sid)
+    return getVariant(options.selections(), selection, variants, name, sid, options.configured(name))
   }
 
   const select = (value: string | undefined, sessionID?: string) => {

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -489,6 +489,7 @@ export const SessionProvider: ParentComponent = (props) => {
     selected,
     session: currentSessionID,
     agent: agentForScope,
+    configured: (agent) => config().agent?.[agent]?.variant ?? undefined,
     find: provider.findModel,
     post: vscode.postMessage,
     listen: vscode.onMessage,


### PR DESCRIPTION
﻿## Issue

Fixes #13514

## Context

When an Agent Manager tab is opened, the configured reasoning effort for its selected agent is not restored. The model is restored correctly, but the reasoning selector falls back to the model default instead of the agent's configured value.

## Implementation

Use the configured agent variant as the final fallback when resolving the effective reasoning effort. Existing session and picker selections still take precedence, and an explicit model-default selection still clears the configured override.

## How to Test

### Manual/local verification

- `bun test tests/unit/session-variant-store.test.ts tests/unit/session-variants.test.ts` — 28 tests passed.
- `bun run typecheck` from `packages/kilo-vscode/` — passed.
- `bun run lint` from `packages/kilo-vscode/` — passed.
- `git diff --check` — passed.

### Reviewer test steps

1. Configure an Agent with a model reasoning variant such as `Max` in Agent Behaviour settings.
2. Open a new Agent Manager tab and select that Agent.
3. Confirm the reasoning selector restores the configured variant instead of the model default.
4. Select the model default explicitly and confirm it remains the selected default.

### Blocked checks and substitute verification

The repository pre-push hook also runs the JetBrains typecheck. The 29 non-JetBrains packages passed; the JetBrains check could not start because Java/JAVA_HOME is not available in this environment. This change only touches Agent Manager variant resolution and its tests.

## Checklist

- [x] Issue linked above
- [x] Tests/verification described
- [x] Screenshots/video not applicable
- [x] Changeset added
- [x] I reviewed the diff and can explain the change, including the assisted implementation.
