### PR TITLE
fix(cli): avoid protected parent access during checkpoint cleanup

### DIFF
--- a/.changeset/fix-checkpoint-cleanup-parent-access.md
+++ b/.changeset/fix-checkpoint-cleanup-parent-access.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Avoid checkpoint cleanup errors when deleting worktrees under protected parent folders.

--- a/packages/opencode/src/kilocode/snapshot/cleanup.ts
+++ b/packages/opencode/src/kilocode/snapshot/cleanup.ts
@@ -31,56 +31,41 @@ export namespace KiloSnapshotCleanup {
 
   const alias = (value: string, canonical: string) =>
     process.platform === "darwin" &&
-    ((value === "/var" && canonical === "/private/var") || (value === "/tmp" && canonical === "/private/tmp"))
+    canonical === `/private${value}` &&
+    ["/var", "/tmp"].some((root) => value === root || value.startsWith(`${root}/`))
 
   const inspect = Effect.fnUntraced(function* (fs: FSUtil.Interface, target: string) {
-    const root = path.parse(target).root
-    const parts = path.relative(root, target).split(path.sep).filter(Boolean)
-    let current = root
-    let canonical = yield* fs
-      .realPath(root)
-      .pipe(Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(root)))
+    const missing: string[] = []
+    let current = target
 
-    for (const [index, name] of parts.entries()) {
-      const info = yield* fs
-        .stat(current)
+    while (true) {
+      const canonical = yield* fs
+        .realPath(current)
         .pipe(Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(undefined)))
-      if (!info) {
+      if (canonical !== undefined) {
+        if (normalized(canonical) !== normalized(current) && !alias(current, canonical))
+          return yield* Effect.fail(new Error("trusted path contains an unexpected symlink"))
+        const info = yield* fs.stat(current)
+        if (missing.length > 0 && info.type !== "Directory")
+          return yield* Effect.fail(new Error("trusted path parent is not a directory"))
+        if (normalized(yield* fs.realPath(current)) !== normalized(canonical))
+          return yield* Effect.fail(new Error("trusted path changed during inspection"))
         return {
-          canonical: path.join(canonical, ...parts.slice(index)),
-          exists: false,
-        } satisfies Checked
-      }
-      if (info.type !== "Directory") return yield* Effect.fail(new Error("trusted path parent is not a directory"))
-
-      const entries = yield* fs.readDirectoryEntries(current)
-      const entry = entries.find((item) => item.name === name)
-      if (!entry) {
-        canonical = yield* fs.realPath(current)
-        return {
-          canonical: path.join(canonical, ...parts.slice(index)),
-          exists: false,
+          canonical: path.join(canonical, ...missing),
+          exists: missing.length === 0,
+          type: info.type === "Directory" ? "directory" : "other",
         } satisfies Checked
       }
 
-      const next = path.join(current, name)
-      const real = yield* fs.realPath(next)
-      const again = (yield* fs.readDirectoryEntries(current)).find((item) => item.name === name)
-      if (!again || (again.type === "symlink" && !alias(next, real)) || again.type !== entry.type)
-        return yield* Effect.fail(new Error("trusted path contains an unexpected symlink"))
-
-      current = next
-      canonical = real
-      if (index === parts.length - 1) {
-        return {
-          canonical,
-          exists: true,
-          type: again.type === "symlink" && alias(next, real) ? "directory" : again.type,
-        } satisfies Checked
-      }
+      const link = yield* fs
+        .readLink(current)
+        .pipe(Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(undefined)))
+      if (link !== undefined) return yield* Effect.fail(new Error("trusted path contains an unexpected symlink"))
+      const parent = path.dirname(current)
+      if (parent === current) return yield* Effect.fail(new Error("trusted path root is missing"))
+      missing.unshift(path.basename(current))
+      current = parent
     }
-
-    return { canonical, exists: true, type: "directory" } satisfies Checked
   })
 
   const dir = (value: Checked, name: string) => {

--- a/packages/opencode/test/kilocode/snapshot-repository-cleanup.test.ts
+++ b/packages/opencode/test/kilocode/snapshot-repository-cleanup.test.ts
@@ -297,6 +297,36 @@ it.live("removes an absent snapshot repository idempotently", () =>
   }),
 )
 
