### PR TITLE
fix(vscode): show background agents inline with overflow and direct access

### DIFF
--- a/.changeset/inline-background-agent-names.md
+++ b/.changeset/inline-background-agent-names.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Show running background agent names in the collapsed header when space is available.
+Show each running background agent with its own status indicator, and switch to a count when the header has too little space.

--- a/.changeset/inline-background-agent-names.md
+++ b/.changeset/inline-background-agent-names.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Show each running background agent with its own status indicator, and switch to a count when the header has too little space.
+Open running background agents directly from the header and show an overflow count for agents that do not fit.

--- a/.changeset/inline-background-agent-names.md
+++ b/.changeset/inline-background-agent-names.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show running background agent names in the collapsed header when space is available.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/task-header-background-agents-1280-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/task-header-background-agents-1280-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a356afcc1d81da64ec5b498840abeadc77c44bb2da9cebbb3ffff99dd7183d6
+size 9020

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/task-header-background-agents-200-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/task-header-background-agents-200-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c802176dc42720d51bb0cccaea93c863c98b2886c46600daa98cd13ff121ee6
+size 3827

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/task-header-background-agents-420-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/task-header-background-agents-420-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4b01ca8648de21f8847bdfd8d166f028d1924e9534ac50bb64f520060a92ecf
+size 6391

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/task-header-single-background-agent-420-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/chat/task-header-single-background-agent-420-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ebd62d9dda76da0d8e430ed7c81e5cb66c3233bc6193f4aa077bd1d6d53fbef6
+size 5370

--- a/packages/kilo-vscode/tests/accessibility.spec.ts
+++ b/packages/kilo-vscode/tests/accessibility.spec.ts
@@ -53,6 +53,26 @@ test.describe("webview accessibility ratchet", () => {
     })
   }
 
