### PR TITLE
fix(jetbrains): linkify urls inside inline code

### DIFF
--- a/.changeset/jetbrains-inline-code-urls.md
+++ b/.changeset/jetbrains-inline-code-urls.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-jetbrains": patch
+---
+
+Make `http`/`https` URLs written inside backticks clickable in chat messages. Previously only bare URLs became links, so URLs rendered as inline code — release links, PR links, run URLs — were inert text.

--- a/packages/kilo-jetbrains/frontend/build.gradle.kts
+++ b/packages/kilo-jetbrains/frontend/build.gradle.kts
@@ -26,6 +26,9 @@ dependencies {
     implementation(libs.commonmark.autolink)
     implementation(libs.commonmark.tables)
     implementation(libs.commonmark.strikethrough)
+    // Bundled explicitly rather than relied on as a transitive of commonmark-ext-autolink: the URL
+    // scanner is used directly to linkify code spans.
+    implementation(libs.autolink)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.zxing.core)
 

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/md/MdCommon.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/md/MdCommon.kt
@@ -19,13 +19,11 @@ internal object MdCommon {
     private val code = Regex("<code(\\s[^>]*)?>(.*?)</code>", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
     private val tag = Regex("<[^>]+>")
     private val ref = Regex("(?<![\\w@:/.-])((?:\\.?[A-Za-z0-9_-]{1,80}/){1,20}[A-Za-z0-9_.-]{1,120}\\.[A-Za-z0-9_-]{1,20}(?::\\d{1,7}(?:-\\d{1,7})?)?|[A-Za-z0-9_.-]{1,120}\\.(?:ts|tsx|js|jsx|mjs|cjs|kt|kts|java|md|mdx|txt|json|jsonc|yaml|yml|toml|xml|html|css|scss|rs|go|py|rb|php|swift|c|h|cpp|hpp|cs|sh|zsh|bash|sql|gradle)(?::\\d{1,7}(?:-\\d{1,7})?)?)")
-    private val url = Regex("https?://[^\\s<>\"'`]+", RegexOption.IGNORE_CASE)
     private val single = setOf("readme.md", "package.json", "tsconfig.json", "jsconfig.json", "kilo.json", "kilo.jsonc")
-    // Entities the markdown renderer emits for characters that cannot appear in a URL; a match that
-    // runs into one of them is cut short so the link stops at the original delimiter.
-    private val entities = listOf("&lt;", "&gt;", "&quot;")
-    private const val TRAIL = ".,;:!?"
     private const val REF_SEGMENT_LIMIT = 16_384
+
+    /** Anchor class [ai.kilocode.client.ui.md.hybrid.MdProjector]'s code-span linkifier tags its links with. */
+    const val URL_REF_CLASS = "kilo-url-ref"
 
     val tags = listOf(
         "body", "p", "div", "span", "ul", "ol", "li", "table", "thead", "tbody", "tr", "th", "td",
@@ -41,7 +39,7 @@ internal object MdCommon {
         .replace("\r", " ")
 
     fun inlineCode(html: String, opts: MdStyle): String {
-        if (!html.contains('<') && !scan(html)) return html
+        if (!html.contains('<') && !html.contains('.')) return html
         val color = hex(opts.inlineCodeFg)
         val styled = if (html.contains("<code", ignoreCase = true)) {
             val out = StringBuilder()
@@ -80,7 +78,7 @@ internal object MdCommon {
         rules.append("em, i { color: ${hex(opts.emphasisFg)} } ")
         rules.append("a { color: ${hex(opts.linkColor)} } ")
         rules.append("a.kilo-file-ref, code a.kilo-file-ref { color: ${hex(SessionUiStyle.View.Markdown.string())}; font-family: '${css(opts.codeFont)}', monospace; text-decoration: underline } ")
-        rules.append("a.kilo-url-ref, code a.kilo-url-ref { color: ${hex(opts.linkColor)}; font-family: '${css(opts.codeFont)}', monospace; text-decoration: underline } ")
+        rules.append("a.$URL_REF_CLASS, code a.$URL_REF_CLASS { color: ${hex(opts.linkColor)}; font-family: '${css(opts.codeFont)}', monospace; text-decoration: underline } ")
         rules.append("ul, ol { color: ${hex(opts.listMarkerFg)} } ")
         rules.append("li { color: ${hex(opts.foreground)} } ")
         rules.append("tt, code, samp, pre, pre code { font-family: '${css(opts.codeFont)}', monospace; border-width: 0 } ")
@@ -142,7 +140,7 @@ internal object MdCommon {
     }
 
     private fun refs(html: String): String {
-        if (!scan(html)) return html
+        if (!html.contains('.')) return html
         val out = StringBuilder()
         var at = 0
         for (match in protect.findAll(html)) {
@@ -155,7 +153,7 @@ internal object MdCommon {
     }
 
     private fun tags(html: String): String {
-        if (!scan(html)) return html
+        if (!html.contains('.')) return html
         val out = StringBuilder()
         var at = 0
         for (match in tag.findAll(html)) {
@@ -167,29 +165,8 @@ internal object MdCommon {
         return out.toString()
     }
 
-    /**
-     * Linkifies plain text between tags: `http(s)` URLs first, then file references in whatever text
-     * is left over. URLs are handled here rather than by the markdown parser because CommonMark's
-     * autolink extension skips code spans, so a URL in backticks would otherwise stay inert text.
-     */
     private fun paths(text: String): String {
-        if (text.length > REF_SEGMENT_LIMIT || !scan(text)) return text
-        if (!text.contains("://")) return files(text)
-        val out = StringBuilder()
-        var at = 0
-        for (match in url.findAll(text)) {
-            out.append(files(text.substring(at, match.range.first)))
-            val link = cut(match.value)
-            at = match.range.first + link.length
-            // The renderer already escaped the source, so the matched text is a valid attribute value.
-            out.append("<a class=\"kilo-url-ref\" href=\"$link\">$link</a>")
-        }
-        out.append(files(text.substring(at)))
-        return out.toString()
-    }
-
-    private fun files(text: String): String {
-        if (!text.contains('.')) return text
+        if (text.length > REF_SEGMENT_LIMIT || !text.contains('.')) return text
         return ref.replace(text) { match ->
             val path = match.value
             if (!pathish(path)) return@replace path
@@ -199,35 +176,6 @@ internal object MdCommon {
             "<a class=\"kilo-file-ref\" href=\"${attr(href)}\">$path</a>"
         }
     }
-
-    /** Trims a raw URL match down to the part that belongs to the link. */
-    private fun cut(value: String): String {
-        var end = value.length
-        for (item in entities) {
-            val at = value.indexOf(item)
-            if (at in 0 until end) end = at
-        }
-        while (end > 0) {
-            val char = value[end - 1]
-            if (char in TRAIL) {
-                end--
-                continue
-            }
-            val open = when (char) {
-                ')' -> '('
-                ']' -> '['
-                '}' -> '{'
-                else -> break
-            }
-            val head = value.substring(0, end)
-            if (head.count { it == open } >= head.count { it == char }) break
-            end--
-        }
-        return value.substring(0, end)
-    }
-
-    /** True when [text] can contain a file reference or a URL worth scanning for. */
-    private fun scan(text: String): Boolean = text.contains('.') || text.contains("://")
 
     private fun pathish(path: String): Boolean {
         if (path.contains('/')) return true

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/md/MdCommon.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/md/MdCommon.kt
@@ -19,7 +19,12 @@ internal object MdCommon {
     private val code = Regex("<code(\\s[^>]*)?>(.*?)</code>", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
     private val tag = Regex("<[^>]+>")
     private val ref = Regex("(?<![\\w@:/.-])((?:\\.?[A-Za-z0-9_-]{1,80}/){1,20}[A-Za-z0-9_.-]{1,120}\\.[A-Za-z0-9_-]{1,20}(?::\\d{1,7}(?:-\\d{1,7})?)?|[A-Za-z0-9_.-]{1,120}\\.(?:ts|tsx|js|jsx|mjs|cjs|kt|kts|java|md|mdx|txt|json|jsonc|yaml|yml|toml|xml|html|css|scss|rs|go|py|rb|php|swift|c|h|cpp|hpp|cs|sh|zsh|bash|sql|gradle)(?::\\d{1,7}(?:-\\d{1,7})?)?)")
+    private val url = Regex("https?://[^\\s<>\"'`]+", RegexOption.IGNORE_CASE)
     private val single = setOf("readme.md", "package.json", "tsconfig.json", "jsconfig.json", "kilo.json", "kilo.jsonc")
+    // Entities the markdown renderer emits for characters that cannot appear in a URL; a match that
+    // runs into one of them is cut short so the link stops at the original delimiter.
+    private val entities = listOf("&lt;", "&gt;", "&quot;")
+    private const val TRAIL = ".,;:!?"
     private const val REF_SEGMENT_LIMIT = 16_384
 
     val tags = listOf(
@@ -36,7 +41,7 @@ internal object MdCommon {
         .replace("\r", " ")
 
     fun inlineCode(html: String, opts: MdStyle): String {
-        if (!html.contains('<') && !html.contains('.')) return html
+        if (!html.contains('<') && !scan(html)) return html
         val color = hex(opts.inlineCodeFg)
         val styled = if (html.contains("<code", ignoreCase = true)) {
             val out = StringBuilder()
@@ -75,6 +80,7 @@ internal object MdCommon {
         rules.append("em, i { color: ${hex(opts.emphasisFg)} } ")
         rules.append("a { color: ${hex(opts.linkColor)} } ")
         rules.append("a.kilo-file-ref, code a.kilo-file-ref { color: ${hex(SessionUiStyle.View.Markdown.string())}; font-family: '${css(opts.codeFont)}', monospace; text-decoration: underline } ")
+        rules.append("a.kilo-url-ref, code a.kilo-url-ref { color: ${hex(opts.linkColor)}; font-family: '${css(opts.codeFont)}', monospace; text-decoration: underline } ")
         rules.append("ul, ol { color: ${hex(opts.listMarkerFg)} } ")
         rules.append("li { color: ${hex(opts.foreground)} } ")
         rules.append("tt, code, samp, pre, pre code { font-family: '${css(opts.codeFont)}', monospace; border-width: 0 } ")
@@ -136,7 +142,7 @@ internal object MdCommon {
     }
 
     private fun refs(html: String): String {
-        if (!html.contains('.')) return html
+        if (!scan(html)) return html
         val out = StringBuilder()
         var at = 0
         for (match in protect.findAll(html)) {
@@ -149,7 +155,7 @@ internal object MdCommon {
     }
 
     private fun tags(html: String): String {
-        if (!html.contains('.')) return html
+        if (!scan(html)) return html
         val out = StringBuilder()
         var at = 0
         for (match in tag.findAll(html)) {
@@ -161,8 +167,29 @@ internal object MdCommon {
         return out.toString()
     }
 
+    /**
+     * Linkifies plain text between tags: `http(s)` URLs first, then file references in whatever text
+     * is left over. URLs are handled here rather than by the markdown parser because CommonMark's
+     * autolink extension skips code spans, so a URL in backticks would otherwise stay inert text.
+     */
     private fun paths(text: String): String {
-        if (text.length > REF_SEGMENT_LIMIT || !text.contains('.')) return text
+        if (text.length > REF_SEGMENT_LIMIT || !scan(text)) return text
+        if (!text.contains("://")) return files(text)
+        val out = StringBuilder()
+        var at = 0
+        for (match in url.findAll(text)) {
+            out.append(files(text.substring(at, match.range.first)))
+            val link = cut(match.value)
+            at = match.range.first + link.length
+            // The renderer already escaped the source, so the matched text is a valid attribute value.
+            out.append("<a class=\"kilo-url-ref\" href=\"$link\">$link</a>")
+        }
+        out.append(files(text.substring(at)))
+        return out.toString()
+    }
+
+    private fun files(text: String): String {
+        if (!text.contains('.')) return text
         return ref.replace(text) { match ->
             val path = match.value
             if (!pathish(path)) return@replace path
@@ -172,6 +199,35 @@ internal object MdCommon {
             "<a class=\"kilo-file-ref\" href=\"${attr(href)}\">$path</a>"
         }
     }
+
+    /** Trims a raw URL match down to the part that belongs to the link. */
+    private fun cut(value: String): String {
+        var end = value.length
+        for (item in entities) {
+            val at = value.indexOf(item)
+            if (at in 0 until end) end = at
+        }
+        while (end > 0) {
+            val char = value[end - 1]
+            if (char in TRAIL) {
+                end--
+                continue
+            }
+            val open = when (char) {
+                ')' -> '('
+                ']' -> '['
+                '}' -> '{'
+                else -> break
+            }
+            val head = value.substring(0, end)
+            if (head.count { it == open } >= head.count { it == char }) break
+            end--
+        }
+        return value.substring(0, end)
+    }
+
+    /** True when [text] can contain a file reference or a URL worth scanning for. */
+    private fun scan(text: String): Boolean = text.contains('.') || text.contains("://")
 
     private fun pathish(path: String): Boolean {
         if (path.contains('/')) return true

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/md/hybrid/MdProjector.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/md/hybrid/MdProjector.kt
@@ -1,5 +1,6 @@
 package ai.kilocode.client.ui.md.hybrid
 
+import ai.kilocode.client.ui.md.MdCommon
 import com.intellij.openapi.fileTypes.PlainTextFileType
 import org.commonmark.ext.autolink.AutolinkExtension
 import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension
@@ -7,13 +8,19 @@ import org.commonmark.ext.gfm.tables.TableBlock
 import org.commonmark.ext.gfm.tables.TablesExtension
 import org.commonmark.node.AbstractVisitor
 import org.commonmark.node.Block
+import org.commonmark.node.Code
 import org.commonmark.node.Document
 import org.commonmark.node.FencedCodeBlock
 import org.commonmark.node.IndentedCodeBlock
 import org.commonmark.node.Node
 import org.commonmark.node.ThematicBreak
 import org.commonmark.parser.Parser
+import org.commonmark.renderer.NodeRenderer
+import org.commonmark.renderer.html.HtmlNodeRendererContext
 import org.commonmark.renderer.html.HtmlRenderer
+import org.nibor.autolink.LinkExtractor
+import org.nibor.autolink.LinkSpan
+import org.nibor.autolink.LinkType
 
 internal class MdProjector {
     private val extensions = listOf(
@@ -28,6 +35,9 @@ internal class MdProjector {
         .extensions(extensions)
         .escapeHtml(true)
         .sanitizeUrls(true)
+        // HtmlRenderer always appends the core node renderer last, so any factory added here wins
+        // for the node types it handles.
+        .nodeRendererFactory { context -> CodeLinks(context) }
         .build()
 
     fun project(text: String): Projection {
@@ -211,6 +221,46 @@ internal class MdProjector {
             }
         }
     }
+}
+
+/**
+ * Renders `Code` (inline code span) nodes, linkifying any `http(s)` URL found in the literal text.
+ *
+ * CommonMark's [AutolinkExtension] only scans [org.commonmark.node.Text] nodes, so a URL written in
+ * backticks is otherwise never linkified. This reuses the same URL scanner the extension is built on
+ * ([LinkExtractor], from the `autolink` library CommonMark depends on) to detect links, then relies on
+ * [org.commonmark.renderer.html.HtmlWriter] to escape both the link text and the `href` attribute the
+ * same way the core renderer would.
+ */
+private class CodeLinks(private val context: HtmlNodeRendererContext) : NodeRenderer {
+    companion object {
+        private val EXTRACTOR: LinkExtractor = LinkExtractor.builder().linkTypes(setOf(LinkType.URL)).build()
+    }
+
+    override fun getNodeTypes(): Set<Class<out Node>> = setOf(Code::class.java)
+
+    override fun render(node: Node) {
+        val code = node as Code
+        val html = context.writer
+        html.tag("code", context.extendAttributes(code, "code", emptyMap()))
+        val literal = code.literal
+        for (span in EXTRACTOR.extractSpans(literal)) {
+            val text = literal.substring(span.beginIndex, span.endIndex)
+            if (span !is LinkSpan || !web(text)) {
+                html.text(text)
+                continue
+            }
+            html.tag("a", mapOf("class" to MdCommon.URL_REF_CLASS, "href" to text))
+            html.text(text)
+            html.tag("/a")
+        }
+        html.tag("/code")
+    }
+
+    // LinkExtractor.linkTypes(URL) matches any "scheme://…", not just http(s) (e.g. file://, ftp://);
+    // restrict to what SessionFileLinks.isFileHref routes to the browser opener.
+    private fun web(text: String): Boolean =
+        text.startsWith("http://", ignoreCase = true) || text.startsWith("https://", ignoreCase = true)
 }
 
 internal sealed class Desc {

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/ui/md/MdViewHybridTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/ui/md/MdViewHybridTest.kt
@@ -344,6 +344,27 @@ class MdViewHybridTest : BasePlatformTestCase() {
         assertTrue(html.contains("href=\"native-plan-prompt.txt:37-38\">native-plan-prompt.txt:37-38</a>."))
     }
 
+    fun `test inline code url renders a live anchor that dispatches link events`() {
+        val received = mutableListOf<MdView.LinkEvent>()
+        view.addLinkListener { received.add(it) }
+        view.set("Release PR: `https://example.com/pull/13524`")
+        val pane = htmls().single()
+        val iter = (pane.document as HTMLDocument).getIterator(HTML.Tag.A)
+
+        assertTrue("code span url must render as an anchor", iter.isValid)
+        assertEquals("https://example.com/pull/13524", iter.attributes.getAttribute(HTML.Attribute.HREF))
+
+        val event = HyperlinkEvent(
+            pane,
+            HyperlinkEvent.EventType.ACTIVATED,
+            URI("https://example.com/pull/13524").toURL(),
+            "https://example.com/pull/13524",
+        )
+        pane.hyperlinkListeners.forEach { it.hyperlinkUpdate(event) }
+
+        assertEquals("https://example.com/pull/13524", received.single().href)
+    }
+
     fun `test existing links are not nested as file refs`() {
         view.set("[prompt](packages/opencode/src/session/prompt.ts)")
         val html = view.html()

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/ui/md/MdViewTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/ui/md/MdViewTest.kt
@@ -236,6 +236,13 @@ class MdViewTest : BasePlatformTestCase() {
         assertTrue(html.contains("<a class=\"kilo-file-ref\" href=\"packages/opencode/src/session/prompt.ts\">"))
     }
 
+    fun `test inline code urls stop at characters that cannot appear in a url`() {
+        view.set("See `https://example.com/a<b>`")
+        val html = view.html()
+
+        assertTrue(html.contains("href=\"https://example.com/a\">https://example.com/a</a>&lt;b&gt;"))
+    }
+
     // ---- append ----
 
     fun `test append accumulates source`() {

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/ui/md/MdViewTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/ui/md/MdViewTest.kt
@@ -166,6 +166,76 @@ class MdViewTest : BasePlatformTestCase() {
         assertTrue(view.html().contains("https://example.com"))
     }
 
+    fun `test inline code urls become underlined link colored links`() {
+        view.set("Release PR: `https://github.com/Kilo-Org/kilocode/pull/13524`")
+        val code = MdCommon.hex(MdCommon.defaults(SessionEditorStyle.current()).inlineCodeFg)
+        val link = MdCommon.hex(MdCommon.defaults(SessionEditorStyle.current()).linkColor)
+        val html = view.html()
+        val sheet = view.overrideSheet()
+
+        assertTrue(
+            html.contains(
+                "<code style=\"color: $code\">" +
+                    "<a class=\"kilo-url-ref\" href=\"https://github.com/Kilo-Org/kilocode/pull/13524\">" +
+                    "https://github.com/Kilo-Org/kilocode/pull/13524</a></code>",
+            ),
+        )
+        assertTrue(sheet.contains("a.kilo-url-ref, code a.kilo-url-ref { color: $link; font-family:"))
+        assertTrue(sheet.contains("monospace; text-decoration: underline"))
+    }
+
+    fun `test inline code urls keep query separators in href`() {
+        view.set("Open `https://example.com/a?b=1&c=2` now")
+        val html = view.html()
+
+        assertTrue(html.contains("href=\"https://example.com/a?b=1&amp;c=2\">https://example.com/a?b=1&amp;c=2</a>"))
+    }
+
+    fun `test inline code urls exclude trailing punctuation and unbalanced brackets`() {
+        view.set("See `https://example.com/a.` and `(https://example.com/b)`")
+        val html = view.html()
+
+        assertTrue(html.contains("href=\"https://example.com/a\">https://example.com/a</a>."))
+        assertTrue(html.contains("(<a class=\"kilo-url-ref\" href=\"https://example.com/b\">https://example.com/b</a>)"))
+    }
+
+    fun `test inline code urls keep balanced brackets inside link`() {
+        view.set("See `https://example.com/a_(b)`")
+        val html = view.html()
+
+        assertTrue(html.contains("href=\"https://example.com/a_(b)\">https://example.com/a_(b)</a>"))
+    }
+
+    fun `test autolinked urls are not wrapped again`() {
+        view.set("Visit https://example.com/a for details")
+        val html = view.html()
+
+        assertFalse(html.contains("kilo-url-ref"))
+    }
+
+    fun `test markdown link urls are not wrapped again`() {
+        view.set("[docs](https://example.com/a)")
+        val html = view.html()
+
+        assertFalse(html.contains("kilo-url-ref"))
+    }
+
+    fun `test fenced code urls are not links`() {
+        view.set("```text\nhttps://example.com/a\n```")
+        val html = view.html()
+
+        assertTrue(html.contains("https://example.com/a"))
+        assertFalse(html.contains("kilo-url-ref"))
+    }
+
+    fun `test inline code urls do not swallow following file refs`() {
+        view.set("`https://example.com/a` then packages/opencode/src/session/prompt.ts")
+        val html = view.html()
+
+        assertTrue(html.contains("href=\"https://example.com/a\">https://example.com/a</a>"))
+        assertTrue(html.contains("<a class=\"kilo-file-ref\" href=\"packages/opencode/src/session/prompt.ts\">"))
+    }
+
     // ---- append ----
 
     fun `test append accumulates source`() {

--- a/packages/kilo-jetbrains/gradle/libs.versions.toml
+++ b/packages/kilo-jetbrains/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ okhttp = "4.12.0"
 openapi-generator = "7.21.0"
 detekt = "1.23.8"
 commonmark = "0.28.0"
+autolink = "0.12.0"
 zxing = "3.5.3"
 changelog = "2.5.0"
 commons-compress = "1.28.0"
@@ -21,6 +22,7 @@ commonmark = { module = "org.commonmark:commonmark", version.ref = "commonmark" 
 commonmark-autolink = { module = "org.commonmark:commonmark-ext-autolink", version.ref = "commonmark" }
 commonmark-tables = { module = "org.commonmark:commonmark-ext-gfm-tables", version.ref = "commonmark" }
 commonmark-strikethrough = { module = "org.commonmark:commonmark-ext-gfm-strikethrough", version.ref = "commonmark" }
+autolink = { module = "org.nibor.autolink:autolink", version.ref = "autolink" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-sse = { module = "com.squareup.okhttp3:okhttp-sse", version.ref = "okhttp" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }


### PR DESCRIPTION
## Issue

No issue filed; reported directly while reviewing a JetBrains release report where every URL was unclickable.

## Context

In the JetBrains chat transcript, `http`/`https` URLs written inside backticks render as inert text — no hover, no cursor change, no click. Agents routinely emit URLs as inline code (release reports, PR links, run URLs), so a large share of the links a user sees in the JetBrains plugin are dead.

The link plumbing itself was fine. The gap is that CommonMark's `AutolinkExtension` only visits text nodes, never code spans, so `` `https://…` `` never becomes an anchor. Bare URLs already worked end to end.

## Implementation

The HTML renderer now overrides CommonMark's core `Code` node renderer. It runs `org.nibor.autolink.LinkExtractor` over each raw inline-code literal and emits anchors for `http`/`https` spans before `HtmlWriter` escapes their text and attributes. This is the same URL scanner used by CommonMark's existing autolink extension, so trailing punctuation, balanced brackets, quote boundaries, control characters, and Unicode whitespace follow the library's tested behavior instead of custom URL parsing.

Only `http` and `https` matches become links. `LinkType.URL` can detect any `scheme://…`, while the session link router sends non-file schemes to the browser; filtering here prevents `file`, `ftp`, or other schemes from being routed incorrectly.

`org.nibor.autolink:autolink:0.12.0` is declared explicitly as an `implementation` dependency in the frontend module and pinned in the version catalog. We do not rely on an IntelliJ-bundled classpath or on CommonMark's transitive dependency edge. `buildPlugin` packages it as `kilo.jetbrains/lib/autolink-0.12.0.jar` in the distributable ZIP.

`MdCommon` only retains the CSS rule for the generated `kilo-url-ref` anchors: standard IDE link color and underline while preserving the inline-code monospace font. Existing click handling remains unchanged (`MdView.LinkEvent` → `openSessionLink` → `BrowserUtil.browse`), and fenced code remains on the separate editor/code-block rendering path.

## Screenshots / Video

N/A — the visual delta is that an inline-code URL picks up the standard IDE link color and underline; there is no new UI surface. Behavior is asserted in tests against the rendered `HTMLDocument`.

## How to Test

### Manual/local verification

- `./gradlew test` from `packages/kilo-jetbrains/` — passed (executed by the agent)
- `./gradlew typecheck` from `packages/kilo-jetbrains/` — passed (executed by the agent)
- `./gradlew buildPlugin` from `packages/kilo-jetbrains/` — passed (executed by the agent)
- Inspected `build/distributions/kilo.jetbrains-7.1.0.zip`; it contains `kilo.jetbrains/lib/autolink-0.12.0.jar` (executed by the agent)
- New tests in `MdViewTest` (executed by the agent): a code-span URL produces `<a class="kilo-url-ref">` plus the matching CSS rule; query separators survive in the href; trailing punctuation and unbalanced brackets stay outside the link; balanced brackets stay inside; URL scanning stops at characters that cannot appear in a URL; autolinked and markdown-link URLs are not wrapped a second time; fenced-code URLs are not linkified; a URL followed by a file reference produces both link kinds.
- New test in `MdViewHybridTest` (executed by the agent): the rendered `HTMLDocument` contains a live `A` element with the expected `href`, and activating it dispatches an `MdView.LinkEvent`.

### Reviewer test steps

1. Run the plugin: `./gradlew runIde` from `packages/kilo-jetbrains/`
2. In a Kilo chat, send a message that renders a URL in backticks, for example: ``Release PR: `https://github.com/Kilo-Org/kilocode/pull/13524` ``
3. Confirm the URL is underlined in the IDE link color, shows a hand cursor on hover, and opens in the browser on click
4. Confirm a URL inside a fenced code block is still plain text, and that an ordinary bare URL and `[text](url)` link still behave as before

### Blocked checks and substitute verification

- None; all relevant checks ran.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

N/A
