### PR TITLE
fix(vscode): prevent drained questions from reappearing

### DIFF
--- a/.changeset/clear-drained-question-recovery.md
+++ b/.changeset/clear-drained-question-recovery.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent cleared questions from reappearing after saving settings.

--- a/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/connection-service.ts
@@ -595,6 +595,7 @@ export class KiloConnectionService {
         for (const q of qs) {
           const { error } = await client.question.reject({ requestID: q.id, directory: dir })
           if (error && !isNotFound(error)) throw new Error(`Failed to reject question ${q.id}: ${String(error)}`)
+          this.clearQuestionDirectory(q.id)
         }
       }
     })

--- a/packages/kilo-vscode/tests/unit/connection-service-question.test.ts
+++ b/packages/kilo-vscode/tests/unit/connection-service-question.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { KiloConnectionService } from "../../src/services/cli-backend/connection-service"
 
 describe("KiloConnectionService question routing", () => {
-  test("ignores stale NotFoundError rejects while draining questions", async () => {
+  test.each([undefined, { _tag: "NotFound" }])("invalidates recovery after draining (%j)", async (error) => {
     const service = new KiloConnectionService({} as any)
     const client = {
       permission: {
@@ -10,7 +10,7 @@ describe("KiloConnectionService question routing", () => {
       },
       question: {
         list: async () => ({ data: [{ id: "que_test" }] }),
-        reject: async () => ({ error: { _tag: "NotFound" } }),
+        reject: async () => ({ error }),
       },
       suggestion: {
         list: async () => ({ data: [] }),
@@ -22,8 +22,14 @@ describe("KiloConnectionService question routing", () => {
 
     ;(service as any).client = client
     ;(service as any).directoryProviders.add(() => ["/tmp/workspace"])
+    service.recordQuestionDirectory("que_test", "/tmp/workspace")
+    const revisions: number[] = []
+    service.onClearPendingPrompts(() => revisions.push(service.getQuestionRevision()))
 
     await expect(service.drainPendingPrompts()).resolves.toBeUndefined()
+
+    expect(service.getQuestionDirectory("que_test")).toBeUndefined()
+    expect(revisions).toEqual([1])
   })
 
   test("records and clears request origins from SSE events", () => {


### PR DESCRIPTION
Settings saves reject pending questions and clear the UI, but a delayed recovery scan can replay an old question before the rejection SSE arrives.

Invalidate recovery immediately after a successful rejection or NotFound response, using the existing revision guard. Keep the fix to one production line; snapshot backend behavior is unchanged.

The focused regression covers both outcomes and verifies invalidation before the clear notification. It fails without the fix and passes with it. All 19 focused tests, extension/webview typechecks, lint, knip, and the change-marker guard pass. The live VS Code heavy-load scenario was not exercised.