+  test("Background agent summary and visible agents remain pointer-accessible", async ({ page }) => {
+    await page.setViewportSize({ width: 200, height: 720 })
+    await open(page, "chat--task-header-background-agents-200")
+
+    const agents = page.locator('[data-component="task-header-agents"]')
+    const summary = agents.locator('[data-slot="task-header-agents-summary"]')
+    const list = agents.locator('[data-slot="task-header-todos-list"]')
+    await expect(summary).toHaveAttribute("aria-hidden", "false")
+    await summary.click()
+    await expect(list).toBeVisible()
+    await summary.click()
+    await expect(list).toBeHidden()
+
+    await page.setViewportSize({ width: 1280, height: 720 })
+    const item = agents.locator('[data-slot="task-header-agents-item"]').first()
+    await expect(item).toHaveAttribute("aria-hidden", "false")
+    await item.click()
+    await expect(list).toBeHidden()
+  })
+
   test("Agent Manager keeps virtualized transcript fragments laid out", async ({ page }) => {
     await open(page, "agentmanager--sidebar-search-open")
 

--- a/packages/kilo-vscode/tests/unit/background-agents.test.ts
+++ b/packages/kilo-vscode/tests/unit/background-agents.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test"
 import {
   backgroundAgents,
   backgroundJobAgents,
+  fitBackgroundAgents,
   showBackgroundAgent,
 } from "../../webview-ui/src/components/chat/background-agents"
 import { childForeground, showChildPromotion } from "../../webview-ui/src/components/chat/task-tool-state"
@@ -48,6 +49,29 @@ function taskPart(opts: TaskOptions = {}): ToolPart {
 
 const busy: SessionStatusInfo = { type: "busy" }
 const idle: SessionStatusInfo = { type: "idle" }
+
+describe("fitBackgroundAgents", () => {
+  it("uses the full width when all agents fit without an overflow button", () => {
+    expect(fitBackgroundAgents([30, 30], 66, 80, 6)).toBe(2)
+  })
+
+  it("reserves the overflow button and spacing while fitting a prefix", () => {
+    expect(fitBackgroundAgents([100, 120, 80], 285, 50, 6)).toBe(2)
+    expect(fitBackgroundAgents([100, 120, 80], 281, 50, 6)).toBe(1)
+  })
+
+  it("falls back to the summary when no agent fits with the overflow button", () => {
+    expect(fitBackgroundAgents([100, 120], 155, 50, 6)).toBe(0)
+    expect(fitBackgroundAgents([100, 120], 156, 50, 6)).toBe(1)
+  })
+
+  it("handles single agents, empty lists, and hidden containers", () => {
+    expect(fitBackgroundAgents([100], 100, 50, 6)).toBe(1)
+    expect(fitBackgroundAgents([100], 99, 50, 6)).toBe(0)
+    expect(fitBackgroundAgents([], 100, 50, 6)).toBe(0)
+    expect(fitBackgroundAgents([100, 120], 0, 50, 6)).toBe(0)
+  })
+})
 
 describe("backgroundAgents", () => {
   it("lists a running background agent from tool state metadata", () => {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
@@ -19,7 +19,13 @@ import { useLanguage } from "../../context/language"
 import { useSession } from "../../context/session"
 import { useVSCode } from "../../context/vscode"
 import { useWorktreeMode } from "../../context/worktree-mode"
-import { backgroundAgents, backgroundJobAgents, showBackgroundAgent, type BackgroundAgent } from "./background-agents"
+import {
+  backgroundAgents,
+  backgroundJobAgents,
+  fitBackgroundAgents,
+  showBackgroundAgent,
+  type BackgroundAgent,
+} from "./background-agents"
 import { openSubagent } from "./open-subagent"
 
 export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
@@ -106,20 +112,37 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
   const active = createMemo(() =>
     visible().filter((agent) => agent.status === "running" || agent.permission || agent.question),
   )
-  const [box, setBox] = createSignal<HTMLSpanElement>()
-  const [preview, setPreview] = createSignal<HTMLSpanElement>()
-  const [fits, setFits] = createSignal(false)
-  const detailed = createMemo(() => !open() && active().length > 0 && fits())
+  const keys = createMemo(() => active().map((agent) => agent.jobID))
+  const signature = createMemo(() => keys().join("\0"))
+  const [box, setBox] = createSignal<HTMLDivElement>()
+  const [preview, setPreview] = createSignal<HTMLDivElement>()
+  const [overflow, setOverflow] = createSignal<HTMLButtonElement>()
+  const [layout, setLayout] = createSignal({ count: 0, offset: 0 })
+  const count = createMemo(() => (open() ? 0 : Math.min(layout().count, active().length)))
+  const remaining = createMemo(() => active().length - count())
   const caption = createMemo(() => (waiting() > 0 ? language.t("task.backgroundAgents.waiting") : summary()))
+  const more = (count: number) => language.t("task.backgroundAgents.more", { count: String(count) })
 
   createEffect(() => {
     const container = box()
     const content = preview()
-    if (!container || !content || typeof ResizeObserver === "undefined") return
-    const measure = () => setFits(container.clientWidth > 0 && content.scrollWidth <= container.clientWidth)
+    const control = overflow()
+    if (!signature() || !container || !content || !control || typeof ResizeObserver === "undefined") return
+    const items = Array.from(content.children)
+    const measure = () => {
+      const widths = items.map((item) => item.getBoundingClientRect().width)
+      const gap = Number.parseFloat(getComputedStyle(content).columnGap) || 0
+      const count =
+        container.clientWidth > 0
+          ? fitBackgroundAgents(widths, container.clientWidth, control.getBoundingClientRect().width, gap)
+          : 0
+      const offset = widths.slice(0, count).reduce((sum, width) => sum + width + gap, 0)
+      setLayout({ count, offset })
+    }
     const observer = new ResizeObserver(measure)
     observer.observe(container)
-    observer.observe(content)
+    observer.observe(control)
+    for (const item of items) observer.observe(item)
     onCleanup(() => observer.disconnect())
     measure()
   })
@@ -164,58 +187,88 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
     <Show when={visible().length > 0}>
       <div data-component="task-header-agents">
         <div data-slot="task-header-agents-toolbar">
-          <Show when={visible().length > 0}>
-            <button
-              data-slot="task-header-todos-trigger"
-              onClick={() => setOpen((value) => !value)}
+          <div data-slot="task-header-agents-content" ref={setBox}>
+            <Button
+              data-slot="task-header-agents-summary"
+              variant="ghost"
+              size="small"
+              aria-hidden={count() > 0}
+              tabIndex={count() > 0 ? -1 : 0}
               aria-expanded={open()}
-              aria-label={detailed() ? `${caption()}: ${active().map(label).join(", ")}` : undefined}
+              onClick={() => setOpen((value) => !value)}
             >
-              <span data-slot="task-header-agents-content" ref={setBox}>
-                <span data-slot="task-header-agents-summary" aria-hidden={detailed()}>
-                  <Show
-                    when={waiting() > 0}
-                    fallback={
-                      <Show
-                        when={visible().some((agent) => agent.status === "running")}
-                        fallback={<Icon name="task" size="small" />}
-                      >
-                        <Spinner />
-                      </Show>
-                    }
-                  >
-                    <Icon name="warning" size="small" />
+              <Show
+                when={waiting() > 0}
+                fallback={
+                  <Show when={active().length > 0} fallback={<Icon name="task" size="small" />}>
+                    <Spinner />
                   </Show>
-                  <span data-slot="task-header-todos-summary">{caption()}</span>
-                </span>
-                <span data-slot="task-header-agents-preview" ref={setPreview} aria-hidden={!detailed()}>
-                  <For each={active()}>
+                }
+              >
+                <Icon name="warning" size="small" />
+              </Show>
+              <span data-slot="task-header-todos-summary">{caption()}</span>
+            </Button>
+            <div data-slot="task-header-agents-preview" ref={setPreview}>
+              <For each={keys()}>
+                {(id, index) => (
+                  <Show when={active().find((agent) => agent.jobID === id)}>
                     {(agent) => (
-                      <span
+                      <Button
                         data-slot="task-header-agents-item"
-                        title={
-                          agent.permission || agent.question
-                            ? language.t("task.backgroundAgents.needsInput")
-                            : undefined
-                        }
+                        variant="ghost"
+                        size="small"
+                        aria-hidden={index() >= count()}
+                        tabIndex={index() < count() ? 0 : -1}
+                        title={`${language.t("task.backgroundAgents.open")}: ${label(agent())}`}
+                        aria-label={`${language.t("task.backgroundAgents.open")}: ${label(agent())}${
+                          agent().permission || agent().question
+                            ? ` (${language.t("task.backgroundAgents.needsInput")})`
+                            : ""
+                        }`}
+                        onClick={() => openAgent(agent())}
                       >
-                        <Show when={agent.permission || agent.question} fallback={<Spinner />}>
+                        <Show when={agent().permission || agent().question} fallback={<Spinner />}>
                           <Icon name="warning" size="small" />
                         </Show>
-                        <span dir="auto">{label(agent)}</span>
-                      </span>
+                        <span dir="auto">{label(agent())}</span>
+                      </Button>
                     )}
-                  </For>
-                </span>
+                  </Show>
+                )}
+              </For>
+            </div>
+            <Button
+              data-slot="task-header-agents-overflow"
+              ref={setOverflow}
+              variant="ghost"
+              size="small"
+              style={{ "inset-inline-start": `${layout().offset}px` }}
+              aria-hidden={count() === 0 || remaining() === 0}
+              tabIndex={count() > 0 && remaining() > 0 ? 0 : -1}
+              aria-expanded={open()}
+              aria-label={`${more(remaining())}: ${caption()}`}
+              title={caption()}
+              onClick={() => setOpen((value) => !value)}
+            >
+              <span data-slot="task-header-agents-overflow-label">
+                <span aria-hidden="true">{more(active().length)}</span>
+                <span>{more(remaining())}</span>
               </span>
-              <Icon
-                name="chevron-down"
-                size="small"
-                data-slot="task-header-todos-arrow"
-                data-open={open() ? "" : undefined}
-              />
-            </button>
-          </Show>
+            </Button>
+          </div>
+          <Button
+            data-slot="task-header-agents-toggle"
+            variant="ghost"
+            size="small"
+            icon={waiting() > 0 ? "warning" : undefined}
+            aria-label={caption()}
+            title={caption()}
+            aria-expanded={open()}
+            onClick={() => setOpen((value) => !value)}
+          >
+            <Icon name={open() ? "chevron-up" : "chevron-down"} size="small" />
+          </Button>
           <Show when={!props.readonly && visible().some((agent) => agent.status !== "running")}>
             <Button
               icon="close-small"

--- a/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
@@ -103,6 +103,13 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
   const label = (agent: BackgroundAgent) =>
     agent.description ?? agent.agent ?? language.t("task.backgroundAgents.untitled")
 
+  const names = createMemo(() =>
+    visible()
+      .filter((agent) => agent.status === "running")
+      .map(label)
+      .join(" · "),
+  )
+
   const status = (agent: BackgroundAgent) => language.t(`task.backgroundAgents.status.${agent.status}`)
 
   const icon = (agent: BackgroundAgent) => {
@@ -148,7 +155,6 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
               data-slot="task-header-todos-trigger"
               onClick={() => setOpen((value) => !value)}
               aria-expanded={open()}
-              aria-label={waiting() > 0 ? language.t("task.backgroundAgents.waiting") : undefined}
             >
               <Show
                 when={waiting() > 0}
@@ -168,6 +174,11 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
                   {language.t("task.backgroundAgents.waiting")}
                 </Show>
               </span>
+              <Show when={!open() && names()}>
+                <span data-slot="task-header-agents-preview" title={names()} dir="auto">
+                  {names()}
+                </span>
+              </Show>
               <Icon
                 name="chevron-down"
                 size="small"

--- a/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
@@ -103,12 +103,26 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
   const label = (agent: BackgroundAgent) =>
     agent.description ?? agent.agent ?? language.t("task.backgroundAgents.untitled")
 
-  const names = createMemo(() =>
-    visible()
-      .filter((agent) => agent.status === "running")
-      .map(label)
-      .join(" · "),
+  const active = createMemo(() =>
+    visible().filter((agent) => agent.status === "running" || agent.permission || agent.question),
   )
+  const [box, setBox] = createSignal<HTMLSpanElement>()
+  const [preview, setPreview] = createSignal<HTMLSpanElement>()
+  const [fits, setFits] = createSignal(false)
+  const detailed = createMemo(() => !open() && active().length > 0 && fits())
+  const caption = createMemo(() => (waiting() > 0 ? language.t("task.backgroundAgents.waiting") : summary()))
+
+  createEffect(() => {
+    const container = box()
+    const content = preview()
+    if (!container || !content || typeof ResizeObserver === "undefined") return
+    const measure = () => setFits(container.clientWidth > 0 && content.scrollWidth <= container.clientWidth)
+    const observer = new ResizeObserver(measure)
+    observer.observe(container)
+    observer.observe(content)
+    onCleanup(() => observer.disconnect())
+    measure()
+  })
 
   const status = (agent: BackgroundAgent) => language.t(`task.backgroundAgents.status.${agent.status}`)
 
@@ -155,30 +169,45 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
               data-slot="task-header-todos-trigger"
               onClick={() => setOpen((value) => !value)}
               aria-expanded={open()}
+              aria-label={detailed() ? `${caption()}: ${active().map(label).join(", ")}` : undefined}
             >
-              <Show
-                when={waiting() > 0}
-                fallback={
+              <span data-slot="task-header-agents-content" ref={setBox}>
+                <span data-slot="task-header-agents-summary" aria-hidden={detailed()}>
                   <Show
-                    when={visible().some((agent) => agent.status === "running")}
-                    fallback={<Icon name="task" size="small" />}
+                    when={waiting() > 0}
+                    fallback={
+                      <Show
+                        when={visible().some((agent) => agent.status === "running")}
+                        fallback={<Icon name="task" size="small" />}
+                      >
+                        <Spinner />
+                      </Show>
+                    }
                   >
-                    <Spinner />
+                    <Icon name="warning" size="small" />
                   </Show>
-                }
-              >
-                <Icon name="warning" size="small" />
-              </Show>
-              <span data-slot="task-header-todos-summary">
-                <Show when={waiting() > 0} fallback={summary()}>
-                  {language.t("task.backgroundAgents.waiting")}
-                </Show>
-              </span>
-              <Show when={!open() && names()}>
-                <span data-slot="task-header-agents-preview" title={names()} dir="auto">
-                  {names()}
+                  <span data-slot="task-header-todos-summary">{caption()}</span>
                 </span>
-              </Show>
+                <span data-slot="task-header-agents-preview" ref={setPreview} aria-hidden={!detailed()}>
+                  <For each={active()}>
+                    {(agent) => (
+                      <span
+                        data-slot="task-header-agents-item"
+                        title={
+                          agent.permission || agent.question
+                            ? language.t("task.backgroundAgents.needsInput")
+                            : undefined
+                        }
+                      >
+                        <Show when={agent.permission || agent.question} fallback={<Spinner />}>
+                          <Icon name="warning" size="small" />
+                        </Show>
+                        <span dir="auto">{label(agent)}</span>
+                      </span>
+                    )}
+                  </For>
+                </span>
+              </span>
               <Icon
                 name="chevron-down"
                 size="small"

--- a/packages/kilo-vscode/webview-ui/src/components/chat/background-agents.ts
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/background-agents.ts
@@ -37,6 +37,20 @@ export interface BackgroundAgent {
   question?: QuestionRequest
 }
 
+export function fitBackgroundAgents(widths: number[], space: number, overflow: number, gap: number): number {
+  const total = widths.reduce((sum, width) => sum + width, 0) + Math.max(0, widths.length - 1) * gap
+  if (total <= space) return widths.length
+  let used = 0
+  let count = 0
+  for (const width of widths) {
+    const next = used + width + (count > 0 ? gap : 0)
+    if (next + gap + overflow > space) break
+    used = next
+    count += 1
+  }
+  return count
+}
+
 export function showBackgroundAgent(agent: BackgroundAgent, hidden: ReadonlySet<string>): boolean {
   return agent.status === "running" || !hidden.has(agent.jobID)
 }

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -1223,6 +1223,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} مهام مكتملة",
   "task.backgroundAgents.running.one": "وكيل خلفي واحد",
   "task.backgroundAgents.running.many": "{{count}} وكلاء خلفيون",
+  "task.backgroundAgents.more": "+{{count}} آخرون",
   "task.backgroundAgents.open": "فتح الوكيل الخلفي",
   "task.backgroundAgents.cancel": "إيقاف",
   "task.backgroundAgents.continueInBackground": "متابعة في الخلفية",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -1266,6 +1266,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} tarefas concluídas",
   "task.backgroundAgents.running.one": "1 agente em segundo plano",
   "task.backgroundAgents.running.many": "{{count}} agentes em segundo plano",
+  "task.backgroundAgents.more": "+{{count}} mais",
   "task.backgroundAgents.open": "Abrir agente em segundo plano",
   "task.backgroundAgents.cancel": "Parar",
   "task.backgroundAgents.continueInBackground": "Continuar em segundo plano",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -1257,6 +1257,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} zadataka završeno",
   "task.backgroundAgents.running.one": "1 agent u pozadini",
   "task.backgroundAgents.running.many": "{{count}} agenata u pozadini",
+  "task.backgroundAgents.more": "+{{count}} još",
   "task.backgroundAgents.open": "Otvori agenta u pozadini",
   "task.backgroundAgents.cancel": "Zaustavi",
   "task.backgroundAgents.continueInBackground": "Nastavi u pozadini",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -1252,6 +1252,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} opgaver udført",
   "task.backgroundAgents.running.one": "1 baggrundsagent",
   "task.backgroundAgents.running.many": "{{count}} baggrundsagenter",
+  "task.backgroundAgents.more": "+{{count}} flere",
   "task.backgroundAgents.open": "Åbn baggrundsagent",
   "task.backgroundAgents.cancel": "Stop",
   "task.backgroundAgents.continueInBackground": "Fortsæt i baggrunden",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -1281,6 +1281,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} Aufgaben erledigt",
   "task.backgroundAgents.running.one": "1 Hintergrund-Agent",
   "task.backgroundAgents.running.many": "{{count}} Hintergrund-Agenten",
+  "task.backgroundAgents.more": "+{{count}} weitere",
   "task.backgroundAgents.open": "Hintergrund-Agent öffnen",
   "task.backgroundAgents.cancel": "Stoppen",
   "task.backgroundAgents.continueInBackground": "Im Hintergrund fortsetzen",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1244,6 +1244,7 @@ export const dict = {
   "task.backgroundAgents.dismiss": "Dismiss",
   "task.backgroundAgents.clearFinished": "Clear finished",
   "task.backgroundAgents.summary": "{{running}} of {{total}} background agents running",
+  "task.backgroundAgents.more": "+{{count}} more",
   "task.backgroundAgents.status.running": "Running",
   "task.backgroundAgents.status.completed": "Done",
   "task.backgroundAgents.status.cancelled": "Cancelled",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -1268,6 +1268,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} tareas completadas",
   "task.backgroundAgents.running.one": "1 agente en segundo plano",
   "task.backgroundAgents.running.many": "{{count}} agentes en segundo plano",
+  "task.backgroundAgents.more": "+{{count}} más",
   "task.backgroundAgents.open": "Abrir agente en segundo plano",
   "task.backgroundAgents.cancel": "Detener",
   "task.backgroundAgents.continueInBackground": "Continuar en segundo plano",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
@@ -1248,6 +1248,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} کار انجام شد",
   "task.backgroundAgents.running.one": "1 عامل پس‌زمینه",
   "task.backgroundAgents.running.many": "{{count}} عامل پس‌زمینه",
+  "task.backgroundAgents.more": "+{{count}} بیشتر",
   "task.backgroundAgents.open": "باز کردن عامل پس‌زمینه",
   "task.backgroundAgents.cancel": "توقف",
   "task.backgroundAgents.continueInBackground": "ادامه در پس‌زمینه",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -1289,6 +1289,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} tâches terminées",
   "task.backgroundAgents.running.one": "1 agent en arrière-plan",
   "task.backgroundAgents.running.many": "{{count}} agents en arrière-plan",
+  "task.backgroundAgents.more": "+{{count}} de plus",
   "task.backgroundAgents.open": "Ouvrir l'agent en arrière-plan",
   "task.backgroundAgents.cancel": "Arrêter",
   "task.backgroundAgents.continueInBackground": "Continuer en arrière-plan",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -1124,6 +1124,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} to-do completati",
   "task.backgroundAgents.running.one": "1 agente in background",
   "task.backgroundAgents.running.many": "{{count}} agenti in background",
+  "task.backgroundAgents.more": "+{{count}} altri",
   "task.backgroundAgents.open": "Apri agente in background",
   "task.backgroundAgents.cancel": "Arresta",
   "task.backgroundAgents.continueInBackground": "Continua in background",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -1244,6 +1244,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} タスク完了",
   "task.backgroundAgents.running.one": "バックグラウンドエージェント 1 件",
   "task.backgroundAgents.running.many": "バックグラウンドエージェント {{count}} 件",
