### PR TITLE
feat(vscode): resume interrupted tasks from the send button

### DIFF
--- a/.changeset/empty-send-continue.md
+++ b/.changeset/empty-send-continue.md
@@ -1,0 +1,7 @@
+---
+"kilo-code": patch
+"@kilocode/cli": patch
+"@kilocode/sdk": patch
+---
+
+Resume interrupted tasks from the empty send button without adding a chat message.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1046,6 +1046,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
           post: (msg) => this.postMessage(msg),
           browserSettings: () => this.sendBrowserSettings(),
           exportTranscript: (sessionID) => this.handleExportSessionTranscript(sessionID),
+          resume: (sessionID, messageID, requestID) => this.handleResumeSession(sessionID, messageID, requestID),
           copy: (text) => vscode.env.clipboard.writeText(text),
           openSessions: (ids) => this.trackOpenSessions(ids),
           activity: (state) => {
@@ -4203,6 +4204,27 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     return this.aborts.stop(client, sid, dir, (dir, action) =>
       this.connectionService.runExplicitAbort(sid, dir, action),
     )
+  }
+
+  private async handleResumeSession(sessionID: string, messageID: string, requestID: string): Promise<void> {
+    try {
+      if (!this.client) throw new Error("Not connected to CLI backend")
+      const directory = this.getWorkspaceDirectory(sessionID)
+      await this.checkpoints.get(sessionID)
+      await this.client.kilocode.resumeSession(
+        { sessionID, messageID, directory, snapshotInitialization: this.opts.snapshotInitialization },
+        { throwOnError: true },
+      )
+      this.postMessage({ type: "sessionResumeResult", sessionID, requestID })
+    } catch (error) {
+      console.error("[Kilo New] Failed to resume session:", error)
+      this.postMessage({
+        type: "sessionResumeResult",
+        sessionID,
+        requestID,
+        error: getErrorMessage(error) || "Failed to resume session",
+      })
+    }
   }
 
   private async handleAbort(sessionID?: string): Promise<void> {

--- a/packages/kilo-vscode/src/kilo-provider/early-message.ts
+++ b/packages/kilo-vscode/src/kilo-provider/early-message.ts
@@ -17,6 +17,7 @@ type Ctx = {
   post: (msg: unknown) => void
   browserSettings: () => void
   exportTranscript: (sessionID: string) => Promise<void>
+  resume: (sessionID: string, messageID: string, requestID: string) => Promise<void>
   copy: (text: string) => PromiseLike<void>
   openSessions: (ids: string[]) => void
   activity: (state: unknown) => void
@@ -56,10 +57,27 @@ async function routeBackgroundMessage(
   return undefined
 }
 
+function isResume(input: { sessionID?: unknown; messageID?: unknown; requestID?: unknown }): input is {
+  sessionID: string
+  messageID: string
+  requestID: string
+} {
+  return (
+    typeof input.sessionID === "string" && typeof input.messageID === "string" && typeof input.requestID === "string"
+  )
+}
+
 export async function routeEarlyMessage(
   message: { type: string; id?: unknown; text?: unknown; state?: unknown },
   ctx: Ctx,
 ): Promise<boolean> {
+  if (message.type === "resumeSession") {
+    const input = message as { sessionID?: unknown; messageID?: unknown; requestID?: unknown }
+    if (isResume(input)) {
+      await ctx.resume(input.sessionID, input.messageID, input.requestID)
+    }
+    return true
+  }
   if (message.type === "copyToClipboard") {
     if (typeof message.id !== "string") return true
     if (typeof message.text !== "string") {

--- a/packages/kilo-vscode/tests/unit/early-message.test.ts
+++ b/packages/kilo-vscode/tests/unit/early-message.test.ts
@@ -43,6 +43,22 @@ describe("routeEarlyMessage clipboard handling", () => {
   })
 })
 
+describe("routeEarlyMessage resume", () => {
+  it("forwards the original session, assistant, and request IDs without sending text", async () => {
+    const calls: string[][] = []
+    const ctx = {
+      resume: async (...ids: string[]) => {
+        calls.push(ids)
+      },
+    } as Ctx
+    const message = { type: "resumeSession", sessionID: "ses_1", messageID: "msg_1", requestID: "request-1" }
+    expect(await routeEarlyMessage(message, ctx)).toBe(true)
+    expect(calls).toEqual([["ses_1", "msg_1", "request-1"]])
+    expect(await routeEarlyMessage({ ...message, messageID: undefined }, ctx)).toBe(true)
+    expect(calls).toHaveLength(1)
+  })
+})
+
 describe("routeEarlyMessage activity", () => {
   it("forwards authoritative webview presentation state without interpreting session events", async () => {
     const calls: unknown[] = []

--- a/packages/kilo-vscode/tests/unit/prompt-continue.test.ts
+++ b/packages/kilo-vscode/tests/unit/prompt-continue.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test"
+import { continuation } from "../../webview-ui/src/context/session-continuation"
+import type { Message, Part } from "../../webview-ui/src/types/messages"
+
+const user: Message = { id: "user", sessionID: "session", role: "user", createdAt: "2026-01-01" }
+const assistant: Message = {
+  id: "assistant",
+  sessionID: "session",
+  role: "assistant",
+  parentID: user.id,
+  createdAt: "2026-01-01",
+  error: { name: "MessageAbortedError" },
+}
+const input = {
+  id: "session",
+  status: "idle",
+  messages: [user, assistant],
+  parts: (_: string): Part[] => [],
+  submitting: false,
+  blocked: false,
+  loading: false,
+  reverted: false,
+}
+
+describe("empty prompt continuation", () => {
+  it("targets the stopped assistant rather than creating a new user turn", () => {
+    expect(continuation(input)).toBe(assistant.id)
+    expect(continuation({ ...input, messages: [user, { ...assistant, finish: "stop" }] })).toBe(assistant.id)
+  })
+
+  it("accepts unfinished assistant and tool-call turns", () => {
+    for (const finish of [undefined, "tool-calls"]) {
+      expect(continuation({ ...input, messages: [user, { ...assistant, error: undefined, finish }] })).toBe(
+        assistant.id,
+      )
+    }
+  })
+
+  it("does not resume completed, filtered, limited, or failed responses", () => {
+    for (const finish of ["stop", "length", "unknown", "content-filter", "error"]) {
+      expect(continuation({ ...input, messages: [user, { ...assistant, error: undefined, finish }] })).toBeUndefined()
+    }
+    expect(continuation({ ...input, messages: [user, { ...assistant, error: { name: "APIError" } }] })).toBeUndefined()
+  })
+
+  it("does not resume empty chats, previews, or a different user turn", () => {
+    expect(continuation({ ...input, id: undefined })).toBeUndefined()
+    expect(continuation({ ...input, id: "cloud:preview" })).toBeUndefined()
+    expect(continuation({ ...input, messages: [] })).toBeUndefined()
+    expect(continuation({ ...input, messages: [user] })).toBeUndefined()
+    expect(continuation({ ...input, messages: [user, { ...assistant, parentID: "older-user" }] })).toBeUndefined()
+    expect(continuation({ ...input, messages: [user, assistant, { ...user, id: "next-user" }] })).toBeUndefined()
+    expect(continuation({ ...input, messages: [user, { ...assistant, summary: true }] })).toBeUndefined()
+  })
+
+  it("keeps busy, pending, blocked, loading, and reverted sessions unavailable", () => {
+    for (const status of ["busy", "retry", "offline"]) {
+      expect(continuation({ ...input, status })).toBeUndefined()
+    }
+    for (const key of ["submitting", "blocked", "loading", "reverted"] as const) {
+      expect(continuation({ ...input, [key]: true })).toBeUndefined()
+    }
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -544,15 +544,15 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const canUseSpeech = () => canUseSpeechToText(config(), provider.authStates())
   const speechModel = () => selectedSpeechToTextModel(config(), speechModels.models())
   const hasInput = () => text().trim().length > 0 || imageAttach.images().length > 0 || reviewComments().length > 0
+  const sendReady = () => !isDisabled() && !terminal.pending() && !git.pending() && !props.blocked?.()
+  const canContinue = () => speech.state() === "idle" && !hasInput() && session.canResume()
   const canSend = () =>
-    !isDisabled() &&
-    !terminal.pending() &&
-    !git.pending() &&
-    !props.blocked?.() &&
-    (speech.state() === "recording" || (hasInput() && !speech.active()))
+    sendReady() && (speech.state() === "recording" || (!speech.active() && (hasInput() || canContinue())))
+  const canSendContinue = () => sendReady() && !speech.active() && canContinue()
   const sendLabel = () => {
     if (props.blocked?.()) return language.t("prompt.action.send.blocked")
     if (speech.state() === "recording") return language.t("prompt.action.send.recording")
+    if (canSendContinue()) return language.t("prompt.action.continue")
     return language.t("prompt.action.send")
   }
   const showStop = () => isBusy() && !hasInput() && speech.state() !== "recording"
@@ -1155,17 +1155,13 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const imgs = imageAttach.images()
     const pending = reviewComments()
     const review = pending.length > 0 ? formatReviewCommentsMarkdown(pending) : ""
+    if (canSendContinue()) {
+      session.resume()
+      return
+    }
     const message = draft && review ? `${review}\n\n${draft}` : draft || review
     const data = review ? { version: 1 as const, comments: pending } : undefined
-    if (
-      (!message && imgs.length === 0) ||
-      isDisabled() ||
-      speech.active() ||
-      terminal.pending() ||
-      git.pending() ||
-      props.blocked?.()
-    )
-      return
+    if ((!message && imgs.length === 0) || !sendReady() || speech.active()) return
 
     const mentionFiles = mention.parseFileAttachments(draft)
     const imgFiles = imgs.map((img) => ({ mime: img.mime, url: img.dataUrl, filename: img.filename }))

--- a/packages/kilo-vscode/webview-ui/src/context/session-continuation.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-continuation.ts
@@ -1,0 +1,33 @@
+import type { Message, Part } from "../types/messages"
+
+export function continuation(input: {
+  id?: string
+  status: string
+  messages: Message[]
+  parts: (id: string) => Part[]
+  submitting: boolean
+  blocked: boolean
+  loading: boolean
+  reverted: boolean
+}) {
+  if (!input.id || input.id.startsWith("cloud:") || input.status !== "idle") return
+  if (input.submitting || input.blocked || input.loading || input.reverted) return
+  const user = input.messages.findLast((message) => message.role === "user")
+  const assistant = input.messages.at(-1)
+  if (!user || !assistant || assistant.role !== "assistant" || assistant.summary === true) return
+  if (assistant.parentID !== user.id) return
+  if (input.parts(user.id).some((part) => part.type === "compaction")) return
+  if (
+    input.messages
+      .slice(input.messages.indexOf(user) + 1)
+      .some((message) =>
+        input
+          .parts(message.id)
+          .some((part) => part.type === "tool" && part.tool === "plan_exit" && part.state.status === "completed"),
+      )
+  )
+    return
+  if (assistant.error?.name === "MessageAbortedError") return assistant.id
+  if (assistant.error) return
+  if (!assistant.finish || assistant.finish === "tool-calls") return assistant.id
+}

--- a/packages/kilo-vscode/webview-ui/src/context/session-types.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-types.ts
@@ -40,6 +40,8 @@ export interface SessionContextValue {
   statusText: Accessor<string | undefined>
   busySince: Accessor<number | undefined>
   submitting: Accessor<boolean>
+  canResume: Accessor<boolean>
+  resume: () => void
   isSubmitting: (id: string) => boolean
   loading: Accessor<boolean>
   loadingOlderMessages: Accessor<boolean>

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -91,6 +91,7 @@ import { reviewMetadata, type ReviewMessageData } from "../../../src/shared/revi
 import { activeUserMessageID, visibleMessages as filterVisibleMessages } from "./session-queue"
 import { clearSessionDraftDiscarded, deleteDraftsForSession } from "../utils/draft-store"
 import { createAbortState } from "./abort-state"
+import { continuation } from "./session-continuation"
 import { clearIfOn, createCloudPrune } from "./session-cloud-prune"
 import { isSameSessionTree } from "./model-usage"
 import { createDraftAgentSeed, resolvePromptAgent } from "./session-agent"
@@ -898,6 +899,7 @@ export const SessionProvider: ParentComponent = (props) => {
     refreshModelUsageForMessage(message)
     if (handleStreamMessage(message)) return
     handleCommandCompletion(message)
+    handleResumeResult(message)
     cah.handleMessage(message)
     switch (message.type) {
       case "sessionCreated":
@@ -1402,6 +1404,12 @@ export const SessionProvider: ParentComponent = (props) => {
       setStore("parts", message.id, message.parts.map(isolate))
     }
     rebuildToolParts(message.sessionID, store.messages[message.sessionID] ?? [])
+  }
+
+  function handleResumeResult(message: ExtensionMessage): void {
+    if (message.type !== "sessionResumeResult" || !message.error) return
+    finishSubmission(message.requestID)
+    showToast({ variant: "error", title: language.t("prompt.action.continue"), description: message.error })
   }
 
   function handleCommandCompletion(message: ExtensionMessage): void {
@@ -2280,6 +2288,32 @@ export const SessionProvider: ParentComponent = (props) => {
     })
   }
 
+  const resumable = () =>
+    continuation({
+      id: currentSessionID(),
+      status: status(),
+      messages: messages(),
+      parts: getParts,
+      submitting: submitting(),
+      loading: loading(),
+      reverted: !!revert(),
+      blocked:
+        scopedPermissions(currentSessionID()).length > 0 ||
+        scopedQuestions(currentSessionID()).length > 0 ||
+        scopedSuggestions(currentSessionID()).length > 0,
+    })
+
+  function resume() {
+    const sessionID = currentSessionID()
+    const messageID = resumable()
+    if (!server.isConnected() || !sessionID || !messageID) return
+    const requestID = crypto.randomUUID()
+    clearClose(sessionID)
+    startSubmission(sessionID, requestID)
+    vscode.postMessage({ type: "resumeSession", sessionID, messageID, requestID })
+    queueMicrotask(() => window.dispatchEvent(new CustomEvent("resumeAutoScroll")))
+  }
+
   function abort() {
     const sessionID = currentSessionID()
     const scope = sessionID ?? draftSessionID()
@@ -2814,6 +2848,8 @@ export const SessionProvider: ParentComponent = (props) => {
     statusText,
     busySince,
     submitting,
+    canResume: () => !!resumable(),
+    resume,
     isSubmitting,
     loading,
     loadingOlderMessages,

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -174,6 +174,7 @@ export const dict = {
   "prompt.worktrees.search": "البحث في Worktrees",
   "prompt.thinking.tooltip": "جهد الاستدلال",
   "prompt.action.send": "إرسال",
+  "prompt.action.continue": "متابعة",
   "prompt.action.send.blocked": "أجب عن السؤال المعلق أو تجاهله أولاً",
   "prompt.action.send.recording": "تفريغ وإرسال",
   "prompt.action.stop": "توقف",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -178,6 +178,7 @@ export const dict = {
   "prompt.worktrees.search": "Pesquisar Worktrees",
   "prompt.thinking.tooltip": "Esforço de raciocínio",
   "prompt.action.send": "Enviar",
+  "prompt.action.continue": "Continuar",
   "prompt.action.send.blocked": "Responda ou feche a pergunta pendente primeiro",
   "prompt.action.send.recording": "Transcrever e enviar",
   "prompt.action.stop": "Parar",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -179,6 +179,7 @@ export const dict = {
   "prompt.worktrees.search": "Pretraži Worktree-ove",
   "prompt.thinking.tooltip": "Napor razmišljanja",
   "prompt.action.send": "Pošalji",
+  "prompt.action.continue": "Nastavi",
   "prompt.action.send.blocked": "Prvo odgovorite ili odbacite pitanje na čekanju",
   "prompt.action.send.recording": "Transkribuj i pošalji",
   "prompt.action.stop": "Zaustavi",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -178,6 +178,7 @@ export const dict = {
   "prompt.worktrees.search": "Søg i Worktrees",
   "prompt.thinking.tooltip": "Ræsonnementsindsats",
   "prompt.action.send": "Send",
+  "prompt.action.continue": "Fortsæt",
   "prompt.action.send.blocked": "Besvar eller afvis det afventende spørgsmål først",
   "prompt.action.send.recording": "Transskriber og send",
   "prompt.action.stop": "Stop",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -184,6 +184,7 @@ export const dict = {
   "prompt.worktrees.search": "Worktrees durchsuchen",
   "prompt.thinking.tooltip": "Reasoning-Aufwand",
   "prompt.action.send": "Senden",
+  "prompt.action.continue": "Fortsetzen",
   "prompt.action.send.blocked": "Beantworten oder verwerfen Sie zuerst die ausstehende Frage",
   "prompt.action.send.recording": "Transkribieren und senden",
   "prompt.action.stop": "Stopp",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -178,6 +178,7 @@ export const dict = {
   "prompt.worktrees.search": "Search worktrees",
   "prompt.thinking.tooltip": "Reasoning effort",
   "prompt.action.send": "Send",
+  "prompt.action.continue": "Continue",
   "prompt.action.send.blocked": "Answer or dismiss the pending question first",
   "prompt.action.send.recording": "Transcribe and send",
   "prompt.action.stop": "Stop",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -179,6 +179,7 @@ export const dict = {
   "prompt.worktrees.search": "Buscar Worktrees",
   "prompt.thinking.tooltip": "Esfuerzo de razonamiento",
   "prompt.action.send": "Enviar",
+  "prompt.action.continue": "Continuar",
   "prompt.action.send.blocked": "Responda o descarte la pregunta pendiente primero",
   "prompt.action.send.recording": "Transcribir y enviar",
   "prompt.action.stop": "Detener",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
@@ -179,6 +179,7 @@ export const dict = {
   "prompt.worktrees.search": "جستجوی worktree‌ها",
   "prompt.thinking.tooltip": "میزان استدلال",
   "prompt.action.send": "ارسال",
+  "prompt.action.continue": "ادامه",
   "prompt.action.send.blocked": "ابتدا به سؤال در انتظار پاسخ دهید یا آن را رد کنید",
   "prompt.action.send.recording": "رونویسی و ارسال",
   "prompt.action.stop": "توقف",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -179,6 +179,7 @@ export const dict = {
   "prompt.worktrees.search": "Rechercher des Worktrees",
   "prompt.thinking.tooltip": "Effort de raisonnement",
   "prompt.action.send": "Envoyer",
+  "prompt.action.continue": "Continuer",
   "prompt.action.send.blocked": "Répondez ou rejetez d'abord la question en attente",
   "prompt.action.send.recording": "Transcrire et envoyer",
   "prompt.action.stop": "Arrêter",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -158,6 +158,7 @@ export const dict = {
   "prompt.worktrees.search": "Cerca worktree",
   "prompt.thinking.tooltip": "Sforzo di ragionamento",
   "prompt.action.send": "Invia",
+  "prompt.action.continue": "Continua",
   "prompt.action.send.blocked": "Rispondi alla domanda in sospeso o ignorala prima di continuare",
   "prompt.action.stop": "Ferma",
   "prompt.action.enhance": "Migliora prompt",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -178,6 +178,7 @@ export const dict = {
   "prompt.worktrees.search": "Worktreeを検索",
   "prompt.thinking.tooltip": "推論の強度",
   "prompt.action.send": "送信",
+  "prompt.action.continue": "続行",
   "prompt.action.send.blocked": "最初に保留中の質問に答えるか、閉じてください",
   "prompt.action.send.recording": "文字起こしして送信",
   "prompt.action.stop": "停止",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -181,6 +181,7 @@ export const dict = {
   "prompt.worktrees.search": "Worktree 검색",
   "prompt.thinking.tooltip": "추론 강도",
   "prompt.action.send": "전송",
+  "prompt.action.continue": "계속",
   "prompt.action.send.blocked": "먼저 대기 중인 질문에 답하거나 닫아주세요",
   "prompt.action.send.recording": "텍스트 변환 및 전송",
   "prompt.action.stop": "중지",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -179,6 +179,7 @@ export const dict = {
   "prompt.worktrees.search": "Worktrees doorzoeken",
   "prompt.thinking.tooltip": "Redeneringsinspanning",
   "prompt.action.send": "Verzenden",
+  "prompt.action.continue": "Doorgaan",
   "prompt.action.send.blocked": "Beantwoord of negeer eerst de openstaande vraag",
   "prompt.action.send.recording": "Transcriberen en verzenden",
   "prompt.action.stop": "Stop",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -181,6 +181,7 @@ export const dict = {
   "prompt.worktrees.search": "Søk i Worktrees",
   "prompt.thinking.tooltip": "Resonnementsinnsats",
   "prompt.action.send": "Send",
+  "prompt.action.continue": "Fortsett",
   "prompt.action.send.blocked": "Svar på eller avvis det ventende spørsmålet først",
   "prompt.action.send.recording": "Transkriber og send",
   "prompt.action.stop": "Stopp",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -178,6 +178,7 @@ export const dict = {
   "prompt.worktrees.search": "Wyszukaj Worktree",
   "prompt.thinking.tooltip": "Wysiłek rozumowania",
   "prompt.action.send": "Wyślij",
+  "prompt.action.continue": "Kontynuuj",
   "prompt.action.send.blocked": "Najpierw odpowiedz na oczekujące pytanie lub je odrzuć",
   "prompt.action.send.recording": "Transkrybuj i wyślij",
   "prompt.action.stop": "Zatrzymaj",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -177,6 +177,7 @@ export const dict = {
   "prompt.worktrees.search": "Поиск worktrees",
   "prompt.thinking.tooltip": "Усилие рассуждения",
   "prompt.action.send": "Отправить",
+  "prompt.action.continue": "Продолжить",
   "prompt.action.send.blocked": "Сначала ответьте на ожидающий вопрос или отклоните его",
   "prompt.action.send.recording": "Расшифровать и отправить",
   "prompt.action.stop": "Остановить",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -177,6 +177,7 @@ export const dict = {
   "prompt.worktrees.search": "ค้นหา Worktree",
   "prompt.thinking.tooltip": "ความพยายามในการให้เหตุผล",
   "prompt.action.send": "ส่ง",
+  "prompt.action.continue": "ดำเนินการต่อ",
   "prompt.action.send.blocked": "โปรดตอบหรือข้ามคำถามที่รอดำเนินการก่อน",
   "prompt.action.send.recording": "ถอดเสียงและส่ง",
   "prompt.action.stop": "หยุด",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -178,6 +178,7 @@ export const dict = {
   "prompt.worktrees.search": "Worktree'leri ara",
   "prompt.thinking.tooltip": "Akıl yürütme eforu",
   "prompt.action.send": "Gönder",
+  "prompt.action.continue": "Devam et",
   "prompt.action.send.blocked": "Bekleyen soruyu önce yanıtlayın veya kapatın",
   "prompt.action.send.recording": "Yazıya dök ve gönder",
   "prompt.action.stop": "Durdur",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -179,6 +179,7 @@ export const dict = {
   "prompt.worktrees.search": "Пошук робочих дерев",
   "prompt.thinking.tooltip": "Зусилля міркування",
   "prompt.action.send": "Надіслати",
+  "prompt.action.continue": "Продовжити",
   "prompt.action.send.blocked": "Спочатку дайте відповідь або закрийте очікуюче питання",
   "prompt.action.send.recording": "Транскрибувати та надіслати",
   "prompt.action.stop": "Зупинити",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -178,6 +178,7 @@ export const dict = {
   "prompt.action.autoApprove.enabled": "自动审批已启用。权限请求将自动获批。",
   "prompt.action.autoApprove.disabled": "自动审批已禁用。点击以自动批准权限请求。",
   "prompt.action.send": "发送",
+  "prompt.action.continue": "继续",
   "prompt.action.send.blocked": "请先回答或忽略待处理的问题",
   "prompt.action.send.recording": "转录并发送",
   "prompt.action.stop": "停止",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -173,6 +173,7 @@ export const dict = {
   "prompt.worktrees.search": "搜尋 Worktree",
   "prompt.thinking.tooltip": "推理強度",
   "prompt.action.send": "傳送",
+  "prompt.action.continue": "繼續",
   "prompt.action.send.blocked": "請先回答或忽略待處理的問題",
   "prompt.action.send.recording": "轉錄並傳送",
   "prompt.action.stop": "停止",

--- a/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
@@ -202,6 +202,8 @@ export function mockSessionValue(overrides?: {
     loadingOlderMessages: () => false,
     hasOlderMessages: () => false,
     submitting: () => false,
+    canResume: () => false,
+    resume: noop,
     draftSessionID: () => undefined,
     setDraftSessionID: noop,
     userClearedSession: () => false,

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -145,6 +145,13 @@ export interface SendMessageFailedMessage {
   review?: import("../../../../src/shared/review-comments").ReviewMessageData
 }
 
+export interface SessionResumeResultMessage {
+  type: "sessionResumeResult"
+  sessionID: string
+  requestID: string
+  error?: string
+}
+
 export interface SessionCommandCompletedMessage {
   type: "sessionCommandCompleted"
   messageID: string
@@ -1427,6 +1434,7 @@ export type ExtensionMessage =
   | ConnectionStateMessage
   | ErrorMessage
   | SendMessageFailedMessage
+  | SessionResumeResultMessage
   | SessionCommandCompletedMessage
   | PartUpdatedMessage
   | PartsUpdatedMessage

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -40,6 +40,13 @@ export interface SendMessageRequest {
   contextDirectory?: string
 }
 
+export interface ResumeSessionRequest {
+  type: "resumeSession"
+  sessionID: string
+  messageID: string
+  requestID: string
+}
+
 export interface AbortRequest {
   type: "abort"
   sessionID: string
@@ -1497,6 +1504,7 @@ export type WebviewMessage =
   | DocumentCloseMessage
   | DocumentSendCommentsMessage
   | SendMessageRequest
+  | ResumeSessionRequest
   | AbortRequest
   | RequestBackgroundJobsMessage
   | CancelBackgroundJobMessage

--- a/packages/opencode/src/kilocode/server/httpapi/groups/kilocode.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/groups/kilocode.ts
@@ -23,7 +23,8 @@ import {
   Result as NotebookResult,
 } from "@/kilocode/notebook/protocol"
 import { ModelUsage } from "@/kilocode/session/model-usage"
-import { SessionID } from "@/session/schema"
+import { MessageID, SessionID } from "@/session/schema"
+import { ApiNotFoundError, InvalidRequestError } from "@/server/routes/instance/httpapi/errors"
 import { CommandFiles } from "@/kilocode/command-files"
 
 const root = "/kilocode"
@@ -62,6 +63,11 @@ export const RemoveSnapshotPayload = Schema.Struct({
   worktree: Schema.String,
 })
 
+export const ResumeSessionPayload = Schema.Struct({
+  messageID: MessageID,
+  snapshotInitialization: Schema.optional(Schema.Literal("wait")),
+})
+
 export const NotebookReplyPayload = Schema.Struct({ result: NotebookResult })
 export const NotebookRejectPayload = Schema.Struct({ error: NotebookFailure })
 export const AgentManagerReplyPayload = Schema.Struct({ result: AgentManagerResult })
@@ -83,6 +89,7 @@ export const KilocodePaths = {
   agentManagerReply: `${root}/agent-manager/:requestID/reply`,
   agentManagerReject: `${root}/agent-manager/:requestID/reject`,
   sessionModelUsage: `/session/:sessionID/model-usage`,
+  resumeSession: `${root}/session/:sessionID/resume`,
   backgroundJobs: `${root}/background-jobs`,
   backgroundJobCancel: `${root}/background-jobs/:jobID/cancel`,
   backgroundJobPromote: `${root}/background-jobs/:jobID/promote`,
@@ -92,6 +99,20 @@ export const KilocodeApi = HttpApi.make("kilocode")
   .add(
     HttpApiGroup.make("kilocode")
       .add(
+        HttpApiEndpoint.post("resumeSession", KilocodePaths.resumeSession, {
+          params: { sessionID: SessionID },
+          query: WorkspaceRoutingQuery,
+          payload: ResumeSessionPayload,
+          success: described(Schema.Boolean, "Session continuation accepted"),
+          error: [ApiNotFoundError, InvalidRequestError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "kilocode.resumeSession",
+            summary: "Resume an interrupted session",
+            description:
+              "Resume the specified unfinished assistant turn without adding a user message. Active, completed, reverted, and blocked sessions cannot be resumed.",
+          }),
+        ),
         HttpApiEndpoint.post("heapSnapshot", KilocodePaths.heapSnapshot, {
           query: WorkspaceRoutingQuery,
           success: described(Schema.String, "Heap snapshot file path"),

--- a/packages/opencode/src/kilocode/server/httpapi/handlers/kilocode.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/kilocode.ts
@@ -1,4 +1,14 @@
-import { Effect } from "effect"
+import { Cause, Effect, Scope } from "effect"
+import { NamedError } from "@opencode-ai/core/util/error"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { KiloSessionContinuation } from "@/kilocode/session/continuation"
+import { Suggestion } from "@/kilocode/suggestion"
+import { Permission } from "@/permission"
+import { Question } from "@/question"
+import { Session } from "@/session/session"
+import { SessionPrompt } from "@/session/prompt"
+import { SessionStatus } from "@/session/status"
+import { mapStorageNotFound } from "@/server/routes/instance/httpapi/handlers/session-errors"
 import { HttpApiBuilder, HttpApiError } from "effect/unstable/httpapi"
 import * as KiloAgent from "@/kilocode/agent"
 import { CommandFiles } from "@/kilocode/command-files"
@@ -40,6 +50,7 @@ import {
   RemoveCommandPayload,
   RemoveSkillPayload,
   RemoveSnapshotPayload,
+  ResumeSessionPayload,
   BackgroundJobInfo,
   BackgroundJobsQuery,
 } from "../groups/kilocode"
@@ -59,6 +70,59 @@ export const kilocodeHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilocode"
     const locations = yield* LocationServiceMap.Service
     const fs = yield* FSUtil.Service
     const flock = yield* EffectFlock.Service
+    const sessions = yield* Session.Service
+    const prompt = yield* SessionPrompt.Service
+    const status = yield* SessionStatus.Service
+    const permission = yield* Permission.Service
+    const question = yield* Question.Service
+    const events = yield* EventV2Bridge.Service
+    const scope = yield* Scope.Scope
+
+    const resumeSession = Effect.fn("KilocodeHttpApi.resumeSession")(function* (ctx: {
+      params: { sessionID: SessionID }
+      payload: typeof ResumeSessionPayload.Type
+    }) {
+      const id = ctx.params.sessionID
+      const session = yield* mapStorageNotFound(sessions.get(id))
+      const blocked = new InvalidRequestError({ message: "This session cannot be resumed in its current state." })
+      if (session.revert || session.time.archived) return yield* blocked
+      yield* runState.assertNotBusy(id).pipe(Effect.mapError(() => blocked))
+      if ((yield* status.get(id)).type !== "idle") return yield* blocked
+      const pending = [
+        ...(yield* permission.list()),
+        ...(yield* question.list()),
+        ...(yield* Effect.promise(() => Suggestion.list())),
+      ]
+      if (pending.length > 0) {
+        const family = new Set([id])
+        for (const parent of family) {
+          for (const child of yield* sessions.children(parent)) family.add(child.id)
+        }
+        if (pending.some((request) => family.has(request.sessionID))) return yield* blocked
+      }
+      const messages = yield* mapStorageNotFound(sessions.messages({ sessionID: id }))
+      if (KiloSessionContinuation.target(messages) !== ctx.payload.messageID) return yield* blocked
+      yield* prompt
+        .loop({
+          sessionID: id,
+          resume: ctx.payload.messageID,
+          snapshotInitialization: ctx.payload.snapshotInitialization,
+        })
+        .pipe(
+          Effect.catchCause((cause) => {
+            if (Cause.hasInterruptsOnly(cause)) return Effect.void
+            return Effect.gen(function* () {
+              yield* Effect.logError("session resume failed", { sessionID: id, cause })
+              yield* events.publish(Session.Event.Error, {
+                sessionID: id,
+                error: new NamedError.Unknown({ message: Cause.pretty(cause) }).toObject(),
+              })
+            })
+          }),
+          Effect.forkIn(scope, { startImmediately: true }),
+        )
+      return true
+    })
 
     // Location-scoped services, keyed by the request's directory and workspace.
     const located = Effect.fnUntraced(function* <A, E, R>(effect: Effect.Effect<A, E, R>) {
@@ -269,6 +333,7 @@ export const kilocodeHandlers = HttpApiBuilder.group(InstanceHttpApi, "kilocode"
     })
 
     return handlers
+      .handle("resumeSession", resumeSession)
       .handle("heapSnapshot", heapSnapshot)
       .handle("commandFiles", commandFiles)
       .handle("removeCommand", removeCommand)

--- a/packages/opencode/src/kilocode/session/continuation.ts
+++ b/packages/opencode/src/kilocode/session/continuation.ts
@@ -1,0 +1,40 @@
+import type { ModelMessage } from "ai"
+import { MessageV2 } from "@/session/message-v2"
+import { KiloSessionMessageOrder } from "./message-order"
+
+export namespace KiloSessionContinuation {
+  export function target(messages: MessageV2.WithParts[]) {
+    const latest = KiloSessionMessageOrder.latest(messages)
+    const user = latest.userMessage
+    const assistant = latest.assistantMessage
+    if (!user || !assistant || assistant.info.role !== "assistant") return undefined
+    if (assistant.info.parentID !== user.info.id || assistant.info.summary) return undefined
+    if (KiloSessionMessageOrder.compare(user, assistant, messages.indexOf(user), messages.indexOf(assistant)) >= 0)
+      return undefined
+    if (user.parts.some((part) => part.type === "subtask" || part.type === "compaction")) return undefined
+    if (
+      messages
+        .slice(messages.indexOf(user) + 1)
+        .some((message) =>
+          message.parts.some(
+            (part) => part.type === "tool" && part.tool === "plan_exit" && part.state.status === "completed",
+          ),
+        )
+    )
+      return undefined
+    if (MessageV2.AbortedError.isInstance(assistant.info.error)) return assistant.info.id
+    if (assistant.info.error) return undefined
+    return !assistant.info.finish || assistant.info.finish === "tool-calls" ? assistant.info.id : undefined
+  }
+
+  export function context(resume: boolean): ModelMessage[] {
+    if (!resume) return []
+    return [
+      {
+        role: "user",
+        content:
+          "[TASK RESUMPTION] Resume the interrupted task using the existing conversation. Check the current state before retrying interrupted tools. Do not repeat work that already completed.",
+      },
+    ]
+  }
+}

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -89,6 +89,7 @@ import { SessionTools } from "./tools"
 import { LLMEvent } from "@opencode-ai/llm"
 import { RepositoryCache } from "@opencode-ai/core/repository-cache" // kilocode_change
 import { SessionResume } from "@/kilocode/session-resume" // kilocode_change
+import { KiloSessionContinuation } from "@/kilocode/session/continuation" // kilocode_change
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -1496,6 +1497,7 @@ export const layer = Layer.effect(
         const { user: lastUser, assistant: lastAssistant, finished: lastFinished, tasks } = latest
         // kilocode_change end
 
+        if (input.resume && step === 0 && KiloSessionContinuation.target(msgs) !== input.resume) break // kilocode_change
         if (!lastUser) throw new Error("No user message found in stream. This should never happen.")
 
         const lastAssistantMsg = msgs.findLast(
@@ -1542,6 +1544,7 @@ export const layer = Layer.effect(
         if (
           lastAssistant?.finish &&
           !["tool-calls"].includes(lastAssistant.finish) &&
+          lastAssistant.id !== input.resume && // kilocode_change
           !hasToolCalls &&
           lastAssistant.parentID === lastUser.id && // kilocode_change - unrelated later assistants do not answer this turn
           userBeforeAssistant // kilocode_change - compare chronology, not generated IDs
@@ -1773,6 +1776,7 @@ export const layer = Layer.effect(
             system,
             messages: [
               ...modelMsgs,
+              ...KiloSessionContinuation.context(!!input.resume && step === 1), // kilocode_change
               ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS_PROMPT }] : []), // kilocode_change - avoid provider-incompatible assistant prefill
             ],
             tools,
@@ -1912,9 +1916,11 @@ export const layer = Layer.effect(
     )(function* (input: LoopInput) {
       // kilocode_change start
       const session = yield* sessions.get(input.sessionID)
-      yield* KiloSessionPrompt.recoverDanglingAssistant({ sessionID: input.sessionID, status, sessions })
-      yield* KiloSessionPrompt.recoverProviderFinishError({ sessionID: input.sessionID, status, sessions })
-      yield* KiloSessionPrompt.recoverFailedAssistant({ sessionID: input.sessionID, status, sessions })
+      if (!input.resume) {
+        yield* KiloSessionPrompt.recoverDanglingAssistant({ sessionID: input.sessionID, status, sessions })
+        yield* KiloSessionPrompt.recoverProviderFinishError({ sessionID: input.sessionID, status, sessions })
+        yield* KiloSessionPrompt.recoverFailedAssistant({ sessionID: input.sessionID, status, sessions })
+      }
       yield* KiloSession.publishTurnOpen({ sessionID: input.sessionID })
       return yield* Effect.onExit(
         state.ensureRunning(
@@ -2540,6 +2546,7 @@ export type PromptInput = Omit<Schema.Schema.Type<typeof PromptInput>, "parts" |
 
 export class LoopInput extends Schema.Class<LoopInput>("SessionPrompt.LoopInput")({
   sessionID: SessionID,
+  resume: Schema.optional(MessageID), // kilocode_change
   snapshotInitialization: Schema.optional(Schema.Literal("wait")), // kilocode_change
 }) {
   static readonly zod = zod(this)

--- a/packages/opencode/test/kilocode/server/httpapi-exercise-scenarios.ts
+++ b/packages/opencode/test/kilocode/server/httpapi-exercise-scenarios.ts
@@ -553,6 +553,15 @@ export const kiloScenarios: Scenario[] = [
     .at((ctx) => ({ path: "/enhance-prompt", headers: ctx.headers(), body: { text: "" } }))
     .status(400),
   http.protected
+    .post("/kilocode/session/{sessionID}/resume", "kilocode.resumeSession")
+    .seeded((ctx) => ctx.session({ title: "Empty resume" }))
+    .at((ctx) => ({
+      path: route("/kilocode/session/{sessionID}/resume", { sessionID: ctx.state.id }),
+      headers: ctx.headers(),
+      body: { messageID: "msg_httpapi_missing" },
+    }))
+    .status(400),
+  http.protected
     .get("/session/{sessionID}/model-usage", "kilocode.sessionModelUsage")
     .seeded((ctx) => ctx.session({ title: "Model usage" }))
     .at((ctx) => ({

--- a/packages/opencode/test/kilocode/server/session-resume.test.ts
+++ b/packages/opencode/test/kilocode/server/session-resume.test.ts
@@ -1,20 +1,35 @@
-import { afterEach, expect, test } from "bun:test"
-import { Effect } from "effect"
+import { afterEach, expect } from "bun:test"
+import { Effect, Fiber } from "effect"
+import { AppNodeBuilderV1 } from "@/effect/app-node-builder-v1"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { InstanceStore } from "@/project/instance-store"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
-import { AppRuntime } from "@/effect/app-runtime"
-import { InstanceRef } from "@/effect/instance-ref"
 import { Server } from "@/server/server"
 import { Session } from "@/session/session"
 import { MessageV2 } from "@/session/message-v2"
 import { MessageID, PartID } from "@/session/schema"
 import { Question } from "@/question"
 import { Permission } from "@/permission"
-import { disposeAllInstances, reloadTestInstance, tmpdir } from "../../fixture/fixture"
+import { disposeAllInstances, provideInstanceEffect, tmpdirScoped } from "../../fixture/fixture"
 import { resetDatabase } from "../../fixture/db"
-import { pollWithTimeout } from "../../lib/effect"
+import { pollWithTimeout, testEffectShared } from "../../lib/effect"
 
+const it = testEffectShared(
+  AppNodeBuilderV1.build(
+    LayerNode.group([
+      Session.node,
+      Question.node,
+      Permission.node,
+      InstanceStore.node,
+      SessionProjector.node,
+      CrossSpawnSpawner.node,
+    ]),
+  ),
+)
 const password = Flag.KILO_SERVER_PASSWORD
 
 afterEach(async () => {
@@ -23,195 +38,179 @@ afterEach(async () => {
   await resetDatabase()
 })
 
-test("HTTP resume preserves the user turn and refuses blocked, completed, and stale requests", async () => {
-  Flag.KILO_SERVER_PASSWORD = undefined
-  const calls: unknown[] = []
-  const gate = Promise.withResolvers<void>()
-  const provider = Bun.serve({
-    port: 0,
-    hostname: "127.0.0.1",
-    async fetch(request) {
-      calls.push(await request.json())
-      await gate.promise
-      const events = [
-        { delta: { role: "assistant", content: "Resumed task finished" } },
-        { delta: {}, finish_reason: "stop" },
-      ]
-      return new Response(
-        events.map((choice) => `data: ${JSON.stringify({ id: "test", choices: [choice] })}\n\n`).join("") +
-          "data: [DONE]\n\n",
-        {
-          headers: { "Content-Type": "text/event-stream" },
-        },
-      )
-    },
-  })
-  await using tmp = await tmpdir({
-    config: {
-      model: "test/test-model",
-      enabled_providers: ["test"],
-      formatter: false,
-      lsp: false,
-      provider: {
-        test: {
-          name: "Test",
-          npm: "@ai-sdk/openai-compatible",
-          options: { apiKey: "test-key", baseURL: `${provider.url.origin}/v1` },
-          models: { "test-model": { name: "Test", limit: { context: 100000, output: 10000 } } },
-        },
-      },
-    },
-  })
-  const context = await reloadTestInstance({ directory: tmp.path })
-  const run = <A, E>(work: Effect.Effect<A, E, Session.Service | Question.Service | Permission.Service>) =>
-    AppRuntime.runPromise(work.pipe(Effect.provideService(InstanceRef, context)))
-  const seed = await run(
+it.live(
+  "HTTP resume preserves the user turn and refuses blocked, completed, and stale requests",
+  () =>
     Effect.gen(function* () {
-      const sessions = yield* Session.Service
-      const session = yield* sessions.create({ title: "HTTP resume regression" })
-      const user = yield* sessions.updateMessage({
-        id: MessageID.ascending(),
-        sessionID: session.id,
-        role: "user",
-        agent: "code",
-        model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("test-model") },
-        time: { created: Date.now() },
+      Flag.KILO_SERVER_PASSWORD = undefined
+      const calls: unknown[] = []
+      const gate = Promise.withResolvers<void>()
+      const provider = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        async fetch(request) {
+          calls.push(await request.json())
+          await gate.promise
+          const events = [
+            { delta: { role: "assistant", content: "Resumed task finished" } },
+            { delta: {}, finish_reason: "stop" },
+          ]
+          return new Response(
+            events.map((choice) => `data: ${JSON.stringify({ id: "test", choices: [choice] })}\n\n`).join("") +
+              "data: [DONE]\n\n",
+            { headers: { "Content-Type": "text/event-stream" } },
+          )
+        },
       })
-      yield* sessions.updatePart({
-        id: PartID.ascending(),
-        sessionID: session.id,
-        messageID: user.id,
-        type: "text",
-        text: "Finish this task",
+      yield* Effect.addFinalizer(() =>
+        Effect.promise(async () => {
+          gate.resolve()
+          await provider.stop(true)
+        }),
+      )
+      const tmp = yield* tmpdirScoped({
+        config: {
+          model: "test/test-model",
+          enabled_providers: ["test"],
+          formatter: false,
+          lsp: false,
+          provider: {
+            test: {
+              name: "Test",
+              npm: "@ai-sdk/openai-compatible",
+              options: { apiKey: "test-key", baseURL: `${provider.url.origin}/v1` },
+              models: { "test-model": { name: "Test", limit: { context: 100000, output: 10000 } } },
+            },
+          },
+        },
       })
-      const assistant = yield* sessions.updateMessage({
-        id: MessageID.ascending(),
-        sessionID: session.id,
-        role: "assistant",
-        parentID: user.id,
-        agent: "code",
-        mode: "code",
-        providerID: user.model.providerID,
-        modelID: user.model.modelID,
-        path: { cwd: tmp.path, root: tmp.path },
-        cost: 0,
-        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-        time: { created: Date.now(), completed: Date.now() },
-        finish: "stop",
-      })
-      yield* sessions.updatePart({
-        id: PartID.ascending(),
-        sessionID: session.id,
-        messageID: assistant.id,
-        type: "text",
-        text: "Partial work",
-      })
-      return { session, user, assistant }
-    }),
-  )
-  const listener = await Server.listen({ hostname: "127.0.0.1", port: 0 })
-  const resume = (id = seed.assistant.id) =>
-    fetch(new URL(`/kilocode/session/${seed.session.id}/resume`, listener.url), {
-      method: "POST",
-      headers: { "Content-Type": "application/json", "x-kilo-directory": tmp.path },
-      body: JSON.stringify({ messageID: id }),
-    })
-  try {
-    expect((await resume()).status).toBe(400)
-    await run(
-      Session.Service.use((sessions) =>
-        sessions.updateMessage({
-          ...seed.assistant,
+      yield* Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const questions = yield* Question.Service
+        const permissions = yield* Permission.Service
+        const session = yield* sessions.create({ title: "HTTP resume regression" })
+        const user = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          sessionID: session.id,
+          role: "user",
+          agent: "code",
+          model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("test-model") },
+          time: { created: Date.now() },
+        })
+        yield* sessions.updatePart({
+          id: PartID.ascending(),
+          sessionID: session.id,
+          messageID: user.id,
+          type: "text",
+          text: "Finish this task",
+        })
+        const assistant = yield* sessions.updateMessage({
+          id: MessageID.ascending(),
+          sessionID: session.id,
+          role: "assistant",
+          parentID: user.id,
+          agent: "code",
+          mode: "code",
+          providerID: user.model.providerID,
+          modelID: user.model.modelID,
+          path: { cwd: tmp, root: tmp },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          time: { created: Date.now(), completed: Date.now() },
+          finish: "stop",
+        })
+        yield* sessions.updatePart({
+          id: PartID.ascending(),
+          sessionID: session.id,
+          messageID: assistant.id,
+          type: "text",
+          text: "Partial work",
+        })
+        const listener = yield* Effect.acquireRelease(
+          Effect.promise(() => Server.listen({ hostname: "127.0.0.1", port: 0 })),
+          (listener) => Effect.promise(() => listener.stop(true)),
+        )
+        const resume = (id = assistant.id) =>
+          Effect.promise(() =>
+            fetch(new URL(`/kilocode/session/${session.id}/resume`, listener.url), {
+              method: "POST",
+              headers: { "Content-Type": "application/json", "x-kilo-directory": tmp },
+              body: JSON.stringify({ messageID: id }),
+            }),
+          )
+        expect((yield* resume()).status).toBe(400)
+        yield* sessions.updateMessage({
+          ...assistant,
           error: new MessageV2.AbortedError({ message: "Stopped" }).toObject(),
-        }),
-      ),
-    )
-    expect((await resume(seed.user.id)).status).toBe(400)
+        })
+        expect((yield* resume(user.id)).status).toBe(400)
 
-    const answering = run(
-      Question.Service.use((questions) =>
-        questions.ask({
-          sessionID: seed.session.id,
-          questions: [
-            { header: "Choice", question: "Choose an action", options: [{ label: "Wait", description: "Wait" }] },
-          ],
-        }),
-      ).pipe(Effect.exit),
-    )
-    const question = await run(
-      pollWithTimeout(
-        Question.Service.use((questions) => questions.list()).pipe(
-          Effect.map((items) => items.find((item) => item.sessionID === seed.session.id)),
-        ),
-        "question did not become pending",
-      ),
-    )
-    expect((await resume()).status).toBe(400)
-    expect(await run(Question.Service.use((questions) => questions.list()))).toHaveLength(1)
-    await run(Question.Service.use((questions) => questions.reject(question.id)))
-    await answering
+        const answering = yield* questions
+          .ask({
+            sessionID: session.id,
+            questions: [
+              { header: "Choice", question: "Choose an action", options: [{ label: "Wait", description: "Wait" }] },
+            ],
+          })
+          .pipe(Effect.exit, Effect.forkChild)
+        const question = yield* pollWithTimeout(
+          questions.list().pipe(Effect.map((items) => items.find((item) => item.sessionID === session.id))),
+          "question did not become pending",
+        )
+        expect((yield* resume()).status).toBe(400)
+        expect(yield* questions.list()).toHaveLength(1)
+        yield* questions.reject(question.id)
+        yield* Fiber.join(answering)
 
-    const approving = run(
-      Permission.Service.use((permissions) =>
-        permissions.ask({
-          sessionID: seed.session.id,
-          permission: "bash",
-          patterns: ["pwd"],
-          metadata: {},
-          always: [],
-          ruleset: [],
-        }),
-      ).pipe(Effect.exit),
-    )
-    const permission = await run(
-      pollWithTimeout(
-        Permission.Service.use((permissions) => permissions.list()).pipe(
-          Effect.map((items) => items.find((item) => item.sessionID === seed.session.id)),
-        ),
-        "permission did not become pending",
-      ),
-    )
-    expect((await resume()).status).toBe(400)
-    expect(await run(Permission.Service.use((permissions) => permissions.list()))).toHaveLength(1)
-    await run(Permission.Service.use((permissions) => permissions.reply({ requestID: permission.id, reply: "reject" })))
-    await approving
+        const approving = yield* permissions
+          .ask({
+            sessionID: session.id,
+            permission: "bash",
+            patterns: ["pwd"],
+            metadata: {},
+            always: [],
+            ruleset: [],
+          })
+          .pipe(Effect.exit, Effect.forkChild)
+        const permission = yield* pollWithTimeout(
+          permissions.list().pipe(Effect.map((items) => items.find((item) => item.sessionID === session.id))),
+          "permission did not become pending",
+        )
+        expect((yield* resume()).status).toBe(400)
+        expect(yield* permissions.list()).toHaveLength(1)
+        yield* permissions.reply({ requestID: permission.id, reply: "reject" })
+        yield* Fiber.join(approving)
 
-    expect((await resume()).status).toBe(200)
-    await run(
-      pollWithTimeout(
-        Effect.sync(() => (calls.length > 0 ? true : undefined)),
-        "resume did not start",
-      ),
-    )
-    expect((await resume()).status).toBe(400)
-    gate.resolve()
-    const messages = await run(
-      pollWithTimeout(
-        Session.Service.use((sessions) => sessions.messages({ sessionID: seed.session.id })).pipe(
-          Effect.map((messages) => {
-            const last = messages.at(-1)
-            return last?.info.role === "assistant" && last.info.id !== seed.assistant.id && last.info.time.completed
-              ? messages
-              : undefined
-          }),
-        ),
-        "resumed response did not complete",
-        "10 seconds",
-      ),
-    )
-    expect(messages.filter((message) => message.info.role === "user").map((message) => message.info.id)).toEqual([
-      seed.user.id,
-    ])
-    expect(messages.at(-1)?.parts.some((part) => part.type === "text" && part.text === "Resumed task finished")).toBe(
-      true,
-    )
-    expect(JSON.stringify(messages)).not.toContain("[TASK RESUMPTION]")
-    expect(calls).toHaveLength(1)
-    expect((await resume()).status).toBe(400)
-    expect(calls).toHaveLength(1)
-  } finally {
-    gate.resolve()
-    await listener.stop(true)
-    await provider.stop(true)
-  }
-}, 30_000)
+        expect((yield* resume()).status).toBe(200)
+        yield* pollWithTimeout(
+          Effect.sync(() => (calls.length > 0 ? true : undefined)),
+          "resume did not start",
+        )
+        expect((yield* resume()).status).toBe(400)
+        gate.resolve()
+        const messages = yield* pollWithTimeout(
+          sessions.messages({ sessionID: session.id }).pipe(
+            Effect.map((messages) => {
+              const last = messages.at(-1)
+              return last?.info.role === "assistant" && last.info.id !== assistant.id && last.info.time.completed
+                ? messages
+                : undefined
+            }),
+          ),
+          "resumed response did not complete",
+          "10 seconds",
+        )
+        expect(messages.filter((message) => message.info.role === "user").map((message) => message.info.id)).toEqual([
+          user.id,
+        ])
+        expect(
+          messages.at(-1)?.parts.some((part) => part.type === "text" && part.text === "Resumed task finished"),
+        ).toBe(true)
+        expect(JSON.stringify(messages)).not.toContain("[TASK RESUMPTION]")
+        expect(calls).toHaveLength(1)
+        expect((yield* resume()).status).toBe(400)
+        expect(calls).toHaveLength(1)
+      }).pipe(provideInstanceEffect(tmp))
+    }),
+  30_000,
+)

--- a/packages/opencode/test/kilocode/server/session-resume.test.ts
+++ b/packages/opencode/test/kilocode/server/session-resume.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { Flag } from "@opencode-ai/core/flag/flag"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { AppRuntime } from "@/effect/app-runtime"
+import { InstanceRef } from "@/effect/instance-ref"
+import { Server } from "@/server/server"
+import { Session } from "@/session/session"
+import { MessageV2 } from "@/session/message-v2"
+import { MessageID, PartID } from "@/session/schema"
+import { Question } from "@/question"
+import { Permission } from "@/permission"
+import { disposeAllInstances, reloadTestInstance, tmpdir } from "../../fixture/fixture"
+import { resetDatabase } from "../../fixture/db"
+import { pollWithTimeout } from "../../lib/effect"
+
+const password = Flag.KILO_SERVER_PASSWORD
+
+afterEach(async () => {
+  Flag.KILO_SERVER_PASSWORD = password
+  await disposeAllInstances()
+  await resetDatabase()
+})
+
+test("HTTP resume preserves the user turn and refuses blocked, completed, and stale requests", async () => {
+  Flag.KILO_SERVER_PASSWORD = undefined
+  const calls: unknown[] = []
+  const gate = Promise.withResolvers<void>()
+  const provider = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    async fetch(request) {
+      calls.push(await request.json())
+      await gate.promise
+      const events = [
+        { delta: { role: "assistant", content: "Resumed task finished" } },
+        { delta: {}, finish_reason: "stop" },
+      ]
+      return new Response(
+        events.map((choice) => `data: ${JSON.stringify({ id: "test", choices: [choice] })}\n\n`).join("") +
+          "data: [DONE]\n\n",
+        {
+          headers: { "Content-Type": "text/event-stream" },
+        },
+      )
+    },
+  })
+  await using tmp = await tmpdir({
+    config: {
+      model: "test/test-model",
+      enabled_providers: ["test"],
+      formatter: false,
+      lsp: false,
+      provider: {
+        test: {
+          name: "Test",
+          npm: "@ai-sdk/openai-compatible",
+          options: { apiKey: "test-key", baseURL: `${provider.url.origin}/v1` },
+          models: { "test-model": { name: "Test", limit: { context: 100000, output: 10000 } } },
+        },
+      },
+    },
+  })
+  const context = await reloadTestInstance({ directory: tmp.path })
+  const run = <A, E>(work: Effect.Effect<A, E, Session.Service | Question.Service | Permission.Service>) =>
+    AppRuntime.runPromise(work.pipe(Effect.provideService(InstanceRef, context)))
+  const seed = await run(
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({ title: "HTTP resume regression" })
+      const user = yield* sessions.updateMessage({
+        id: MessageID.ascending(),
+        sessionID: session.id,
+        role: "user",
+        agent: "code",
+        model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("test-model") },
+        time: { created: Date.now() },
+      })
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        sessionID: session.id,
+        messageID: user.id,
+        type: "text",
+        text: "Finish this task",
+      })
+      const assistant = yield* sessions.updateMessage({
+        id: MessageID.ascending(),
+        sessionID: session.id,
+        role: "assistant",
+        parentID: user.id,
+        agent: "code",
+        mode: "code",
+        providerID: user.model.providerID,
+        modelID: user.model.modelID,
+        path: { cwd: tmp.path, root: tmp.path },
+        cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        time: { created: Date.now(), completed: Date.now() },
+        finish: "stop",
+      })
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        sessionID: session.id,
+        messageID: assistant.id,
+        type: "text",
+        text: "Partial work",
+      })
+      return { session, user, assistant }
+    }),
+  )
+  const listener = await Server.listen({ hostname: "127.0.0.1", port: 0 })
+  const resume = (id = seed.assistant.id) =>
+    fetch(new URL(`/kilocode/session/${seed.session.id}/resume`, listener.url), {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-kilo-directory": tmp.path },
+      body: JSON.stringify({ messageID: id }),
+    })
+  try {
+    expect((await resume()).status).toBe(400)
+    await run(
+      Session.Service.use((sessions) =>
+        sessions.updateMessage({
+          ...seed.assistant,
+          error: new MessageV2.AbortedError({ message: "Stopped" }).toObject(),
+        }),
+      ),
+    )
+    expect((await resume(seed.user.id)).status).toBe(400)
+
+    const answering = run(
+      Question.Service.use((questions) =>
+        questions.ask({
+          sessionID: seed.session.id,
+          questions: [
+            { header: "Choice", question: "Choose an action", options: [{ label: "Wait", description: "Wait" }] },
+          ],
+        }),
+      ).pipe(Effect.exit),
+    )
+    const question = await run(
+      pollWithTimeout(
+        Question.Service.use((questions) => questions.list()).pipe(
+          Effect.map((items) => items.find((item) => item.sessionID === seed.session.id)),
+        ),
+        "question did not become pending",
+      ),
+    )
+    expect((await resume()).status).toBe(400)
+    expect(await run(Question.Service.use((questions) => questions.list()))).toHaveLength(1)
+    await run(Question.Service.use((questions) => questions.reject(question.id)))
+    await answering
+
+    const approving = run(
+      Permission.Service.use((permissions) =>
+        permissions.ask({
+          sessionID: seed.session.id,
+          permission: "bash",
+          patterns: ["pwd"],
+          metadata: {},
+          always: [],
+          ruleset: [],
+        }),
+      ).pipe(Effect.exit),
+    )
+    const permission = await run(
+      pollWithTimeout(
+        Permission.Service.use((permissions) => permissions.list()).pipe(
+          Effect.map((items) => items.find((item) => item.sessionID === seed.session.id)),
+        ),
+        "permission did not become pending",
+      ),
+    )
+    expect((await resume()).status).toBe(400)
+    expect(await run(Permission.Service.use((permissions) => permissions.list()))).toHaveLength(1)
+    await run(Permission.Service.use((permissions) => permissions.reply({ requestID: permission.id, reply: "reject" })))
+    await approving
+
+    expect((await resume()).status).toBe(200)
+    await run(
+      pollWithTimeout(
+        Effect.sync(() => (calls.length > 0 ? true : undefined)),
+        "resume did not start",
+      ),
+    )
+    expect((await resume()).status).toBe(400)
+    gate.resolve()
+    const messages = await run(
+      pollWithTimeout(
+        Session.Service.use((sessions) => sessions.messages({ sessionID: seed.session.id })).pipe(
+          Effect.map((messages) => {
+            const last = messages.at(-1)
+            return last?.info.role === "assistant" && last.info.id !== seed.assistant.id && last.info.time.completed
+              ? messages
+              : undefined
+          }),
+        ),
+        "resumed response did not complete",
+        "10 seconds",
+      ),
+    )
+    expect(messages.filter((message) => message.info.role === "user").map((message) => message.info.id)).toEqual([
+      seed.user.id,
+    ])
+    expect(messages.at(-1)?.parts.some((part) => part.type === "text" && part.text === "Resumed task finished")).toBe(
+      true,
+    )
+    expect(JSON.stringify(messages)).not.toContain("[TASK RESUMPTION]")
+    expect(calls).toHaveLength(1)
+    expect((await resume()).status).toBe(400)
+    expect(calls).toHaveLength(1)
+  } finally {
+    gate.resolve()
+    await listener.stop(true)
+    await provider.stop(true)
+  }
+}, 30_000)

--- a/packages/opencode/test/kilocode/session/resume.test.ts
+++ b/packages/opencode/test/kilocode/session/resume.test.ts
@@ -1,0 +1,172 @@
+import path from "path"
+import { expect } from "bun:test"
+import { Effect, Fiber, Stream } from "effect"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { Session } from "@/session/session"
+import { SessionPrompt } from "@/session/prompt"
+import { SessionStatus } from "@/session/status"
+import { MessageV2 } from "@/session/message-v2"
+import { PartID } from "@/session/schema"
+import { TestInstance } from "../../fixture/fixture"
+import { awaitWithTimeout, testEffect } from "../../lib/effect"
+import { reply, TestLLMServer } from "../../lib/llm-server"
+
+const it = testEffect(
+  LayerNode.compile(
+    LayerNode.group([
+      SessionPrompt.node,
+      Session.node,
+      SessionProjector.node,
+      SessionStatus.node,
+      EventV2Bridge.node,
+      FSUtil.node,
+      LayerNode.make({ service: TestLLMServer, layer: TestLLMServer.layer, deps: [] }),
+    ]),
+  ),
+)
+
+const setup = Effect.fnUntraced(function* () {
+  const llm = yield* TestLLMServer
+  const fs = yield* FSUtil.Service
+  const instance = yield* TestInstance
+  yield* fs.writeWithDirs(
+    path.join(instance.directory, "opencode.json"),
+    JSON.stringify({
+      model: "test/test-model",
+      small_model: "test/test-model",
+      enabled_providers: ["test"],
+      formatter: false,
+      lsp: false,
+      provider: {
+        test: {
+          name: "Test",
+          npm: "@ai-sdk/openai-compatible",
+          options: { apiKey: "test-key", baseURL: llm.url },
+          models: {
+            "test-model": {
+              name: "Test Model",
+              tool_call: true,
+              limit: { context: 100000, output: 10000 },
+            },
+          },
+        },
+      },
+    }),
+  )
+  const sessions = yield* Session.Service
+  const prompt = yield* SessionPrompt.Service
+  const status = yield* SessionStatus.Service
+  const session = yield* sessions.create({ title: "Resume validation" })
+  const user = yield* prompt.prompt({
+    sessionID: session.id,
+    agent: "code",
+    model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("test-model") },
+    noReply: true,
+    parts: [{ type: "text", text: "Complete the original task" }],
+  })
+  return { llm, sessions, prompt, status, session, user }
+})
+
+it.instance(
+  "resumes an aborted OpenCode stream on the original user turn",
+  () =>
+    Effect.gen(function* () {
+      const { llm, sessions, prompt, status, session, user } = yield* setup()
+      const events = yield* EventV2Bridge.Service
+      const received = yield* events.subscribe(MessageV2.Event.PartDelta).pipe(
+        Stream.filter((event) => event.data.sessionID === session.id && event.data.delta === "Partial result"),
+        Stream.take(1),
+        Stream.runDrain,
+        Effect.forkChild({ startImmediately: true }),
+      )
+      yield* llm.push(reply().text("Partial result").hang())
+      const fiber = yield* prompt.loop({ sessionID: session.id }).pipe(Effect.forkChild)
+      yield* awaitWithTimeout(Fiber.join(received), "partial output never arrived", "10 seconds")
+      yield* prompt.cancel(session.id)
+      yield* Fiber.join(fiber)
+      expect((yield* status.get(session.id)).type).toBe("idle")
+      const stopped = (yield* sessions.messages({ sessionID: session.id })).at(-1)
+      expect(stopped?.info.role === "assistant" && MessageV2.AbortedError.isInstance(stopped.info.error)).toBe(true)
+
+      if (!stopped) throw new Error("Missing interrupted assistant")
+      yield* llm.text("Finished the original task")
+      const resumed = yield* prompt.loop({ sessionID: session.id, resume: stopped.info.id })
+      expect(resumed.info.role === "assistant" && resumed.info.parentID).toBe(user.info.id)
+      expect(resumed.parts.some((part) => part.type === "text" && part.text === "Finished the original task")).toBe(
+        true,
+      )
+      const messages = yield* sessions.messages({ sessionID: session.id })
+      expect(messages.filter((message) => message.info.role === "user").map((message) => message.info.id)).toEqual([
+        user.info.id,
+      ])
+      expect(messages.some((message) => message.info.id === stopped?.info.id)).toBe(true)
+      const body = (yield* llm.hits).at(-1)?.body
+      expect(JSON.stringify(body)).toContain("Partial result")
+      expect(Array.isArray(body?.messages) && body.messages.at(-1)).toMatchObject({
+        role: "user",
+        content: expect.stringContaining("[TASK RESUMPTION]"),
+      })
+      expect(JSON.stringify(messages)).not.toContain("[TASK RESUMPTION]")
+      expect(yield* llm.hits).toHaveLength(2)
+    }),
+  30_000,
+)
+
+it.instance(
+  "does not restart a completed OpenCode response",
+  () =>
+    Effect.gen(function* () {
+      const { llm, prompt, session } = yield* setup()
+      yield* llm.text("Done")
+      const completed = yield* prompt.loop({ sessionID: session.id })
+      const repeated = yield* prompt.loop({ sessionID: session.id, resume: completed.info.id })
+      expect(repeated.info.id).toBe(completed.info.id)
+      expect(yield* llm.hits).toHaveLength(1)
+    }),
+  30_000,
+)
+
+it.instance(
+  "retains interrupted tool results when resuming an unfinished OpenCode turn",
+  () =>
+    Effect.gen(function* () {
+      const { llm, sessions, prompt, session, user } = yield* setup()
+      yield* llm.text("Partial result")
+      const completed = yield* prompt.loop({ sessionID: session.id })
+      if (completed.info.role !== "assistant") throw new Error("Expected assistant")
+      yield* sessions.updateMessage({
+        ...completed.info,
+        finish: "stop",
+        error: new MessageV2.AbortedError({ message: "Stopped" }).toObject(),
+      })
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        sessionID: session.id,
+        messageID: completed.info.id,
+        type: "tool",
+        tool: "read",
+        callID: "interrupted-read",
+        state: {
+          status: "error",
+          input: { filePath: "/missing.txt" },
+          error: "Tool execution aborted",
+          metadata: { interrupted: true },
+          time: { start: 1, end: 2 },
+        },
+      })
+      yield* llm.text("Continued with the interruption recorded")
+      const resumed = yield* prompt.loop({ sessionID: session.id, resume: completed.info.id })
+      expect(resumed.info.role === "assistant" && resumed.info.parentID).toBe(user.info.id)
+      expect(JSON.stringify((yield* llm.hits).at(-1)?.body)).toContain("Tool execution aborted")
+      expect(
+        (yield* sessions.messages({ sessionID: session.id })).filter((message) => message.info.role === "user"),
+      ).toHaveLength(1)
+      expect(yield* llm.hits).toHaveLength(2)
+    }),
+  30_000,
+)

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -211,6 +211,8 @@ import type {
   KilocodeRemoveSkillResponses,
   KilocodeRemoveSnapshotErrors,
   KilocodeRemoveSnapshotResponses,
+  KilocodeResumeSessionErrors,
+  KilocodeResumeSessionResponses,
   KilocodeSessionImportMessageErrors,
   KilocodeSessionImportMessageResponses,
   KilocodeSessionImportPartErrors,
@@ -8321,6 +8323,51 @@ export class SessionImport extends HeyApiClient {
 
 export class Kilocode extends HeyApiClient {
   /**
+   * Resume an interrupted session
+   *
+   * Resume the specified unfinished assistant turn without adding a user message. Active, completed, reverted, and blocked sessions cannot be resumed.
+   */
+  public resumeSession<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+      messageID: string
+      snapshotInitialization?: "wait"
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "messageID" },
+            { in: "body", key: "snapshotInitialization" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      KilocodeResumeSessionResponses,
+      KilocodeResumeSessionErrors,
+      ThrowOnError
+    >({
+      url: "/kilocode/session/{sessionID}/resume",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
    * List command files
    *
    * List commands with editable file locations for settings clients.
@@ -8481,10 +8528,10 @@ export class Kilocode extends HeyApiClient {
    * Remove the snapshot repository for an already deleted Agent Manager worktree.
    */
   public removeSnapshot<ThrowOnError extends boolean = false>(
-    parameters?: {
+    parameters: {
       directory?: string
       workspace?: string
-      worktree?: string
+      worktree: string
     },
     options?: Options<never, ThrowOnError>,
   ) {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -16590,6 +16590,43 @@ export type KiloCloudSessionImportResponses = {
 
 export type KiloCloudSessionImportResponse = KiloCloudSessionImportResponses[keyof KiloCloudSessionImportResponses]
 
+export type KilocodeResumeSessionData = {
+  body?: {
+    messageID: string
+    snapshotInitialization?: "wait"
+  }
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/kilocode/session/{sessionID}/resume"
+}
+
+export type KilocodeResumeSessionErrors = {
+  /**
+   * InvalidRequestError
+   */
+  400: InvalidRequestError
+  /**
+   * NotFoundError
+   */
+  404: NotFoundError
+}
+
+export type KilocodeResumeSessionError = KilocodeResumeSessionErrors[keyof KilocodeResumeSessionErrors]
+
+export type KilocodeResumeSessionResponses = {
+  /**
+   * Session continuation accepted
+   */
+  200: boolean
+}
+
+export type KilocodeResumeSessionResponse = KilocodeResumeSessionResponses[keyof KilocodeResumeSessionResponses]
+
 export type KilocodeHeapSnapshotData = {
   body?: never
   path?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -15082,6 +15082,108 @@
         ]
       }
     },
+    "/kilocode/session/{sessionID}/resume": {
+      "post": {
+        "tags": ["kilocode"],
+        "operationId": "kilocode.resumeSession",
+        "parameters": [
+          {
+            "name": "sessionID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^ses.*"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session continuation accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean",
+                  "description": "Session continuation accepted"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/InvalidRequestError"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InvalidRequestError"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Resume the specified unfinished assistant turn without adding a user message. Active, completed, reverted, and blocked sessions cannot be resumed.",
+        "summary": "Resume an interrupted session",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "messageID": {
+                    "type": "string",
+                    "pattern": "^msg"
+                  },
+                  "snapshotInitialization": {
+                    "type": "string",
+                    "enum": ["wait"]
+                  }
+                },
+                "required": ["messageID"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.kilocode.resumeSession({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/kilocode/heap/snapshot": {
       "post": {
         "tags": ["kilocode"],
@@ -16527,6 +16629,79 @@
           {
             "lang": "js",
             "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.kilocode.backgroundJob.cancel({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/kilocode/background-jobs/{jobID}/promote": {
+      "post": {
+        "tags": ["kilocode"],
+        "operationId": "kilocode.backgroundJob.promote",
+        "parameters": [
+          {
+            "name": "jobID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Background job promoted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean",
+                  "description": "Background job promoted"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Continue one foreground subagent in the background.",
+        "summary": "Promote background job",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createKiloClient } from \"@kilocode/sdk\"\n\nconst client = createKiloClient()\nawait client.kilocode.backgroundJob.promote({\n  ...\n})"
           }
         ]
       }
@@ -26537,9 +26712,6 @@
             "$ref": "#/components/schemas/EventSandboxStatusChanged"
           },
           {
-            "$ref": "#/components/schemas/EventLspClientDiagnostics"
-          },
-          {
             "$ref": "#/components/schemas/EventSuggestionShown"
           },
           {
@@ -26565,6 +26737,9 @@
           },
           {
             "$ref": "#/components/schemas/EventKilo-sessionsRemote-status-changed"
+          },
+          {
+            "$ref": "#/components/schemas/EventLspClientDiagnostics"
           },
           {
             "$ref": "#/components/schemas/EventMemoryStatus1"
@@ -29734,9 +29909,6 @@
                 "$ref": "#/components/schemas/EventSandboxStatusChanged"
               },
               {
-                "$ref": "#/components/schemas/EventLspClientDiagnostics"
-              },
-              {
                 "$ref": "#/components/schemas/EventSuggestionShown"
               },
               {
@@ -29762,6 +29934,9 @@
               },
               {
                 "$ref": "#/components/schemas/EventKilo-sessionsRemote-status-changed"
+              },
+              {
+                "$ref": "#/components/schemas/EventLspClientDiagnostics"
               },
               {
                 "$ref": "#/components/schemas/EventMemoryStatus"
@@ -41555,33 +41730,6 @@
         "required": ["id", "type", "properties"],
         "additionalProperties": false
       },
-      "EventLspClientDiagnostics": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["lsp.client.diagnostics"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "serverID": {
-                "type": "string"
-              },
-              "path": {
-                "type": "string"
-              }
-            },
-            "required": ["serverID", "path"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
       "EventSuggestionShown": {
         "type": "object",
         "properties": {
@@ -41872,6 +42020,33 @@
               }
             },
             "required": ["enabled", "connected"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventLspClientDiagnostics": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["lsp.client.diagnostics"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "serverID": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string"
+              }
+            },
+            "required": ["serverID", "path"],
             "additionalProperties": false
           }
         },


### PR DESCRIPTION
## What Problem This Solves

Resuming a stopped task currently requires another typed prompt. Sending a literal `continue` creates a new user turn, even though the original task is still unfinished.

## Why This Change Was Made

Use the existing OpenCode prompt loop to resume the original user turn instead. The empty send button becomes **Continue** only when the latest assistant response is eligible for continuation. Its tooltip and accessible label change together.

The backend checks the target assistant ID and current session state before starting. Busy, completed, reverted, archived, and blocked sessions are rejected. Pending permissions, questions, and suggestions are not answered or dismissed by this action. Partial output and interrupted tool results remain in history.

A request-only resumption instruction is added for the model so the request does not end in partial assistant text. It is not stored as a new user message or displayed in the transcript.

## User Impact

- Stop a response, leave the composer empty, and click **Continue** to resume it without another user bubble.
- Text, images, and review comments keep the existing Send behavior. Empty new chats and completed responses remain unavailable.
- Continue uses the original turn's model and agent. It starts another model request, not the same interrupted network stream.
- This does not add general error recovery. Terminal provider or authentication errors still require a new typed prompt; existing automatic retries are unchanged.
- Resume does not roll back tool side effects or guarantee exactly-once execution. The model is instructed to check current state before retrying interrupted tools.

## Evidence

Validated the actual OpenCode runtime with a controlled local provider: stopped streaming resumes on the original user turn, interrupted tool results are retained, completed turns do not produce another request, and HTTP requests for stale, active, or blocked turns are rejected.

After rebasing onto main, the extension build, lint, typechecks, Knip, change-marker guards, 186 focused extension tests, and 12 backend tests passed. The new route also passed focused coverage, authentication, and execution checks. The broader local HTTP route sweep exceeded its 120-second timeout; no full-suite pass is claimed.

In isolated VS Code, verified empty new-chat Send is disabled, Stop changes the button and tooltip to Continue, Continue finishes the task with no new user bubble, empty Send becomes disabled after completion, and typing a follow-up enables normal Send. This used a local deterministic provider, not live-model validation across providers.

**Continue after Stop**

<img width="420" alt="The empty composer shows a Continue tooltip after stopping a response" src="https://marius-kilocode.github.io/pr-assets/20260828-resume-turn-continue-tooltip-1107.png" />

**Resumed task with the original user message**

<img width="360" alt="A single user message followed by the partial response and resumed completion, with no continue message added" src="https://marius-kilocode.github.io/pr-assets/20260828-resume-turn-completed-transcript-1107.png" />
