### PR TITLE
feat: allow experimental task model selection

### DIFF
--- a/.changeset/task-model-selection.md
+++ b/.changeset/task-model-selection.md
@@ -1,0 +1,7 @@
+---
+"@kilocode/cli": minor
+"@kilocode/sdk": minor
+"kilo-code": minor
+---
+
+Allow the orchestrating agent to choose a model, provider, and reasoning effort for each subagent task behind an experimental setting.

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -304,6 +304,9 @@ export const Info = Schema.Struct({
       native_notebook_tools: Schema.optional(Schema.Boolean).annotate({
         description: "Enable native tools for reading, editing, and executing VS Code notebooks",
       }),
+      task_model_selection: Schema.optional(Schema.Boolean).annotate({
+        description: "Allow task subagents to select a model, provider, and reasoning effort",
+      }),
       speech_to_text_model: Schema.optional(Schema.String).annotate({
         description: "Speech-to-text transcription model ID to use for voice input",
       }),

--- a/packages/kilo-vscode/tests/unit/task-model-selection.test.ts
+++ b/packages/kilo-vscode/tests/unit/task-model-selection.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test"
+import { ConfigState } from "../../webview-ui/src/utils/config-utils"
+
+describe("task subagent model selection config", () => {
+  it("stages the experimental toggle and discards it", () => {
+    const state = new ConfigState()
+    state.handleConfigLoaded({ experimental: { task_model_selection: false } })
+
+    state.updateConfig({ experimental: { task_model_selection: true } })
+
+    expect(state.config.experimental?.task_model_selection).toBe(true)
+    expect(state.draft.experimental?.task_model_selection).toBe(true)
+    expect(state.dirty).toBe(true)
+
+    state.discardConfig()
+
+    expect(state.config.experimental?.task_model_selection).toBe(false)
+    expect(state.dirty).toBe(false)
+  })
+
+  it("clears the draft after the backend confirms the save", () => {
+    const state = new ConfigState()
+    state.handleConfigLoaded({ experimental: { task_model_selection: false } })
+    state.updateConfig({ experimental: { task_model_selection: true } })
+    state.saveConfig()
+
+    expect(state.saving).toBe(true)
+
+    state.handleConfigUpdated({ experimental: { task_model_selection: true } })
+
+    expect(state.config.experimental?.task_model_selection).toBe(true)
+    expect(state.dirty).toBe(false)
+    expect(state.saving).toBe(false)
+    expect(state.draft).toEqual({})
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/settings/ExperimentalTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/ExperimentalTab.tsx
@@ -217,6 +217,19 @@ const ExperimentalTab: Component = () => {
           </Switch>
         </SettingsRow>
 
+        <SettingsRow
+          title={language.t("settings.experimental.taskModelSelection.title")}
+          description={language.t("settings.experimental.taskModelSelection.description")}
+        >
+          <Switch
+            checked={experimental().task_model_selection ?? false}
+            onChange={(checked) => updateExperimental("task_model_selection", checked)}
+            hideLabel
+          >
+            {language.t("settings.experimental.taskModelSelection.title")}
+          </Switch>
+        </SettingsRow>
+
         {/* MCP timeout */}
         <SettingsRow
           title={language.t("settings.experimental.mcpTimeout.title")}

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -871,6 +871,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "إدارة متعددة المشاريع",
   "settings.experimental.multiProject.description":
     "تفعيل إدارة الجلسات وأشجار العمل عبر مستودعات متعددة في Agent Manager. المستودع الحالي هو دائمًا المشروع الافتراضي.",
+  "settings.experimental.taskModelSelection.title": "اختيار نموذج الوكيل الفرعي لـ Task",
+  "settings.experimental.taskModelSelection.description":
+    "السماح باختيار النموذج والمزوّد ومستوى الاستدلال صراحةً للوكلاء الفرعيين في Task.",
   "settings.experimental.mcpTimeout.title": "مهلة MCP (مللي ثانية)",
   "settings.experimental.mcpTimeout.description": "مهلة طلبات خادم MCP بالمللي ثانية",
   "settings.experimental.remote.title": "التحكم Remote",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -900,6 +900,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "Agent Manager Multi-Projeto",
   "settings.experimental.multiProject.description":
     "Ativar gerenciamento de sessões e worktrees em múltiplos repositórios no Agent Manager. O repositório do workspace atual é sempre o projeto padrão.",
+  "settings.experimental.taskModelSelection.title": "Seleção de modelo de subagente do Task",
+  "settings.experimental.taskModelSelection.description":
+    "Permite selecionar explicitamente o modelo, o provedor e o esforço de raciocínio dos subagentes do Task.",
   "settings.experimental.mcpTimeout.title": "Tempo limite MCP (ms)",
   "settings.experimental.mcpTimeout.description": "Tempo limite para solicitações do servidor MCP em milissegundos",
   "settings.experimental.remote.title": "Controle Remote",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -894,6 +894,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "Višeprojektni Agent Manager",
   "settings.experimental.multiProject.description":
     "Omogući upravljanje sesijama i worktree-ima kroz više repozitorija u Agent Manager-u. Trenutni workspace repozitorij je uvijek zadani projekat.",
+  "settings.experimental.taskModelSelection.title": "Odabir modela podagenta za Task",
+  "settings.experimental.taskModelSelection.description":
+    "Omogućava izričit odabir modela, provajdera i napora zaključivanja za Task podagente.",
   "settings.experimental.mcpTimeout.title": "MCP istek vremena (ms)",
   "settings.experimental.mcpTimeout.description": "Istek vremena za MCP server zahtjeve u milisekundama",
   "settings.experimental.remote.title": "Remote kontrola",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -893,6 +893,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "Multi-projekt Agent Manager",
   "settings.experimental.multiProject.description":
     "Aktivér styring af sessioner og worktrees på tværs af flere repositories i Agent Manager. Det nuværende workspace-repository er altid standardprojektet.",
+  "settings.experimental.taskModelSelection.title": "Valg af Task-underagentmodel",
+  "settings.experimental.taskModelSelection.description":
+    "Tillad eksplicit valg af model, udbyder og ræsonnementsindsats for Task-underagenter.",
   "settings.experimental.mcpTimeout.title": "MCP-timeout (ms)",
   "settings.experimental.mcpTimeout.description": "Timeout for MCP-serveranmodninger i millisekunder",
   "settings.experimental.remote.title": "Remote-styring",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -913,6 +913,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "Multi-Projekt Agent Manager",
   "settings.experimental.multiProject.description":
     "Aktivieren Sie die Verwaltung von Sitzungen und Worktrees über mehrere Repositories im Agent Manager. Das aktuelle Workspace-Repository ist immer das Standardprojekt.",
+  "settings.experimental.taskModelSelection.title": "Task-Subagent-Modellauswahl",
+  "settings.experimental.taskModelSelection.description":
+    "Erlaubt die explizite Auswahl von Modell, Anbieter und Schlussfolgerungsaufwand für Task-Subagenten.",
   "settings.experimental.mcpTimeout.title": "MCP-Zeitlimit (ms)",
   "settings.experimental.mcpTimeout.description": "Zeitlimit für MCP-Server-Anfragen in Millisekunden",
   "settings.experimental.remote.title": "Remote-Steuerung",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -873,6 +873,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "Multi-Project Agent Manager",
   "settings.experimental.multiProject.description":
     "Enable managing sessions and worktrees across multiple repositories in Agent Manager. The current workspace repository is always the default project.",
+  "settings.experimental.taskModelSelection.title": "Task Subagent Model Selection",
+  "settings.experimental.taskModelSelection.description":
+    "Allow task subagents to use an explicitly selected model, provider, and reasoning effort.",
   "settings.experimental.mcpTimeout.title": "MCP Timeout (ms)",
   "settings.experimental.mcpTimeout.description": "Timeout for MCP server requests in milliseconds",
   "settings.experimental.remote.title": "Remote Control",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -902,6 +902,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "Agent Manager Multi-Proyecto",
   "settings.experimental.multiProject.description":
     "Habilitar la gestión de sesiones y worktrees en múltiples repositorios en Agent Manager. El repositorio del workspace actual es siempre el proyecto predeterminado.",
+  "settings.experimental.taskModelSelection.title": "Selección de modelo de subagente de Task",
+  "settings.experimental.taskModelSelection.description":
+    "Permite seleccionar explícitamente el modelo, proveedor y esfuerzo de razonamiento de los subagentes de Task.",
   "settings.experimental.mcpTimeout.title": "Tiempo de espera MCP (ms)",
   "settings.experimental.mcpTimeout.description": "Tiempo de espera para solicitudes del servidor MCP en milisegundos",
   "settings.experimental.remote.title": "Control Remote",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
@@ -879,6 +879,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "مدیر agent چندپروژه‌ای",
   "settings.experimental.multiProject.description":
     "مدیریت sessionها و worktreeها را در چند مخزن در Agent Manager فعال می‌کند. مخزن فضای کاری فعلی همیشه پروژه پیش‌فرض است.",
+  "settings.experimental.taskModelSelection.title": "انتخاب مدل زیرعامل Task",
+  "settings.experimental.taskModelSelection.description":
+    "انتخاب صریح مدل، ارائه‌دهنده و میزان استدلال برای زیرعامل‌های Task را فعال می‌کند.",
   "settings.experimental.mcpTimeout.title": "زمان‌وقفه MCP (میلی‌ثانیه)",
   "settings.experimental.mcpTimeout.description": "زمان‌وقفه برای درخواست‌های سرور MCP بر حسب میلی‌ثانیه",
   "settings.experimental.remote.title": "کنترل از راه دور",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -915,6 +915,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "Agent Manager Multi-Projet",
   "settings.experimental.multiProject.description":
     "Activer la gestion des sessions et worktrees sur plusieurs dépôts dans Agent Manager. Le dépôt de l'espace de travail actuel est toujours le projet par défaut.",
+  "settings.experimental.taskModelSelection.title": "Sélection du modèle des sous-agents Task",
+  "settings.experimental.taskModelSelection.description":
+    "Permet de sélectionner explicitement le modèle, le fournisseur et l'effort de raisonnement des sous-agents Task.",
   "settings.experimental.mcpTimeout.title": "Délai MCP (ms)",
   "settings.experimental.mcpTimeout.description": "Délai des requêtes du serveur MCP en millisecondes",
   "settings.experimental.remote.title": "Contrôle Remote",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -764,6 +764,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "Agent Manager Multi-Progetto",
   "settings.experimental.multiProject.description":
     "Abilita la gestione di sessioni e worktree su più repository in Agent Manager. Il repository dell'area di lavoro corrente è sempre il progetto predefinito.",
+  "settings.experimental.taskModelSelection.title": "Selezione del modello del sub-agent Task",
+  "settings.experimental.taskModelSelection.description":
+    "Consente di selezionare esplicitamente modello, provider e sforzo di ragionamento per i sub-agent Task.",
   "settings.experimental.mcpTimeout.title": "Timeout MCP (ms)",
   "settings.experimental.mcpTimeout.description": "Timeout per richieste server MCP in millisecondi",
   "settings.experimental.remote.title": "Controllo remoto",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -887,6 +887,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "マルチプロジェクト Agent Manager",
   "settings.experimental.multiProject.description":
     "Agent Managerで複数のリポジトリにまたがるセッションとワークツリーの管理を有効にします。現在のワークスペースリポジトリは常にデフォルトプロジェクトです。",
+  "settings.experimental.taskModelSelection.title": "Task サブエージェントモデルの選択",
+  "settings.experimental.taskModelSelection.description":
+    "Task サブエージェントに使用するモデル、プロバイダー、推論の労力を明示的に選択できます。",
   "settings.experimental.mcpTimeout.title": "MCPタイムアウト（ミリ秒）",
   "settings.experimental.mcpTimeout.description": "MCPサーバーリクエストのタイムアウト（ミリ秒）",
   "settings.experimental.remote.title": "Remote コントロール",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -884,6 +884,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "멀티 프로젝트 Agent Manager",
   "settings.experimental.multiProject.description":
     "Agent Manager에서 여러 저장소에 걸친 세션과 워크트리 관리를 활성화합니다. 현재 워크스페이스 저장소는 항상 기본 프로젝트입니다.",
+  "settings.experimental.taskModelSelection.title": "Task 하위 에이전트 모델 선택",
+  "settings.experimental.taskModelSelection.description":
+    "Task 하위 에이전트에 대해 모델, 제공자 및 추론 수준을 명시적으로 선택합니다.",
   "settings.experimental.mcpTimeout.title": "MCP 타임아웃 (ms)",
   "settings.experimental.mcpTimeout.description": "MCP 서버 요청의 타임아웃 시간 (밀리초)",
   "settings.experimental.remote.title": "Remote 제어",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -892,6 +892,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "Multi-project Agent Manager",
   "settings.experimental.multiProject.description":
     "Schakel het beheren van sessies en worktrees over meerdere repositories in Agent Manager in. De huidige workspace-repository is altijd het standaardproject.",
+  "settings.experimental.taskModelSelection.title": "Task-subagentmodel selecteren",
+  "settings.experimental.taskModelSelection.description":
+    "Sta toe dat je expliciet een model, provider en redeneerinspanning kiest voor Task-subagents.",
   "settings.experimental.mcpTimeout.title": "MCP Timeout (ms)",
   "settings.experimental.mcpTimeout.description": "Timeout voor MCP-serververzoeken in milliseconden",
   "settings.experimental.remote.title": "Remote-bediening",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -854,6 +854,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "Multi-prosjekt Agent Manager",
   "settings.experimental.multiProject.description":
     "Aktiver administrering av økter og worktrees på tvers av flere repositories i Agent Manager. Det nåværende workspace-repositoryet er alltid standardprosjektet.",
+  "settings.experimental.taskModelSelection.title": "Valg av Task-underagentmodell",
+  "settings.experimental.taskModelSelection.description":
+    "Tillat eksplisitt valg av modell, leverandør og resonneringsinnsats for Task-underagenter.",
   "settings.experimental.mcpTimeout.title": "MCP-tidsavbrudd (ms)",
   "settings.experimental.mcpTimeout.description": "Tidsavbrudd for MCP-serverforespørsler i millisekunder",
   "settings.experimental.remote.title": "Remote-kontroll",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -851,6 +851,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "Wieloprojektowy Agent Manager",
   "settings.experimental.multiProject.description":
     "Włącz zarządzanie sesjami i worktree w wielu repozytoriach w Agent Managerze. Bieżące repozytorium obszaru roboczego jest zawsze projektem domyślnym.",
+  "settings.experimental.taskModelSelection.title": "Wybór modelu podagenta Task",
+  "settings.experimental.taskModelSelection.description":
+    "Umożliwia jawny wybór modelu, dostawcy i wysiłku wnioskowania dla podagentów Task.",
   "settings.experimental.mcpTimeout.title": "Limit czasu MCP (ms)",
   "settings.experimental.mcpTimeout.description": "Limit czasu żądań serwera MCP w milisekundach",
   "settings.experimental.remote.title": "Sterowanie Remote",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -890,6 +890,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "Мультипроектный Agent Manager",
   "settings.experimental.multiProject.description":
     "Включите управление сессиями и рабочими деревьями в нескольких репозиториях в Agent Manager. Текущий репозиторий рабочего пространства всегда является проектом по умолчанию.",
+  "settings.experimental.taskModelSelection.title": "Выбор модели субагента Task",
+  "settings.experimental.taskModelSelection.description":
+    "Позволяет явно выбирать модель, провайдера и уровень рассуждения для субагентов Task.",
   "settings.experimental.mcpTimeout.title": "Таймаут MCP (мс)",
   "settings.experimental.mcpTimeout.description": "Таймаут запросов MCP-сервера в миллисекундах",
   "settings.experimental.remote.title": "Управление Remote",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -879,6 +879,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "Agent Manager หลายโปรเจกต์",
   "settings.experimental.multiProject.description":
     "เปิดใช้งานการจัดการเซสชันและเวิร์กทรีข้ามหลาย Repository ใน Agent Manager Repository ของ workspace ปัจจุบันเป็นโปรเจกต์เริ่มต้นเสมอ",
+  "settings.experimental.taskModelSelection.title": "การเลือกโมเดลตัวแทนย่อยของ Task",
+  "settings.experimental.taskModelSelection.description":
+    "เปิดให้เลือกโมเดล ผู้ให้บริการ และระดับการใช้เหตุผลสำหรับตัวแทนย่อยของ Task ได้อย่างชัดเจน",
   "settings.experimental.mcpTimeout.title": "หมดเวลา MCP (มิลลิวินาที)",
   "settings.experimental.mcpTimeout.description": "หมดเวลาสำหรับคำขอเซิร์ฟเวอร์ MCP เป็นมิลลิวินาที",
   "settings.experimental.remote.title": "การควบคุม Remote",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -883,6 +883,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "Çoklu Proje Agent Manager",
   "settings.experimental.multiProject.description":
     "Agent Manager'da birden fazla depo genelinde oturum ve worktree yönetimini etkinleştirin. Mevcut çalışma alanı deposu her zaman varsayılan projedir.",
+  "settings.experimental.taskModelSelection.title": "Task Alt Aracı Modeli Seçimi",
+  "settings.experimental.taskModelSelection.description":
+    "Task alt aracıları için model, sağlayıcı ve akıl yürütme çabasını açıkça seçmeye izin verin.",
   "settings.experimental.mcpTimeout.title": "MCP Zaman Aşımı (ms)",
   "settings.experimental.mcpTimeout.description": "MCP sunucu istekleri için milisaniye cinsinden zaman aşımı",
   "settings.experimental.remote.title": "Remote Kontrolü",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -884,6 +884,9 @@ export const dict = {
   "settings.experimental.multiProject.title": "Мультипроєктний Agent Manager",
   "settings.experimental.multiProject.description":
     "Увімкніть керування сеансами та робочими деревами в кількох репозиторіях в Agent Manager. Поточний репозиторій робочого простору завжди є проєктом за замовчуванням.",
+  "settings.experimental.taskModelSelection.title": "Вибір моделі субагента Task",
+  "settings.experimental.taskModelSelection.description":
+    "Дозволяє явно вибирати модель, провайдера та рівень міркування для субагентів Task.",
   "settings.experimental.mcpTimeout.title": "Тайм-аут MCP (мс)",
   "settings.experimental.mcpTimeout.description": "Тайм-аут у мілісекундах для запитів до MCP-сервера",
   "settings.experimental.remote.title": "Керування Remote",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -858,6 +858,8 @@ export const dict = {
   "settings.experimental.multiProject.title": "多项目 Agent Manager",
   "settings.experimental.multiProject.description":
     "在 Agent Manager 中启用跨多个仓库的会话和工作树管理。当前工作区仓库始终是默认项目。",
+  "settings.experimental.taskModelSelection.title": "Task 子代理模型选择",
+  "settings.experimental.taskModelSelection.description": "允许为 Task 子代理选择指定的模型、提供商和推理工作量。",
   "settings.experimental.mcpTimeout.title": "MCP 超时（毫秒）",
   "settings.experimental.mcpTimeout.description": "MCP 服务器请求的超时时间（毫秒）",
   "settings.experimental.remote.title": "Remote 控制",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -818,6 +818,8 @@ export const dict = {
   "settings.experimental.multiProject.title": "多專案 Agent Manager",
   "settings.experimental.multiProject.description":
     "在 Agent Manager 中啟用跨多個儲存庫的工作階段和工作樹管理。當前工作區儲存庫始終是預設專案。",
+  "settings.experimental.taskModelSelection.title": "Task 子代理模型選擇",
+  "settings.experimental.taskModelSelection.description": "允許為 Task 子代理選擇指定的模型、提供者和推理工作量。",
   "settings.experimental.mcpTimeout.title": "MCP 逾時（毫秒）",
   "settings.experimental.mcpTimeout.description": "MCP 伺服器請求的逾時時間（毫秒）",
   "settings.experimental.remote.title": "Remote 控制",

--- a/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/config.ts
@@ -52,6 +52,7 @@ export interface ExperimentalConfig {
   batch_tool?: boolean
   image_generation?: boolean
   image_generation_model?: string
+  task_model_selection?: boolean
   native_notebook_tools?: boolean
   speech_to_text_model?: string
   primary_tools?: string[]

--- a/packages/opencode/src/kilocode/tool/agent-manager-models.ts
+++ b/packages/opencode/src/kilocode/tool/agent-manager-models.ts
@@ -4,6 +4,7 @@ import { Tool } from "@/tool/tool"
 import { Effect, Schema } from "effect"
 import { matchesQuery } from "./model-search"
 import DESCRIPTION from "./agent-manager-models.txt"
+import { Config } from "@/config/config"
 
 const Params = Schema.Struct({
   query: Schema.optional(Schema.String).annotate({
@@ -61,39 +62,49 @@ function view(entry: Entry) {
 export const AgentManagerModelsTool = Tool.define<
   typeof Params,
   { count: number; total: number },
-  Provider.Service,
+  Provider.Service | Config.Service,
   "agent_manager_models"
 >(
   "agent_manager_models",
   Effect.gen(function* () {
     const provider = yield* Provider.Service
-    return {
-      description: DESCRIPTION,
-      parameters: Params,
-      execute: (params) =>
-        Effect.gen(function* () {
-          const providers = yield* provider.list()
-          const all = entries(providers)
-          const query = params.query?.trim()
-          const matches = query ? all.filter((entry) => matchesQuery([entry.name, ...entry.ids], query)) : all
-          const offset = params.offset ?? 0
-          const limit = Math.min(params.limit ?? MAX_LIMIT, MAX_LIMIT)
-          const models = matches.slice(offset, offset + limit).map(view)
-          const nextOffset = offset + models.length < matches.length ? offset + models.length : undefined
-          return {
-            title: query
-              ? `${matches.length} model${matches.length === 1 ? "" : "s"} matching "${params.query?.trim()}"`
-              : `${matches.length} available models`,
-            output: JSON.stringify({
-              models,
-              offset,
-              total: matches.length,
-              nextOffset,
-              hint: "Pass a model name (or one of its providers/IDs) as the agent_manager task `model`. Add the task `provider` to force one of the listed providers; otherwise Agent Manager prefers the provider used by the current turn.",
+    const config = yield* Config.Service
+    return () =>
+      Effect.gen(function* () {
+        const cfg = yield* config.get()
+        const selection = cfg.experimental?.task_model_selection === true
+        return {
+          description: selection
+            ? `${DESCRIPTION}\n\nExperimental Task model selection is enabled. Also use this tool before choosing model, provider, or variant for the task subagent tool. You may choose these settings to suit the subagent task without creating an Agent Manager session.`
+            : DESCRIPTION,
+          parameters: Params,
+          execute: (params) =>
+            Effect.gen(function* () {
+              const providers = yield* provider.list()
+              const all = entries(providers)
+              const query = params.query?.trim()
+              const matches = query ? all.filter((entry) => matchesQuery([entry.name, ...entry.ids], query)) : all
+              const offset = params.offset ?? 0
+              const limit = Math.min(params.limit ?? MAX_LIMIT, MAX_LIMIT)
+              const models = matches.slice(offset, offset + limit).map(view)
+              const nextOffset = offset + models.length < matches.length ? offset + models.length : undefined
+              return {
+                title: query
+                  ? `${matches.length} model${matches.length === 1 ? "" : "s"} matching "${params.query?.trim()}"`
+                  : `${matches.length} available models`,
+                output: JSON.stringify({
+                  models,
+                  offset,
+                  total: matches.length,
+                  nextOffset,
+                  hint: selection
+                    ? "Pass a model name as `model`, a listed provider ID as `provider`, and a supported reasoning effort as `variant` to task or agent_manager. Task selection is experimental and does not create Agent Manager sessions."
+                    : "Pass a model name (or one of its providers/IDs) as the agent_manager task `model`. Add the task `provider` to force one of the listed providers; otherwise Agent Manager prefers the provider used by the current turn.",
+                }),
+                metadata: { count: models.length, total: matches.length },
+              }
             }),
-            metadata: { count: models.length, total: matches.length },
-          }
-        }),
-    }
+        }
+      })
   }),
 )

--- a/packages/opencode/src/kilocode/tool/agent-manager.ts
+++ b/packages/opencode/src/kilocode/tool/agent-manager.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 import { Bus } from "@/bus"
 import { InstanceState } from "@/effect/instance-state"
 import { AgentManagerEvent, type AgentManagerTask } from "@/kilocode/agent-manager/event"
@@ -11,7 +10,7 @@ import { SessionID } from "@/session/schema"
 import * as ToolJsonSchema from "@/tool/json-schema"
 import { Tool } from "@/tool/tool"
 import { Effect, Schema } from "effect"
-import { matchesQuery } from "./model-search"
+import { selectModel } from "./model-selection"
 import DESCRIPTION from "./agent-manager.txt"
 
 const Task = Schema.Struct({
@@ -172,7 +171,6 @@ const WireParams = Schema.Struct({
 
 type Input = Schema.Schema.Type<typeof Task>
 type Selected = { task?: AgentManagerTask; error?: string }
-type Candidate = { providerID: string; model: Provider.Info["models"][string] }
 type Source = { model: NonNullable<AgentManagerTask["model"]>; variant?: string }
 
 function abort(signal: AbortSignal) {
@@ -189,59 +187,9 @@ function run(effect: Effect.Effect<Result, HostError>, signal: AbortSignal) {
   return effect.pipe(Effect.raceFirst(abort(signal)), Effect.orDie)
 }
 
-function candidates(providers: Record<string, Provider.Info>): Candidate[] {
-  return Object.values(providers).flatMap((provider) =>
-    Object.values(provider.models).map((model) => ({ providerID: provider.id, model })),
-  )
-}
-
-// Resolve a model query to the candidates for a single logical model (possibly
-// offered by several providers). Exact id/name win first so a precise request is
-// never drowned out; otherwise fall back to lenient fuzzy matching so the agent
-// does not need the exact model name.
-function lookup(all: Candidate[], value: string): { pool: Candidate[]; names: string[] } {
-  const query = value.toLowerCase()
-  const exactId = all.filter((item) => `${item.providerID}/${item.model.id}`.toLowerCase() === query)
-  const exactName = exactId.length ? exactId : all.filter((item) => item.model.name.toLowerCase() === query)
-  const pool = exactName.length
-    ? exactName
-    : all.filter((item) => matchesQuery([item.model.name, `${item.providerID}/${item.model.id}`], value))
-  const names = [...new Set(pool.map((item) => item.model.name))]
-  return { pool, names }
-}
-
-// Closest model names to a query that found no full match, so a wrong guess is
-// self-correcting without a separate agent_manager_models round-trip.
-function suggest(all: Candidate[], value: string): string[] {
-  const tokens = value
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
-    .filter(Boolean)
-  if (tokens.length === 0) return []
-  const scored = new Map<string, number>()
-  for (const item of all) {
-    const text = `${item.model.name} ${item.providerID}/${item.model.id}`.toLowerCase().replace(/[^a-z0-9]+/g, "")
-    const score = tokens.filter((token) => text.includes(token)).length
-    if (score > 0) scored.set(item.model.name, Math.max(scored.get(item.model.name) ?? 0, score))
-  }
-  return [...scored.entries()]
-    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
-    .slice(0, 3)
-    .map((entry) => entry[0])
-}
-
-// Prefer the provider the user already uses for the invoking turn, then the Kilo Gateway,
-// so a model name resolves to the provider with the best chance of working
-// without forcing the agent to know about provider plumbing.
-function rank(providerID: string, preferred: string | undefined): number {
-  if (providerID === preferred) return 0
-  if (providerID === "kilo") return 1
-  return 2
-}
-
 function select(
   task: Input,
-  all: Candidate[],
+  providers: Record<string, Provider.Info>,
   preferred: string | undefined,
   source: Source | undefined,
   index: number,
@@ -251,80 +199,12 @@ function select(
     ...(task.name != null ? { name: task.name } : {}),
     ...(task.branchName != null ? { branchName: task.branchName } : {}),
   }
-  const value = task.model?.trim()
-  const provider = task.provider?.trim()
-  const variant = task.variant?.trim()
-  if (!value) {
-    if (!variant) {
-      if (!task.prompt?.trim() || !source) return { task: base }
-      return { task: { ...base, ...source } }
-    }
-    if (!source) {
-      return { error: `Task ${index + 1} variant override requires an available current model.` }
-    }
-    const active = all.find(
-      (item) => item.providerID === source.model.providerID && item.model.id === source.model.modelID,
-    )
-    if (!active) {
-      return {
-        error: `Task ${index + 1} current model is no longer available: ${source.model.providerID}/${source.model.modelID}. Specify a model override.`,
-      }
-    }
-    if (!active.model.variants || !Object.hasOwn(active.model.variants, variant)) {
-      const available = Object.keys(active.model.variants ?? {})
-      return {
-        error: `Task ${index + 1} variant "${variant}" is not available for ${active.model.name}. Available variants: ${available.join(", ") || "none"}`,
-      }
-    }
-    return { task: { ...base, model: source.model, variant } }
+  if (!task.model?.trim() && !task.variant?.trim()) {
+    return { task: task.prompt?.trim() && source ? { ...base, ...source } : base }
   }
-
-  const scope = provider ? all.filter((item) => item.providerID === provider) : all
-  if (provider && scope.length === 0) {
-    return {
-      error: `Task ${index + 1} provider is not available for model selection: ${provider}. Requested model: ${value}.`,
-    }
-  }
-
-  const { pool, names } = lookup(scope, value)
-  if (pool.length === 0) {
-    const close = suggest(scope, value)
-    const hint = close.length ? ` Closest matches: ${close.join(", ")}.` : ""
-    return {
-      error: provider
-        ? `Task ${index + 1} model is not available from provider "${provider}": ${value}.${hint} Use agent_manager_models to search models.`
-        : `Task ${index + 1} model is not available: ${value}.${hint} Use agent_manager_models to search models.`,
-    }
-  }
-  if (names.length > 1) {
-    return {
-      error: `Task ${index + 1} model "${value}" is ambiguous and matches several models: ${names.slice(0, 5).join(", ")}. Use a more specific name.`,
-    }
-  }
-
-  const eligible = variant
-    ? pool.filter((item) => item.model.variants && Object.hasOwn(item.model.variants, variant))
-    : pool
-  if (variant && eligible.length === 0) {
-    const available = [...new Set(pool.flatMap((item) => Object.keys(item.model.variants ?? {})))]
-    return {
-      error: `Task ${index + 1} variant "${variant}" is not available for ${names[0]}. Available variants: ${available.join(", ") || "none"}`,
-    }
-  }
-
-  const chosen = [...eligible].sort(
-    (a, b) =>
-      rank(a.providerID, preferred) - rank(b.providerID, preferred) ||
-      a.providerID.localeCompare(b.providerID) ||
-      a.model.id.localeCompare(b.model.id),
-  )[0]!
-  return {
-    task: {
-      ...base,
-      model: { providerID: chosen.model.providerID, modelID: chosen.model.id },
-      ...(variant ? { variant } : {}),
-    },
-  }
+  const selected = selectModel(task, providers, source, preferred)
+  if ("error" in selected) return { error: `Task ${index + 1} ${selected.error}` }
+  return { task: { ...base, ...selected } }
 }
 
 export const AgentManagerTool = Tool.define<
@@ -498,7 +378,6 @@ export const AgentManagerTool = Tool.define<
             : undefined
           const need = params.tasks.some((task) => task.model?.trim() || task.provider?.trim() || task.variant?.trim())
           const providers = need ? yield* provider.list() : undefined
-          const all = providers ? candidates(providers) : []
           const preferred = need
             ? (source?.model.providerID ??
               (yield* provider.defaultModel().pipe(
@@ -506,7 +385,7 @@ export const AgentManagerTool = Tool.define<
                 Effect.catch(() => Effect.succeed(undefined)),
               )))
             : undefined
-          const selected = params.tasks.map((task, index) => select(task, all, preferred, source, index))
+          const selected = params.tasks.map((task, index) => select(task, providers ?? {}, preferred, source, index))
           const errors = selected.flatMap((item) => (item.error ? [item.error] : []))
           if (errors.length > 0) {
             return {
@@ -548,9 +427,7 @@ export const AgentManagerTool = Tool.define<
           // and the user can confirm the resolution without opening the session.
           const resolved = tasks.flatMap((task, index) => {
             if (!params.tasks[index]?.model?.trim() || !task.model) return []
-            const name = all.find(
-              (item) => item.providerID === task.model!.providerID && item.model.id === task.model!.modelID,
-            )?.model.name
+            const name = providers?.[task.model.providerID]?.models[task.model.modelID]?.name
             const label = task.name?.trim() || task.branchName?.trim() || "session"
             const variant = task.variant ? ` · ${task.variant}` : ""
             return [`- ${label}: ${name ?? task.model.modelID} (${task.model.providerID})${variant}`]

--- a/packages/opencode/src/kilocode/tool/model-selection.ts
+++ b/packages/opencode/src/kilocode/tool/model-selection.ts
@@ -1,0 +1,117 @@
+import type { Provider } from "@/provider/provider"
+import { matchesQuery } from "./model-search"
+
+type Source = {
+  model: { providerID: Provider.Model["providerID"]; modelID: Provider.Model["id"] }
+  variant?: string
+}
+type Candidate = { providerID: string; model: Provider.Info["models"][string] }
+type Selection = Source | { error: string }
+
+function lookup(all: Candidate[], value: string) {
+  const query = value.toLowerCase()
+  const exact = all.filter((item) => `${item.providerID}/${item.model.id}`.toLowerCase() === query)
+  const named = exact.length ? exact : all.filter((item) => item.model.name.toLowerCase() === query)
+  const pool = named.length
+    ? named
+    : all.filter((item) => matchesQuery([item.model.name, `${item.providerID}/${item.model.id}`], value))
+  return { pool, names: [...new Set(pool.map((item) => item.model.name))] }
+}
+
+function suggest(all: Candidate[], value: string) {
+  const tokens = value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+  const scored = new Map<string, number>()
+  for (const item of all) {
+    const text = `${item.model.name} ${item.providerID}/${item.model.id}`.toLowerCase().replace(/[^a-z0-9]+/g, "")
+    const score = tokens.filter((token) => text.includes(token)).length
+    if (score > 0) scored.set(item.model.name, Math.max(scored.get(item.model.name) ?? 0, score))
+  }
+  return [...scored.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 3)
+    .map((entry) => entry[0])
+}
+
+function rank(provider: string, preferred?: string) {
+  if (provider === preferred) return 0
+  if (provider === "kilo") return 1
+  return 2
+}
+
+export function selectModel(
+  input: { model?: string | null; provider?: string | null; variant?: string | null },
+  providers: Record<string, Provider.Info>,
+  source?: Source,
+  preferred: string | undefined = source?.model.providerID,
+): Selection {
+  const all = Object.values(providers).flatMap((provider) =>
+    Object.values(provider.models).map((model) => ({ providerID: provider.id, model })),
+  )
+  const value = input.model?.trim()
+  const provider = input.provider?.trim()
+  const variant = input.variant?.trim()
+  if (!value) {
+    if (provider) return { error: "provider requires a model." }
+    if (!source) return { error: "variant override requires an available current model." }
+    if (!variant) return source
+    const active = all.find(
+      (item) => item.providerID === source.model.providerID && item.model.id === source.model.modelID,
+    )
+    if (!active) {
+      return {
+        error: `current model is no longer available: ${source.model.providerID}/${source.model.modelID}. Specify a model override.`,
+      }
+    }
+    if (!active.model.variants || !Object.hasOwn(active.model.variants, variant)) {
+      return {
+        error: `variant "${variant}" is not available for ${active.model.name}. Available variants: ${Object.keys(active.model.variants ?? {}).join(", ") || "none"}`,
+      }
+    }
+    return { model: source.model, variant }
+  }
+
+  const scope = provider ? all.filter((item) => item.providerID === provider) : all
+  if (provider && scope.length === 0) {
+    return { error: `provider is not available for model selection: ${provider}. Requested model: ${value}.` }
+  }
+  const { pool, names } = lookup(scope, value)
+  if (pool.length === 0) {
+    const close = suggest(scope, value)
+    const hint = close.length ? ` Closest matches: ${close.join(", ")}.` : ""
+    return {
+      error: provider
+        ? `model is not available from provider "${provider}": ${value}.${hint} Use agent_manager_models to search models.`
+        : `model is not available: ${value}.${hint} Use agent_manager_models to search models.`,
+    }
+  }
+  if (names.length > 1) {
+    return {
+      error: `model "${value}" is ambiguous and matches several models: ${names.slice(0, 5).join(", ")}. Use a more specific name.`,
+    }
+  }
+  const eligible = variant
+    ? pool.filter((item) => item.model.variants && Object.hasOwn(item.model.variants, variant))
+    : pool
+  if (variant && eligible.length === 0) {
+    const available = [...new Set(pool.flatMap((item) => Object.keys(item.model.variants ?? {})))]
+    return {
+      error: `variant "${variant}" is not available for ${names.at(0)}. Available variants: ${available.join(", ") || "none"}`,
+    }
+  }
+  const chosen = [...eligible]
+    .sort(
+      (a, b) =>
+        rank(a.providerID, preferred) - rank(b.providerID, preferred) ||
+        a.providerID.localeCompare(b.providerID) ||
+        a.model.id.localeCompare(b.model.id),
+    )
+    .at(0)
+  if (!chosen) return { error: `model is not available: ${value}. Use agent_manager_models to search models.` }
+  return {
+    model: { providerID: chosen.model.providerID, modelID: chosen.model.id },
+    ...(variant ? { variant } : {}),
+  }
+}

--- a/packages/opencode/src/kilocode/tool/registry.ts
+++ b/packages/opencode/src/kilocode/tool/registry.ts
@@ -206,7 +206,9 @@ export namespace KiloToolRegistry {
       notebookEdit?: Tool.Def
       notebookExecute?: Tool.Def
     },
-    cfg: { experimental?: { image_generation?: boolean; native_notebook_tools?: boolean } },
+    cfg: {
+      experimental?: { image_generation?: boolean; native_notebook_tools?: boolean; task_model_selection?: boolean }
+    },
   ): Tool.Def[] {
     return [
       ...(cfg.experimental?.image_generation === true ? [tools.image] : []),
@@ -217,7 +219,10 @@ export namespace KiloToolRegistry {
       ...(Flag.KILO_CLIENT === "vscode" ? [tools.chart] : []),
       ...(Flag.KILO_CLIENT === "cli" || Flag.KILO_CLIENT === "vscode" ? [tools.process] : []),
       ...(Flag.KILO_CLIENT === "cli" && tools.terminal ? [tools.terminal] : []),
-      ...(Flag.KILO_CLIENT === "vscode" ? [tools.managerModels, tools.manager] : []),
+      ...(Flag.KILO_CLIENT === "vscode" || cfg.experimental?.task_model_selection === true
+        ? [tools.managerModels]
+        : []),
+      ...(Flag.KILO_CLIENT === "vscode" ? [tools.manager] : []),
       ...(Flag.KILO_CLIENT === "vscode" &&
       cfg.experimental?.native_notebook_tools === true &&
       tools.notebookRead &&

--- a/packages/opencode/src/kilocode/tool/task.ts
+++ b/packages/opencode/src/kilocode/tool/task.ts
@@ -1,4 +1,3 @@
-// kilocode_change - new file
 import { Effect, Schema } from "effect"
 import path from "path"
 import { Permission } from "@/permission"
@@ -13,6 +12,7 @@ import type { Agent } from "../../agent/agent"
 import type { Config } from "../../config/config"
 import { Provider } from "../../provider/provider"
 import z from "zod"
+import { selectModel } from "./model-selection"
 
 const log = Log.create({ service: "kilocode-task-model" })
 
@@ -33,6 +33,24 @@ const ModelState = z
   .passthrough()
 
 export namespace KiloTask {
+  export const ModelFields = {
+    model: Schema.optional(Schema.String).annotate({
+      description:
+        "Optional subagent model name or qualified provider/model ID from agent_manager_models. Choose a model suited to this task; omit to use the normal subagent model.",
+    }),
+    provider: Schema.optional(Schema.String).annotate({
+      description:
+        "Optional provider ID from agent_manager_models. Requires model; omit to prefer the current turn's provider, then Kilo Gateway.",
+    }),
+    variant: Schema.optional(Schema.String).annotate({
+      description:
+        "Optional reasoning effort variant from agent_manager_models. Can be used without model to change only the normal subagent model's reasoning effort.",
+    }),
+  }
+
+  export const modelDescription =
+    "Experimental subagent model selection is enabled. You may choose model, provider, and variant (reasoning effort) for each task based on its complexity, cost, and latency needs. Use agent_manager_models to find available models, providers, and variants before selecting them; do not guess. This does not create Agent Manager sessions. Omit these fields to keep the normal subagent defaults. Resumed tasks keep their last model and variant unless overridden. A model override does not inherit the parent's reasoning effort; specify variant when a particular effort is needed."
+
   /** Reject primary agents used as subagents */
   export function validate(info: Agent.Info, name: string) {
     if (info.mode === "primary") throw new Error(`Agent "${name}" is a primary agent and cannot be used as a subagent`)
@@ -146,8 +164,7 @@ export namespace KiloTask {
     }
   })
 
-  /** Resolve the task subagent model while discarding stale unavailable overrides. */
-  export const resolveModel = Effect.fn("KiloTask.resolveModel")(function* (input: {
+  const defaults = Effect.fn("KiloTask.defaultModel")(function* (input: {
     name: string
     agent: Pick<Agent.Info, "model" | "variant">
     config: Pick<Config.Info, "subagent_model" | "subagent_variant" | "subagent_variant_overrides">
@@ -210,6 +227,41 @@ export namespace KiloTask {
       .pipe(Effect.catchTag("ProviderModelNotFoundError", () => Effect.succeed(undefined)))
     const variant = full?.variants?.[value] ? value : input.variant
     return { model: input.parent, variant }
+  })
+
+  export const resolveModel = Effect.fn("KiloTask.resolveModel")(function* (
+    input: Parameters<typeof defaults>[0] & {
+      enabled?: boolean
+      selection?: { model?: string; provider?: string; variant?: string }
+      resume?: Session.Info["model"]
+    },
+  ) {
+    const selection = input.selection ?? {}
+    const requested = Object.values(selection).some((value) => value !== undefined)
+    if (requested && !input.enabled) {
+      return yield* Effect.fail(
+        new Error("Task model selection requires experimental.task_model_selection=true in Kilo config"),
+      )
+    }
+    if (requested && Object.values(selection).some((value) => value !== undefined && !value.trim())) {
+      return yield* Effect.fail(new Error("Task model, provider, and variant must not be empty when specified"))
+    }
+    if (selection.provider && !selection.model) {
+      return yield* Effect.fail(new Error("Task provider requires a model"))
+    }
+    const source = selection.model
+      ? undefined
+      : input.enabled && input.resume
+        ? {
+            model: { providerID: input.resume.providerID, modelID: input.resume.id },
+            variant: input.resume.variant === "default" ? undefined : input.resume.variant,
+          }
+        : yield* defaults(input)
+    if (!requested && source) return source
+    const providers = yield* input.provider.list()
+    const selected = selectModel(selection, providers, source, input.parent.providerID)
+    if ("error" in selected) return yield* Effect.fail(new Error(`Task ${selected.error}`))
+    return selected
   })
 
   export function workflow(value: unknown): Workflow | undefined {

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -63,6 +63,7 @@ const BaseParameters = Schema.Struct(BaseParameterFields)
 
 export const Parameters = Schema.Struct({
   ...BaseParameterFields,
+  ...KiloTask.ModelFields, // kilocode_change
   background: Schema.optional(Schema.Boolean).annotate({
     description:
       "Run the agent in the background. You will be notified when it completes. DO NOT sleep, poll, or proactively check on its progress",
@@ -107,6 +108,7 @@ export const TaskTool = Tool.define(
       ctx: Tool.Context,
     ) {
       const cfg = yield* config.get()
+      const selection = cfg.experimental?.task_model_selection === true // kilocode_change
       const runInBackground = params.background === true
       if (runInBackground && !flags.experimentalBackgroundSubagents) {
         return yield* Effect.fail(new Error("Background subagents require KILO_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true"))
@@ -164,6 +166,29 @@ export const TaskTool = Tool.define(
           new Error(`Cannot resume session ${params.task_id}: not a child of the current session`),
         ) // kilocode_change - prevent cross-session task resume
       }
+      // kilocode_change start
+      const msg = yield* MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID }).pipe(
+        Effect.provideService(Database.Service, database),
+        Effect.orDie,
+      )
+      if (msg.info.role !== "assistant") return yield* Effect.fail(new Error("Not an assistant message"))
+      const source = { modelID: msg.info.modelID, providerID: msg.info.providerID }
+      const selected = yield* KiloTask.resolveModel({
+        name: next.name,
+        agent: next,
+        config: cfg,
+        parent: source,
+        variant: msg.info.variant,
+        workflow: KiloTask.workflow(ctx.extra),
+        provider,
+        enabled: selection,
+        selection: { model: params.model, provider: params.provider, variant: params.variant },
+        resume: session?.model,
+      })
+      const model = selected.model
+      const variant = selected.variant
+      const reasoning = msg.info.variant
+      // kilocode_change end
       // kilocode_change start — inherit edit/bash/MCP restrictions from calling agent
       const caller = yield* agent.get(ctx.agent)
       const rules = KiloTask.inherited({ caller, session: parent, mcp: cfg.mcp })
@@ -208,28 +233,6 @@ export const TaskTool = Tool.define(
       )
       // kilocode_change end
 
-      const msg = yield* MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID }).pipe(
-        Effect.provideService(Database.Service, database),
-        Effect.orDie,
-      )
-      if (msg.info.role !== "assistant") return yield* Effect.fail(new Error("Not an assistant message"))
-
-      // kilocode_change start — prefer valid subagent overrides, safely inheriting when overrides go stale
-      const selected = yield* KiloTask.resolveModel({
-        name: next.name,
-        agent: next,
-        config: cfg,
-        parent: {
-          modelID: msg.info.modelID,
-          providerID: msg.info.providerID,
-        },
-        variant: msg.info.variant,
-        workflow: KiloTask.workflow(ctx.extra), // kilocode_change
-        provider,
-      })
-      const model = selected.model
-      const variant = selected.variant
-      // kilocode_change end
       const metadata = {
         parentSessionId: ctx.sessionID,
         sessionId: nextSession.id,
@@ -295,7 +298,12 @@ export const TaskTool = Tool.define(
           .prompt({
             sessionID: ctx.sessionID,
             agent: currentParent.agent ?? ctx.agent,
-            variant,
+            model: selection
+              ? currentParent.model
+                ? { providerID: currentParent.model.providerID, modelID: currentParent.model.id }
+                : source
+              : undefined,
+            variant: selection ? (currentParent.model?.variant ?? reasoning) : variant,
             parts: [
               {
                 type: "text",
@@ -466,14 +474,29 @@ export const TaskTool = Tool.define(
       )
     })
 
-    return {
-      description: flags.experimentalBackgroundSubagents
-        ? [DESCRIPTION, BACKGROUND_DESCRIPTION].join("\n\n")
-        : DESCRIPTION,
-      parameters: Parameters,
-      jsonSchema: flags.experimentalBackgroundSubagents ? undefined : ToolJsonSchema.fromSchema(BaseParameters),
-      execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
-        run(params, ctx).pipe(Effect.orDie),
-    }
+    // kilocode_change start
+    return () =>
+      Effect.gen(function* () {
+        const cfg = yield* config.get()
+        const selection = cfg.experimental?.task_model_selection === true
+        return {
+          description: [
+            DESCRIPTION,
+            ...(flags.experimentalBackgroundSubagents ? [BACKGROUND_DESCRIPTION] : []),
+            ...(selection ? [KiloTask.modelDescription] : []),
+          ].join("\n\n"),
+          parameters: Parameters,
+          jsonSchema: ToolJsonSchema.fromSchema(
+            Schema.Struct({
+              ...BaseParameters.fields,
+              ...(flags.experimentalBackgroundSubagents ? { background: Parameters.fields.background } : {}),
+              ...(selection ? KiloTask.ModelFields : {}),
+            }),
+          ),
+          execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
+            run(params, ctx).pipe(Effect.orDie),
+        }
+      })
+    // kilocode_change end
   }),
 )

--- a/packages/opencode/test/kilocode/agent-manager-models-tool.test.ts
+++ b/packages/opencode/test/kilocode/agent-manager-models-tool.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test"
 import { Effect, Layer, ManagedRuntime } from "effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Agent } from "../../src/agent/agent"
+import { Config } from "../../src/config/config"
 import { AgentManagerModelsTool } from "../../src/kilocode/tool/agent-manager-models"
 import { Provider } from "../../src/provider/provider"
 import { MessageID, SessionID } from "../../src/session/schema"
@@ -52,6 +53,7 @@ const runtime = ManagedRuntime.make(
   Layer.mergeAll(
     AppNodeBuilder.build(Truncate.node),
     AppNodeBuilder.build(Agent.node),
+    AppNodeBuilder.build(Config.node),
     AppNodeBuilder.build(CrossSpawnSpawner.node),
     Layer.mock(Provider.Service, { list: () => Effect.succeed(providers) }),
   ),
@@ -68,13 +70,15 @@ const ctx = {
   ask: () => Effect.void,
 }
 
-function run(params: Record<string, unknown>) {
+function run(params: Record<string, unknown>, selection = false) {
   return runtime.runPromise(
-    provideTmpdirInstance(() =>
-      Effect.gen(function* () {
-        const tool = yield* Tool.init(yield* AgentManagerModelsTool)
-        return yield* tool.execute(params, ctx)
-      }),
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const tool = yield* Tool.init(yield* AgentManagerModelsTool)
+          return yield* tool.execute(params, ctx)
+        }),
+      { config: { experimental: { task_model_selection: selection } } },
     ).pipe(Effect.scoped),
   )
 }
@@ -84,6 +88,13 @@ function json<T>(value: string): T {
 }
 
 describe("agent_manager_models tool", () => {
+  test("explains Task selection only when the experiment is enabled", async () => {
+    const disabled = await run({ query: "shared" })
+    const enabled = await run({ query: "shared" }, true)
+    expect(json<{ hint: string }>(disabled.output).hint).not.toContain("to task or agent_manager")
+    expect(json<{ hint: string }>(enabled.output).hint).toContain("to task or agent_manager")
+  })
+
   test("returns models grouped by name, capped at 20", async () => {
     const result = await run({})
     const output = json<{ models: Array<{ name: string }>; total: number; nextOffset?: number }>(result.output)

--- a/packages/opencode/test/kilocode/server/config-overlay.test.ts
+++ b/packages/opencode/test/kilocode/server/config-overlay.test.ts
@@ -94,6 +94,57 @@ async function setGlobal(dir: string, value: Config.Info) {
 }
 
 describe("config overlay routes", () => {
+  test("saving task model selection refreshes cached tools without restarting the server", async () => {
+    await using global = await tmpdir()
+    await using project = await tmpdir()
+    await using other = await tmpdir()
+    ;(Global.Path as { config: string }).config = global.path
+    const target = Server.Default().app
+    const provider = {
+      enabled_providers: ["test"],
+      provider: {
+        test: {
+          npm: "@ai-sdk/openai-compatible",
+          options: { apiKey: "test", baseURL: "http://localhost:1/v1" },
+          models: { model: { name: "Test", limit: { context: 10000, output: 1000 } } },
+        },
+      },
+    }
+    await config(project.path, provider)
+    await config(other.path, provider)
+    const check = async (dir: string, enabled: boolean) => {
+      const tools = await json<
+        Array<{
+          id: string
+          description: string
+          parameters: { properties: Record<string, unknown> }
+        }>
+      >(await request(target, dir, "/experimental/tool?provider=test&model=model"))
+      const task = tools.find((tool) => tool.id === "task")
+      expect(task).toBeDefined()
+      for (const field of ["model", "provider", "variant"]) {
+        expect(Object.hasOwn(task!.parameters.properties, field)).toBe(enabled)
+      }
+      expect(task!.description.includes("Experimental subagent model selection is enabled")).toBe(enabled)
+      if (enabled) expect(tools.some((tool) => tool.id === "agent_manager_models")).toBe(true)
+    }
+    await check(project.path, false)
+    await check(other.path, false)
+    for (const enabled of [true, false, true]) {
+      const saved = await json<Overlay>(
+        await request(target, project.path, "/config/overlay", {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ scope: "global", set: { experimental: { task_model_selection: enabled } } }),
+        }),
+      )
+      expect(saved.effective?.experimental?.task_model_selection).toBe(enabled)
+      expect(await Bun.file(saved.targets.global.path).text()).toContain(`"task_model_selection": ${enabled}`)
+      await check(project.path, enabled)
+      await check(other.path, enabled)
+    }
+  })
+
   test("writes a missing project target atomically", async () => {
     await using project = await tmpdir()
     const target = await KilocodeConfigOverlay.target({ scope: "project", directory: project.path })
@@ -700,16 +751,15 @@ describe("config overlay routes", () => {
     const edit = body.effective.permission.edit
     const after = await json<Agent[]>(await req(project.path, "/agent"))
 
-      expect(typeof edit === "string" ? edit : edit?.["*"]).toBe("ask")
-      expect(
-        Permission.evaluate("edit", "*", after.find((item) => item.name === "code")?.permission ?? []).action,
-      ).toBe("ask")
-      expect(body.collections.permission.find((item) => item.key === "edit")).toMatchObject({
-        source: "project",
-        overridden: true,
-      })
-    },
-  )
+    expect(typeof edit === "string" ? edit : edit?.["*"]).toBe("ask")
+    expect(Permission.evaluate("edit", "*", after.find((item) => item.name === "code")?.permission ?? []).action).toBe(
+      "ask",
+    )
+    expect(body.collections.permission.find((item) => item.key === "edit")).toMatchObject({
+      source: "project",
+      overridden: true,
+    })
+  })
 
   test.serial("refreshes agent permissions after global permission update", async () => {
     await using global = await tmpdir()

--- a/packages/opencode/test/kilocode/tool-registry-indexing.test.ts
+++ b/packages/opencode/test/kilocode/tool-registry-indexing.test.ts
@@ -375,6 +375,18 @@ describe("kilocode tool registry indexing", () => {
         "send_file",
       ])
 
+      for (const client of ["cli", "run", "acp"]) {
+        process.env["KILO_CLIENT"] = client
+        const enabled = KiloToolRegistry.extra(tools, { experimental: { task_model_selection: true } }).map(
+          (tool) => tool.id,
+        )
+        expect(enabled).toContain("agent_manager_models")
+        expect(enabled).not.toContain("agent_manager")
+        expect(
+          KiloToolRegistry.extra(tools, { experimental: { task_model_selection: false } }).map((tool) => tool.id),
+        ).not.toContain("agent_manager_models")
+      }
+
       process.env["KILO_CLIENT"] = "vscode"
       expect(KiloToolRegistry.extra(tools, {}).map((tool) => tool.id)).toEqual([
         "semantic_search",

--- a/packages/opencode/test/kilocode/tool-task-model.test.ts
+++ b/packages/opencode/test/kilocode/tool-task-model.test.ts
@@ -1,7 +1,7 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { afterEach, beforeAll, describe, expect } from "bun:test"
-import { Effect } from "effect"
+import { Cause, Deferred, Effect, Exit } from "effect"
 import { Database } from "@opencode-ai/core/database/database"
 import fs from "fs/promises"
 import path from "path"
@@ -207,6 +207,9 @@ function run(input: {
   client?: string
   variant?: string
   config?: Pick<Config.Info, "subagent_model" | "subagent_variant" | "subagent_variant_overrides">
+  enabled?: boolean
+  selection?: { model?: string; provider?: string; variant?: string }
+  resume?: Session.Info["model"]
 }) {
   return provideTmpdirInstance(
     () =>
@@ -215,28 +218,41 @@ function run(input: {
         if (input.state) yield* writeState(input.state)
 
         const { chat, assistant } = yield* seed(input.agent, input.variant)
+        const sessions = yield* Session.Service
+        const child = input.resume ? yield* sessions.create({ parentID: chat.id, model: input.resume }) : undefined
         const tool = yield* TaskTool
         const def = yield* tool.init()
         let seen: SessionPrompt.PromptInput | undefined
         const promptOps = stubOps({ onPrompt: (value) => (seen = value) })
 
-        const result = yield* def.execute(
-          {
-            description: `run ${input.agent}`,
-            prompt: "inspect resolution",
-            subagent_type: input.agent,
-          },
-          {
-            sessionID: chat.id,
-            messageID: assistant.id,
-            agent: "build",
-            abort: new AbortController().signal,
-            extra: { promptOps, bypassAgentCheck: true },
-            messages: [],
-            metadata: () => Effect.void,
-            ask: () => Effect.void,
-          },
-        )
+        const result = yield* def
+          .execute(
+            {
+              description: `run ${input.agent}`,
+              prompt: "inspect resolution",
+              subagent_type: input.agent,
+              task_id: child?.id,
+              ...input.selection,
+            },
+            {
+              sessionID: chat.id,
+              messageID: assistant.id,
+              agent: "build",
+              abort: new AbortController().signal,
+              extra: { promptOps, bypassAgentCheck: true },
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          )
+          .pipe(
+            Effect.onError(() =>
+              Effect.gen(function* () {
+                expect(seen).toBeUndefined()
+                expect(yield* sessions.children(chat.id)).toHaveLength(child ? 1 : 0)
+              }),
+            ),
+          )
 
         return {
           prompt: seen?.model,
@@ -249,6 +265,7 @@ function run(input: {
       config: {
         ...catalog,
         ...input.config,
+        experimental: { task_model_selection: input.enabled ?? false },
         agent: {
           worker: { mode: "subagent" },
           pinned: { mode: "subagent", model: "config-provider/config-model", variant: cfgVariant },
@@ -259,6 +276,169 @@ function run(input: {
 }
 
 describe("tool.task model resolution", () => {
+  for (const example of [
+    { selection: { model: "sub-provider/sub-model", variant: subVariant }, model: sub, variant: subVariant },
+    { selection: { model: "SUB model", provider: "sub-provider" }, model: sub, variant: undefined },
+    { selection: { variant: overrideVariant }, model: cfg, variant: overrideVariant },
+    { selection: {}, model: cfg, variant: cfgVariant },
+  ]) {
+    it.live(`selects ${JSON.stringify(example.selection)} when enabled`, () =>
+      run({ agent: "pinned", enabled: true, selection: example.selection, variant: inherited }).pipe(
+        Effect.tap((result) =>
+          Effect.sync(() => {
+            expect(result.prompt).toEqual(example.model)
+            expect(result.variant).toEqual(example.variant)
+            expect(result.model).toEqual(example.model)
+            expect(result.metadataVariant).toEqual(example.variant)
+          }),
+        ),
+      ),
+    )
+  }
+
+  for (const example of [
+    { enabled: false, selection: { model: "sub-model" }, error: "experimental.task_model_selection=true" },
+    { enabled: false, selection: { variant: "full" }, error: "experimental.task_model_selection=true" },
+    { enabled: true, selection: { provider: "sub-provider" }, error: "provider requires a model" },
+    { enabled: true, selection: { model: "missing" }, error: "model is not available" },
+    { enabled: true, selection: { model: "model" }, error: "is ambiguous" },
+    { enabled: true, selection: { model: "sub-model", provider: "missing" }, error: "provider is not available" },
+    { enabled: true, selection: { model: "sub-model", variant: "missing" }, error: "Available variants:" },
+    { enabled: true, selection: { variant: "missing" }, error: "Available variants:" },
+    { enabled: true, selection: { model: " " }, error: "must not be empty" },
+    { enabled: true, selection: { variant: "__proto__" }, error: "Available variants:" },
+  ]) {
+    it.live(`rejects ${JSON.stringify(example.selection)} with selection ${example.enabled}`, () =>
+      run({ agent: "worker", enabled: example.enabled, selection: example.selection }).pipe(
+        Effect.exit,
+        Effect.tap((result) =>
+          Effect.sync(() => {
+            expect(Exit.isFailure(result)).toBe(true)
+            if (Exit.isFailure(result)) expect(Cause.pretty(result.cause)).toContain(example.error)
+          }),
+        ),
+      ),
+    )
+  }
+
+  for (const enabled of [false, true]) {
+    it.live(`uses ${enabled ? "persisted" : "normal"} defaults on resume`, () =>
+      run({
+        agent: "pinned",
+        enabled,
+        resume: { id: sub.modelID, providerID: sub.providerID, variant: subVariant },
+      }).pipe(
+        Effect.tap((result) =>
+          Effect.sync(() => {
+            expect(result.prompt).toEqual(enabled ? sub : cfg)
+            expect(result.variant).toEqual(enabled ? subVariant : cfgVariant)
+          }),
+        ),
+      ),
+    )
+  }
+
+  it.live("allows a reasoning override on a resumed model", () =>
+    run({
+      agent: "pinned",
+      enabled: true,
+      resume: { id: sub.modelID, providerID: sub.providerID, variant: subVariant },
+      selection: { variant: overrideVariant },
+    }).pipe(
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.prompt).toEqual(sub)
+          expect(result.variant).toEqual(overrideVariant)
+        }),
+      ),
+    ),
+  )
+
+  for (const enabled of [undefined, false, true]) {
+    for (const background of [false, true]) {
+      it.live(`advertises selection ${enabled} independently of background ${background}`, () =>
+        provideTmpdirInstance(
+          () =>
+            Effect.gen(function* () {
+              const tool = yield* TaskTool.pipe(
+                Effect.provide(RuntimeFlags.layer({ experimentalBackgroundSubagents: background })),
+              )
+              const def = yield* tool.init()
+              const fields = def.jsonSchema?.properties ?? {}
+              for (const field of ["model", "provider", "variant"]) expect(field in fields).toBe(enabled === true)
+              expect("background" in fields).toBe(background)
+              expect(def.description.includes("Experimental subagent model selection is enabled")).toBe(
+                enabled === true,
+              )
+            }),
+          { config: { experimental: { task_model_selection: enabled } } },
+        ),
+      )
+    }
+  }
+
+  it.live("keeps the latest parent model and reasoning when a background override completes", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const { chat, assistant } = yield* seed("background", inherited)
+          const sessions = yield* Session.Service
+          const notified = yield* Deferred.make<SessionPrompt.PromptInput>()
+          const calls: SessionPrompt.PromptInput[] = []
+          const tool = yield* TaskTool.pipe(
+            Effect.provide(RuntimeFlags.layer({ experimentalBackgroundSubagents: true })),
+          )
+          const def = yield* tool.init()
+          const promptOps: TaskPromptOps = {
+            ...stubOps(),
+            prompt: (input) =>
+              Effect.gen(function* () {
+                calls.push(input)
+                if (input.sessionID === chat.id) yield* Deferred.succeed(notified, input)
+                if (input.sessionID !== chat.id) {
+                  yield* sessions.setAgentModel({
+                    sessionID: chat.id,
+                    agent: "build",
+                    model: { id: cfg.modelID, providerID: cfg.providerID, variant: cfgVariant },
+                    time: Date.now(),
+                  })
+                }
+                return reply(input, "done")
+              }),
+          }
+          const result = yield* def.execute(
+            {
+              description: "background selection",
+              prompt: "inspect selection",
+              subagent_type: "general",
+              background: true,
+              model: "sub-model",
+              provider: "sub-provider",
+              variant: subVariant,
+            },
+            {
+              sessionID: chat.id,
+              messageID: assistant.id,
+              agent: "build",
+              abort: new AbortController().signal,
+              extra: { promptOps, bypassAgentCheck: true },
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          )
+          const notice = yield* Deferred.await(notified).pipe(Effect.timeout("5 seconds"))
+          expect(result.metadata.model).toEqual(sub)
+          expect(result.metadata.variant).toEqual(subVariant)
+          expect(calls.at(0)?.model).toEqual(sub)
+          expect(calls.at(0)?.variant).toEqual(subVariant)
+          expect(notice.model).toEqual(cfg)
+          expect(notice.variant).toEqual(cfgVariant)
+        }),
+      { config: { ...catalog, experimental: { task_model_selection: true } } },
+    ),
+  )
+
   it.live("saved model beats agent config for pinned", () =>
     run({
       agent: "pinned",

--- a/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
+++ b/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
@@ -376,8 +376,16 @@ exports[`tool parameters JSON Schema (wire shape) task 1`] = `
       "description": "A short (3-5 words) description of the task",
       "type": "string",
     },
+    "model": {
+      "description": "Optional subagent model name or qualified provider/model ID from agent_manager_models. Choose a model suited to this task; omit to use the normal subagent model.",
+      "type": "string",
+    },
     "prompt": {
       "description": "The task for the agent to perform",
+      "type": "string",
+    },
+    "provider": {
+      "description": "Optional provider ID from agent_manager_models. Requires model; omit to prefer the current turn's provider, then Kilo Gateway.",
       "type": "string",
     },
     "subagent_type": {
@@ -386,6 +394,10 @@ exports[`tool parameters JSON Schema (wire shape) task 1`] = `
     },
     "task_id": {
       "description": "This should only be set if you mean to resume a previous task (you can pass a prior task_id and the task will continue the same subagent session as before instead of creating a fresh one)",
+      "type": "string",
+    },
+    "variant": {
+      "description": "Optional reasoning effort variant from agent_manager_models. Can be used without model to change only the normal subagent model's reasoning effort.",
       "type": "string",
     },
   },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2680,6 +2680,7 @@ export type Config = {
     image_generation?: boolean
     image_generation_model?: string
     native_notebook_tools?: boolean
+    task_model_selection?: boolean
     speech_to_text_model?: string
     openTelemetry?: boolean
     primary_tools?: Array<string>

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -34780,6 +34780,9 @@
               "native_notebook_tools": {
                 "type": "boolean"
               },
+              "task_model_selection": {
+                "type": "boolean"
+              },
               "speech_to_text_model": {
                 "type": "string"
               },


### PR DESCRIPTION
## What Problem This Solves

Internal Task subagents cannot select a model, provider, or reasoning effort for an individual task. An orchestrator must use the configured subagent defaults or switch to Agent Manager sessions, even when an internal subagent is the correct workflow.

## Why This Change Was Made

Add the opt-in `experimental.task_model_selection` config flag and expose it in Kilo's Experimental settings. It uses the existing Save/Discard and backend config refresh path, rather than a startup-only environment variable. Saving the setting refreshes cached Task schemas without restarting the backend.

Task and Agent Manager share model lookup, provider preference, ambiguity handling, and variant validation. Invalid explicit selections fail before creating a child session instead of silently falling back to another model.

## User Impact

- The experiment is off by default. Existing subagent defaults and flag-off behavior remain unchanged.
- After enabling **Task Subagent Model Selection** and clicking **Save**, Task accepts `model`, `provider`, and `variant` overrides. An orchestrator can use `agent_manager_models` to discover valid choices.
- Model discovery works from the VS Code sidebar as well as Agent Manager. Internal subagents do not require opening Agent Manager or creating worktrees. Other CLI clients receive the discovery tool when the experiment is enabled.
- Resumed tasks retain their last model and reasoning variant unless overridden. A model override does not inherit the parent's reasoning effort.
- Background completion preserves the parent's latest model and reasoning selection rather than applying the child's overrides to the parent.

## Evidence

- 200 focused tests passed, including model/provider/variant validation, foreground and background paths, resume behavior, draft/discard/save behavior, and refreshing cached tool schemas across two workspaces on one server.
- Workspace typechecks, extension compilation, lint, and affected ownership guards passed. Root lint excluded ignored nested development worktrees and reported existing warnings.
- Isolated VS Code verification covered Save/Discard, live enable/disable on the same backend process, and persistence after a fresh launch.
- A sidebar run started three internal tasks, one background and two foreground, against a local test endpoint using the Gateway SDK. Captured requests selected three distinct models with `low`, `medium`, and `high` reasoning, and the saved child session metadata matched. This verifies local routing and serialization, not whether a live upstream provider honors a reasoning setting.
- The cloud-hosted config editor schema mirror is maintained in the separate cloud repository and is not included in this PR.

<img width="700" alt="Task Subagent Model Selection enabled in Kilo Experimental settings" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260828-task-model-selection-saved-toggle-fb7faaef.png" />