+  "task.backgroundAgents.more": "+{{count}} 件",
   "task.backgroundAgents.open": "バックグラウンドエージェントを開く",
   "task.backgroundAgents.cancel": "停止",
   "task.backgroundAgents.continueInBackground": "バックグラウンドで続行",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -1231,6 +1231,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} 할 일 완료",
   "task.backgroundAgents.running.one": "백그라운드 에이전트 1개",
   "task.backgroundAgents.running.many": "백그라운드 에이전트 {{count}}개",
+  "task.backgroundAgents.more": "+{{count}}개 더",
   "task.backgroundAgents.open": "백그라운드 에이전트 열기",
   "task.backgroundAgents.cancel": "중지",
   "task.backgroundAgents.continueInBackground": "백그라운드에서 계속",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -1238,6 +1238,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} to-do's voltooid",
   "task.backgroundAgents.running.one": "1 achtergrondagent",
   "task.backgroundAgents.running.many": "{{count}} achtergrondagenten",
+  "task.backgroundAgents.more": "+{{count}} meer",
   "task.backgroundAgents.open": "Achtergrondagent openen",
   "task.backgroundAgents.cancel": "Stoppen",
   "task.backgroundAgents.continueInBackground": "Doorgaan op de achtergrond",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -1248,6 +1248,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} oppgaver fullført",
   "task.backgroundAgents.running.one": "1 bakgrunnsagent",
   "task.backgroundAgents.running.many": "{{count}} bakgrunnsagenter",