+for (const stored of [false, true]) {
+  it.live(`cleans ${stored ? "existing" : "absent"} checkpoints without accessing workspace ancestors`, () =>
+    Effect.gen(function* () {
+      const base = yield* tmpdirScoped()
+      const input = item(path.join(base, "allowed"))
+      const current = stored ? yield* repo(input) : undefined
+      const fs = yield* FSUtil.Service
+      const flock = yield* EffectFlock.Service
+      yield* fs.ensureDir(path.dirname(input.worktree)).pipe(Effect.orDie)
+      yield* drop(input.worktree)
+      const denied = Effect.die(new Error("Workspace ancestor access denied"))
+
+      expect(
+        yield* KiloSnapshotCleanup.remove({
+          ...input,
+          flock,
+          fs: {
+            ...fs,
+            realPath: (target) => (target === base ? denied : fs.realPath(target)),
+            stat: (target) => (target === base ? denied : fs.stat(target)),
+            readDirectoryEntries: (target) => (target === base ? denied : fs.readDirectoryEntries(target)),
+          },
+        }),
+      ).toBe(true)
+      if (current) expect(yield* exist(current.dir)).toBe(false)
+      expect(yield* exist(input.directory)).toBe(true)
+    }),
+  )
+}
+
 it.live("removes safely when the snapshot root, project, or repository is missing", () =>
   Effect.gen(function* () {
     const base = yield* tmpdirScoped()
@@ -381,6 +411,23 @@ it.live("rejects a symlinked snapshot root", () =>
 
     expect(Exit.isFailure(yield* remove(input).pipe(Effect.exit))).toBe(true)
     expect(yield* exist(path.join(outside, "sentinel"))).toBe(true)
+  }),
+)
+
+it.live("rejects symlinks in ancestors of the workspace and snapshot root", () =>
+  Effect.gen(function* () {
+    const base = yield* tmpdirScoped()
+    const ancestor = path.join(base, "ancestor")
+    const input = item(ancestor)
+    const current = yield* repo(input)
+    yield* drop(input.worktree)
+    const fs = yield* FSUtil.Service
+    const outside = path.join(base, "outside")
+    yield* fs.rename(ancestor, outside)
+    yield* link(outside, ancestor)
+
+    expect(Exit.isFailure(yield* remove(input).pipe(Effect.exit))).toBe(true)
+    expect(yield* exist(current.dir)).toBe(true)
   }),
 )
 


### PR DESCRIPTION
## What Problem This Solves

Deleting an Agent Manager worktree could succeed but still show a checkpoint-cleanup error, including when checkpoint recording was disabled. Cleanup inspected every ancestor from the filesystem root. On macOS, access to a protected parent such as Documents can be denied even when the full project path is accessible, causing the cleanup endpoint to return HTTP 400.

## Why This Change Was Made

Correct the protected-parent access regression in the worktree cleanup introduced by #13476. Resolve the complete target first and walk upward only to reconstruct missing path components. Keep canonical containment checks, dangling-symlink rejection, path revalidation, repository locking, and the existing quarantine and pending-materialization safeguards.

Do not skip cleanup when snapshot recording is disabled: old checkpoint data can still exist and should be removed when its worktree is explicitly deleted.

## User Impact

Worktree deletion no longer requires inspecting unrelated protected parent folders. Missing checkpoint repositories remain harmless, existing checkpoint data is removed, and retained sessions remain available in history.

## Evidence

- Added regression cases for inaccessible ancestors with existing and absent checkpoint data, plus a symlinked-ancestor safety case.
- Cleanup and endpoint-auth suites: 41 tests passed with the pinned Bun 1.3.14 runtime.
- CLI typecheck, touched-file lint, formatting, and the upstream annotation guard passed.
- Extension compile passed, including extension/webview typechecks, lint, and bundling.
- A read-only diagnostic against the originally failing path changed from an EPERM error to success, with rename and deletion operations blocked throughout.
- Isolated VS Code self-test with a disposable repository under Documents: verified snapshots were disabled, deleted a worktree without checkpoint data, then deleted another with seeded old checkpoint data. Both completed without cleanup warnings; the seeded data was removed and both sessions remained in history.
- The isolated test instance and fixture data were removed afterward. Manual UI coverage was macOS only.