### PR TITLE
fix(vscode): preserve activity during routine reconnects

### DIFF
--- a/.changeset/stable-reconnect-activity.md
+++ b/.changeset/stable-reconnect-activity.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep session and worktree activity indicators stable during routine server reconnects without hiding connection failures.

--- a/packages/kilo-vscode/src/agent-manager/worktree-activity.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-activity.ts
@@ -147,6 +147,14 @@ export class WorktreeActivity {
     this.publish()
   }
 
+  pause(): void {
+    if (this.dead) return
+    for (const state of this.states) {
+      state.request = undefined
+      state.loaded = false
+    }
+  }
+
   clear(): void {
     if (this.dead) return
     for (const state of this.states) this.invalidate(state)
@@ -385,6 +393,7 @@ export function createWorktreeActivity(opts: FactoryOptions) {
     return activity.sync(force)
   }
   const unsubState = opts.connection.onStateChange((state) => {
+    if (state === "connecting") return activity.pause()
     if (state !== "connected") return activity.clear()
     void sync(true)
   })

--- a/packages/kilo-vscode/tests/fixtures/session-provider-activity.tsx
+++ b/packages/kilo-vscode/tests/fixtures/session-provider-activity.tsx
@@ -403,6 +403,10 @@ try {
   value.setCurrentSessionID("background")
   await emit({ type: "sessionStatus", sessionID: "background", status: "busy" })
   await check("background", "busy")
+  await emit({ type: "connectionState", state: "connecting" })
+  await check("background", "busy")
+  await emit({ type: "connectionState", state: "connected" })
+  await check("background", "busy")
   await emit({ type: "sessionError", eventID: "background-aborted", error: { name: "MessageAbortedError" } })
   await check("background", "busy")
   await emit({ type: "connectionState", state: "disconnected", error: "offline" })
@@ -420,6 +424,10 @@ try {
       questions: [{ question: "Reconnect?", header: "Confirm", options: [] }],
     },
   })
+  await check("background", "waiting")
+  await emit({ type: "connectionState", state: "connecting" })
+  await check("background", "waiting")
+  await emit({ type: "connectionState", state: "connected" })
   await check("background", "waiting")
   await emit({ type: "connectionState", state: "error", error: "failed" })
   await check("background", "error")

--- a/packages/kilo-vscode/tests/unit/worktree-activity.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-activity.test.ts
@@ -450,6 +450,59 @@ describe("WorktreeActivity", () => {
     expect(statuses).toHaveLength(1)
   })
 