+  "task.backgroundAgents.more": "+{{count}} flere",
   "task.backgroundAgents.open": "Åpne bakgrunnsagent",
   "task.backgroundAgents.cancel": "Stopp",
   "task.backgroundAgents.continueInBackground": "Fortsett i bakgrunnen",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -1257,6 +1257,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} zadań ukończono",
   "task.backgroundAgents.running.one": "1 agent w tle",
   "task.backgroundAgents.running.many": "{{count}} agentów w tle",
+  "task.backgroundAgents.more": "+{{count}} więcej",
   "task.backgroundAgents.open": "Otwórz agenta w tle",
   "task.backgroundAgents.cancel": "Zatrzymaj",
   "task.backgroundAgents.continueInBackground": "Kontynuuj w tle",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -1251,6 +1251,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} задач выполнено",
   "task.backgroundAgents.running.one": "1 фоновый агент",
   "task.backgroundAgents.running.many": "Фоновых агентов: {{count}}",
+  "task.backgroundAgents.more": "+{{count}} ещё",
   "task.backgroundAgents.open": "Открыть фонового агента",
   "task.backgroundAgents.cancel": "Остановить",
   "task.backgroundAgents.continueInBackground": "Продолжить в фоне",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -1228,6 +1228,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} งานเสร็จแล้ว",
   "task.backgroundAgents.running.one": "เอเจนต์เบื้องหลัง 1 ตัว",
   "task.backgroundAgents.running.many": "เอเจนต์เบื้องหลัง {{count}} ตัว",
