### PR TITLE
fix(vscode): clear failure banners after overflow recovery

### DIFF
--- a/.changeset/clear-recovered-overflow-errors.md
+++ b/.changeset/clear-recovered-overflow-errors.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Clear false failure banners after successful context overflow recovery while preserving terminal errors.

--- a/packages/kilo-vscode/tests/fixtures/session-provider-activity.tsx
+++ b/packages/kilo-vscode/tests/fixtures/session-provider-activity.tsx
@@ -41,6 +41,7 @@ const { ConfigContext } = await import("../../webview-ui/src/context/config")
 const { LanguageContext } = await import("../../webview-ui/src/context/language")
 const { ProviderContext } = await import("../../webview-ui/src/context/provider")
 const { SessionProvider, useSession } = await import("../../webview-ui/src/context/session")
+const { terminal } = await import("../../webview-ui/src/context/session-outcome")
 
 const provider = {
   providers: () => ({}),
@@ -371,6 +372,7 @@ try {
   await emit({ type: "sessionError", eventID: "root-error", error: { name: "ProviderError" } })
   await check("root", "error")
   assert.equal(value.inUseFor("root"), false)
+  await emit({ type: "sessionError", eventID: "later-overflow", error: { name: "ContextOverflowError" } })
   await emit({ type: "sessionTurnClosed", sessionID: "root", reason: "completed" })
   await check("root", "error")
 
@@ -379,6 +381,79 @@ try {
   await emit({ type: "sessionStatus", sessionID: "root", status: "idle" })
   await check("root", "idle")
 
+  for (const order of ["before", "after"]) {
+    await emit({ type: "sessionStatus", sessionID: "root", status: "busy" })
+    await emit({
+      type: "sessionError",
+      sessionID: "root",
+      eventID: `overflow-${order}`,
+      error: { name: "ContextOverflowError", data: { message: "Request Entity Too Large" } },
+    })
+    await check("root", "busy")
+    await emit({
+      type: "sessionError",
+      sessionID: "root",
+      eventID: `retry-${order}`,
+      error: { name: "ContextOverflowError", data: { message: "Request Entity Too Large" } },
+    })
+    await emit({
+      type: "messageCreated",
+      message: {
+        id: `recovered-${order}`,
+        sessionID: "root",
+        role: "assistant",
+        createdAt: new Date().toISOString(),
+        finish: "stop",
+      },
+    })
+    if (order === "before") await emit({ type: "sessionStatus", sessionID: "root", status: "idle" })
+    await emit({ type: "sessionTurnClosed", sessionID: "root", reason: "completed" })
+    if (order === "after") await emit({ type: "sessionStatus", sessionID: "root", status: "idle" })
+    await check("root", "done")
+    assert.equal(value.closeReason(), "completed")
+    assert.equal(
+      value.messages().some((message) => message.sessionErrorID === `overflow-${order}`),
+      false,
+    )
+    assert.equal(
+      value.messages().some((message) => message.sessionErrorID === `retry-${order}`),
+      false,
+    )
+    assert.equal(terminal({ reason: value.closeReason(), messages: value.visibleMessages(), todos: [] }), undefined)
+    assert.equal(
+      value.messages().some((message) => message.sessionErrorID === "root-error"),
+      true,
+    )
+    assert.equal(
+      value.messages().some((message) => message.sessionErrorID === "later-overflow"),
+      true,
+    )
+  }
+
+  for (const reason of ["error", "completed"]) {
+    await emit({ type: "sessionStatus", sessionID: "root", status: "busy" })
+    await emit({
+      type: "sessionError",
+      sessionID: "root",
+      eventID: `unrecovered-${reason}`,
+      error: { name: "ContextOverflowError", data: { message: "Context limit reached" } },
+    })
+    if (reason === "completed") {
+      await emit({ type: "sessionError", sessionID: "root", eventID: "terminal-error", error: { name: "APIError" } })
+    }
+    await emit({ type: "sessionTurnClosed", sessionID: "root", reason })
+    await emit({ type: "sessionStatus", sessionID: "root", status: "idle" })
+    await emit({ type: "sessionTurnClosed", sessionID: "root", reason: "completed" })
+    await check("root", "error")
+    assert.equal(value.closeReason(), "error")
+    assert.equal(
+      value.messages().some((message) => message.sessionErrorID === `unrecovered-${reason}`),
+      true,
+    )
+  }
+
+  await emit({ type: "sessionStatus", sessionID: "root", status: "busy" })
+  await emit({ type: "sessionStatus", sessionID: "root", status: "idle" })
   await emit({
     type: "questionRequest",
     question: {

--- a/packages/kilo-vscode/tests/unit/session-outcome.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-outcome.test.ts
@@ -121,6 +121,7 @@ describe("terminal", () => {
       remaining: 1,
     })
     expect(terminal({ reason: "error", messages: [message("error")], todos: [] })?.kind).toBe("error")
+    expect(terminal({ reason: "error", messages: [message("stop")], todos: [] })?.kind).toBe("error")
   })
 
   it("does not duplicate a concrete rendered failure", () => {

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -150,6 +150,7 @@ export const SessionProvider: ParentComponent = (props) => {
   const [busySinceMap, setBusySinceMap] = createStore<Record<string, number>>({})
   const [submissionMap, setSubmissionMap] = createStore<Record<string, number>>({})
   const pendingSubmissions = new Map<string, string>()
+  const recoveries = new Map<string, Set<string>>()
   const removedSessions = new Set<string>()
   const aborts = createAbortState()
 
@@ -165,12 +166,14 @@ export const SessionProvider: ParentComponent = (props) => {
     const id = currentSessionID()
     return id ? closeMap[id]?.reason : undefined
   }
-  const clearClose = (id: string) =>
+  const clearClose = (id: string) => {
+    recoveries.delete(id)
     setCloseMap(
       produce((map) => {
         delete map[id]
       }),
     )
+  }
   const busySince = () => {
     const id = currentSessionID() ?? draftSessionID()
     return id ? busySinceMap[id] : undefined
@@ -816,10 +819,22 @@ export const SessionProvider: ParentComponent = (props) => {
 
   function closed(message: Extract<ExtensionMessage, { type: "sessionTurnClosed" }>) {
     if (message.reason === "completed" && closeMap[message.sessionID]?.reason === "error") return
+    const ids = recoveries.get(message.sessionID)
+    if (message.reason === "completed" && ids) {
+      setStore("messages", message.sessionID, (msgs = []) => msgs.filter((msg) => !ids.has(msg.id)))
+    }
+    recoveries.delete(message.sessionID)
     setCloseMap(message.sessionID, { reason: message.reason, parentID: message.parentID })
   }
 
-  function failed(id: string) {
+  function failed(id: string, message: Message) {
+    if (message.error?.name === "ContextOverflowError" && closeMap[id]?.reason !== "error") {
+      const ids = recoveries.get(id) ?? new Set<string>()
+      ids.add(message.id)
+      recoveries.set(id, ids)
+      return
+    }
+    recoveries.delete(id)
     setCloseMap(id, { reason: "error", parentID: store.sessions[id]?.parentID ?? undefined })
   }
 
@@ -970,7 +985,6 @@ export const SessionProvider: ParentComponent = (props) => {
         if (!message.error || message.error.name === "MessageAbortedError") break
         const sid = message.sessionID ?? currentSessionID()
         if (!sid) break
-        failed(sid)
         // Find the last user message in this session to use as parentID
         const msgs = store.messages[sid] ?? []
         const parent = [...msgs].reverse().find((m) => m.role === "user")
@@ -983,6 +997,7 @@ export const SessionProvider: ParentComponent = (props) => {
           error: message.error,
           sessionErrorID: message.eventID,
         }
+        failed(sid, errorMsg)
         handleMessageCreated(errorMsg)
         break
       }


### PR DESCRIPTION
## What Problem This Solves

A context-overflow request can fail, recover through automatic compaction, and then finish normally. The VS Code session state treated the temporary `session.error` event as a terminal failure and ignored the later successful turn close. This left a false “Turn failed” outcome and an old overflow error card after the response had recovered.

## Why This Change Was Made

Track temporary overflow errors separately from terminal turn failures. Keep recovery active and remove only that turn's temporary overflow cards after a successful close.

A non-overflow error or an explicitly failed turn must remain failed, even if a later completion event arrives. Earlier failed turns must also remain inspectable. The change preserves those cases instead of clearing every error when an assistant message ends with `finish: "stop"`.

This is a session-status and error-display fix. It does not change image compression, gateway request-size limits, or compaction thresholds.

## User Impact

Successful overflow recovery no longer leaves the sidebar or Agent Manager reporting a failed turn. Unrecoverable overflows and other terminal failures remain visible.

## Evidence

The regression was reproduced before the fix. The session-provider fixture now exercises repeated overflow events, both idle/completion event orders, successful recovery, explicit terminal failures, and non-overflow failures before or after an overflow.

The rebuilt extension was also exercised in isolated VS Code with synthetic backend events, not a live provider-generated 413. The screenshots show the result after this change: successful recovery clears the overflow card, while a terminal overflow remains visible even after a late completion event.

| Successful recovery | Terminal failure preserved |
|---|---|
| <img width="340" alt="A completed response after overflow recovery, with no error banner" src="https://marius-kilocode.github.io/pr-assets/20260828-overflow-recovery-completed-1105.png" /> | <img width="340" alt="An unrecoverable context overflow remains visible after a late completion event" src="https://marius-kilocode.github.io/pr-assets/20260828-overflow-recovery-terminal-1105.png" /> |
