### PR TITLE
fix(vscode): build missing bundles before isolated launch

### DIFF
--- a/packages/kilo-vscode/script/launch.ts
+++ b/packages/kilo-vscode/script/launch.ts
@@ -236,11 +236,12 @@ function newest(paths: string[]) {
 // ---------------------------------------------------------------------------
 
 async function compile() {
-  if (!shouldBuild) {
+  if (!shouldBuild && existsSync(join(root, "dist", "extension.js"))) {
     console.log("[launch] Skipping build (--no-build)")
     return
   }
 
+  if (!shouldBuild) console.log("[launch] dist/extension.js is missing in this worktree, building first...")
   await ensureDependencies()
   console.log("[launch] Building extension...")
   await $`bun run build:launch`.cwd(root).env(cleanEnv(process.env))

--- a/packages/kilo-vscode/tests/unit/launch.test.ts
+++ b/packages/kilo-vscode/tests/unit/launch.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { cpSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { delimiter, dirname, join, resolve } from "node:path"
+
+const source = resolve(import.meta.dir, "../../../..")
+const dirs: string[] = []
+
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+async function fixture() {
+  const repo = realpathSync(mkdtempSync(join(tmpdir(), "kilo-launch-")))
+  dirs.push(repo)
+  for (const path of ["", "packages/kilo-vscode", "packages/opencode", "packages/sdk/js"]) {
+    const dir = join(repo, path)
+    mkdirSync(dir, { recursive: true })
+    symlinkSync(join(source, path, "node_modules"), join(dir, "node_modules"), "junction")
+  }
+  const root = join(repo, "packages/kilo-vscode")
+  mkdirSync(join(root, "script"))
+  cpSync(join(source, "packages/kilo-vscode/script/launch.ts"), join(root, "script/launch.ts"))
+  await Bun.write(join(root, "package.json"), JSON.stringify({ scripts: { "build:launch": "bun build.ts" } }))
+  await Bun.write(join(root, "build.ts"), 'await Bun.write("dist/extension.js", "built")')
+  const workspace = join(repo, "workspace")
+  await Bun.write(join(workspace, "package.json"), JSON.stringify({ main: "index.ts" }))
+  await Bun.write(join(workspace, "index.ts"), 'await Bun.write("opened.json", JSON.stringify(process.argv.slice(2)))')
+  return {
+    root,
+    workspace,
+    run: (args: string[] = ["--no-build"]) =>
+      Bun.spawnSync(
+        [
+          process.execPath,
+          join(root, "script/launch.ts"),
+          "--isolated",
+          "--wait",
+          "--app-path",
+          process.execPath,
+          "--workspace",
+          workspace,
+          ...args,
+        ],
+        {
+          cwd: repo,
+          env: { ...process.env, PATH: [dirname(process.execPath), process.env.PATH].join(delimiter) },
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      ),
+  }
+}
+
+describe("extension launch build", () => {
+  test("builds a fresh worktree before launching even with --no-build", async () => {
+    const item = await fixture()
+    const result = item.run()
+    expect(result.exitCode).toBe(0)
+    expect(await Bun.file(join(item.root, "dist/extension.js")).text()).toBe("built")
+    expect(await Bun.file(join(item.workspace, "opened.json")).json()).toContain(
+      `--extensionDevelopmentPath=${item.root}`,
+    )
+  })
+
+  test("reuses an existing bundle with --no-build", async () => {
+    const item = await fixture()
+    await Bun.write(join(item.root, "dist/extension.js"), "previous")
+    expect(item.run().exitCode).toBe(0)
+    expect(await Bun.file(join(item.root, "dist/extension.js")).text()).toBe("previous")
+    expect(await Bun.file(join(item.workspace, "opened.json")).exists()).toBe(true)
+  })
+
+  test("rebuilds an existing bundle by default", async () => {
+    const item = await fixture()
+    await Bun.write(join(item.root, "dist/extension.js"), "previous")
+    expect(item.run([]).exitCode).toBe(0)
+    expect(await Bun.file(join(item.root, "dist/extension.js")).text()).toBe("built")
+  })
+
+  test("does not launch when the required build fails", async () => {
+    const item = await fixture()
+    await Bun.write(join(item.root, "build.ts"), "process.exit(1)")
+    expect(item.run().exitCode).toBe(1)
+    expect(await Bun.file(join(item.workspace, "opened.json")).exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
## What Problem This Solves

A fresh Agent Manager worktree has no ignored `packages/kilo-vscode/dist/` output. Running `bun run extension:isolated --no-build` still opened VS Code, but activation then failed because the manifest entry point, `dist/extension.js`, did not exist.

## Why This Change Was Made

Treat `--no-build` as reuse of an existing extension bundle. If the entry point is missing, use the existing dependency preparation and `build:launch` pipeline before opening VS Code. A failed build still stops the launch.

This keeps the fix in the developer launcher instead of adding an extension build to every Agent Manager worktree creation. It does not change the compile or release packaging pipelines.

## User Impact

- A fresh worktree can launch for manual extension testing even when `--no-build` is supplied.
- Worktrees with an existing bundle continue to skip rebuilding.
- The default build-enabled launch remains unchanged.

The machine-local `vscode-self-test` harness is separate and unchanged. Its `--build false` still requires an existing bundle; use `--build true` for the first launch.

## Evidence

- The fresh-worktree and build-failure regression tests failed before this change and pass with it. All five focused launcher/build-dependency tests pass.
- `bun run compile`, package typecheck and lint, focused ESLint/Prettier checks, Knip, and the extension change-marker guard pass.
- With the real worktree's `dist/` temporarily moved aside, the isolated launcher rebuilt the host, sidebar, and Agent Manager bundles before starting the application stand-in.
- The self-test workflow then loaded that rebuilt bundle in real VS Code. The sidebar and Agent Manager rendered without a missing-module or activation error. Isolated VS Code instances were closed and cleaned up afterward.
- An additional standalone typecheck of `script/launch.ts` reports seven existing environment-object typing errors. The same diagnostics were confirmed against `HEAD`; the package's normal typecheck passes. Those unrelated lines are unchanged.