+  "task.backgroundAgents.more": "+{{count}} เพิ่มเติม",
   "task.backgroundAgents.open": "เปิดเอเจนต์เบื้องหลัง",
   "task.backgroundAgents.cancel": "หยุด",
   "task.backgroundAgents.continueInBackground": "ทำต่อในเบื้องหลัง",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -1225,6 +1225,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} görev tamamlandı",
   "task.backgroundAgents.running.one": "1 arka plan ajanı",
   "task.backgroundAgents.running.many": "{{count}} arka plan ajanı",
+  "task.backgroundAgents.more": "+{{count}} tane daha",
   "task.backgroundAgents.open": "Arka plan ajanını aç",
   "task.backgroundAgents.cancel": "Durdur",
   "task.backgroundAgents.continueInBackground": "Arka planda devam et",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -1224,6 +1224,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} завдань виконано",
   "task.backgroundAgents.running.one": "1 фоновий агент",
   "task.backgroundAgents.running.many": "Фонових агентів: {{count}}",
+  "task.backgroundAgents.more": "+{{count}} ще",
   "task.backgroundAgents.open": "Відкрити фонового агента",
   "task.backgroundAgents.cancel": "Зупинити",
   "task.backgroundAgents.continueInBackground": "Продовжити у фоні",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1187,6 +1187,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} 个待办已完成",
   "task.backgroundAgents.running.one": "1 个后台智能体",
   "task.backgroundAgents.running.many": "{{count}} 个后台智能体",
