### PR TITLE
fix(vscode): preserve background agent dismissals across navigation

### DIFF
--- a/.changeset/preserve-background-agent-dismissals.md
+++ b/.changeset/preserve-background-agent-dismissals.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep dismissed background agents hidden when switching sessions or returning from History and empty chats.

--- a/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
@@ -36,14 +36,12 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
   const [open, setOpen] = createSignal(false)
   const [jobs, setJobs] = createSignal<BackgroundJobInfo[]>([])
   const [loaded, setLoaded] = createSignal(false)
-  const [hidden, setHidden] = createSignal<Set<string>>(new Set())
   const [mounted, setMounted] = createSignal(false)
   let pending: string | undefined
   let revision = 0
 
   createEffect(
     on(session.currentSessionID, () => {
-      setHidden(new Set<string>())
       setLoaded(false)
       setJobs([])
       pending = undefined
@@ -95,7 +93,12 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
     return fallback()
   })
 
-  const visible = createMemo(() => agents().filter((agent) => showBackgroundAgent(agent, hidden())))
+  const visible = createMemo(() => {
+    const id = session.currentSessionID()
+    if (!id) return []
+    const hidden = session.dismissedBackgroundJobs(id)
+    return agents().filter((agent) => showBackgroundAgent(agent, hidden))
+  })
   const summary = createMemo(() => {
     const running = visible().filter((agent) => agent.status === "running").length
     const total = visible().length
@@ -174,13 +177,16 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
     vscode.postMessage({ type: "cancelBackgroundJob", jobID: agent.jobID, sessionID: id, requestID: pending })
   }
 
+  const hide = (ids: string[]) => {
+    const id = session.currentSessionID()
+    if (id) session.dismissBackgroundJobs(id, ids)
+  }
+
   const hideFinished = () =>
-    setHidden(
-      new Set(
-        agents()
-          .filter((agent) => agent.status !== "running")
-          .map((agent) => agent.jobID),
-      ),
+    hide(
+      agents()
+        .filter((agent) => agent.status !== "running")
+        .map((agent) => agent.jobID),
     )
 
   return (
@@ -334,7 +340,7 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
                       aria-label={`${language.t("task.backgroundAgents.dismiss")}: ${label(agent)}`}
                       onClick={(event: MouseEvent) => {
                         event.stopPropagation()
-                        setHidden((current) => new Set(current).add(agent.jobID))
+                        hide([agent.jobID])
                       }}
                     >
                       <span data-slot="task-header-agent-action-label">

--- a/packages/kilo-vscode/webview-ui/src/context/session-types.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/session-types.ts
@@ -75,6 +75,8 @@ export interface SessionContextValue {
   // Tool parts for a specific session, maintained incrementally for streaming views
   getSessionToolParts: (sessionID: string) => ToolPart[]
   getSessionToolCount: (sessionID: string) => number
+  dismissedBackgroundJobs: (sessionID: string) => ReadonlySet<string>
+  dismissBackgroundJobs: (sessionID: string, ids: string[]) => void
 
   // Hidden after model changes so switching models can clear stale provider errors
   // without removing messages and their checkpoint restore actions.

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -283,6 +283,12 @@ export const SessionProvider: ParentComponent = (props) => {
   // Cloud session preview state
   const [cloudPreviewId, setCloudPreviewId] = createSignal<string | null>(null)
   const [hiddenErrors, setHiddenErrors] = createSignal<Set<string>>(new Set())
+  const [dismissals, setDismissals] = createStore<Record<string, ReadonlySet<string>>>({})
+  const dismissedBackgroundJobs = (id: string): ReadonlySet<string> => dismissals[id] ?? new Set<string>()
+  const dismissBackgroundJobs = (id: string, ids: string[]) => {
+    if (!ids.length) return
+    setDismissals(id, (current) => new Set([...(current ?? []), ...ids]))
+  }
 
   // Live worktree diff stats from extension polling
   const [worktreeStats, setWorktreeStats] = createSignal<
@@ -978,6 +984,11 @@ export const SessionProvider: ParentComponent = (props) => {
 
       case "sessionDeleted":
         handleSessionDeleted(message.sessionID)
+        setDismissals(
+          produce((map) => {
+            delete map[message.sessionID]
+          }),
+        )
         break
 
       case "messageRemoved":
@@ -2879,6 +2890,8 @@ export const SessionProvider: ParentComponent = (props) => {
     getParts,
     getSessionToolParts,
     getSessionToolCount,
+    dismissedBackgroundJobs,
+    dismissBackgroundJobs,
     isErrorHidden: (messageID: string) => hiddenErrors().has(messageID),
     hydrateParts,
     todos,

--- a/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/StoryProviders.tsx
@@ -217,6 +217,8 @@ export function mockSessionValue(overrides?: {
     getParts: () => [],
     getSessionToolParts: () => [],
     getSessionToolCount: () => 0,
+    dismissedBackgroundJobs: () => new Set<string>(),
+    dismissBackgroundJobs: noop,
     isErrorHidden: () => false,
     hydrateParts: noop,
     todos: () => [],


### PR DESCRIPTION
## What Problem This Solves

Dismissed background agents reappear after switching sessions or returning from History or an empty chat. Both Dismiss and Clear finished lose their state when the header changes session or remounts.

Fixes #13507.

## Why This Change Was Made

The persistence work proposed in #13526 was not merged, and #13542 explicitly left it unfinished. A component-local map would still lose dismissals on remount. Store dismissed job IDs in the stable session provider, scoped to each parent session, and remove them when that session is deleted.

## User Impact

- Dismiss and Clear finished stay effective across session switches and chat remounts.
- Running jobs remain visible, and dismissing one parent's jobs does not hide another parent's jobs.
- This is UI-only state for the current webview lifetime. It does not delete backend jobs or persist through a full webview reload.

## Evidence

Reproduced the old failure in the baseline build. Verified the fixed build in isolated VS Code with deterministic session/job responses: tab switching, History remounts, empty chats, parent isolation, restarted jobs, and new finished jobs. No live model prompts were needed.

The full extension unit suite passed. Temporary lifecycle regression coverage also passed and was removed to keep the patch small. The final existing background-agent/session-provider tests passed (23 tests), along with typecheck, lint, compile, Knip, and the Kilo change-marker guard.

After dismissing the completed job and returning through History, the untouched cancelled and failed jobs remain visible:

<img width="700" alt="Only the undismissed cancelled and failed background jobs remain after History navigation" src="https://marius-kilocode.github.io/pr-assets/20260828-background-dismissals-history-1600.png" />

After Clear finished, returning from an empty chat does not restore the background-agent strip:

<img width="700" alt="Session header without a background-agent strip after Clear finished and empty-chat navigation" src="https://marius-kilocode.github.io/pr-assets/20260828-background-dismissals-cleared-1600.png" />