+  it("preserves activity during reconnect without accepting snapshots from the previous stream", async () => {
+    const stale = defer<{ data: Snapshot["statuses"] }>()
+    const fresh = defer<{ data: Snapshot["statuses"] }>()
+    const replies = [Promise.resolve({ data: snapshot({ s1: "busy" }).statuses }), stale.promise, fresh.promise]
+    const client = {
+      session: { status: () => replies.shift()! },
+      permission: { list: async () => ({ data: [] }) },
+      question: { list: async () => ({ data: [] }) },
+    }
+    const conn = connection(client)
+    const posted: string[][] = []
+    const wrapper = createWorktreeActivity({
+      connection: conn as never,
+      paths: () => ["/repo"],
+      post: (active) => posted.push(active),
+      status: () => {},
+      lifecycle: () => {},
+      log: (err) => {
+        throw err
+      },
+    })
+    await wrapper.sync()
+    expect(posted.at(-1)).toEqual(["/repo"])
+
+    const pending = wrapper.sync(true)
+    await Promise.resolve()
+    const count = posted.length
+    conn.change("connecting")
+    await wrapper.sync()
+    expect(posted).toHaveLength(count)
+    expect(posted.at(-1)).toEqual(["/repo"])
+    expect(replies).toHaveLength(1)
+
+    conn.change("connected")
+    const recovered = wrapper.sync()
+    stale.resolve({ data: {} })
+    await pending
+    expect(posted.at(-1)).toEqual(["/repo"])
+    fresh.resolve({ data: {} })
+    await recovered
+    expect(posted.at(-1)).toEqual([])
+    expect(replies).toHaveLength(0)
+
+    conn.emit(status("s1", "busy"), "/repo")
+    expect(posted.at(-1)).toEqual(["/repo"])
+    conn.change("error")
+    expect(posted.at(-1)).toEqual([])
+    conn.change("connecting")
+    await wrapper.sync(true)
+    expect(posted.at(-1)).toEqual([])
+    wrapper.dispose()
+  })
+
   it("replays before a forced sync checks connection state", async () => {
     const client = {
       session: { status: async () => ({ data: { s1: { type: "busy" } } }) },

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -1794,9 +1794,12 @@ export const SessionProvider: ParentComponent = (props) => {
     return suggestions().filter((item) => family.has(item.sessionID))
   }
 
+  const disconnected = createMemo<boolean>((previous) => {
+    const state = server.connectionState()
+    return state === "connecting" ? previous : state !== "connected"
+  }, false)
   const [activityMap, setActivityMap] = createStore<Record<string, Activity>>({})
   createComputed(() => {
-    const connection = server.connectionState()
     setActivityMap(
       reconcile(
         activities({
@@ -1807,7 +1810,7 @@ export const SessionProvider: ParentComponent = (props) => {
             (item) => item.sessionID,
           ),
           submitting: Object.keys(submissionMap),
-          disconnected: connection !== "connected",
+          disconnected: disconnected(),
         }),
       ),
     )


### PR DESCRIPTION
## What Problem This Solves

Agent Manager shares one backend connection across worktrees. A routine event-stream reconnect changed every active or blocked session to an error indicator, making a brief connection retry look like all agents had failed. The directory-level activity cache was also cleared during `connecting`.

## Why This Change Was Made

Treat `connecting` as a transition, not a new failure. Preserve the last confirmed connection-failure state until the connection succeeds: an ordinary reconnect keeps activity visible, but reconnecting after an explicit error or disconnection does not hide that failure.

Keep the worktree activity cache during this transition while invalidating pending snapshots from the previous stream. A successful reconnection refreshes the cache, and late responses from the old stream cannot overwrite the recovered state.

This changes status presentation and refresh handling only. It does not change transport retry behavior, prevent backend crashes, or establish the cause of the original reconnect.

## User Impact

- Running sessions keep their loading spinner during routine reconnects.
- Waiting and completed sessions retain their status. The input still shows “Connecting to server…” while disconnected from the stream.
- Confirmed connection failures remain red until recovery. Session failures remain visible independently of connection recovery.

## Evidence

- The new regressions failed before the fix and pass afterward. Coverage includes rendered session indicators, waiting sessions, failure persistence through retries, cache retention, and rejection of old in-flight snapshots.
- Rebased branch: **4,456 unit tests passed**, plus typecheck, lint, unused-code checks, source-marker checks, and the extension/webview build.
- Isolated VS Code was exercised with ten synthetic worktree cards. Before the fix, sending only `connected → connecting` turned all ten cards red. After the fix, all ten kept their running indicator. Mixed failed/waiting/completed states and explicit connection failure followed by recovery were also verified. These were controlled UI-message scenarios, not a reproduction of the unknown transport trigger. The isolated instance was cleaned up.

### Before: routine reconnect displays ten errors

<img width="700" alt="Before the fix, ten synthetic worktree cards show error indicators during a routine reconnect" src="https://marius-kilocode.github.io/pr-assets/20260828-reconnect-indicators-before-1307.png" />

### After: routine reconnect keeps the running indicators

<img width="700" alt="After the fix, ten synthetic worktree cards retain running indicators while the input shows Connecting to server" src="https://marius-kilocode.github.io/pr-assets/20260828-reconnect-indicators-after-1307.png" />