+  "task.backgroundAgents.more": "+{{count}} 个",
   "task.backgroundAgents.open": "打开后台智能体",
   "task.backgroundAgents.cancel": "停止",
   "task.backgroundAgents.continueInBackground": "在后台继续",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1191,6 +1191,7 @@ export const dict = {
   "task.todos.allDone": "{{count}} 個待辦已完成",
   "task.backgroundAgents.running.one": "1 個背景 Agent",
   "task.backgroundAgents.running.many": "{{count}} 個背景 Agent",
+  "task.backgroundAgents.more": "+{{count}} 個",
   "task.backgroundAgents.open": "開啟背景 Agent",
   "task.backgroundAgents.cancel": "停止",
   "task.backgroundAgents.continueInBackground": "在背景繼續",

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -1203,18 +1203,17 @@ export const TaskHeaderWithTodos: Story = {
 
 export const TaskHeaderBackgroundAgents1280: Story = {
   name: "TaskHeader background agents, wide",
-  render: () => {
-    const tools: ToolPart[] = ["Trace overflow recovery", "Trace outbound request size", "Check request limits"].map(
-      (description, index) => ({
-        id: `task-${index}`,
-        sessionID: SESSION_ID,
-        messageID: headerAssistantID,
-        type: "tool",
-        tool: "task",
-        state: { status: "completed", input: { description }, output: "Started background agent", title: description },
-        metadata: { sessionId: `child-${index}`, background: true },
-      }),
-    )
+  args: { names: ["Trace overflow recovery", "Trace outbound request size", "Check request limits"] },
+  render: (args: { names: string[] }) => {
+    const tools: ToolPart[] = args.names.map((description, index) => ({
+      id: `task-${index}`,
+      sessionID: SESSION_ID,
+      messageID: headerAssistantID,
+      type: "tool",
+      tool: "task",
+      state: { status: "completed", input: { description }, output: "Started background agent", title: description },
+      metadata: { sessionId: `child-${index}`, background: true },
+    }))
     const session = {
       ...mockSessionValue({ id: SESSION_ID }),
       messages: () => headerMessages,
@@ -1240,6 +1239,12 @@ export const TaskHeaderBackgroundAgents1280: Story = {
 export const TaskHeaderBackgroundAgents420: Story = {
   ...TaskHeaderBackgroundAgents1280,
   name: "TaskHeader background agents, narrow",
+}
+
+export const TaskHeaderSingleBackgroundAgent420: Story = {
+  ...TaskHeaderBackgroundAgents1280,
+  name: "TaskHeader single background agent, narrow",
+  args: { names: ["Check request limits"] },
 }
 
 export const TaskHeaderWithTodosAllDone: Story = {

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -26,6 +26,7 @@ import { VscodeUserMessage } from "../components/chat/VscodeUserMessage"
 import { SidebarTopBar } from "../components/chat/SidebarTopBar"
 import { TurnOutcome } from "../components/shared/TurnOutcome"
 import { SessionContext } from "../context/session"
+import type { SessionContextValue } from "../context/session-types"
 import { ProviderContext } from "../context/provider"
 import { ServerContext } from "../context/server"
 import { WorktreeModeProvider } from "../context/worktree-mode"
@@ -38,6 +39,7 @@ import type {
   SessionModelUsage,
   SuggestionRequest,
   TodoItem,
+  ToolPart,
 } from "../types/messages"
 import { formatReviewCommentsMarkdown } from "../utils/review-comment-markdown"
 import { reviewMetadata } from "../../../src/shared/review-comments"
@@ -1197,6 +1199,47 @@ export const TaskHeaderWithTodos: Story = {
       </StoryProviders>
     )
   },
+}
+
+export const TaskHeaderBackgroundAgents1280: Story = {
+  name: "TaskHeader background agents, wide",
+  render: () => {
+    const tools: ToolPart[] = ["Trace overflow recovery", "Trace outbound request size", "Check request limits"].map(
+      (description, index) => ({
+        id: `task-${index}`,
+        sessionID: SESSION_ID,
+        messageID: headerAssistantID,
+        type: "tool",
+        tool: "task",
+        state: { status: "completed", input: { description }, output: "Started background agent", title: description },
+        metadata: { sessionId: `child-${index}`, background: true },
+      }),
+    )
+    const session = {
+      ...mockSessionValue({ id: SESSION_ID }),
+      messages: () => headerMessages,
+      currentSession: () => ({
+        id: SESSION_ID,
+        title: "Investigate request size limits",
+        createdAt: new Date(headerNow).toISOString(),
+        updatedAt: new Date(headerNow).toISOString(),
+      }),
+      getSessionToolParts: () => tools,
+      allStatusMap: () => Object.fromEntries(tools.map((_, index) => [`child-${index}`, { type: "busy" as const }])),
+    }
+    return (
+      <StoryProviders sessionID={SESSION_ID} noPadding>
+        <SessionContext.Provider value={session as unknown as SessionContextValue}>
+          <TaskHeader />
+        </SessionContext.Provider>
+      </StoryProviders>
+    )
+  },
+}
+
+export const TaskHeaderBackgroundAgents420: Story = {
+  ...TaskHeaderBackgroundAgents1280,
+  name: "TaskHeader background agents, narrow",
 }
 
 export const TaskHeaderWithTodosAllDone: Story = {

--- a/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/chat.stories.tsx
@@ -1241,6 +1241,11 @@ export const TaskHeaderBackgroundAgents420: Story = {
   name: "TaskHeader background agents, narrow",
 }
 
+export const TaskHeaderBackgroundAgents200: Story = {
+  ...TaskHeaderBackgroundAgents1280,
+  name: "TaskHeader background agents, compact",
+}
+
 export const TaskHeaderSingleBackgroundAgent420: Story = {
   ...TaskHeaderBackgroundAgents1280,
   name: "TaskHeader single background agent, narrow",

--- a/packages/kilo-vscode/webview-ui/src/styles/task-header.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/task-header.css
@@ -205,6 +205,11 @@
     width: max-content;
     white-space: nowrap;
     color: var(--text-base);
+    pointer-events: none;
+
+    > [aria-hidden="false"] {
+      pointer-events: auto;
+    }
 
     > [aria-hidden="true"] {
       visibility: hidden;

--- a/packages/kilo-vscode/webview-ui/src/styles/task-header.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/task-header.css
@@ -146,6 +146,40 @@
    ============================================ */
 
 [data-component="task-header-agents"] {
+  container: background-agents / inline-size;
+
+  [data-slot="task-header-todos-summary"] {
+    flex: 0 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  [data-slot="task-header-agents-preview"] {
+    display: none;
+    flex: 1;
+    min-width: 0;
+    margin-inline-start: 6px;
+    padding-inline-start: 12px;
+    border-inline-start: 1px solid var(--border-weak-base);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-base);
+  }
+
+  [data-slot="task-header-todos-trigger"] > [data-component="icon"]:last-child {
+    margin-inline-start: auto;
+    flex-shrink: 0;
+  }
+
+  @container background-agents (min-width: 640px) {
+    [data-slot="task-header-agents-preview"] {
+      display: block;
+    }
+  }
+
   /* The shared spinner svg has no intrinsic size, so it must be constrained
      or it stretches to the full row width. */
   [data-component="spinner"] {

--- a/packages/kilo-vscode/webview-ui/src/styles/task-header.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/task-header.css
@@ -146,10 +146,25 @@
    ============================================ */
 
 [data-component="task-header-agents"] {
-  container: background-agents / inline-size;
+  [data-slot="task-header-agents-content"] {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+
+    > [aria-hidden="true"] {
+      visibility: hidden;
+    }
+  }
+
+  [data-slot="task-header-agents-summary"],
+  [data-slot="task-header-agents-item"] {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
 
   [data-slot="task-header-todos-summary"] {
-    flex: 0 1 auto;
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -157,27 +172,19 @@
   }
 
   [data-slot="task-header-agents-preview"] {
-    display: none;
-    flex: 1;
-    min-width: 0;
-    margin-inline-start: 6px;
-    padding-inline-start: 12px;
-    border-inline-start: 1px solid var(--border-weak-base);
-    overflow: hidden;
-    text-overflow: ellipsis;
+    position: absolute;
+    inset-inline-start: 0;
+    top: 0;
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    width: max-content;
     white-space: nowrap;
     color: var(--text-base);
   }
 
   [data-slot="task-header-todos-trigger"] > [data-component="icon"]:last-child {
-    margin-inline-start: auto;
     flex-shrink: 0;
-  }
-
-  @container background-agents (min-width: 640px) {
-    [data-slot="task-header-agents-preview"] {
-      display: block;
-    }
   }
 
   /* The shared spinner svg has no intrinsic size, so it must be constrained

--- a/packages/kilo-vscode/webview-ui/src/styles/task-header.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/task-header.css
@@ -146,10 +146,22 @@
    ============================================ */
 
 [data-component="task-header-agents"] {
+  [data-slot="task-header-agents-toolbar"] {
+    min-height: 31px;
+    padding: 3px 8px 3px 12px;
+    gap: 4px;
+    box-sizing: border-box;
+
+    > [data-component="button"] {
+      margin: 0;
+    }
+  }
+
   [data-slot="task-header-agents-content"] {
     position: relative;
     flex: 1;
     min-width: 0;
+    height: 24px;
     overflow: hidden;
 
     > [aria-hidden="true"] {
@@ -158,10 +170,21 @@
   }
 
   [data-slot="task-header-agents-summary"],
-  [data-slot="task-header-agents-item"] {
-    display: flex;
-    align-items: center;
+  [data-slot="task-header-agents-item"],
+  [data-slot="task-header-agents-overflow"] {
+    padding: 0 4px;
     gap: 6px;
+    font-size: var(--kilo-font-size-12);
+
+    &:focus-visible {
+      outline-offset: -2px;
+    }
+  }
+
+  [data-slot="task-header-agents-summary"] {
+    width: 100%;
+    justify-content: flex-start;
+    color: var(--text-weak);
   }
 
   [data-slot="task-header-todos-summary"] {
@@ -169,6 +192,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    text-align: start;
   }
 
   [data-slot="task-header-agents-preview"] {
@@ -177,14 +201,32 @@
     top: 0;
     display: flex;
     align-items: center;
-    gap: 20px;
+    gap: 6px;
     width: max-content;
     white-space: nowrap;
     color: var(--text-base);
+
+    > [aria-hidden="true"] {
+      visibility: hidden;
+    }
   }
 
-  [data-slot="task-header-todos-trigger"] > [data-component="icon"]:last-child {
-    flex-shrink: 0;
+  [data-slot="task-header-agents-overflow"] {
+    position: absolute;
+    top: 0;
+    color: var(--text-weak);
+  }
+
+  [data-slot="task-header-agents-overflow-label"] {
+    display: grid;
+
+    > span {
+      grid-area: 1 / 1;
+    }
+
+    > [aria-hidden="true"] {
+      visibility: hidden;
+    }
   }
 
   /* The shared spinner svg has no intrinsic size, so it must be constrained


### PR DESCRIPTION
## What Problem This Solves

The collapsed background agent header shows only a count, even when Agent Manager has enough horizontal space to show the active work. Finding and opening a running agent requires expanding the full list and using more vertical space.

## Why This Change Was Made

Show as many complete agent buttons as fit, in their existing order, and summarize only the remaining active agents with `+N more`. This keeps useful details visible instead of making the layout an all-or-nothing choice.

Each agent button opens that subagent directly through the existing navigation path. The overflow count and a separate chevron expand the full list. These are sibling controls, not buttons nested inside an expand trigger.

Fit is based on actual item and control widths. The overflow control reserves a stable width for the count so changing the number of visible agents does not cause repeated layout changes. Job execution is unchanged.

## User Impact

- See each visible running agent with its own loading spinner.
- Keep one or more agent names visible in narrower panes, with `+N more` for the hidden active agents.
- Open an agent directly by clicking its name or pressing Enter. This does not expand the list.
- Use the overflow count or chevron to reveal all agents and their existing actions.
- Fall back to the full count only when no agent button fits alongside the overflow control.
- Preserve input-needed warnings, keyboard focus during job updates, and right-to-left positioning. Hidden controls are not in the tab order.
- Keep the overflow label translated across the supported locales.

## Evidence

Verified the rebuilt extension in isolated VS Code with `vscode-self-test`. Job status responses were supplied as deterministic webview fixtures. Direct navigation opened existing child-session transcripts in the real Agent Manager inspector. No live model requests were sent; job execution and cancellation were not changed or exercised.

With three running agents and two finished jobs:

| Panel width | Collapsed result |
|---|---|
| 320px | Full count, no individual agent fits |
| 430px | One agent and `+2 more` |
| 640px | Two agents and `+1 more` |
| 800px and 1092px | All three agents, no overflow count |

- Repeated shrink/grow checks kept the header 32px tall with no clipped agents, overlapping controls, or horizontal overflow.
- Clicking the first agent opened its transcript without expanding the list. Tab and Enter opened the second agent directly, with a visible inset focus ring.
- Verified stable button identity and focus across repeated job responses, hidden-control tab exclusion, RTL overflow positioning, completion updates, input-needed warnings, and Clear finished.
- Clicking `+N more` expanded all five rows. The separate chevron collapsed them again.
- `bun run compile` and the final `bun run build:check` passed, including extension/webview typechecks, lint, and bundling.
- `bun test tests/unit/background-agents.test.ts`: 22 passed, including four focused fit-calculation regression tests.
- Five focused i18n test files: 34 passed. `bun run knip` and `bun run check-kilocode-change` passed.
- `bun run test:unit --timeout 30000`: all 4,410 tests passed.
- Storybook covers wide, narrow, compact-summary, and single-agent layouts. CI regenerates the Linux visual baselines.
- No webview errors were observed. The console contained an extension-host `url.parse()` deprecation warning. The isolated instance was closed and cleaned up.

### Wide: every running agent is directly accessible

<img width="1092" alt="Three individual background agent buttons with loading spinners and a separate expand control" src="https://marius-kilocode.github.io/pr-assets/20260828-background-agents-partial-wide-gabgzb.png" />

### Medium: two agents and one more

<img width="640" alt="Two visible background agents followed by a plus one more overflow button" src="https://marius-kilocode.github.io/pr-assets/20260828-background-agents-partial-two-ixohjf.png" />

### Narrow: one agent and two more

<img width="430" alt="One visible background agent followed by a plus two more overflow button" src="https://marius-kilocode.github.io/pr-assets/20260828-background-agents-partial-one-usiazk.png" />

### Keyboard access

<img width="640" alt="Visible keyboard focus on the second agent button, which opens that agent directly with Enter" src="https://marius-kilocode.github.io/pr-assets/20260828-background-agents-partial-keyboard-x13lt7.png" />

Manual check: Resize a chat pane with background agents. Click an agent name to open it directly, then click `+N more` to expand the full list. Repeat agent navigation with Tab and Enter.


Related issue: #13507. Supersedes #13526 to avoid conflicts with the background-agent header changes.

**Remaining work:** Incorporate and verify the dismissal-persistence fix from #13526 before closing #13507.