### PR TITLE
fix(cli): reduce startup initialization work

### DIFF
--- a/.changeset/faster-cli-initialization.md
+++ b/.changeset/faster-cli-initialization.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Start the CLI faster while preserving available models, session resumption, and configured reference permissions.

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -26,7 +26,7 @@ import { Effect, Context, Layer, Schema } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import * as Option from "effect/Option"
 import * as OtelTracer from "@effect/opentelemetry/Tracer"
-import { AbsolutePath, type DeepMutable } from "@opencode-ai/core/schema"
+import type { DeepMutable } from "@opencode-ai/core/schema" // kilocode_change
 // kilocode_change start
 import * as KiloAgent from "@/kilocode/agent"
 import { RuntimeFlags } from "@/effect/runtime-flags"
@@ -35,9 +35,7 @@ import * as KiloReference from "@/kilocode/reference"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { LocationServiceMap, locationServiceMapLayer } from "@opencode-ai/core/location-services"
-import { Reference } from "@opencode-ai/core/reference"
-import { Location } from "@opencode-ai/core/location"
-import { PluginV2 } from "@opencode-ai/core/plugin"
+// kilocode_change
 
 export const Info = Schema.Struct({
   name: Schema.String,
@@ -113,17 +111,14 @@ const layer = Layer.effect(
         const cfg = yield* config.get()
         const skillDirs = yield* skill.dirs()
         // kilocode_change start - include global config dirs so agents can read them without prompting
-        const referenceDirs = yield* Effect.gen(function* () {
-          if (Object.keys(cfg.references ?? cfg.reference ?? {}).length) {
-            yield* (yield* PluginV2.Service).wait(PluginV2.ID.make("core/config-reference"))
-          }
-          yield* KiloReference.sync({
+        const referenceDirs = yield* KiloReference.list(
+          {
             references: cfg.references ?? cfg.reference ?? {},
             directory: ctx.directory,
             worktree: ctx.worktree,
-          })
-          return (yield* (yield* Reference.Service).list()).map((reference) => reference.path)
-        }).pipe(Effect.provide(locations.get(Location.Ref.make({ directory: AbsolutePath.make(ctx.directory) }))))
+          },
+          locations,
+        ).pipe(Effect.map((references) => references.map((reference) => reference.path)))
         const whitelistedDirs = [
           Truncate.GLOB,
           path.join(Global.Path.tmp, "*"),

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -14,7 +14,7 @@ import type { EventSource } from "@opencode-ai/tui/context/sdk"
 import { writeHeapSnapshot } from "v8"
 import type { StartInput } from "@/kilocode/cli/cmd/tui/thread" // kilocode_change - runtime imports deferred into handlers
 import { win32InstallCtrlCGuard } from "@opencode-ai/tui/terminal-win32"
-import { validateSession } from "../tui/validate-session"
+import { validate as validateSession } from "@/kilocode/cli/cmd/tui" // kilocode_change
 // kilocode_change start - correlate the TUI worker with its parent process
 import {
   KILO_PROCESS_ROLE,
@@ -276,7 +276,7 @@ export const TuiThreadCommand = cmd({
       exiting: false,
     }
     try {
-      const { TuiConfig } = await import("@/config/tui")
+      // kilocode_change
       if (args.fork && !args.continue && !args.session) {
         UI.error("--fork requires --continue or --session")
         process.exitCode = 1
@@ -418,6 +418,7 @@ export const TuiThreadCommand = cmd({
       // kilocode_change end
 
       const prompt = await input(args.prompt)
+      const { TuiConfig } = await import("@/config/tui") // kilocode_change
       const config = await TuiConfig.get()
 
       const network = resolveNetworkOptionsNoConfig(args)

--- a/packages/opencode/src/kilocode/cli/cmd/tui.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/tui.ts
@@ -2,3 +2,9 @@ export function preload(compiled: boolean, resolve: () => string) {
   if (compiled) return []
   return [resolve()]
 }
+
+export async function validate(input: Parameters<typeof import("@/cli/tui/validate-session").validateSession>[0]) {
+  if (!input.sessionID) return
+  const { validateSession } = await import("@/cli/tui/validate-session")
+  return validateSession(input)
+}

--- a/packages/opencode/src/kilocode/cli/cmd/tui/thread.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/thread.ts
@@ -4,11 +4,8 @@ import type { NetworkOptions } from "@/cli/network"
 import { ServerAuth } from "@/server/auth"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { errorMessage } from "@opencode-ai/tui/util/error"
-import { TuiConfig } from "@/config/tui"
-import { validateSession } from "@/cli/tui/validate-session"
-import { importCloudSession, reportCloudImportError } from "@/kilocode/cloud-session"
+import { validate as validateSession } from "@/kilocode/cli/cmd/tui"
 import { DaemonClient } from "@/kilocode/daemon/client"
-import { createKiloClient } from "@kilocode/sdk/v2"
 
 type TuiInput = import("@opencode-ai/tui").TuiInput
 export type StartInput = Omit<TuiInput, "pluginHost">
@@ -33,6 +30,10 @@ type Input = {
 async function session(input: Input, daemon: DaemonClient.Connection) {
   if (!input.args.cloudFork || !input.args.session) return { ok: true as const, id: input.args.session }
 
+  const [{ createKiloClient }, { importCloudSession, reportCloudImportError }] = await Promise.all([
+    import("@kilocode/sdk/v2"),
+    import("@/kilocode/cloud-session"),
+  ])
   UI.println("Importing session from cloud...")
   const client = createKiloClient({
     baseUrl: daemon.url,
@@ -67,6 +68,7 @@ export namespace KiloTuiThreadDaemon {
     if (!daemon) return false
 
     const prompt = await input.input()
+    const { TuiConfig } = await import("@/config/tui")
     const config = await TuiConfig.get()
 
     const fork = await session(input, daemon)

--- a/packages/opencode/src/kilocode/reference.ts
+++ b/packages/opencode/src/kilocode/reference.ts
@@ -2,7 +2,10 @@ import path from "path"
 import { ConfigReference } from "@opencode-ai/core/config/reference"
 import { Global } from "@opencode-ai/core/global"
 import { parseRepositoryReference, repositoryCachePath, type RemoteReference } from "@/util/repository"
-import { Effect } from "effect"
+import { type Context, Effect, RcMap } from "effect"
+import { Location } from "@opencode-ai/core/location"
+import type { LocationServiceMap } from "@opencode-ai/core/location-services"
+import { PluginV2 } from "@opencode-ai/core/plugin"
 import { RepositoryCache } from "@opencode-ai/core/repository-cache"
 import { Reference } from "@opencode-ai/core/reference"
 import { AbsolutePath } from "@opencode-ai/core/schema"
@@ -188,4 +191,18 @@ export const sync = Effect.fn("KiloReference.sync")(function* (input: {
   const current = new Map((yield* service.list()).map((item) => [item.name, item.source]))
   if (current.size === sources.length && sources.every(([name, source]) => same(current.get(name), source))) return
   yield* service.replace(sources)
+})
+
+export const list = Effect.fn("KiloReference.list")(function* (
+  input: { references: ConfigReference.Info; directory: string; worktree: string },
+  locations: Context.Service.Shape<typeof LocationServiceMap.Service>,
+) {
+  const location = Location.Ref.make({ directory: AbsolutePath.make(input.directory) })
+  const configured = Object.keys(input.references).length > 0
+  if (!configured && !(yield* RcMap.has(locations.rcMap, location))) return []
+  return yield* Effect.gen(function* () {
+    if (configured) yield* (yield* PluginV2.Service).wait(PluginV2.ID.make("core/config-reference"))
+    yield* sync(input)
+    return yield* (yield* Reference.Service).list()
+  }).pipe(Effect.provide(locations.get(location)))
 })

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -19,13 +19,10 @@ import type { Provider } from "@/provider/provider"
 import type { Agent } from "@/agent/agent"
 import { Permission } from "@/permission"
 import { Skill } from "@/skill"
-import { AbsolutePath } from "@opencode-ai/core/schema"
-import { Location } from "@opencode-ai/core/location"
+// kilocode_change
 import { LocationServiceMap, locationServiceMapLayer } from "@opencode-ai/core/location-services"
-import { Reference } from "@opencode-ai/core/reference"
 import { MCP } from "@/mcp"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
-import { PluginV2 } from "@opencode-ai/core/plugin" // kilocode_change
 
 // kilocode_change start
 import SOUL from "../kilocode/soul.txt"
@@ -114,17 +111,14 @@ const layer = Layer.effect(
       ) {
         const ctx = yield* InstanceState.context
         const cfg = yield* config.get()
-        const references = yield* Effect.gen(function* () {
-          if (Object.keys(cfg.references ?? cfg.reference ?? {}).length) {
-            yield* (yield* PluginV2.Service).wait(PluginV2.ID.make("core/config-reference"))
-          }
-          yield* KiloReference.sync({
+        const references = yield* KiloReference.list(
+          {
             references: cfg.references ?? cfg.reference ?? {},
             directory: ctx.directory,
             worktree: ctx.worktree,
-          })
-          return (yield* (yield* Reference.Service).list()).filter((reference) => reference.description !== undefined)
-        }).pipe(Effect.provide(locations.get(Location.Ref.make({ directory: AbsolutePath.make(ctx.directory) }))))
+          },
+          locations,
+        ).pipe(Effect.map((references) => references.filter((reference) => reference.description !== undefined)))
         return [
           ...KilocodeSystemPrompt.environment({ ctx, model, editor: editorContext }),
           references.length === 0

--- a/packages/opencode/test/kilocode/cli/tui/thread.test.ts
+++ b/packages/opencode/test/kilocode/cli/tui/thread.test.ts
@@ -10,7 +10,7 @@ import {
   resolveThreadDirectory,
   runEmbeddedRemoteExitBridge,
 } from "../../../../src/cli/cmd/tui"
-import { preload } from "../../../../src/kilocode/cli/cmd/tui"
+import { preload, validate } from "../../../../src/kilocode/cli/cmd/tui"
 import { KiloTuiThreadDaemon } from "../../../../src/kilocode/cli/cmd/tui/thread"
 import { DaemonClient } from "../../../../src/kilocode/daemon/client"
 
@@ -19,6 +19,14 @@ afterEach(() => {
 })
 
 describe("kilo tui thread", () => {
+  test("starts fresh sessions without requesting session validation", async () => {
+    await expect(validate({ url: "http://127.0.0.1:0" })).resolves.toBeUndefined()
+  })
+
+  test("still rejects invalid IDs when resuming a session", async () => {
+    await expect(validate({ url: "http://127.0.0.1:0", sessionID: "invalid" })).rejects.toThrow("Invalid session ID")
+  })
+
   test("skips preload resolver invocation in compiled mode", () => {
     let calls = 0
 

--- a/packages/opencode/test/kilocode/reference.test.ts
+++ b/packages/opencode/test/kilocode/reference.test.ts
@@ -1,7 +1,7 @@
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { describe, expect, test } from "bun:test"
 import path from "path"
-import { Cause, Effect, Exit, Layer } from "effect"
+import { Cause, Effect, Exit, Layer, RcMap } from "effect"
 import { RepositoryCache } from "@opencode-ai/core/repository-cache"
 import * as Reference from "../../src/kilocode/reference"
 import { Reference as CoreReference } from "@opencode-ai/core/reference"
@@ -25,6 +25,37 @@ function remote() {
 }
 
 describe("configured references", () => {
+  test("does not initialize location services for an empty reference configuration", async () => {
+    await using tmp = await tmpdir()
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const map = yield* LocationServiceMap.Service
+        const references = yield* Reference.list({ references: {}, directory: tmp.path, worktree: tmp.path }, map)
+        return { references, keys: Array.from(yield* RcMap.keys(map.rcMap)) }
+      }).pipe(Effect.provide(buildLocationServiceMap()), Effect.scoped),
+    )
+    expect(result).toEqual({ references: [], keys: [] })
+  })
+
+  test("clears previously initialized references when configuration becomes empty", async () => {
+    await using tmp = await tmpdir({ config: { formatter: false, lsp: false } })
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const map = yield* LocationServiceMap.Service
+        const input = { directory: tmp.path, worktree: tmp.path }
+        const before = yield* Reference.list({ ...input, references: { docs: "./docs" } }, map)
+        const after = yield* Reference.list({ ...input, references: {} }, map)
+        const persisted = yield* CoreReference.Service.use((service) => service.list()).pipe(
+          Effect.provide(map.get(Location.Ref.make({ directory: AbsolutePath.make(tmp.path) }))),
+        )
+        return { before, after, persisted }
+      }).pipe(Effect.provide(buildLocationServiceMap()), Effect.scoped),
+    )
+    expect(result.before.map((reference) => reference.path)).toEqual([AbsolutePath.make(path.join(tmp.path, "docs"))])
+    expect(result.after).toEqual([])
+    expect(result.persisted).toEqual([])
+  }, 15_000)
+
   test("preserves interruption while materializing a repository", async () => {
     const cache = RepositoryCache.Service.of({ ensure: () => Effect.interrupt })
     const exit = await Effect.runPromiseExit(Reference.ensure(cache, remote()))

--- a/packages/opencode/test/kilocode/tui-config-boundary.test.ts
+++ b/packages/opencode/test/kilocode/tui-config-boundary.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test"
+import { fileURLToPath } from "node:url"
+
+test("TUI configuration does not load the terminal renderer", async () => {
+  const entry = fileURLToPath(new URL("../../../tui/src/config/index.tsx", import.meta.url))
+  const config = fileURLToPath(new URL("../../tsconfig.json", import.meta.url))
+  const code = `
+    import { createSolidTransformPlugin } from "@opentui/solid/bun-plugin"
+    const result = await Bun.build({
+      entrypoints: [${JSON.stringify(entry)}],
+      target: "bun",
+      tsconfig: ${JSON.stringify(config)},
+      conditions: ["bun", "node"],
+      write: false,
+      plugins: [
+        createSolidTransformPlugin(),
+        {
+          name: "config-renderer-boundary",
+          setup(build) {
+            build.onResolve({ filter: /^@opentui\\/(?:core|solid)(?:\\/|$)/ }, (args) => {
+              throw new Error("Configuration loaded the terminal renderer: " + args.path)
+            })
+          },
+        },
+      ],
+    })
+    if (!result.success) throw new AggregateError(result.logs)
+  `
+  const proc = Bun.spawn([process.execPath, "--eval", code], {
+    cwd: fileURLToPath(new URL("../..", import.meta.url)),
+    stdout: "pipe",
+    stderr: "pipe",
+    windowsHide: true,
+  })
+  const [exit, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()])
+  expect({ exit, stderr }).toEqual({ exit: 0, stderr: "" })
+})

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -2,7 +2,7 @@ export * as TuiConfig from "."
 
 import { createBindingLookup } from "@opentui/keymap/extras"
 import { Schema } from "effect"
-import { createContext, type JSX, useContext } from "solid-js"
+import { createComponent, createContext, type JSX, useContext } from "solid-js" // kilocode_change
 import { TuiKeybind } from "./keybind"
 import { KiloTitleIcon } from "@/kilocode/cli/cmd/tui/title-icon" // kilocode_change
 
@@ -122,7 +122,16 @@ export function resolve(input: Info, options: ResolveOptions): Resolved {
 const ConfigContext = createContext<Resolved>()
 
 export function TuiConfigProvider(props: { config: Resolved; children: JSX.Element }) {
-  return <ConfigContext.Provider value={props.config}>{props.children}</ConfigContext.Provider>
+  // kilocode_change start
+  return createComponent(ConfigContext.Provider, {
+    get value() {
+      return props.config
+    },
+    get children() {
+      return props.children
+    },
+  })
+  // kilocode_change end
 }
 
 export function useTuiConfig() {

--- a/packages/tui/test/kilocode/config.test.tsx
+++ b/packages/tui/test/kilocode/config.test.tsx
@@ -1,0 +1,32 @@
+import { testRender } from "@opentui/solid"
+import { expect, test } from "bun:test"
+import { createSignal } from "solid-js"
+import { resolve, TuiConfigProvider, useTuiConfig } from "../../src/config"
+
+test("preserves reactive configuration reads through the provider", async () => {
+  const [theme, update] = createSignal("first")
+  const config = {
+    ...resolve({}, { terminalSuspend: true }),
+    get theme() {
+      return theme()
+    },
+  }
+  function Consumer() {
+    const value = useTuiConfig()
+    return <text>{value.theme}</text>
+  }
+  const app = await testRender(() => (
+    <TuiConfigProvider config={config}>
+      <Consumer />
+    </TuiConfigProvider>
+  ))
+  try {
+    await app.renderOnce()
+    expect(app.captureCharFrame()).toContain("first")
+    update("next")
+    await app.renderOnce()
+    expect(app.captureCharFrame()).toContain("next")
+  } finally {
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
## What Problem This Solves

CLI startup still performs unnecessary local work after the earlier startup improvements. Fresh sessions load session-validation and daemon-only dependencies, backend configuration imports pull in the native terminal renderer, and agent permissions initialize a full reference-service scope even when no references are configured.

Network requests can add latency, but the same startup costs remain with recorded API responses served locally.

## Why This Change Was Made

Three changes remove unnecessary work without changing available features:

- Load session validation only for a requested session, keep daemon/cloud-fork dependencies conditional, and let TUI configuration loading overlap worker initialization. Cloud import still completes before local session validation.
- Use Solid's equivalent context-provider factory with reactive getters in shared configuration. This prevents the JSX transform from importing `@opentui/solid` and its native renderer into the backend, while preserving configuration and context behavior.
- Avoid creating a reference-only location scope when the effective reference configuration is empty and that directory scope does not exist. Existing scopes still synchronize, so removing references clears their state. The same lookup is used by agent permissions and system prompts, rather than postponing the work until the first message.

Listener-owned service lifetimes, full model catalogs, validation, and network request behavior remain unchanged. No persistent daemon, reduced timeout, hidden loading state, incomplete payload, or stale catalog cache was added.

Six experiments were measured. Schema-predicate reuse, executable bytecode, and JSON-text snapshot embedding showed no reliable benefit and were reverted. Bytecode also increased the executable from about 180 MiB to 578 MiB. Only the three improvements above remain.

## User Impact

Fresh CLI startup and backend data readiness are about 29% faster in the controlled comparison. Session resumption, model selection, configuration reactivity, and configured-reference permissions retain their existing behavior.

| Boundary | Original median | Optimized median | Reduction | Original range | Optimized range |
|---|---|---|---|---|---|
| TUI prompt and selected model visible | 3,325 ms | 2,356 ms | 29.1% | 3,077-3,814 ms | 2,270-2,383 ms |
| Backend listening | 1,364 ms | 1,106 ms | 19.0% | 1,300-1,520 ms | 1,071-1,220 ms |
| Backend plus initial config/provider/agent data | 2,430 ms | 1,715 ms | 29.4% | 2,169-3,255 ms | 1,639-1,840 ms |

Configured references still require their normal initialization. Network latency and runtime/catalog processing remain, so these results are not a guarantee of the same improvement for every configuration.

## Evidence

### Performance comparison

- Baseline revision: `68804090c0`.
- Apple M4 Pro, 14 logical CPUs; compiled with repository-pinned Bun 1.3.14.
- Seven alternating original/optimized pairs after one warm-up per executable. Every measured pair improved for TUI readiness and backend data readiness.
- Fresh processes, isolated HOME/XDG state, the same empty workspace, and frozen public catalog responses. Both benchmark environments were signed out with telemetry and automatic update checks disabled; product defaults were not changed.
- Readiness requires the usable TUI prompt and selected model, not spinner disappearance or first paint. Backend data measurements include `/config`, `/provider`, `/config/providers`, and `/agent` after a successful health response.
- Complete responses stayed byte-identical across builds, including the catalog fixture with 205 providers and 7,414 models. A configured local reference also preserved response parity.
- Builds and tests did not run concurrently with timed comparisons. Ranges reflect other active machine workloads. Percentages from intermediate iterations were not added together.

### Iteration measurements and decisions

These were separate alternating comparison runs on a busy machine. Their percentages must not be added; the final original-versus-optimized table above is the overall result.

| Iteration | Before | After | Decision and reason |
|---|---|---|---|
| Initial control | TUI median 3,409 ms; backend/data 2,441 ms | Baseline only | Preserved the executable and checked stable API response hashes |
| Reuse the model schema predicate | 108 ms first catalog pass; about 75 ms warm | 104 ms first pass; about 79 ms warm | Reverted: no meaningful benefit |
| Compile executable bytecode | TUI median 3,362 ms; executable 180 MiB | TUI median 3,570 ms; executable 578 MiB | Reverted: no demonstrated speedup and a large size increase |
| Embed the snapshot as JSON text | Backend/data 2,712 ms; TUI 3,404 ms | Backend/data 2,696 ms; TUI 3,853 ms | Reverted: no reliable improvement; scheduling outliers affected the run |
| Conditional imports and overlap with worker startup | TUI median 4,643 ms | TUI median 3,917 ms, 15.6% lower | Retained: five pairs improved; optional validation/cloud code no longer loads unconditionally |
| Remove renderer loading from backend configuration | TUI median 3,179 ms; backend/data 2,475 ms | TUI 2,564 ms, 19.3% lower; backend/data 2,129 ms, 14.0% lower | Retained: avoids an unnecessary native renderer import while preserving Solid context behavior |
| Avoid an unused reference-only scope | TUI median 2,833 ms; backend/data 2,269 ms | TUI 2,415 ms, 14.8% lower; backend/data 1,754 ms, 22.7% lower | Retained: no scope is created for empty configuration, while existing scopes still clear removed references |

The initial source profile also showed about 319 ms involving schema processing in a 672 ms initial API window. That remains real work: this PR does not remove validation or reduce the full model payload. The backend still takes about 1.1 s to listen and roughly another 0.5-0.6 s to prepare initial catalog data. TUI work overlaps those stages, so those times are not a decomposition to sum into the TUI total.

Network waits remain unchanged. The catalog request commonly took 0.25-0.6 s during investigation, with slower samples; injecting a 3 s catalog delay increased provider-request completion from 0.55-0.90 s to 3.65-3.75 s. A separate optimized live-network TUI check reached readiness in about 2.8 s, but it was not a paired performance comparison. Authenticated profile and default-model requests, and configured references, can add further time.

### Regression checks

- 191 focused tests passed, covering startup, session validation, cloud-fork sequencing, configuration, reference cleanup, agent permissions, listener scope isolation, SDK behavior, and TUI data/context behavior.
- Four existing skips remain: three Windows-only configuration tests on macOS and one already-skipped provider V2 not-found test.
- CLI/TUI typechecks, extension compile and host/webview checks, lint, formatting, upstream annotations, and the Effect Promise-facade guard passed. Root lint reported no errors; existing warnings remain.
- Packaged version, embedded model snapshot, and sandbox mutation-worker smoke checks passed.
- The renderer dependency test fails before the configuration change and passes afterward. Reactive context coverage is in a Kilo-owned test file; the shared configuration test file is unchanged.
- Reference tests verify that empty configuration creates no scope and that removing references clears an existing scope.
- A separate read-only review found no blocking issue.

### User-flow checks and limits

- Compiled TUI typing and model selection passed without submitting a prompt.
- Unavailable API fallback, a catalog response delayed by 750 ms, and live public API startup passed.
- Isolated VS Code connected through the optimized CLI and rendered the sidebar, model picker, and model details. Screenshots were inspected, and the test instance was cleaned up.
- No real credentials or paid model requests were used. Real authenticated organization/cloud flows and Windows/Linux release binaries were not exercised. Cloud-import ordering is covered by local HTTP tests.
- CPU and native profiles guided attribution, but the percentage claims above use only the alternating compiled-executable measurements. Some source captures had different system load or catalog cache age.
