### PR TITLE
feat(cli): delegate browser_task through the relay

### DIFF
--- a/.changeset/browser-task.md
+++ b/.changeset/browser-task.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Delegate browser tasks from the CLI to an explicitly enabled browser profile. Keep the signed-in browser panel open, approve each task's tab, and recover results without replaying browser actions.

--- a/packages/opencode/src/kilo-sessions/kilo-sessions.ts
+++ b/packages/opencode/src/kilo-sessions/kilo-sessions.ts
@@ -48,6 +48,7 @@ import { cumulativeSessionDiff } from "@/kilocode/session-portability/cumulative
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder" // kilocode_change
 import { KiloShutdown } from "@/kilocode/cli/shutdown"
+import { BrowserClient } from "@/kilocode/browser-task/client"
 
 async function provide<R>(input: { directory: string; fn: () => R }): Promise<R> {
   const { provide } = await import("@/kilocode/instance")
@@ -270,7 +271,7 @@ export namespace KiloSessions {
   }
 
   const remoteEnabled = process.env["KILO_REMOTE"] === "1"
-  let remote: { conn: RemoteWS.Connection; sender: RemoteSender.Sender } | undefined
+  let remote: { conn: RemoteWS.Connection; sender: RemoteSender.Sender; browser: BrowserClient.Client } | undefined
   let enabling: Promise<void> | undefined
   let remoteSeq = 0
   // kilocode_change - K1 W1: module-level instance advertisement flag.
@@ -775,6 +776,7 @@ export namespace KiloSessions {
         return { type: "heartbeat", sessions: advertised, ...(instance ? { instance } : {}) }
       }
 
+      const browser = BrowserClient.create(() => conn)
       const conn = RemoteWS.connect({
         url,
         getToken: kilocodeToken,
@@ -782,29 +784,24 @@ export namespace KiloSessions {
         getSessions,
         log,
         onOpen: () => {
+          // The negotiation heartbeat also preserves immediate instance advertisement on reconnect.
+          browser.open()
           void Bus.publish(Instance.current, Event.RemoteStatusChanged, { enabled: true, connected: true })
-          // kilocode_change - K1 W1: on reconnect, a headless `kilo remote` host
-          // preserves its module-level advertisement flag but would otherwise not
-          // be re-advertised until the next periodic heartbeat (up to ~10s).
-          // Fire one immediate out-of-band heartbeat when the flag is set.
-          // This is intentionally conditional: tests that do not set the flag
-          // must not see extra heartbeats.
-          if (instanceAdvertisement) {
-            void conn.heartbeat().catch((err) =>
-              log.warn("reconnect advertisement heartbeat failed", {
-                error: String(err),
-              }),
-            )
-          }
         },
         onDisconnect: () => {
+          browser.disconnect()
           void Bus.publish(Instance.current, Event.RemoteStatusChanged, { enabled: !!remote, connected: false })
         },
         onMessage: (msg) => {
-          // Restore the directory context before dispatching an async remote message.
+          if (msg.type === "heartbeat_ack") browser.handle(msg)
+          // Restore the directory context only for the legacy remote sender.
           void provide({ directory, fn: () => sender.handle(msg) })
         },
-        onClose: () => disableRemote(),
+        onBrowserMessage: (msg) => browser.handle(msg),
+        onClose: () => {
+          browser.close()
+          disableRemote()
+        },
       })
 
       const sender = RemoteSender.create({
@@ -851,12 +848,13 @@ export namespace KiloSessions {
       })
 
       if (seq !== remoteSeq) {
+        browser.close()
         sender.dispose()
         conn.close()
         return
       }
 
-      remote = { conn, sender }
+      remote = { conn, sender, browser }
       log.info("remote connection enabled", { connected: conn.connected })
       Telemetry.trackRemoteConnectionOpened()
       void Bus.publish(Instance.current, Event.RemoteStatusChanged, { enabled: true, connected: conn.connected })
@@ -884,11 +882,25 @@ export namespace KiloSessions {
       if (pending) void Bus.publish(Instance.current, Event.RemoteStatusChanged, { enabled: false, connected: false })
       return
     }
+    remote.browser.close()
     remote.sender.dispose()
     remote.conn.close()
     remote = undefined
     log.info("remote connection disabled")
     void Bus.publish(Instance.current, Event.RemoteStatusChanged, { enabled: false, connected: false })
+  }
+
+  /** Browser jobs use only the explicitly enabled, authenticated remote connection. */
+  export function browser(): BrowserClient.Client {
+    if (!remote) {
+      throw new BrowserClient.Error({
+        code: "remote_disabled",
+        message:
+          "Remote access is disabled. Sign in with `kilo auth login`, then explicitly enable `/remote`. No session was uploaded or enabled.",
+        retryable: true,
+      })
+    }
+    return remote.browser
   }
 
   export function remoteStatus() {

--- a/packages/opencode/src/kilo-sessions/remote-ws.ts
+++ b/packages/opencode/src/kilo-sessions/remote-ws.ts
@@ -26,6 +26,8 @@ export namespace RemoteWS {
       warn: (...args: any[]) => void
     }
     onMessage?: (msg: RemoteProtocol.Inbound) => void
+    /** Opt in without widening the legacy callback contract. */
+    onBrowserMessage?: (msg: RemoteProtocol.BrowserResponse | RemoteProtocol.BrowserEvent) => void
     onOpen?: () => void
     onDisconnect?: () => void
     heartbeat?: number
@@ -52,6 +54,7 @@ export namespace RemoteWS {
   export type Connection = {
     readonly connectionId: string
     send(msg: RemoteProtocol.Outbound): void
+    send(msg: RemoteProtocol.OutboundWithBrowser, options: { connectedOnly: true }): boolean
     /**
      * Resolves when a heartbeat built from a FRESH gather has actually been
      * sent over a live socket. Degraded sends and non-live buffered sends
@@ -97,6 +100,7 @@ export namespace RemoteWS {
     let timer: unknown
     let beat: unknown
     let closed = false
+    let negotiated = false
     const buffer: string[] = []
     let beating: Promise<void> | undefined
     let queued = false
@@ -268,7 +272,11 @@ export namespace RemoteWS {
               send({
                 type: "heartbeat",
                 protocolVersion: InstallationVersion,
-                capabilities: { attachments: true, sessionClone: true },
+                capabilities: {
+                  attachments: true,
+                  sessionClone: true,
+                  ...(options.onBrowserMessage ? { browserJobsV1: true } : {}),
+                },
                 sessions: fresh.sessions,
                 ...(fresh.instance ? { instance: fresh.instance } : {}),
               })
@@ -313,7 +321,11 @@ export namespace RemoteWS {
               send({
                 type: "heartbeat",
                 protocolVersion: InstallationVersion,
-                capabilities: { attachments: true, sessionClone: true },
+                capabilities: {
+                  attachments: true,
+                  sessionClone: true,
+                  ...(options.onBrowserMessage ? { browserJobsV1: true } : {}),
+                },
                 sessions: lastGood ?? [],
               })
               waiters = cycleWaiters.concat(waiters)
@@ -457,6 +469,7 @@ export namespace RemoteWS {
             return
           }
           g.opened = true
+          negotiated = false
           stopConnectDeadline()
           options.log.info("remote-ws connected", { gen: g.id, buffered: buffer.length })
           void withContext(() => options.onOpen?.())
@@ -482,12 +495,24 @@ export namespace RemoteWS {
           }
           const preview = RemoteProtocol.Preview.safeParse(json)
           options.log.info("remote-ws received", { bytes: raw.length, ...preview.data })
-          const parsed = RemoteProtocol.Inbound.safeParse(json)
+          const parsed = (
+            options.onBrowserMessage ? RemoteProtocol.InboundWithBrowser : RemoteProtocol.Inbound
+          ).safeParse(json)
           if (!parsed.success) {
-            options.log.warn("remote-ws message parse failed", { error: parsed.error })
+            options.log.warn("remote-ws message parse failed", { bytes: raw.length })
             return
           }
-          options.onMessage?.(parsed.data)
+          const message = parsed.data
+          if (message.type === "heartbeat_ack") {
+            negotiated =
+              !!options.onBrowserMessage &&
+              RemoteProtocol.NormalizedBrowserCapabilities.parse(message.capabilities).browserJobsV1
+          }
+          if (message.type === "browser_response" || message.type === "browser_event") {
+            if (negotiated) options.onBrowserMessage?.(message)
+            return
+          }
+          options.onMessage?.(message)
         }
 
         socket.onclose = (event) => {
@@ -495,6 +520,7 @@ export namespace RemoteWS {
           stopConnectDeadline()
           options.log.info("remote-ws closed", { code: event.code, reason: event.reason, gen: g.id })
           ws = undefined
+          negotiated = false
           stopHeartbeat()
           stopWatchdog()
           if (closed) return
@@ -530,12 +556,17 @@ export namespace RemoteWS {
       backoff = Math.min(backoff * 2, 60000)
     }
 
-    function send(msg: RemoteProtocol.Outbound) {
+    function send(msg: RemoteProtocol.Outbound): void
+    function send(msg: RemoteProtocol.OutboundWithBrowser, opts: { connectedOnly: true }): boolean
+    function send(msg: RemoteProtocol.OutboundWithBrowser, opts?: { connectedOnly: true }): boolean | void {
+      if (msg.type === "browser_request" && (closed || !negotiated)) return false
       const raw = JSON.stringify(msg)
-      if (ws?.readyState === WebSocket.OPEN) {
+      if (!closed && ws?.readyState === WebSocket.OPEN) {
         ws.send(raw)
-        return
+        return true
       }
+      // Legacy callers retain buffering. Browser work must renegotiate and recover, never flush blindly.
+      if (opts?.connectedOnly || msg.type === "browser_request") return false
       buffer.push(raw)
       if (buffer.length > 200) buffer.shift()
     }

--- a/packages/opencode/src/kilocode/browser-task/client.ts
+++ b/packages/opencode/src/kilocode/browser-task/client.ts
@@ -1,0 +1,577 @@
+import { NamedError } from "@opencode-ai/core/util/error"
+import { Effect, Redacted, Schema } from "effect"
+import { RemoteProtocol } from "../../kilo-sessions/remote-protocol"
+import type { RemoteWS } from "../../kilo-sessions/remote-ws"
+import type { BrowserOwner } from "./owner"
+
+export namespace BrowserClient {
+  type Owner = Effect.Success<ReturnType<typeof BrowserOwner.open>>
+  type Intent = Awaited<ReturnType<Owner["prepare"]>> & { handle?: Handle }
+  type Request = RemoteProtocol.BrowserRequest extends infer R
+    ? R extends RemoteProtocol.BrowserRequest
+      ? Omit<R, "type" | "requestId">
+      : never
+    : never
+  type Response = RemoteProtocol.BrowserResponse["response"]
+  type Job = RemoteProtocol.BrowserJobSnapshot
+  type Handle = RemoteProtocol.BrowserJobHandle
+  type Update = Job | RemoteProtocol.BrowserResult
+  type Watch = { intent: Intent; handle?: Handle; latest?: Update; lost?: number }
+  type Hooks = { signal: AbortSignal; metadata: (output: Output) => Promise<void> }
+  export type Output = {
+    status: string
+    reason: string
+    summary: string
+    evidence: RemoteProtocol.BrowserResult["evidence"]
+    effectsUncertain: boolean
+    retryable?: boolean
+    provider_id?: string
+    browser_task_id?: string
+    job_id?: string
+    invocation_id?: string
+    guidance?: string
+    providers?: RemoteProtocol.BrowserResponse["response"] extends infer R
+      ? R extends { kind: "providers"; providers: infer P }
+        ? P
+        : never
+      : never
+    jobs?: Output[]
+  }
+  export type Client = ReturnType<typeof create>
+  type Failure = InstanceType<typeof Error>
+  export const Error = NamedError.create("BrowserClientError", {
+    code: Schema.String,
+    message: Schema.String,
+    retryable: Schema.Boolean,
+  })
+  const recovery = "Use browser_task with operation=recover to retrieve stored status without replay."
+  const panel = "Enable CLI tasks for the browser profile and keep its signed-in panel open. Refresh operation=list."
+  const uncertain =
+    "Close the affected bound tabs, release execution locks, and use the panel recovery action. " +
+    "Then explicitly continue with provider_id and browser_task_id and approve a fresh tab."
+
+  function failure(code: string, retryable = false) {
+    const messages: Record<string, string> = {
+      remote_disabled: "Remote access is disabled. Sign in with `kilo auth login`, then explicitly enable `/remote`.",
+      unsupported: "The relay does not support browser tasks. Update the relay before retrying.",
+      delivery_interrupted:
+        "Browser result delivery was interrupted; this does not establish browser failure. " + recovery,
+      provider_unavailable: "The selected browser provider is unavailable. " + panel,
+      capacity_exceeded: "The browser queue or retained job limit is full. Wait for capacity, then refresh discovery.",
+      cancelled: "The tool call was cancelled. Cancellation does not undo browser actions already issued.",
+      invalid_response: "The browser response does not match this parent's request. No result was delivered.",
+    }
+    return new Error({ code, message: messages[code] ?? `Browser request rejected: ${code}.`, retryable })
+  }
+
+  export function rejected(err: unknown): Output {
+    const data =
+      err instanceof Error
+        ? err.data
+        : { code: "storage_unavailable", message: "Browser state is unavailable.", retryable: true }
+    return {
+      status: data.code === "delivery_interrupted" ? "interrupted" : "rejected",
+      reason: data.code,
+      summary: data.message,
+      evidence: [],
+      effectsUncertain: data.code === "delivery_interrupted" || data.code === "effects_uncertain",
+      retryable: data.retryable,
+      ...(data.code === "effects_uncertain" ? { guidance: uncertain } : {}),
+      ...(data.code === "delivery_interrupted" ? { guidance: recovery } : {}),
+    }
+  }
+
+  function ids(handle: Partial<Record<keyof Handle, string>>) {
+    return {
+      provider_id: handle.providerId,
+      browser_task_id: handle.browserTaskId,
+      job_id: handle.jobId,
+      invocation_id: handle.invocationId,
+    }
+  }
+
+  function output(update: Update): Output {
+    const result = "result" in update ? update.result : "summary" in update ? update : undefined
+    return {
+      ...ids(update),
+      status: update.status,
+      reason: result?.reason ?? update.status,
+      summary:
+        result?.summary ??
+        `Browser task is ${update.status}. Keep the browser panel open; approve a tab when requested.`,
+      evidence: result?.evidence ?? [],
+      effectsUncertain: result?.effectsUncertain ?? false,
+      ...(result?.effectsUncertain ? { guidance: uncertain } : {}),
+    }
+  }
+
+  function matches(expected: Partial<Record<keyof Handle, string>>, actual: Handle) {
+    return (["providerId", "browserTaskId", "jobId", "invocationId"] as const).every(
+      (key) => expected[key] === undefined || expected[key] === actual[key],
+    )
+  }
+
+  function terminal(update: Update | undefined) {
+    return !!update && RemoteProtocol.BrowserTerminalStatus.safeParse(update.status).success
+  }
+
+  function verify(record: Intent, job: Job) {
+    // The local fingerprint guards immutable intent reuse in prepare(), not relay snapshots.
+    // The authenticated relay binds its different fingerprint to the user and parent proof.
+    if (
+      !matches(
+        { providerId: record.providerId, invocationId: record.invocationId, browserTaskId: record.browserTaskId },
+        job,
+      ) ||
+      (record.handle && !matches(record.handle, job))
+    )
+      throw failure("invalid_response")
+  }
+
+  export function create(
+    connection: () => Pick<RemoteWS.Connection, "send" | "heartbeat" | "connected">,
+    options: { timers?: Pick<RemoteWS.Timers, "setTimeout" | "clearTimeout">; now?: () => number } = {},
+  ) {
+    const timers = options.timers ?? {
+      setTimeout: (fn: () => void, ms?: number) => setTimeout(fn, ms),
+      clearTimeout: (id: unknown) => clearTimeout(Number(id)),
+    }
+    const now = options.now ?? Date.now
+    const pending = new Map<string, { resolve: (value: Response) => void; reject: (err: Failure) => void }>()
+    const routes = new Map<string, Watch>()
+    const watches = new Set<Watch>()
+    const changes = new Set<() => void>()
+    let state: "pending" | "ready" | "unsupported" | "closed" = "pending"
+
+    function wake() {
+      for (const notify of changes) notify()
+    }
+
+    function check(signal: AbortSignal) {
+      if (signal.aborted) throw failure("cancelled")
+    }
+
+    function pause(ms: number, signal: AbortSignal, changing = false) {
+      check(signal)
+      return new Promise<void>((resolve, reject) => {
+        const cleanup = () => {
+          timers.clearTimeout(timer)
+          changes.delete(finish)
+          signal.removeEventListener("abort", abort)
+        }
+        const finish = () => {
+          cleanup()
+          resolve()
+        }
+        const abort = () => {
+          cleanup()
+          reject(failure("cancelled"))
+        }
+        const timer = timers.setTimeout(finish, Math.max(0, ms))
+        if (changing) changes.add(finish)
+        signal.addEventListener("abort", abort, { once: true })
+      })
+    }
+
+    async function ready(signal: AbortSignal, end: number) {
+      const deadline = Math.min(end, now() + 5_000)
+      while (true) {
+        check(signal)
+        if (state === "ready" && connection().connected) return
+        if (state === "unsupported") throw failure("unsupported")
+        if (state === "closed" || now() >= deadline) throw failure("delivery_interrupted", true)
+        await pause(deadline - now(), signal, true)
+      }
+    }
+
+    async function request(input: Request, signal: AbortSignal, end: number, watch?: Watch): Promise<Response> {
+      await ready(signal, end)
+      check(signal)
+      if (now() >= end) throw failure("delivery_interrupted", true)
+      const requestId = crypto.randomUUID()
+      const message = RemoteProtocol.BrowserRequest.parse({ ...input, type: "browser_request", requestId })
+      const deferred = Promise.withResolvers<Response>()
+      const abort = () => deferred.reject(failure("cancelled"))
+      const timer = timers.setTimeout(
+        () => deferred.reject(failure("delivery_interrupted", true)),
+        Math.min(10_000, end - now()),
+      )
+      pending.set(requestId, deferred)
+      if (watch) routes.set(requestId, watch)
+      signal.addEventListener("abort", abort, { once: true })
+      try {
+        try {
+          if (!connection().send(message, { connectedOnly: true }))
+            deferred.reject(failure("delivery_interrupted", true))
+        } catch {
+          deferred.reject(failure("delivery_interrupted", true))
+        }
+        const response = await deferred.promise
+        if (response.kind === "error") throw failure(response.code, response.retryable)
+        return response
+      } finally {
+        timers.clearTimeout(timer)
+        signal.removeEventListener("abort", abort)
+        pending.delete(requestId)
+        // A live job keeps its correlated event route until its tool call settles.
+        if (!watch) routes.delete(requestId)
+      }
+    }
+
+    const authority = (owner: Owner) => ({
+      parentSessionId: owner.parentSessionId,
+      parentProof: Redacted.value(owner.proof),
+    })
+
+    async function retry<T>(fn: () => Promise<T>, signal: AbortSignal, end: number): Promise<T> {
+      while (true) {
+        check(signal)
+        try {
+          return await fn()
+        } catch (err) {
+          if (!(err instanceof Error) || err.data.code !== "delivery_interrupted" || now() >= end) throw err
+          await pause(Math.min(1_000, end - now()), signal)
+        }
+      }
+    }
+
+    async function remember(owner: Owner, watch: Watch, value: Handle, hooks: Hooks) {
+      if (
+        !matches(
+          {
+            providerId: watch.intent.providerId,
+            invocationId: watch.intent.invocationId,
+            browserTaskId: watch.intent.browserTaskId,
+          },
+          value,
+        )
+      )
+        throw failure("invalid_response")
+      if (watch.handle && !matches(watch.handle, value)) throw failure("invalid_response")
+      watch.handle = await owner.remember({
+        providerId: value.providerId,
+        browserTaskId: value.browserTaskId,
+        jobId: value.jobId,
+        invocationId: value.invocationId,
+      })
+      await hooks.metadata({
+        ...ids(value),
+        status: "accepted",
+        reason: "accepted",
+        summary: "Browser task accepted.",
+        evidence: [],
+        effectsUncertain: false,
+      })
+    }
+
+    async function lookup(owner: Owner, watch: Watch, hooks: Hooks, end: number) {
+      const response = await retry(
+        () =>
+          request(
+            { operation: "recover", owner: authority(owner), invocationId: watch.intent.invocationId },
+            hooks.signal,
+            end,
+            watch,
+          ),
+        hooks.signal,
+        end,
+      )
+      if (response.kind === "not_found" && response.invocationId === watch.intent.invocationId) return undefined
+      if (response.kind !== "recovered") throw failure("invalid_response")
+      verify(watch.intent, response.job)
+      await remember(owner, watch, response.job, hooks)
+      watch.latest = response.job
+      watch.lost = undefined
+      return response.job
+    }
+
+    function interrupted(watch: Watch, err: Failure = failure("delivery_interrupted", true)): Output {
+      return { ...rejected(err), ...ids(watch.handle ?? watch.intent), guidance: recovery }
+    }
+
+    function release(watch: Watch) {
+      watches.delete(watch)
+      for (const [id, route] of routes) if (route === watch) routes.delete(id)
+    }
+
+    async function wait(owner: Owner, watch: Watch, hooks: Hooks, bound?: number): Promise<Output> {
+      let next = 0
+      let deadline = now() + 30_000
+      while (true) {
+        check(hooks.signal)
+        const latest = watch.latest
+        watch.latest = undefined
+        if (latest) {
+          const value = output(latest)
+          await hooks.metadata(value)
+          if (RemoteProtocol.BrowserTerminalStatus.safeParse(latest.status).success) return value
+          if ("deadlines" in latest)
+            deadline =
+              Date.parse(latest.deadlines.execution ?? latest.deadlines.approval ?? latest.deadlines.queue) + 30_000
+        }
+        const end = Math.min(bound ?? Infinity, deadline, (watch.lost ?? now()) + 30_000)
+        if (now() >= end) return interrupted(watch)
+        if (now() < next) {
+          await pause(Math.min(next, end) - now(), hooks.signal, true)
+          continue
+        }
+        const handle = watch.handle
+        if (!handle) throw failure("invalid_response")
+        const started = now()
+        next = started + 1_000
+        try {
+          const response = await request(
+            { operation: "status", owner: authority(owner), browserTaskId: handle.browserTaskId, jobId: handle.jobId },
+            hooks.signal,
+            end,
+            watch,
+          )
+          if (response.kind !== "status") throw failure("invalid_response")
+          verify({ ...watch.intent, handle }, response.job)
+          // A terminal event received during this status request wins over older progress.
+          if (!watch.latest || !terminal(watch.latest)) watch.latest = response.job
+          watch.lost = undefined
+        } catch (err) {
+          if (!(err instanceof Error) || err.data.code !== "delivery_interrupted") throw err
+          watch.lost ??= started
+        }
+      }
+    }
+
+    async function stop(owner: Owner, watch: Watch, hooks: Hooks): Promise<Output> {
+      const end = now() + 10_000
+      const stopping = { ...hooks, signal: new AbortController().signal }
+      try {
+        if (!watch.handle && !(await lookup(owner, watch, stopping, end))) {
+          return { ...rejected(failure("cancelled")), ...ids(watch.intent), status: "cancelled" }
+        }
+        const handle = watch.handle
+        if (!handle) throw failure("invalid_response")
+        const response = await request(
+          { operation: "cancel", owner: authority(owner), browserTaskId: handle.browserTaskId, jobId: handle.jobId },
+          stopping.signal,
+          end,
+          watch,
+        )
+        if (response.kind !== "ack" || response.operation !== "cancel" || !matches(handle, response))
+          throw failure("invalid_response")
+        return await wait(owner, watch, stopping, end)
+      } catch (err) {
+        if (!(err instanceof Error)) throw err
+        return {
+          ...interrupted(watch),
+          summary: "Cancellation could not be confirmed. Issued browser actions are not undone. " + recovery,
+        }
+      }
+    }
+
+    async function recover(owner: Owner, hooks: Hooks, records?: Intent[]): Promise<Output> {
+      const retained = records ?? (await owner.recover())
+      const end = now() + 30_000
+      const jobs: Output[] = []
+      for (const intent of retained) {
+        const watch: Watch = { intent, handle: intent.handle }
+        watches.add(watch)
+        try {
+          const job = await lookup(owner, watch, hooks, end)
+          jobs.push(
+            job
+              ? output(job)
+              : {
+                  ...ids(intent),
+                  status: "not_found",
+                  reason: "not_found",
+                  summary:
+                    "The relay has no accepted job for this retained intent. " +
+                    "Only the original trusted call can retry its unchanged goal and invocation. " +
+                    "Use an explicit operation=run with provider_id for a new goal; this intent will not replay.",
+                  evidence: [],
+                  effectsUncertain: false,
+                },
+          )
+        } catch (err) {
+          if (!(err instanceof Error)) throw err
+          if (err.data.code === "cancelled") throw err
+          jobs.push({ ...rejected(err), ...ids(watch.handle ?? intent), guidance: recovery })
+        } finally {
+          release(watch)
+        }
+      }
+      return {
+        status: jobs.length ? "recovered" : "empty",
+        reason: jobs.length ? "status_recovery" : "no_retained_intents",
+        summary: jobs.length
+          ? "Retrieved retained browser intents without dispatching work."
+          : "This parent has no retained browser intent to recover.",
+        ...(!jobs.length
+          ? {
+              guidance:
+                "Use browser_task with operation=list to discover providers, then explicitly call operation=run with provider_id and a new goal.",
+            }
+          : {}),
+        evidence: [],
+        effectsUncertain: jobs.some((job) => job.effectsUncertain),
+        jobs,
+      }
+    }
+
+    async function run(owner: Owner, input: Parameters<Owner["prepare"]>[0], hooks: Hooks): Promise<Output> {
+      const records = await owner.recover()
+      const unresolved = records.filter((record) => !record.handle && record.invocationId !== owner.invocationId)
+      if (unresolved.length) {
+        const result = await recover(owner, hooks, unresolved)
+        // Recheck on each explicit call; only authoritative not-found permits this new goal, never prior-intent replay.
+        if (!result.jobs?.every((job) => job.status === "not_found"))
+          return {
+            ...result,
+            status: "recovery_required",
+            summary:
+              "Resolved or surfaced earlier unacknowledged intents before any new submission. Review their status before an explicit new run.",
+            guidance: recovery,
+          }
+      }
+      const saved = records.find((record) => record.invocationId === owner.invocationId)
+      const intent = await owner.prepare(input)
+      const watch: Watch = { intent, handle: saved?.handle }
+      watches.add(watch)
+      const end = now() + 30_000
+      try {
+        if (saved) await lookup(owner, watch, hooks, end)
+        while (!watch.handle) {
+          check(hooks.signal)
+          try {
+            const response = await request(
+              { operation: "invoke", owner: authority(owner), invocationId: intent.invocationId, ...input },
+              hooks.signal,
+              end,
+              watch,
+            )
+            if (response.kind !== "ack" || response.operation !== "invoke") throw failure("invalid_response")
+            await remember(owner, watch, response, hooks)
+          } catch (err) {
+            if (!(err instanceof Error) || err.data.code !== "delivery_interrupted") throw err
+            // Only authoritative not-found permits another send of this exact stored invocation and payload.
+            if (await lookup(owner, watch, hooks, end)) break
+            await pause(Math.min(1_000, Math.max(0, end - now())), hooks.signal)
+          }
+          if (!watch.handle && now() >= end) return interrupted(watch)
+        }
+        return await wait(owner, watch, hooks)
+      } catch (err) {
+        if (hooks.signal.aborted) return await stop(owner, watch, hooks)
+        if (err instanceof Error && err.data.code === "delivery_interrupted") return interrupted(watch)
+        throw err
+      } finally {
+        release(watch)
+      }
+    }
+
+    async function status(
+      owner: Owner,
+      task: Handle["browserTaskId"],
+      job: Handle["jobId"] | undefined,
+      hooks: Hooks,
+      cancel = false,
+    ): Promise<Output> {
+      const owned = await owner.lookup(task, job)
+      const end = now() + 30_000
+      const response = await retry(
+        () =>
+          request({ operation: "status", owner: authority(owner), browserTaskId: task, jobId: job }, hooks.signal, end),
+        hooks.signal,
+        end,
+      ).catch((err: unknown) => {
+        if (err instanceof Error && err.data.code === "delivery_interrupted") return err
+        throw err
+      })
+      if (response instanceof Error) return { ...rejected(response), ...ids(owned) }
+      if (response.kind !== "status" || !matches(owned, response.job)) throw failure("invalid_response")
+      const intent = (await owner.recover()).find((record) => record.invocationId === response.job.invocationId)
+      if (!intent) throw failure("invalid_response")
+      verify(intent, response.job)
+      await hooks.metadata(output(response.job))
+      if (!cancel || response.job.result) return output(response.job)
+      const watch: Watch = { intent, handle: intent.handle, latest: response.job }
+      watches.add(watch)
+      try {
+        return await stop(owner, watch, hooks)
+      } finally {
+        release(watch)
+      }
+    }
+
+    return {
+      run,
+      recover,
+      status,
+      async list(signal: AbortSignal): Promise<Output> {
+        const providers: NonNullable<Output["providers"]> = []
+        const cursors = new Set<string>()
+        const end = now() + 30_000
+        let cursor: Handle["providerId"] | undefined
+        do {
+          const response = await retry(() => request({ operation: "list", cursor }, signal, end), signal, end)
+          if (response.kind !== "providers") throw failure("invalid_response")
+          providers.push(...response.providers)
+          cursor = response.nextCursor
+          if (cursor && cursors.has(cursor)) throw failure("invalid_response")
+          if (cursor) cursors.add(cursor)
+        } while (cursor)
+        return {
+          status: providers.length ? "available" : "empty",
+          reason: providers.length ? "providers" : "no_enabled_providers",
+          summary: providers.length
+            ? "Choose an explicit provider_id for every run or continuation."
+            : "No enabled browser provider is available. " + panel,
+          evidence: [],
+          effectsUncertain: false,
+          providers,
+        }
+      },
+      open() {
+        state = "pending"
+        wake()
+        void connection()
+          .heartbeat()
+          .catch(() => {
+            if (state !== "closed") wake()
+          })
+      },
+      disconnect() {
+        state = "pending"
+        for (const watch of watches) watch.lost ??= now()
+        for (const waiter of pending.values()) waiter.reject(failure("delivery_interrupted", true))
+        routes.clear()
+        wake()
+      },
+      close() {
+        state = "closed"
+        for (const waiter of pending.values()) waiter.reject(failure("delivery_interrupted", true))
+        routes.clear()
+        wake()
+      },
+      handle(message: RemoteProtocol.HeartbeatAck | RemoteProtocol.BrowserResponse | RemoteProtocol.BrowserEvent) {
+        if (state === "closed") return
+        if (message.type === "heartbeat_ack") {
+          // Old relays omit this capability; fail closed until every old relay retires.
+          state = RemoteProtocol.NormalizedBrowserCapabilities.parse(message.capabilities).browserJobsV1
+            ? "ready"
+            : "unsupported"
+          wake()
+          return
+        }
+        if (state !== "ready") return
+        if (message.type === "browser_response") {
+          pending.get(message.requestId)?.resolve(message.response)
+          return
+        }
+        const watch = routes.get(message.requestId)
+        const update = message.event === "progress" ? message.job : message.result
+        if (!watch?.handle || !matches(watch.handle, update)) return
+        if (watch.latest && terminal(watch.latest)) return
+        watch.latest = update
+        wake()
+      },
+    }
+  }
+}

--- a/packages/opencode/src/kilocode/browser-task/client.ts
+++ b/packages/opencode/src/kilocode/browser-task/client.ts
@@ -2,7 +2,7 @@ import { NamedError } from "@opencode-ai/core/util/error"
 import { Effect, Redacted, Schema } from "effect"
 import { RemoteProtocol } from "../../kilo-sessions/remote-protocol"
 import type { RemoteWS } from "../../kilo-sessions/remote-ws"
-import type { BrowserOwner } from "./owner"
+import { BrowserOwner } from "./owner"
 
 export namespace BrowserClient {
   type Owner = Effect.Success<ReturnType<typeof BrowserOwner.open>>
@@ -44,8 +44,13 @@ export namespace BrowserClient {
     message: Schema.String,
     retryable: Schema.Boolean,
   })
-  const recovery = "Use browser_task with operation=recover to retrieve stored status without replay."
+  const recovery =
+    "Once private browser storage is available, use browser_task with operation=recover to retrieve stored status without replay. " +
+    "Recovery uses the original retained intent. Do not automatically repeat operation=run."
   const panel = "Enable CLI tasks for the browser profile and keep its signed-in panel open. Refresh operation=list."
+  const busy =
+    "Use browser_task with operation=status and the same browser_task_id to check the outstanding job. " +
+    "Use operation=cancel with that browser_task_id to request cancellation. Do not automatically retry the continuation."
   const uncertain =
     "Close the affected bound tabs, release execution locks, and use the panel recovery action. " +
     "Then explicitly continue with provider_id and browser_task_id and approve a fresh tab."
@@ -58,6 +63,7 @@ export namespace BrowserClient {
         "Browser result delivery was interrupted; this does not establish browser failure. " + recovery,
       provider_unavailable: "The selected browser provider is unavailable. " + panel,
       capacity_exceeded: "The browser queue or retained job limit is full. Wait for capacity, then refresh discovery.",
+      conversation_busy: "This browser conversation has an outstanding job. " + busy,
       cancelled: "The tool call was cancelled. Cancellation does not undo browser actions already issued.",
       invalid_response: "The browser response does not match this parent's request. No result was delivered.",
     }
@@ -78,6 +84,7 @@ export namespace BrowserClient {
       retryable: data.retryable,
       ...(data.code === "effects_uncertain" ? { guidance: uncertain } : {}),
       ...(data.code === "delivery_interrupted" ? { guidance: recovery } : {}),
+      ...(data.code === "conversation_busy" ? { guidance: busy } : {}),
     }
   }
 
@@ -248,11 +255,24 @@ export namespace BrowserClient {
       )
         throw failure("invalid_response")
       if (watch.handle && !matches(watch.handle, value)) throw failure("invalid_response")
-      watch.handle = await owner.remember({
+      // Relay acceptance remains authoritative even if local persistence fails.
+      watch.handle = {
         providerId: value.providerId,
         browserTaskId: value.browserTaskId,
         jobId: value.jobId,
         invocationId: value.invocationId,
+      }
+      await owner.remember(watch.handle).catch((err: unknown) => {
+        if (!(err instanceof BrowserOwner.Error)) throw err
+        throw new Error({
+          code: "delivery_interrupted",
+          message:
+            "The relay accepted the browser task, but local handle persistence failed. " +
+            err.data.message +
+            " Browser result delivery was interrupted; this does not establish browser failure. " +
+            recovery,
+          retryable: err.data.retryable,
+        })
       })
       await hooks.metadata({
         ...ids(value),
@@ -279,14 +299,22 @@ export namespace BrowserClient {
       if (response.kind === "not_found" && response.invocationId === watch.intent.invocationId) return undefined
       if (response.kind !== "recovered") throw failure("invalid_response")
       verify(watch.intent, response.job)
+      if (!watch.latest || !terminal(watch.latest)) watch.latest = response.job
       await remember(owner, watch, response.job, hooks)
-      watch.latest = response.job
       watch.lost = undefined
       return response.job
     }
 
     function interrupted(watch: Watch, err: Failure = failure("delivery_interrupted", true)): Output {
-      return { ...rejected(err), ...ids(watch.handle ?? watch.intent), guidance: recovery }
+      const latest = watch.latest ? output(watch.latest) : undefined
+      // Local delivery failure cannot replace an already observed terminal outcome.
+      return {
+        ...rejected(err),
+        ...(terminal(watch.latest) ? latest : {}),
+        ...ids(watch.handle ?? watch.intent),
+        ...(latest ? { summary: latest.summary + " " + err.data.message } : {}),
+        guidance: latest?.guidance ? latest.guidance + " " + recovery : recovery,
+      }
     }
 
     function release(watch: Watch) {
@@ -392,7 +420,11 @@ export namespace BrowserClient {
         } catch (err) {
           if (!(err instanceof Error)) throw err
           if (err.data.code === "cancelled") throw err
-          jobs.push({ ...rejected(err), ...ids(watch.handle ?? intent), guidance: recovery })
+          jobs.push(
+            err.data.code === "delivery_interrupted"
+              ? interrupted(watch, err)
+              : { ...rejected(err), ...ids(watch.handle ?? intent), guidance: recovery },
+          )
         } finally {
           release(watch)
         }
@@ -449,7 +481,7 @@ export namespace BrowserClient {
             if (response.kind !== "ack" || response.operation !== "invoke") throw failure("invalid_response")
             await remember(owner, watch, response, hooks)
           } catch (err) {
-            if (!(err instanceof Error) || err.data.code !== "delivery_interrupted") throw err
+            if (watch.handle || !(err instanceof Error) || err.data.code !== "delivery_interrupted") throw err
             // Only authoritative not-found permits another send of this exact stored invocation and payload.
             if (await lookup(owner, watch, hooks, end)) break
             await pause(Math.min(1_000, Math.max(0, end - now())), hooks.signal)
@@ -459,7 +491,7 @@ export namespace BrowserClient {
         return await wait(owner, watch, hooks)
       } catch (err) {
         if (hooks.signal.aborted) return await stop(owner, watch, hooks)
-        if (err instanceof Error && err.data.code === "delivery_interrupted") return interrupted(watch)
+        if (err instanceof Error && err.data.code === "delivery_interrupted") return interrupted(watch, err)
         throw err
       } finally {
         release(watch)

--- a/packages/opencode/src/kilocode/sandbox/network-tools.ts
+++ b/packages/opencode/src/kilocode/sandbox/network-tools.ts
@@ -1,4 +1,5 @@
 export const opaque = [
+  { id: "browser_task", file: "kilocode/tool/browser-task.ts" },
   { id: "semantic_search", file: "kilocode/tool/semantic-search.ts" },
   { id: "lsp", file: "tool/lsp.ts" },
 ] as const

--- a/packages/opencode/src/kilocode/tool/browser-task.ts
+++ b/packages/opencode/src/kilocode/tool/browser-task.ts
@@ -1,0 +1,131 @@
+import { Database } from "@opencode-ai/core/database/database"
+import { assertNetwork } from "@kilocode/sandbox"
+import { Effect, Schema } from "effect"
+import { EffectBridge } from "../../effect/bridge"
+import { KiloSessions } from "../../kilo-sessions/kilo-sessions"
+import { RemoteProtocol } from "../../kilo-sessions/remote-protocol"
+import { BrowserClient } from "../browser-task/client"
+import { BrowserOwner } from "../browser-task/owner"
+import { Tool } from "../../tool/tool"
+
+const Params = Schema.declare<RemoteProtocol.BrowserTaskArguments>(
+  (value): value is RemoteProtocol.BrowserTaskArguments => RemoteProtocol.BrowserTaskArguments.safeParse(value).success,
+)
+
+export const BrowserTaskTool = Tool.define(
+  "browser_task",
+  Effect.gen(function* () {
+    const db = yield* Database.Service
+    return {
+      description:
+        "Delegate a goal to an explicitly enabled browser profile through the authenticated relay. " +
+        "The signed-in browser panel must remain open. List providers without dispatching work. " +
+        "Run requires provider_id and goal, including every continuation with browser_task_id. " +
+        "Status and cancel require an owned browser_task_id, with optional job_id. " +
+        "Recover takes no IDs and retrieves this parent's durable intents without replay. " +
+        "Each run requires tool permission and fresh browser tab consent. Only the new goal reaches the browser, not this chat history. " +
+        "Cancellation cannot undo issued actions. After uncertain execution, close affected tabs, release execution locks, " +
+        "and use panel recovery before an explicit continuation with fresh tab consent.",
+      parameters: Params,
+      // Keep the advertised schema an object for model APIs that reject top-level unions.
+      // Params still enforces each operation's exact fields through the shared strict contract.
+      jsonSchema: {
+        type: "object" as const,
+        additionalProperties: false,
+        properties: {
+          operation: { type: "string" as const, enum: ["list", "run", "status", "cancel", "recover"] },
+          provider_id: {
+            type: "string" as const,
+            description:
+              "Required for run, including continuation. Use an explicit provider ID from list. Omit otherwise.",
+          },
+          goal: {
+            type: "string" as const,
+            minLength: 1,
+            maxLength: RemoteProtocol.BROWSER_GOAL_MAX_BYTES,
+            description: "Required only for run. At most 16 KiB of UTF-8. Send only the new goal.",
+          },
+          browser_task_id: {
+            type: "string" as const,
+            description:
+              "Owned conversation ID. Optional for run continuation; required for status/cancel. Omit for list/recover.",
+          },
+          job_id: {
+            type: "string" as const,
+            description: "Optional for status/cancel. Omit to select the owned conversation's latest job.",
+          },
+        },
+        required: ["operation"],
+      },
+      formatValidationError: () =>
+        "Use only the fields for the selected operation. Run requires provider_id and goal; status/cancel require browser_task_id. Identity fields are forbidden.",
+      execute: (args: RemoteProtocol.BrowserTaskArguments, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          yield* assertNetwork("tool:browser_task", "executeTool")
+          // Getting the client never enables remote access, shares a session, or exposes credentials.
+          const client = yield* Effect.try({ try: () => KiloSessions.browser(), catch: (err) => err })
+          if (args.operation === "list")
+            return yield* Effect.tryPromise({ try: () => client.list(ctx.abort), catch: (err) => err })
+          yield* ctx.ask({
+            permission: "browser_task",
+            patterns: [
+              args.operation === "run"
+                ? args.provider_id
+                : args.operation === "recover"
+                  ? "recover"
+                  : args.browser_task_id,
+            ],
+            always: [],
+            metadata: {
+              operation: args.operation,
+              ...(args.operation === "run" ? { provider_id: args.provider_id, goal: args.goal } : {}),
+            },
+          })
+          const owner = yield* BrowserOwner.open(ctx).pipe(Effect.provideService(Database.Service, db))
+          const bridge = yield* EffectBridge.make()
+          const hooks = {
+            signal: ctx.abort,
+            metadata: (value: BrowserClient.Output) =>
+              bridge.promise(ctx.metadata({ title: `Browser task: ${value.status}`, metadata: value })),
+          }
+          return yield* Effect.tryPromise({
+            try: async () => {
+              if (args.operation === "recover") return client.recover(owner, hooks)
+              if (args.operation !== "run")
+                return client.status(owner, args.browser_task_id, args.job_id, hooks, args.operation === "cancel")
+              await owner.approve(args.provider_id)
+              return client.run(
+                owner,
+                {
+                  providerId: args.provider_id,
+                  goal: args.goal,
+                  ...(args.browser_task_id ? { browserTaskId: args.browser_task_id } : {}),
+                },
+                hooks,
+              )
+            },
+            catch: (err) => err,
+          })
+        }).pipe(
+          Effect.catch((err) => {
+            if (err instanceof BrowserOwner.Error)
+              return Effect.succeed({
+                status: "rejected",
+                reason: err.data.code,
+                summary: err.data.message,
+                evidence: [],
+                effectsUncertain: false,
+                retryable: err.data.retryable,
+              } satisfies BrowserClient.Output)
+            if (err instanceof BrowserClient.Error) return Effect.succeed(BrowserClient.rejected(err))
+            return Effect.die(err)
+          }),
+          Effect.map((result) => ({
+            title: `Browser task: ${result.status}`,
+            output: JSON.stringify(result, null, 2),
+            metadata: { ...result },
+          })),
+        ),
+    }
+  }),
+)

--- a/packages/opencode/src/kilocode/tool/registry.ts
+++ b/packages/opencode/src/kilocode/tool/registry.ts
@@ -2,6 +2,7 @@ import { RecallTool } from "../../tool/recall"
 import { AgentManagerModelsTool } from "./agent-manager-models"
 import { AgentManagerTool } from "./agent-manager"
 import { BackgroundProcessTool } from "./background-process"
+import { BrowserTaskTool } from "./browser-task"
 import { ChartTool } from "./chart"
 import { GenerateImageTool } from "./generate-image"
 import { InteractiveTerminalTool } from "./interactive-terminal"
@@ -75,6 +76,7 @@ export namespace KiloToolRegistry {
       const process = yield* BackgroundProcessTool
       const chart = yield* ChartTool
       const image = yield* GenerateImageTool
+      const browser = yield* BrowserTaskTool
       const terminal = yield* InteractiveTerminalTool
       // The notify_user tool depends on KiloSessions.Service, which the tool-registry layer provides
       // via KiloSessions.defaultLayer (see src/tool/registry.ts). Grabs the service from the surrounding
@@ -83,13 +85,27 @@ export namespace KiloToolRegistry {
       const notify = yield* NotifyUserTool.pipe(Effect.provideService(KiloSessions.Service, sessions))
       const send = yield* SendFileTool
       if (!notebook)
-        return { recall, managerModels, memory, save, manager, process, chart, image, terminal, notify, send }
+        return { recall, managerModels, memory, save, manager, process, chart, image, terminal, notify, send, browser }
       const tools = yield* Effect.all({
         notebookRead: NotebookReadTool,
         notebookEdit: NotebookEditTool,
         notebookExecute: NotebookExecuteTool,
       }).pipe(Effect.provideService(Notebook.Service, notebook))
-      return { recall, managerModels, memory, save, manager, process, chart, image, terminal, notify, send, ...tools }
+      return {
+        recall,
+        managerModels,
+        memory,
+        save,
+        manager,
+        process,
+        chart,
+        image,
+        terminal,
+        notify,
+        send,
+        browser,
+        ...tools,
+      }
     })
   }
 
@@ -108,6 +124,7 @@ export namespace KiloToolRegistry {
       terminal?: Tool.Info
       notify: Tool.Info
       send: Tool.Info
+      browser?: Tool.Info
       notebookRead?: Tool.Info
       notebookEdit?: Tool.Info
       notebookExecute?: Tool.Info
@@ -129,6 +146,7 @@ export namespace KiloToolRegistry {
         send: Tool.init(tools.send),
       })
       const terminal = tools.terminal ? yield* Tool.init(tools.terminal) : undefined
+      const browser = tools.browser ? yield* Tool.init(tools.browser) : undefined
       const notebooks =
         tools.notebookRead && tools.notebookEdit && tools.notebookExecute
           ? yield* Effect.all({
@@ -138,7 +156,7 @@ export namespace KiloToolRegistry {
             })
           : {}
       const semantic = yield* semanticTool(deps, loaders)
-      return { ...base, terminal, ...notebooks, semantic, notify: base.notify, send: base.send }
+      return { ...base, terminal, browser, ...notebooks, semantic, notify: base.notify, send: base.send }
     })
   }
 
@@ -202,6 +220,7 @@ export namespace KiloToolRegistry {
       terminal?: Tool.Def
       notify: Tool.Def
       send: Tool.Def
+      browser?: Tool.Def
       notebookRead?: Tool.Def
       notebookEdit?: Tool.Def
       notebookExecute?: Tool.Def
@@ -227,6 +246,7 @@ export namespace KiloToolRegistry {
         : []),
       tools.notify,
       tools.send,
+      ...(tools.browser ? [tools.browser] : []),
     ]
   }
 

--- a/packages/opencode/test/kilocode/browser-task/client.test.ts
+++ b/packages/opencode/test/kilocode/browser-task/client.test.ts
@@ -1,0 +1,957 @@
+import { describe, expect, test } from "bun:test"
+import { createHash } from "node:crypto"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { Database } from "@opencode-ai/core/database/database"
+import { Global } from "@opencode-ai/core/global"
+import { ProjectV2 } from "@opencode-ai/core/project"
+import { ProjectTable } from "@opencode-ai/core/project/sql"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { MessageTable, SessionTable } from "@opencode-ai/core/session/sql"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { Effect, Layer } from "effect"
+import { BrowserClient } from "../../../src/kilocode/browser-task/client"
+import { BrowserOwner } from "../../../src/kilocode/browser-task/owner"
+import { RemoteProtocol } from "../../../src/kilo-sessions/remote-protocol"
+import { MessageID, SessionID } from "../../../src/session/schema"
+import type { Tool } from "../../../src/tool/tool"
+import { tmpdir } from "../../fixture/fixture"
+import { testEffect } from "../../lib/effect"
+
+const it = testEffect(Database.layerFromPath(":memory:"))
+const provider = "bp_00000000-0000-4000-8000-000000000001"
+const input = { providerId: provider, goal: "Read the page title" } as const
+type Request = RemoteProtocol.BrowserRequest
+type Owner = Parameters<BrowserClient.Client["run"]>[0]
+
+function seed(sessionID = SessionID.make(`ses_${crypto.randomUUID()}`)) {
+  return Effect.gen(function* () {
+    const db = yield* Database.Service
+    const ctx: Tool.Context = {
+      sessionID,
+      messageID: MessageID.ascending(),
+      callID: crypto.randomUUID(),
+      agent: "test",
+      abort: new AbortController().signal,
+      messages: [],
+      ask: () => Effect.void,
+      metadata: () => Effect.void,
+    }
+    const project = ProjectV2.ID.make("b".repeat(40))
+    yield* db.db
+      .insert(ProjectTable)
+      .values({ id: project, worktree: AbsolutePath.make(Global.Path.data), sandboxes: [] })
+      .onConflictDoNothing()
+      .run()
+    yield* db.db
+      .insert(SessionTable)
+      .values({
+        id: sessionID,
+        project_id: project,
+        slug: "browser-client",
+        directory: AbsolutePath.make(Global.Path.data),
+        title: "Browser client",
+        version: "test",
+      })
+      .onConflictDoNothing()
+      .run()
+    const data = {
+      role: "assistant" as const,
+      time: { created: Date.now() },
+      parentID: SessionV1.MessageID.make("msg_parent"),
+      providerID: "test",
+      modelID: "test",
+      mode: "test",
+      agent: "test",
+      path: { cwd: Global.Path.data, root: Global.Path.data },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    }
+    yield* db.db
+      .insert(MessageTable)
+      .values({
+        id: SessionV1.MessageID.make(ctx.messageID),
+        session_id: sessionID,
+        time_created: Date.now(),
+        data,
+      })
+      .run()
+    const owner = yield* BrowserOwner.open(ctx)
+    yield* Effect.promise(() => owner.approve(provider))
+    return { ctx, owner }
+  })
+}
+
+class Clock {
+  now = Date.now()
+  timers = new Map<unknown, { at: number; fn: () => void }>()
+  setTimeout(fn: () => void, ms = 0) {
+    const id = {}
+    this.timers.set(id, { at: this.now + ms, fn })
+    return id
+  }
+  clearTimeout(id: unknown) {
+    this.timers.delete(id)
+  }
+  async advance(ms: number) {
+    const end = this.now + ms
+    for (;;) {
+      for (let n = 0; n < 30; n++) await Promise.resolve()
+      const next = [...this.timers]
+        .filter(([, timer]) => timer.at <= end)
+        .sort((a, b) => a[1].at - b[1].at)
+        .at(0)
+      if (!next) {
+        this.now = end
+        return
+      }
+      this.now = next[1].at
+      this.timers.delete(next[0])
+      next[1].fn()
+    }
+  }
+}
+
+function link(clock = new Clock()) {
+  const requests: Request[] = []
+  const unread: Request[] = []
+  const waiting = new Map<string, (request: Request) => void>()
+  const updates: BrowserClient.Output[] = []
+  const controller = new AbortController()
+  const connection = {
+    connected: true,
+    heartbeat: async () => {},
+    send(message: RemoteProtocol.OutboundWithBrowser) {
+      if (message.type !== "browser_request" || !connection.connected) return false
+      requests.push(message)
+      const resolve = waiting.get(message.operation)
+      if (resolve) {
+        waiting.delete(message.operation)
+        resolve(message)
+      } else unread.push(message)
+      return true
+    },
+  }
+  const client = BrowserClient.create(() => connection, { timers: clock, now: () => clock.now })
+  const hooks = {
+    signal: controller.signal,
+    metadata: async (value: BrowserClient.Output) => {
+      updates.push(value)
+    },
+  }
+  const negotiate = () => client.handle({ type: "heartbeat_ack", capabilities: { browserJobsV1: true } })
+  const reply = (request: Request, response: RemoteProtocol.BrowserResponse["response"]) =>
+    client.handle(
+      RemoteProtocol.BrowserResponse.parse({ type: "browser_response", requestId: request.requestId, response }),
+    )
+  function next(operation: Request["operation"]) {
+    const index = unread.findIndex((request) => request.operation === operation)
+    if (index !== -1) return Promise.resolve(unread.splice(index, 1).at(0)!)
+    return new Promise<Request>((resolve) => waiting.set(operation, resolve))
+  }
+  negotiate()
+  return { client, connection, requests, updates, controller, hooks, clock, negotiate, reply, next }
+}
+
+async function snapshot(owner: Owner, request: Request): Promise<RemoteProtocol.BrowserJobSnapshot> {
+  if (request.operation !== "invoke") throw new Error("Expected an invocation")
+  const intent = (await owner.recover()).find((record) => record.invocationId === request.invocationId)
+  if (!intent) throw new Error("Dispatch occurred before durable intent publication")
+  const created = Number(request.invocationId.split(".").at(1))
+  // The relay hashes JSON fields, including the authenticated user and proof digest, not the local intent hash.
+  const hash = (fields: string[]) => createHash("sha256").update(JSON.stringify(fields)).digest("hex")
+  return RemoteProtocol.BrowserJobSnapshot.parse({
+    providerId: request.providerId,
+    browserTaskId: request.browserTaskId ?? `bt_${crypto.randomUUID()}`,
+    jobId: `bj_${crypto.randomUUID()}`,
+    invocationId: request.invocationId,
+    payloadFingerprint: hash([
+      "user_1",
+      request.owner.parentSessionId,
+      hash([request.owner.parentProof]),
+      request.providerId,
+      request.browserTaskId ?? "",
+      request.goal,
+    ]),
+    generation: 1,
+    status: "queued",
+    createdAt: new Date(created).toISOString(),
+    expiresAt: new Date(created + 604_800_000).toISOString(),
+    deadlines: { queue: new Date(created + 600_000).toISOString() },
+  })
+}
+
+function completed(
+  job: RemoteProtocol.BrowserJobSnapshot,
+  summary = "The page title is Example Domain.",
+): RemoteProtocol.BrowserJobSnapshot {
+  return RemoteProtocol.BrowserJobSnapshot.parse({
+    ...job,
+    status: "succeeded",
+    result: {
+      providerId: job.providerId,
+      browserTaskId: job.browserTaskId,
+      jobId: job.jobId,
+      invocationId: job.invocationId,
+      status: "succeeded",
+      reason: "completed",
+      effectsUncertain: false,
+      summary,
+      evidence: [{ title: "Example Domain", url: "https://example.com" }],
+    },
+  })
+}
+
+function ack(
+  wire: ReturnType<typeof link>,
+  request: Request,
+  job: RemoteProtocol.BrowserJobSnapshot,
+  operation: "invoke" | "cancel" = "invoke",
+) {
+  wire.reply(request, {
+    kind: "ack",
+    operation,
+    providerId: job.providerId,
+    browserTaskId: job.browserTaskId,
+    jobId: job.jobId,
+    invocationId: job.invocationId,
+  })
+}
+
+async function finish(wire: ReturnType<typeof link>, job: RemoteProtocol.BrowserJobSnapshot) {
+  const request = await wire.next("status")
+  wire.reply(request, { kind: "status", job: completed(job) })
+}
+
+describe("browser client delivery", () => {
+  test("requires negotiation, exposes empty discovery, and never dispatches list work", async () => {
+    const wire = link()
+    wire.client.open()
+    const pending = wire.client.list(wire.controller.signal)
+    await wire.clock.advance(4_999)
+    expect(wire.requests).toEqual([])
+    wire.negotiate()
+    const request = await wire.next("list")
+    wire.reply(request, { kind: "providers", providers: [] })
+    const result = await pending
+    expect(result.providers).toEqual([])
+    expect(result.summary).toContain("Enable CLI tasks")
+    expect(result.summary).toContain("panel open")
+    expect(wire.requests.map((request) => request.operation)).toEqual(["list"])
+    expect(wire.clock.timers.size).toBe(0)
+  })
+
+  test("rejects a legacy relay without sending a browser request", async () => {
+    const wire = link()
+    wire.client.handle({ type: "heartbeat_ack" })
+    expect(await wire.client.list(wire.controller.signal).catch((err: unknown) => err)).toMatchObject({
+      data: { code: "unsupported", retryable: false },
+    })
+    expect(wire.requests).toEqual([])
+  })
+
+  it.live("persists accepted IDs through metadata before status and returns the owned result", () =>
+    Effect.gen(function* () {
+      const { owner } = yield* seed()
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const pending = wire.client.run(owner, input, wire.hooks)
+        const request = await wire.next("invoke")
+        const job = await snapshot(owner, request)
+        ack(wire, request, job)
+        const status = await wire.next("status")
+        expect((await owner.recover()).at(0)?.handle?.jobId).toBe(job.jobId)
+        expect(wire.updates.at(0)).toMatchObject({
+          status: "accepted",
+          browser_task_id: job.browserTaskId,
+          job_id: job.jobId,
+        })
+        wire.reply(status, { kind: "status", job: completed(job) })
+        expect(await pending).toMatchObject({
+          status: "succeeded",
+          reason: "completed",
+          summary: "The page title is Example Domain.",
+          evidence: [{ title: "Example Domain", url: "https://example.com" }],
+          browser_task_id: job.browserTaskId,
+          job_id: job.jobId,
+          effectsUncertain: false,
+        })
+        expect(wire.clock.timers.size).toBe(0)
+      })
+    }),
+  )
+
+  it.live("recovers a lost acknowledgement without sending another invocation", () =>
+    Effect.gen(function* () {
+      const { owner } = yield* seed()
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const pending = wire.client.run(owner, input, wire.hooks)
+        const request = await wire.next("invoke")
+        const job = completed(await snapshot(owner, request))
+        await wire.clock.advance(10_000)
+        const lookup = await wire.next("recover")
+        expect(lookup).toMatchObject({ invocationId: job.invocationId })
+        wire.reply(lookup, { kind: "recovered", job })
+        expect((await pending).summary).toBe(job.result!.summary)
+        expect(wire.requests.filter((request) => request.operation === "invoke")).toHaveLength(1)
+      })
+    }),
+  )
+
+  it.live("retries only the stored invocation and unchanged payload after authoritative not-found", () =>
+    Effect.gen(function* () {
+      const { owner } = yield* seed()
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const pending = wire.client.run(owner, input, wire.hooks)
+        const first = await wire.next("invoke")
+        wire.client.disconnect()
+        wire.client.open()
+        wire.negotiate()
+        const lookup = await wire.next("recover")
+        wire.reply(lookup, { kind: "not_found", invocationId: owner.invocationId })
+        await wire.clock.advance(1_000)
+        const second = await wire.next("invoke")
+        expect(second).toMatchObject({
+          operation: "invoke",
+          invocationId: owner.invocationId,
+          providerId: provider,
+          goal: input.goal,
+        })
+        expect({ ...second, requestId: first.requestId }).toEqual(first)
+        const job = await snapshot(owner, second)
+        ack(wire, second, job)
+        await finish(wire, job)
+        expect((await pending).status).toBe("succeeded")
+      })
+    }),
+  )
+
+  it.live("reconnects after acceptance with status only and waits beyond a short command timeout", () =>
+    Effect.gen(function* () {
+      const { owner } = yield* seed()
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const pending = wire.client.run(owner, input, wire.hooks)
+        const request = await wire.next("invoke")
+        const job = await snapshot(owner, request)
+        ack(wire, request, job)
+        for (let n = 0; n < 35; n++) {
+          wire.reply(await wire.next("status"), { kind: "status", job })
+          await wire.clock.advance(1_000)
+        }
+        await wire.next("status")
+        wire.client.disconnect()
+        wire.connection.connected = false
+        await wire.clock.advance(20_000)
+        const before = wire.requests.length
+        wire.connection.connected = true
+        wire.client.open()
+        await wire.clock.advance(1_000)
+        expect(wire.requests).toHaveLength(before)
+        wire.negotiate()
+        await finish(wire, job)
+        expect((await pending).status).toBe("succeeded")
+        expect(wire.requests.filter((request) => request.operation === "invoke")).toHaveLength(1)
+      })
+    }),
+  )
+
+  it.live("retains known IDs and recovery guidance when owned status delivery is interrupted", () =>
+    Effect.gen(function* () {
+      const { owner } = yield* seed()
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const pending = wire.client.run(owner, input, wire.hooks)
+        const request = await wire.next("invoke")
+        const job = await snapshot(owner, request)
+        ack(wire, request, job)
+        await finish(wire, job)
+        await pending
+        const polling = wire.client.status(owner, job.browserTaskId, job.jobId, wire.hooks)
+        await wire.next("status")
+        await wire.clock.advance(30_000)
+        const result = await polling
+        expect(result).toMatchObject({
+          status: "interrupted",
+          reason: "delivery_interrupted",
+          browser_task_id: job.browserTaskId,
+          job_id: job.jobId,
+          effectsUncertain: true,
+        })
+        expect(result.guidance).toContain("operation=recover")
+        expect(result.summary).toContain("does not establish browser failure")
+        expect(wire.requests.filter((request) => request.operation === "invoke")).toHaveLength(1)
+        expect(wire.clock.timers.size).toBe(0)
+      })
+    }),
+  )
+
+  it.live("bounds lost acceptance recovery at thirty seconds and retains the intent", () =>
+    Effect.gen(function* () {
+      const { owner } = yield* seed()
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const pending = wire.client.run(owner, input, wire.hooks)
+        await wire.next("invoke")
+        await wire.clock.advance(30_000)
+        const result = await pending
+        expect(result).toMatchObject({
+          status: "interrupted",
+          reason: "delivery_interrupted",
+          invocation_id: owner.invocationId,
+          effectsUncertain: true,
+        })
+        expect(result.summary).toContain("does not establish browser failure")
+        expect(result.guidance).toContain("operation=recover")
+        expect(wire.requests.filter((request) => request.operation === "invoke")).toHaveLength(1)
+        expect((await owner.recover()).at(0)?.handle).toBeUndefined()
+        expect(wire.clock.timers.size).toBe(0)
+      })
+    }),
+  )
+
+  it.live("uses progress and result events only for their exact parent and job", () =>
+    Effect.gen(function* () {
+      const first = yield* seed()
+      const second = yield* seed()
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const left = wire.client.run(first.owner, input, wire.hooks)
+        const one = await wire.next("invoke")
+        const a = await snapshot(first.owner, one)
+        const other = { signal: new AbortController().signal, metadata: async (_value: BrowserClient.Output) => {} }
+        const right = wire.client.run(second.owner, input, other)
+        const two = await wire.next("invoke")
+        const b = await snapshot(second.owner, two)
+        ack(wire, one, a)
+        const sa = await wire.next("status")
+        ack(wire, two, b)
+        const sb = await wire.next("status")
+        wire.client.handle({
+          type: "browser_event",
+          requestId: one.requestId,
+          event: "result",
+          result: completed(b, "Foreign secret").result!,
+        })
+        wire.client.handle({
+          type: "browser_event",
+          requestId: crypto.randomUUID(),
+          event: "result",
+          result: completed(a, "Uncorrelated secret").result!,
+        })
+        wire.client.handle({
+          type: "browser_event",
+          requestId: one.requestId,
+          event: "progress",
+          job: { ...a, status: "awaiting_approval" },
+        })
+        wire.client.handle({
+          type: "browser_event",
+          requestId: one.requestId,
+          event: "result",
+          result: completed(a, "First parent").result!,
+        })
+        wire.client.handle({
+          type: "browser_event",
+          requestId: two.requestId,
+          event: "result",
+          result: completed(b, "Second parent").result!,
+        })
+        wire.reply(sa, { kind: "status", job: a })
+        wire.reply(sb, { kind: "status", job: b })
+        expect((await left).summary).toBe("First parent")
+        expect((await right).summary).toBe("Second parent")
+        const count = wire.updates.length
+        wire.client.handle({
+          type: "browser_event",
+          requestId: one.requestId,
+          event: "result",
+          result: completed(a, "Late secret").result!,
+        })
+        expect(wire.updates).toHaveLength(count)
+        expect(JSON.stringify(wire.updates)).not.toContain("secret")
+      })
+    }),
+  )
+
+  it.live("delivers relay progress despite its different payload fingerprint", () =>
+    Effect.gen(function* () {
+      const { owner } = yield* seed()
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const pending = wire.client.run(owner, input, wire.hooks)
+        const request = await wire.next("invoke")
+        const job = await snapshot(owner, request)
+        expect(job.payloadFingerprint).not.toBe((await owner.recover()).at(0)?.payloadFingerprint)
+        ack(wire, request, job)
+        wire.reply(await wire.next("status"), { kind: "status", job })
+        await wire.clock.advance(0)
+        wire.client.handle({
+          type: "browser_event",
+          requestId: request.requestId,
+          event: "progress",
+          job: { ...job, status: "awaiting_approval" },
+        })
+        await wire.clock.advance(0)
+        expect(wire.updates.at(-1)).toMatchObject({
+          status: "awaiting_approval",
+          browser_task_id: job.browserTaskId,
+          job_id: job.jobId,
+          invocation_id: job.invocationId,
+        })
+        wire.client.handle({
+          type: "browser_event",
+          requestId: request.requestId,
+          event: "result",
+          result: completed(job).result!,
+        })
+        expect((await pending).summary).toBe("The page title is Example Domain.")
+        expect(wire.clock.timers.size).toBe(0)
+      })
+    }),
+  )
+
+  for (const [key, value] of [
+    ["providerId", `bp_${crypto.randomUUID()}`],
+    ["browserTaskId", `bt_${crypto.randomUUID()}`],
+    ["jobId", `bj_${crypto.randomUUID()}`],
+    ["invocationId", `b1.${Date.now()}.${"f".repeat(64)}`],
+  ] as const) {
+    it.live(`rejects a mismatched ${key} in status and recovery snapshots`, () =>
+      Effect.gen(function* () {
+        const { owner } = yield* seed()
+        yield* Effect.promise(async () => {
+          const wire = link()
+          const pending = wire.client.run(owner, input, wire.hooks)
+          const request = await wire.next("invoke")
+          const job = await snapshot(owner, request)
+          ack(wire, request, job)
+          await finish(wire, job)
+          await pending
+          const count = wire.updates.length
+          const foreign = completed({ ...job, [key]: value }, "Foreign secret")
+          const polling = wire.client.status(owner, job.browserTaskId, job.jobId, wire.hooks)
+          wire.reply(await wire.next("status"), { kind: "status", job: foreign })
+          expect(await polling.catch((err: unknown) => err)).toMatchObject({ data: { code: "invalid_response" } })
+          const recovery = wire.client.recover(owner, wire.hooks)
+          wire.reply(await wire.next("recover"), { kind: "recovered", job: foreign })
+          expect(await recovery).toMatchObject({ jobs: [{ status: "rejected", reason: "invalid_response" }] })
+          expect(wire.updates).toHaveLength(count)
+          expect(JSON.stringify(wire.updates)).not.toContain("Foreign secret")
+          expect((await owner.recover()).at(0)?.handle?.jobId).toBe(job.jobId)
+        })
+      }),
+    )
+  }
+
+  it.live("rejects a changed goal locally before retrying the stored invocation", () =>
+    Effect.gen(function* () {
+      const { owner } = yield* seed()
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const pending = wire.client.run(owner, input, wire.hooks)
+        const request = await wire.next("invoke")
+        const job = await snapshot(owner, request)
+        ack(wire, request, job)
+        await finish(wire, job)
+        await pending
+        const saved = await owner.recover()
+        const count = wire.requests.length
+        expect(
+          await wire.client.run(owner, { ...input, goal: "Changed goal" }, wire.hooks).catch((err: unknown) => err),
+        ).toMatchObject({ data: { code: "invocation_conflict", retryable: false } })
+        expect(wire.requests).toHaveLength(count)
+        expect(await owner.recover()).toEqual(saved)
+      })
+    }),
+  )
+
+  it.live("rejects a mismatched acknowledgement without persisting or returning its handle", () =>
+    Effect.gen(function* () {
+      const { owner } = yield* seed()
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const pending = wire.client.run(owner, input, wire.hooks)
+        const request = await wire.next("invoke")
+        const job = await snapshot(owner, request)
+        ack(wire, request, { ...job, invocationId: `b1.${Date.now()}.${"f".repeat(64)}` })
+        expect(await pending.catch((err: unknown) => err)).toMatchObject({ data: { code: "invalid_response" } })
+        expect(wire.updates).toEqual([])
+        expect((await owner.recover()).at(0)?.handle).toBeUndefined()
+      })
+    }),
+  )
+
+  it.live("sends cancellation on abort but does not mistake its acknowledgement for a terminal result", () =>
+    Effect.gen(function* () {
+      const { owner } = yield* seed()
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const pending = wire.client.run(owner, input, wire.hooks)
+        const request = await wire.next("invoke")
+        const job = await snapshot(owner, request)
+        ack(wire, request, job)
+        await wire.next("status")
+        wire.controller.abort()
+        const cancel = await wire.next("cancel")
+        expect(cancel).toMatchObject({ browserTaskId: job.browserTaskId, jobId: job.jobId })
+        ack(wire, cancel, job, "cancel")
+        const status = await wire.next("status")
+        const result = {
+          ...completed(job).result!,
+          status: "cancelled" as const,
+          reason: "cancelled" as const,
+          effectsUncertain: true,
+          summary: "Stopped future actions; issued actions are not undone.",
+          evidence: [],
+        }
+        wire.reply(status, { kind: "status", job: { ...job, status: "cancelled", result } })
+        expect(await pending).toMatchObject({
+          status: "cancelled",
+          reason: "cancelled",
+          effectsUncertain: true,
+          evidence: [],
+        })
+        expect(wire.clock.timers.size).toBe(0)
+      })
+    }),
+  )
+
+  it.live("releases the tool within ten seconds when cancellation delivery also drops", () =>
+    Effect.gen(function* () {
+      const { owner } = yield* seed()
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const pending = wire.client.run(owner, input, wire.hooks)
+        const request = await wire.next("invoke")
+        const job = await snapshot(owner, request)
+        ack(wire, request, job)
+        await wire.next("status")
+        wire.controller.abort()
+        await wire.next("cancel")
+        await wire.clock.advance(10_000)
+        expect(await pending).toMatchObject({
+          status: "interrupted",
+          reason: "delivery_interrupted",
+          browser_task_id: job.browserTaskId,
+          job_id: job.jobId,
+          effectsUncertain: true,
+        })
+        expect(wire.clock.timers.size).toBe(0)
+      })
+    }),
+  )
+
+  it.live("surfaces recovered prior jobs before allowing a new run", () =>
+    Effect.gen(function* () {
+      const { ctx, owner } = yield* seed()
+      yield* Effect.promise(() => owner.prepare(input))
+      const next = yield* BrowserOwner.open({ ...ctx, callID: "new-run" })
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const pending = wire.client.run(next, { ...input, goal: "New goal" }, wire.hooks)
+        const request = await wire.next("recover")
+        if (request.operation !== "recover") throw new Error("Expected recovery before submission")
+        expect(request.invocationId).toBe(owner.invocationId)
+        const job = completed(await snapshot(owner, { ...request, operation: "invoke", ...input }))
+        wire.reply(request, { kind: "recovered", job })
+        expect(await pending).toMatchObject({
+          status: "recovery_required",
+          jobs: [{ invocation_id: owner.invocationId, status: "succeeded" }],
+        })
+        expect(wire.requests.map((request) => request.operation)).toEqual(["recover"])
+        expect(await next.recover()).toHaveLength(1)
+      })
+    }),
+  )
+
+  it.live("permits a new explicit goal after rejection and authoritative not-found recovery", () =>
+    Effect.gen(function* () {
+      const { ctx, owner } = yield* seed()
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const pending = wire.client.run(owner, input, wire.hooks)
+        wire.reply(await wire.next("invoke"), {
+          kind: "error",
+          code: "provider_unavailable",
+          retryable: true,
+          message: "Provider unavailable",
+        })
+        expect(await pending.catch((err: unknown) => err)).toMatchObject({
+          data: { code: "provider_unavailable", retryable: true },
+        })
+        const recovery = wire.client.recover(owner, wire.hooks)
+        wire.reply(await wire.next("recover"), { kind: "not_found", invocationId: owner.invocationId })
+        const result = await recovery
+        expect(result).toMatchObject({ jobs: [{ status: "not_found", invocation_id: owner.invocationId }] })
+        expect(wire.requests.map((request) => request.operation)).toEqual(["invoke", "recover"])
+        wire.client.close()
+      })
+      const saved = yield* Effect.promise(() => owner.recover())
+      const next = yield* BrowserOwner.open({ ...ctx, callID: "new-run" })
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const pending = wire.client.run(next, { ...input, goal: "New goal" }, wire.hooks)
+        const lookup = await wire.next("recover")
+        expect(lookup).toMatchObject({ invocationId: owner.invocationId })
+        wire.reply(lookup, { kind: "not_found", invocationId: owner.invocationId })
+        const request = await Promise.race([wire.next("invoke"), pending])
+        expect(request).toMatchObject({
+          operation: "invoke",
+          invocationId: next.invocationId,
+          providerId: provider,
+          goal: "New goal",
+        })
+        if (!("operation" in request)) throw new Error("The explicit new run did not submit")
+        const job = await snapshot(next, request)
+        ack(wire, request, job)
+        await finish(wire, job)
+        expect(await pending).toMatchObject({ status: "succeeded", invocation_id: next.invocationId })
+        expect(wire.requests.map((request) => request.operation)).toEqual(["recover", "invoke", "status"])
+        expect((await owner.recover()).find((record) => record.invocationId === owner.invocationId)).toEqual(
+          saved.at(0),
+        )
+        expect(wire.clock.timers.size).toBe(0)
+      })
+    }),
+  )
+
+  for (const code of ["delivery_interrupted", "invalid_response", "owner_mismatch"] as const) {
+    it.live(`blocks a new goal when prior recovery returns ${code}`, () =>
+      Effect.gen(function* () {
+        const { ctx, owner } = yield* seed()
+        yield* Effect.promise(() => owner.prepare(input))
+        const next = yield* BrowserOwner.open({ ...ctx, callID: "new-run" })
+        yield* Effect.promise(async () => {
+          const wire = link()
+          const saved = await owner.recover()
+          const pending = wire.client.run(next, { ...input, goal: "New goal" }, wire.hooks)
+          const request = await wire.next("recover")
+          if (code === "delivery_interrupted") await wire.clock.advance(30_000)
+          if (code === "invalid_response") wire.reply(request, { kind: "not_found", invocationId: next.invocationId })
+          if (code === "owner_mismatch")
+            wire.reply(request, { kind: "error", code, retryable: false, message: "Wrong owner" })
+          const result = await pending
+          expect(result).toMatchObject({
+            status: "recovery_required",
+            jobs: [
+              {
+                status: code === "delivery_interrupted" ? "interrupted" : "rejected",
+                reason: code,
+                invocation_id: owner.invocationId,
+              },
+            ],
+          })
+          expect(result.guidance).toContain("operation=recover")
+          expect(wire.requests.every((request) => request.operation === "recover")).toBe(true)
+          expect(await next.recover()).toEqual(saved)
+          expect(wire.clock.timers.size).toBe(0)
+        })
+      }),
+    )
+  }
+
+  it.live("continues only the owned conversation and sends only its new goal", () =>
+    Effect.gen(function* () {
+      const { ctx, owner } = yield* seed()
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const pending = wire.client.run(owner, input, wire.hooks)
+        const request = await wire.next("invoke")
+        const job = await snapshot(owner, request)
+        ack(wire, request, job)
+        await finish(wire, job)
+        await pending
+      })
+      const next = yield* BrowserOwner.open({ ...ctx, callID: "continue" })
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const task = (await next.recover()).at(0)!.handle!.browserTaskId
+        const pending = wire.client.run(next, { ...input, browserTaskId: task, goal: "Read the next page" }, wire.hooks)
+        const request = await wire.next("invoke")
+        expect(request).toMatchObject({
+          browserTaskId: task,
+          providerId: provider,
+          goal: "Read the next page",
+          invocationId: next.invocationId,
+        })
+        expect(Object.keys(request).sort()).toEqual([
+          "browserTaskId",
+          "goal",
+          "invocationId",
+          "operation",
+          "owner",
+          "providerId",
+          "requestId",
+          "type",
+        ])
+        const job = await snapshot(next, request)
+        ack(wire, request, job)
+        await finish(wire, job)
+        expect((await pending).browser_task_id).toBe(task)
+      })
+    }),
+  )
+
+  it.live("returns empty recovery without a network request", () =>
+    Effect.gen(function* () {
+      const { owner } = yield* seed()
+      yield* Effect.promise(async () => {
+        const wire = link()
+        const result = await wire.client.recover(owner, wire.hooks)
+        expect(result).toMatchObject({ status: "empty", jobs: [], evidence: [] })
+        expect(result.guidance).toContain("operation=list")
+        expect(result.guidance).toContain("operation=run")
+        expect(result.guidance).toContain("provider_id")
+        expect(result.provider_id).toBeUndefined()
+        expect(wire.requests).toEqual([])
+      })
+    }),
+  )
+
+  for (const [code, retryable] of [
+    ["provider_unavailable", true],
+    ["capacity_exceeded", true],
+    ["invocation_expired", false],
+    ["invocation_conflict", false],
+    ["owner_mismatch", false],
+  ] as const) {
+    it.live(`preserves ${code} without replay`, () =>
+      Effect.gen(function* () {
+        const { owner } = yield* seed()
+        yield* Effect.promise(async () => {
+          const wire = link()
+          const pending = wire.client.run(owner, input, wire.hooks)
+          wire.reply(await wire.next("invoke"), { kind: "error", code, retryable, message: "Relay rejection" })
+          expect(await pending.catch((err: unknown) => err)).toMatchObject({ data: { code, retryable } })
+          expect(wire.requests.map((request) => request.operation)).toEqual(["invoke"])
+          expect(wire.clock.timers.size).toBe(0)
+        })
+      }),
+    )
+  }
+})
+
+it.live(
+  "recovers after process death between accepted dispatch and any acknowledgement or handle persistence",
+  () =>
+    Effect.gen(function* () {
+      const tmp = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      )
+      const database = path.join(tmp.path, "browser-restart.db")
+      yield* Effect.gen(function* () {
+        const { ctx, owner } = yield* seed()
+        yield* Effect.promise(async () => {
+          const accepted = Promise.withResolvers<Request>()
+          const requests: Request[] = []
+          let job: RemoteProtocol.BrowserJobSnapshot | undefined
+          const server = Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            fetch(request, server) {
+              return server.upgrade(request) ? undefined : new Response("Not found", { status: 404 })
+            },
+            websocket: {
+              message(socket, raw) {
+                const message = RemoteProtocol.OutboundWithBrowser.parse(JSON.parse(String(raw)))
+                if (message.type === "heartbeat") {
+                  socket.send(JSON.stringify({ type: "heartbeat_ack", capabilities: { browserJobsV1: true } }))
+                  return
+                }
+                if (message.type !== "browser_request") return
+                requests.push(message)
+                if (message.operation === "invoke") {
+                  accepted.resolve(message)
+                  return
+                }
+                if (message.operation !== "recover" || !job)
+                  throw new Error("Restart must recover the retained invocation")
+                socket.send(
+                  JSON.stringify({
+                    type: "browser_response",
+                    requestId: message.requestId,
+                    response: { kind: "recovered", job },
+                  }),
+                )
+              },
+            },
+          })
+          const program = `
+        import { Effect } from "effect"
+        import { Database } from "@opencode-ai/core/database/database"
+        import { Global } from "@opencode-ai/core/global"
+        import { BrowserOwner } from ${JSON.stringify(new URL("../../../src/kilocode/browser-task/owner.ts", import.meta.url).href)}
+        import { BrowserClient } from ${JSON.stringify(new URL("../../../src/kilocode/browser-task/client.ts", import.meta.url).href)}
+        import { RemoteWS } from ${JSON.stringify(new URL("../../../src/kilo-sessions/remote-ws.ts", import.meta.url).href)}
+        const mode = process.argv[1]
+        Global.Path.data = ${JSON.stringify(Global.Path.data)}
+        const ctx = ${JSON.stringify({ sessionID: ctx.sessionID, messageID: ctx.messageID, callID: ctx.callID })}
+        if (mode === "recover") ctx.callID = "after-process-death"
+        const owner = await Effect.runPromise(BrowserOwner.open(ctx).pipe(Effect.provide(Database.layerFromPath(${JSON.stringify(database)}))))
+        await owner.approve(${JSON.stringify(provider)})
+        const client = BrowserClient.create(() => connection)
+        const connection = RemoteWS.connect({ url: ${JSON.stringify(`ws://127.0.0.1:${server.port}`)}, getToken: async () => "test-token", getSessions: async () => ({ sessions: [] }), log: { info() {}, warn() {}, error() {} }, onOpen: () => client.open(), onDisconnect: () => client.disconnect(), onMessage: (message) => { if (message.type === "heartbeat_ack") client.handle(message) }, onBrowserMessage: (message) => client.handle(message), onClose: () => client.close() })
+        const hooks = { signal: new AbortController().signal, metadata: async () => {} }
+        const result = mode === "run" ? await client.run(owner, ${JSON.stringify(input)}, hooks) : await client.recover(owner, hooks)
+        console.log("BROWSER_RESULT " + JSON.stringify(result))
+        client.close()
+        connection.close()
+        process.exit(0)
+      `
+          const spawn = (mode: string) =>
+            Bun.spawn([process.execPath, "--eval", program, mode], {
+              cwd: path.resolve(import.meta.dir, "../../.."),
+              stdout: "pipe",
+              stderr: "pipe",
+              windowsHide: true,
+            })
+          const child = spawn("run")
+          try {
+            const request = await Promise.race([
+              accepted.promise,
+              child.exited.then(async (code) => {
+                throw new Error(`Child exited before dispatch (${code}): ${await new Response(child.stderr).text()}`)
+              }),
+            ])
+            job = completed(await snapshot(owner, request))
+            child.kill()
+            await child.exited
+            expect((await owner.recover()).at(0)?.handle).toBeUndefined()
+            const restarted = spawn("recover")
+            try {
+              const [code, text, error] = await Promise.all([
+                restarted.exited,
+                new Response(restarted.stdout).text(),
+                new Response(restarted.stderr).text(),
+              ])
+              expect(error).not.toContain("BrowserClientError")
+              expect(code).toBe(0)
+              const result = text.split(/\r?\n/).find((line) => line.startsWith("BROWSER_RESULT "))
+              expect(result).toBeDefined()
+              expect(JSON.parse(result!.slice("BROWSER_RESULT ".length)).jobs).toMatchObject([
+                { status: "succeeded", browser_task_id: job.browserTaskId, job_id: job.jobId },
+              ])
+              expect(requests.map((request) => request.operation)).toEqual(["invoke", "recover"])
+              expect((await owner.recover()).at(0)?.handle?.jobId).toBe(job.jobId)
+              expect(
+                await fs.readFile(
+                  path.join(Global.Path.data, "browser-owner", ctx.sessionID, `intent-${job.invocationId}.json`),
+                  "utf8",
+                ),
+              ).not.toContain(input.goal)
+            } finally {
+              restarted.kill()
+            }
+          } finally {
+            child.kill()
+            await server.stop(true)
+          }
+        })
+      }).pipe(Effect.provide(Layer.fresh(Database.layerFromPath(database))))
+    }),
+  30_000,
+)

--- a/packages/opencode/test/kilocode/browser-task/client.test.ts
+++ b/packages/opencode/test/kilocode/browser-task/client.test.ts
@@ -281,6 +281,108 @@ describe("browser client delivery", () => {
     }),
   )
 
+  it.live("retains accepted identity after failed handle persistence and recovers only the original intent", () =>
+    Effect.gen(function* () {
+      const { ctx, owner } = yield* seed()
+      const wire = link()
+      const job = yield* Effect.promise(async () => {
+        const pending = wire.client.run(owner, input, wire.hooks)
+        const request = await wire.next("invoke")
+        const job = await snapshot(owner, request)
+        const dir = path.join(Global.Path.data, "browser-owner", ctx.sessionID)
+        await fs.rename(dir, `${dir}.unavailable`)
+        try {
+          ack(wire, request, job)
+          const result = await pending
+          expect(result).toMatchObject({
+            status: "interrupted",
+            reason: "delivery_interrupted",
+            provider_id: provider,
+            browser_task_id: job.browserTaskId,
+            job_id: job.jobId,
+            invocation_id: job.invocationId,
+            effectsUncertain: true,
+            retryable: true,
+            evidence: [],
+          })
+          expect(result.summary).toContain("accepted")
+          expect(result.summary).toContain("persistence failed")
+          expect(result.summary).toContain("does not establish browser failure")
+          expect(result.guidance).toContain("Once private browser storage is available")
+          expect(result.guidance).toContain("operation=recover")
+          expect(result.guidance).toContain("without replay")
+          expect(result.guidance).toContain("Do not automatically repeat operation=run")
+          expect(wire.requests.map((request) => request.operation)).toEqual(["invoke"])
+          expect(wire.clock.timers.size).toBe(0)
+        } finally {
+          await fs.rename(`${dir}.unavailable`, dir)
+        }
+        expect((await owner.recover()).at(0)?.handle).toBeUndefined()
+        return job
+      })
+      const reopened = yield* BrowserOwner.open({ ...ctx, callID: "recover-after-storage-failure" })
+      yield* Effect.promise(async () => {
+        const pending = wire.client.recover(reopened, wire.hooks)
+        const request = await wire.next("recover")
+        const first = wire.requests.at(0)
+        if (request.operation !== "recover" || first?.operation !== "invoke")
+          throw new Error("Expected lookup after acceptance")
+        expect(request.invocationId).toBe(owner.invocationId)
+        expect(request.owner).toEqual(first.owner)
+        wire.reply(request, { kind: "recovered", job: completed(job) })
+        expect(await pending).toMatchObject({
+          status: "recovered",
+          jobs: [{ status: "succeeded", job_id: job.jobId, invocation_id: owner.invocationId }],
+        })
+        expect((await reopened.recover()).at(0)?.handle?.jobId).toBe(job.jobId)
+        expect(wire.requests.map((request) => request.operation)).toEqual(["invoke", "recover"])
+        expect(wire.clock.timers.size).toBe(0)
+      })
+    }),
+  )
+
+  it.live("preserves authoritative terminal facts when recovered handle persistence fails", () =>
+    Effect.gen(function* () {
+      const { ctx, owner } = yield* seed()
+      yield* Effect.promise(async () => {
+        await owner.prepare(input)
+        const wire = link()
+        const pending = wire.client.recover(owner, wire.hooks)
+        const request = await wire.next("recover")
+        if (request.operation !== "recover") throw new Error("Expected recovery")
+        const job = completed(await snapshot(owner, { ...request, operation: "invoke", ...input }))
+        const dir = path.join(Global.Path.data, "browser-owner", ctx.sessionID)
+        await fs.rename(dir, `${dir}.unavailable`)
+        try {
+          wire.reply(request, { kind: "recovered", job })
+          const result = await pending
+          expect(result).toMatchObject({
+            status: "recovered",
+            effectsUncertain: false,
+            jobs: [
+              {
+                status: "succeeded",
+                reason: "completed",
+                browser_task_id: job.browserTaskId,
+                job_id: job.jobId,
+                invocation_id: owner.invocationId,
+                evidence: [{ title: "Example Domain", url: "https://example.com" }],
+                effectsUncertain: false,
+              },
+            ],
+          })
+          expect(result.jobs?.at(0)?.summary).toContain("The page title is Example Domain.")
+          expect(result.jobs?.at(0)?.summary).toContain("persistence failed")
+          expect(result.jobs?.at(0)?.guidance).toContain("operation=recover")
+          expect(wire.requests.map((request) => request.operation)).toEqual(["recover"])
+          expect(wire.clock.timers.size).toBe(0)
+        } finally {
+          await fs.rename(`${dir}.unavailable`, dir)
+        }
+      })
+    }),
+  )
+
   it.live("recovers a lost acknowledgement without sending another invocation", () =>
     Effect.gen(function* () {
       const { owner } = yield* seed()
@@ -814,6 +916,7 @@ describe("browser client delivery", () => {
   for (const [code, retryable] of [
     ["provider_unavailable", true],
     ["capacity_exceeded", true],
+    ["conversation_busy", true],
     ["invocation_expired", false],
     ["invocation_conflict", false],
     ["owner_mismatch", false],

--- a/packages/opencode/test/kilocode/sandbox/network.test.ts
+++ b/packages/opencode/test/kilocode/sandbox/network.test.ts
@@ -92,6 +92,24 @@ describe("model network boundaries", () => {
     }),
   )
 
+  for (const mode of ["allow", "deny"] as const) {
+    it.effect(`treats browser_task as opaque network authority in ${mode} mode`, () =>
+      Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          run(profile(mode), Network.tool(Network.builtin({ id: "browser_task" }), Effect.succeed("browser dispatch"))),
+        )
+        if (mode === "allow") {
+          expect(Exit.isSuccess(exit) && exit.value).toBe("browser dispatch")
+          return
+        }
+        expect(Exit.isFailure(exit)).toBe(true)
+        if (Exit.isFailure(exit)) {
+          expect(Cause.pretty(exit.cause)).toContain("Sandbox denied outbound network access")
+        }
+      }),
+    )
+  }
+
   it.effect("fails closed before opaque network helper tools run", () =>
     Effect.gen(function* () {
       let called = false

--- a/packages/opencode/test/kilocode/sessions/remote-ws.test.ts
+++ b/packages/opencode/test/kilocode/sessions/remote-ws.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import { RemoteWS } from "../../../src/kilo-sessions/remote-ws"
+import { BrowserClient } from "../../../src/kilocode/browser-task/client"
 import type { ServerWebSocket } from "bun"
 
 function nolog() {
@@ -641,6 +642,147 @@ describe("RemoteWS", () => {
     }
   }
 
+  test("browser frames require fresh negotiation and never enter the legacy reconnect buffer", async () => {
+    await withFakeWebSocket(async (clock) => {
+      const legacy: unknown[] = []
+      const browser: unknown[] = []
+      conn = RemoteWS.connect({
+        url: "ws://example.test",
+        getToken: async () => "tok",
+        getSessions: async () => ({ sessions: [] }),
+        log: nolog(),
+        timers: clock,
+        now: () => clock.now,
+        onMessage: (message) => legacy.push(message),
+        onBrowserMessage: (message) => browser.push(message),
+      })
+      const request = {
+        type: "browser_request",
+        requestId: crypto.randomUUID(),
+        operation: "invoke",
+        owner: { parentSessionId: "ses_parent", parentProof: "1".repeat(64) },
+        providerId: "bp_00000000-0000-4000-8000-000000000001",
+        invocationId: `b1.${Date.now()}.${"2".repeat(64)}`,
+        goal: "Read the page title",
+      } as const
+      const response = {
+        type: "browser_response",
+        requestId: request.requestId,
+        response: {
+          kind: "ack",
+          operation: "invoke",
+          providerId: request.providerId,
+          browserTaskId: "bt_00000000-0000-4000-8000-000000000002",
+          jobId: "bj_00000000-0000-4000-8000-000000000003",
+          invocationId: request.invocationId,
+        },
+      }
+      expect(conn.send(request, { connectedOnly: true })).toBe(false)
+      await flush()
+      const first = FakeWebSocket.instances.at(0)!
+      first.open()
+      expect(conn.send(request, { connectedOnly: true })).toBe(false)
+      first.receive(response)
+      expect(browser).toEqual([])
+      first.receive({ type: "heartbeat_ack" })
+      expect(conn.send(request, { connectedOnly: true })).toBe(false)
+      first.receive({ type: "heartbeat_ack", capabilities: { browserJobsV1: true } })
+      expect(conn.send(request, { connectedOnly: true })).toBe(true)
+      first.receive(response)
+      expect(browser).toEqual([response])
+      expect(legacy).toHaveLength(2)
+      const beat = conn.heartbeat()
+      await flushLong()
+      await beat
+      expect(JSON.parse(first.sent.at(-1)!).capabilities.browserJobsV1).toBe(true)
+      first.disconnect()
+      expect(conn.send(request, { connectedOnly: true })).toBe(false)
+      conn.send({ type: "response", id: "legacy", result: "buffered" })
+      expect(conn.send({ type: "response", id: "connected-only" }, { connectedOnly: true })).toBe(false)
+      clock.advance(1_000)
+      await flush()
+      const second = FakeWebSocket.instances.at(1)!
+      second.open()
+      expect(second.sent.map((value) => JSON.parse(value))).toEqual([
+        { type: "response", id: "legacy", result: "buffered" },
+      ])
+      expect(conn.send(request, { connectedOnly: true })).toBe(false)
+      second.receive({ type: "heartbeat_ack", capabilities: { browserJobsV1: true } })
+      expect(conn.send(request, { connectedOnly: true })).toBe(true)
+      expect(second.sent.filter((value) => JSON.parse(value).type === "browser_request")).toHaveLength(1)
+    })
+  })
+
+  test("browser negotiation preserves immediate instance advertisement on reconnect", async () => {
+    await withFakeWebSocket(async (clock) => {
+      const instance = { name: "headless", projectName: "browser-project", version: "1.2.3" }
+      const browser = BrowserClient.create(() => conn!, { timers: clock, now: () => clock.now })
+      conn = RemoteWS.connect({
+        url: "ws://example.test",
+        getToken: async () => "tok",
+        getSessions: async () => ({ sessions: [], instance }),
+        log: nolog(),
+        timers: clock,
+        now: () => clock.now,
+        onOpen: () => browser.open(),
+        onDisconnect: () => browser.disconnect(),
+        onBrowserMessage: (message) => browser.handle(message),
+      })
+      await flush()
+      const first = FakeWebSocket.instances.at(0)!
+      first.open()
+      await flushLong()
+      expect(first.sent.map((value) => JSON.parse(value))).toEqual([
+        expect.objectContaining({
+          type: "heartbeat",
+          instance,
+          capabilities: expect.objectContaining({ browserJobsV1: true }),
+        }),
+      ])
+      first.disconnect()
+      clock.advance(1_000)
+      await flush()
+      const second = FakeWebSocket.instances.at(1)!
+      second.open()
+      await flushLong()
+      expect(second.sent.map((value) => JSON.parse(value))).toEqual([
+        expect.objectContaining({
+          type: "heartbeat",
+          instance,
+          capabilities: expect.objectContaining({ browserJobsV1: true }),
+        }),
+      ])
+      browser.close()
+    })
+  })
+
+  test("legacy callbacks reject browser envelopes without logging secret fields", async () => {
+    await withFakeWebSocket(async () => {
+      const cap = capture()
+      const received: unknown[] = []
+      conn = RemoteWS.connect({
+        url: "ws://example.test",
+        getToken: async () => "tok",
+        getSessions: async () => ({ sessions: [] }),
+        log: cap.log,
+        onMessage: (message) => received.push(message),
+      })
+      await flush()
+      const socket = FakeWebSocket.instances.at(0)!
+      socket.open()
+      socket.receive({
+        type: "browser_response",
+        requestId: crypto.randomUUID(),
+        response: { kind: "providers", providers: [] },
+        PRIVATE_PROOF: "secret",
+      })
+      socket.receive({ type: "subscribe", sessionId: "legacy" })
+      expect(received).toEqual([{ type: "subscribe", sessionId: "legacy" }])
+      expect(JSON.stringify(cap.calls)).not.toContain("PRIVATE_PROOF")
+      expect(JSON.stringify(cap.calls)).not.toContain("secret")
+    })
+  })
+
   test("AC2a: getToken() rejection schedules a bounded retry and later succeeds", async () => {
     await withFakeWebSocket(async (clock) => {
       let attempt = 0
@@ -816,7 +958,7 @@ describe("RemoteWS", () => {
           heartbeat: 60_000,
           timers: clock,
           now: () => clock.now,
-        timeout: 300_000,
+          timeout: 300_000,
           connectTimeout: 1000,
         })
 
@@ -1103,7 +1245,7 @@ describe("RemoteWS", () => {
           heartbeat: 60_000,
           timers: clock,
           now: () => clock.now,
-        timeout: 300_000,
+          timeout: 300_000,
           onClose: (c) => codes.push(c),
         })
 
@@ -1277,9 +1419,7 @@ describe("RemoteWS", () => {
   test("AC4a: degraded heartbeat preserves the last known-good non-empty session list", async () => {
     await withFakeWebSocket(async (clock) => {
       let mode: "fresh" | "wedge" = "fresh"
-      const knownGoodSessions = [
-        { id: "s1", status: "active" as const, title: "One" },
-      ] as RemoteWS.SessionInfo[]
+      const knownGoodSessions = [{ id: "s1", status: "active" as const, title: "One" }] as RemoteWS.SessionInfo[]
       const getSessions = () =>
         mode === "fresh"
           ? Promise.resolve({ sessions: knownGoodSessions })
@@ -1372,9 +1512,7 @@ describe("RemoteWS", () => {
   test("AC4c: after a timed-out cycle, a later fresh-gather cycle sends fresh sessions", async () => {
     await withFakeWebSocket(async (clock) => {
       let mode: "wedge" | "fresh" = "wedge"
-      const freshSessions = [
-        { id: "fresh", status: "active" as const, title: "Fresh" },
-      ] as RemoteWS.SessionInfo[]
+      const freshSessions = [{ id: "fresh", status: "active" as const, title: "Fresh" }] as RemoteWS.SessionInfo[]
       const getSessions = () =>
         mode === "wedge"
           ? new Promise<{ sessions: RemoteWS.SessionInfo[] }>(() => {})
@@ -1422,9 +1560,7 @@ describe("RemoteWS", () => {
       let calls = 0
       let mode: "wedge" | "fresh" = "wedge"
       const wedgeResolvers: Array<(v: { sessions: RemoteWS.SessionInfo[] }) => void> = []
-      const freshSessions = [
-        { id: "fresh", status: "active" as const, title: "Fresh" },
-      ] as RemoteWS.SessionInfo[]
+      const freshSessions = [{ id: "fresh", status: "active" as const, title: "Fresh" }] as RemoteWS.SessionInfo[]
       const getSessions = () => {
         calls++
         if (mode === "wedge") {
@@ -1494,9 +1630,7 @@ describe("RemoteWS", () => {
     await withFakeWebSocket(async (clock) => {
       let calls = 0
       let mode: "reject" | "fresh" = "reject"
-      const freshSessions = [
-        { id: "fresh", status: "active" as const, title: "Fresh" },
-      ] as RemoteWS.SessionInfo[]
+      const freshSessions = [{ id: "fresh", status: "active" as const, title: "Fresh" }] as RemoteWS.SessionInfo[]
       const getSessions = () => {
         calls++
         return mode === "reject"
@@ -1547,9 +1681,7 @@ describe("RemoteWS", () => {
     await withFakeWebSocket(async (clock) => {
       let calls = 0
       let mode: "throw" | "fresh" = "throw"
-      const freshSessions = [
-        { id: "fresh", status: "active" as const, title: "Fresh" },
-      ] as RemoteWS.SessionInfo[]
+      const freshSessions = [{ id: "fresh", status: "active" as const, title: "Fresh" }] as RemoteWS.SessionInfo[]
       const getSessions = () => {
         calls++
         if (mode === "throw") {
@@ -1619,9 +1751,7 @@ describe("RemoteWS", () => {
   test("AC6a: heartbeat() does not resolve on degraded, resolves on the next fresh send", async () => {
     await withFakeWebSocket(async (clock) => {
       let mode: "wedge" | "fresh" = "wedge"
-      const freshSessions = [
-        { id: "fresh", status: "active" as const, title: "Fresh" },
-      ] as RemoteWS.SessionInfo[]
+      const freshSessions = [{ id: "fresh", status: "active" as const, title: "Fresh" }] as RemoteWS.SessionInfo[]
       const getSessions = () =>
         mode === "wedge"
           ? new Promise<{ sessions: RemoteWS.SessionInfo[] }>(() => {})
@@ -1678,9 +1808,7 @@ describe("RemoteWS", () => {
   test("AC6b: pending heartbeat() survives disconnect+reconnect and resolves on fresh send over the new socket", async () => {
     await withFakeWebSocket(async (clock) => {
       let mode: "wedge" | "fresh" = "wedge"
-      const freshSessions = [
-        { id: "fresh", status: "active" as const, title: "Fresh" },
-      ] as RemoteWS.SessionInfo[]
+      const freshSessions = [{ id: "fresh", status: "active" as const, title: "Fresh" }] as RemoteWS.SessionInfo[]
       const getSessions = () =>
         mode === "wedge"
           ? new Promise<{ sessions: RemoteWS.SessionInfo[] }>(() => {})
@@ -1745,8 +1873,7 @@ describe("RemoteWS", () => {
 
   test("AC6c: pending heartbeat() rejects (does not hang) when close() is called", async () => {
     await withFakeWebSocket(async (clock) => {
-      const getSessions = () =>
-        new Promise<{ sessions: RemoteWS.SessionInfo[] }>(() => {}) // wedge
+      const getSessions = () => new Promise<{ sessions: RemoteWS.SessionInfo[] }>(() => {}) // wedge
 
       conn = RemoteWS.connect({
         url: "ws://example.test",
@@ -1806,8 +1933,7 @@ describe("RemoteWS", () => {
       const targetSession = { id: "target", status: "active" as const, title: "Target" }
       const listWithout = [otherSession] as RemoteWS.SessionInfo[]
       const listWith = [otherSession, targetSession] as RemoteWS.SessionInfo[]
-      const getSessions = () =>
-        Promise.resolve({ sessions: mode === "without" ? listWithout : listWith })
+      const getSessions = () => Promise.resolve({ sessions: mode === "without" ? listWithout : listWith })
 
       conn = RemoteWS.connect({
         url: "ws://example.test",

--- a/packages/opencode/test/kilocode/tool/browser-task.test.ts
+++ b/packages/opencode/test/kilocode/tool/browser-task.test.ts
@@ -1,0 +1,433 @@
+import { afterEach, describe, expect, mock, spyOn } from "bun:test"
+import { createHash } from "node:crypto"
+import fs from "node:fs/promises"
+import path from "node:path"
+import { Database } from "@opencode-ai/core/database/database"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Global } from "@opencode-ai/core/global"
+import { ProjectV2 } from "@opencode-ai/core/project"
+import { ProjectTable } from "@opencode-ai/core/project/sql"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { MessageTable, SessionTable } from "@opencode-ai/core/session/sql"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { run as sandbox, type Profile } from "@kilocode/sandbox"
+import { Cause, Effect, Exit, Fiber, Layer } from "effect"
+import { Agent } from "../../../src/agent/agent"
+import { Config } from "../../../src/config/config"
+import { RuntimeFlags } from "../../../src/effect/runtime-flags"
+import { KiloSessions } from "../../../src/kilo-sessions/kilo-sessions"
+import { RemoteProtocol } from "../../../src/kilo-sessions/remote-protocol"
+import { BrowserClient } from "../../../src/kilocode/browser-task/client"
+import { BrowserOwner } from "../../../src/kilocode/browser-task/owner"
+import * as Network from "../../../src/kilocode/sandbox/network"
+import { BrowserTaskTool } from "../../../src/kilocode/tool/browser-task"
+import { MessageID, SessionID } from "../../../src/session/schema"
+import { Tool } from "../../../src/tool/tool"
+import { ToolRegistry } from "../../../src/tool/registry"
+import * as Truncate from "../../../src/tool/truncate"
+import { TestConfig } from "../../fixture/config"
+import { testEffect } from "../../lib/effect"
+
+const provider = "bp_00000000-0000-4000-8000-000000000001"
+const task = "bt_00000000-0000-4000-8000-000000000002"
+const args = { operation: "run", provider_id: provider, goal: "Read this page" } as const
+const layer = Layer.mergeAll(
+  Database.layerFromPath(":memory:"),
+  Layer.mock(Agent.Service, {
+    get: () => Effect.succeed({ name: "test", mode: "primary", permission: [], options: {} } satisfies Agent.Info),
+  }),
+  Layer.mock(Truncate.Service, { output: (text) => Effect.succeed({ content: text, truncated: false }) }),
+)
+const it = testEffect(layer)
+const denied: Profile = {
+  filesystem: { allowWrite: [], denyWrite: [], denyNames: [] },
+  network: { mode: "deny", allowedHosts: [] },
+  environment: { deny: [], set: {} },
+}
+afterEach(() => mock.restore())
+
+function context(): Tool.Context {
+  return {
+    sessionID: SessionID.make(`ses_${crypto.randomUUID()}`),
+    messageID: MessageID.ascending(),
+    callID: crypto.randomUUID(),
+    agent: "test",
+    abort: new AbortController().signal,
+    messages: [],
+    ask: () => Effect.void,
+    metadata: () => Effect.void,
+  }
+}
+
+function seed(ctx: Tool.Context) {
+  return Effect.gen(function* () {
+    const db = yield* Database.Service
+    const project = ProjectV2.ID.make("c".repeat(40))
+    yield* db.db
+      .insert(ProjectTable)
+      .values({ id: project, worktree: AbsolutePath.make(Global.Path.data), sandboxes: [] })
+      .onConflictDoNothing()
+      .run()
+    yield* db.db
+      .insert(SessionTable)
+      .values({
+        id: ctx.sessionID,
+        project_id: project,
+        slug: "browser-tool",
+        directory: AbsolutePath.make(Global.Path.data),
+        title: "Browser tool",
+        version: "test",
+      })
+      .run()
+    const data = {
+      role: "assistant" as const,
+      time: { created: Date.now() },
+      parentID: SessionV1.MessageID.make("msg_parent"),
+      providerID: "test",
+      modelID: "test",
+      mode: "test",
+      agent: "test",
+      path: { cwd: Global.Path.data, root: Global.Path.data },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    }
+    yield* db.db
+      .insert(MessageTable)
+      .values({
+        id: SessionV1.MessageID.make(ctx.messageID),
+        session_id: ctx.sessionID,
+        time_created: Date.now(),
+        data,
+      })
+      .run()
+  })
+}
+
+function relay() {
+  const requests: RemoteProtocol.BrowserRequest[] = []
+  const queued: RemoteProtocol.BrowserRequest[] = []
+  let resolve: ((request: RemoteProtocol.BrowserRequest) => void) | undefined
+  const client = BrowserClient.create(() => ({
+    connected: true,
+    heartbeat: async () => {},
+    send(message) {
+      if (message.type !== "browser_request") return false
+      requests.push(message)
+      if (resolve) {
+        const next = resolve
+        resolve = undefined
+        next(message)
+      } else queued.push(message)
+      return true
+    },
+  }))
+  client.handle({ type: "heartbeat_ack", capabilities: { browserJobsV1: true } })
+  spyOn(KiloSessions, "browser").mockReturnValue(client)
+  return {
+    client,
+    requests,
+    next: () =>
+      queued.length
+        ? Promise.resolve(queued.shift()!)
+        : new Promise<RemoteProtocol.BrowserRequest>((next) => {
+            resolve = next
+          }),
+    reply: (request: RemoteProtocol.BrowserRequest, response: RemoteProtocol.BrowserResponse["response"]) =>
+      client.handle(
+        RemoteProtocol.BrowserResponse.parse({ type: "browser_response", requestId: request.requestId, response }),
+      ),
+  }
+}
+
+const tool = Effect.gen(function* () {
+  return yield* Tool.init(yield* BrowserTaskTool)
+})
+const folder = (ctx: Tool.Context) => path.join(Global.Path.data, "browser-owner", ctx.sessionID)
+
+describe("browser_task permission and schema", () => {
+  it.live("returns actionable remote enablement without creating ownership or enabling sessions", () =>
+    Effect.gen(function* () {
+      const ctx = context()
+      const current = yield* tool
+      const before = KiloSessions.remoteStatus()
+      const result = yield* current.execute(args, ctx)
+      expect(JSON.parse(result.output)).toMatchObject({
+        status: "rejected",
+        reason: "remote_disabled",
+        retryable: true,
+      })
+      expect(result.output).toContain("kilo auth login")
+      expect(result.output).toContain("/remote")
+      expect(KiloSessions.remoteStatus()).toEqual(before)
+      expect(yield* Effect.promise(() => fs.stat(folder(ctx)).catch((err: NodeJS.ErrnoException) => err.code))).toBe(
+        "ENOENT",
+      )
+    }),
+  )
+
+  const invalid: unknown[] = [
+    { operation: "run", goal: "Missing provider" },
+    { operation: "run", goal: "Continuation without provider", browser_task_id: task },
+    { operation: "run", provider_id: provider },
+    { operation: "run", provider_id: provider, goal: "é".repeat(8193) },
+    { operation: "status" },
+    { operation: "cancel" },
+    { operation: "list", provider_id: provider },
+    { operation: "recover", browser_task_id: task },
+    ...[
+      "user",
+      "owner",
+      "parentSessionId",
+      "processId",
+      "capability",
+      "parentProof",
+      "invocationId",
+      "connectionId",
+      "PRIVATE_SECRET",
+    ].map((key) => ({ ...args, [key]: "PRIVATE_SECRET" })),
+  ]
+  for (const [index, input] of invalid.entries()) {
+    it.live(`rejects operation or identity violation ${index} before any request`, () =>
+      Effect.gen(function* () {
+        const wire = relay()
+        const ctx = context()
+        const current: Tool.Def = yield* tool
+        const result = yield* current.execute(input, ctx).pipe(Effect.exit)
+        expect(Exit.isFailure(result)).toBe(true)
+        if (Exit.isFailure(result)) {
+          expect(Cause.pretty(result.cause)).toContain("invalid arguments")
+          expect(Cause.pretty(result.cause)).not.toContain("PRIVATE_SECRET")
+        }
+        expect(wire.requests).toEqual([])
+        expect(yield* Effect.promise(() => fs.stat(folder(ctx)).catch((err: NodeJS.ErrnoException) => err.code))).toBe(
+          "ENOENT",
+        )
+      }),
+    )
+  }
+
+  it.live("honors provider and goal permission denial before deriving ownership", () =>
+    Effect.gen(function* () {
+      const wire = relay()
+      const ctx = context()
+      ctx.ask = (request) =>
+        Effect.sync(() => {
+          expect(request.permission).toBe("browser_task")
+          expect(request.patterns).toEqual([provider])
+          expect(request.metadata).toMatchObject({ provider_id: provider, goal: args.goal })
+          throw new Error("Consent denied")
+        })
+      const current = yield* tool
+      const result = yield* current.execute(args, ctx).pipe(Effect.exit)
+      expect(Exit.isFailure(result)).toBe(true)
+      if (Exit.isFailure(result)) expect(Cause.pretty(result.cause)).toContain("Consent denied")
+      expect(wire.requests).toEqual([])
+      expect(yield* Effect.promise(() => fs.stat(folder(ctx)).catch((err: NodeJS.ErrnoException) => err.code))).toBe(
+        "ENOENT",
+      )
+    }),
+  )
+
+  it.live("fails closed at the sandbox boundary before permission or browser dispatch", () =>
+    Effect.gen(function* () {
+      const wire = relay()
+      const ctx = context()
+      ctx.ask = () => Effect.die(new Error("Permission must not run"))
+      const current = yield* tool
+      const result = yield* sandbox(denied, current.execute(args, ctx)).pipe(Effect.exit)
+      expect(Exit.isFailure(result)).toBe(true)
+      if (Exit.isFailure(result)) {
+        expect(Cause.pretty(result.cause)).toContain("Sandbox denied outbound network access")
+        expect(Cause.pretty(result.cause)).not.toContain("Permission must not run")
+      }
+      expect(wire.requests).toEqual([])
+      expect(yield* Effect.promise(() => fs.stat(folder(ctx)).catch((err: NodeJS.ErrnoException) => err.code))).toBe(
+        "ENOENT",
+      )
+    }),
+  )
+
+  for (const operation of ["status", "cancel", "run"] as const) {
+    it.live(`denies a foreign conversation during ${operation} without network authority`, () =>
+      Effect.gen(function* () {
+        const wire = relay()
+        const foreign = context()
+        yield* seed(foreign)
+        const owner = yield* BrowserOwner.open(foreign)
+        yield* Effect.promise(async () => {
+          await owner.approve(provider)
+          await owner.prepare({ providerId: provider, goal: "A different parent's browser goal" })
+          await owner.remember({
+            providerId: provider,
+            browserTaskId: task,
+            jobId: `bj_${crypto.randomUUID()}`,
+            invocationId: owner.invocationId,
+          })
+        })
+        const ctx = context()
+        yield* seed(ctx)
+        const current = yield* tool
+        const input: RemoteProtocol.BrowserTaskArguments =
+          operation === "run" ? { ...args, browser_task_id: task } : { operation, browser_task_id: task }
+        const result = yield* current.execute(input, ctx)
+        expect(JSON.parse(result.output)).toMatchObject({ status: "rejected", reason: "not_found", retryable: false })
+        expect(wire.requests).toEqual([])
+      }),
+    )
+  }
+
+  it.live("discovery stays read-only and does not create a default provider or owner", () =>
+    Effect.gen(function* () {
+      const wire = relay()
+      const ctx = context()
+      const current = yield* tool
+      const pending = yield* current.execute({ operation: "list" }, ctx).pipe(Effect.forkChild)
+      const request = yield* Effect.promise(wire.next)
+      expect(request.operation).toBe("list")
+      wire.reply(request, {
+        kind: "providers",
+        providers: [{ providerId: provider, label: "Work profile", availability: "available", queueDepth: 0 }],
+      })
+      const result = yield* Fiber.join(pending)
+      expect(JSON.parse(result.output).providers).toEqual([
+        { providerId: provider, label: "Work profile", availability: "available", queueDepth: 0 },
+      ])
+      expect(wire.requests).toHaveLength(1)
+      expect(yield* Effect.promise(() => fs.stat(folder(ctx)).catch((err: NodeJS.ErrnoException) => err.code))).toBe(
+        "ENOENT",
+      )
+    }),
+  )
+})
+
+it.live("requires panel recovery and fresh consent after an uncertain execution rejection", () =>
+  Effect.gen(function* () {
+    const wire = relay()
+    const ctx = context()
+    yield* seed(ctx)
+    const current = yield* tool
+    const pending = yield* current.execute(args, ctx).pipe(Effect.forkChild)
+    const request = yield* Effect.promise(wire.next)
+    wire.reply(request, {
+      kind: "error",
+      code: "effects_uncertain",
+      retryable: false,
+      message: "Prior effects are uncertain",
+    })
+    const result = yield* Fiber.join(pending)
+    expect(JSON.parse(result.output)).toMatchObject({
+      status: "rejected",
+      reason: "effects_uncertain",
+      effectsUncertain: true,
+      retryable: false,
+    })
+    expect(result.output).toContain("Close the affected bound tabs")
+    expect(result.output).toContain("release execution locks")
+    expect(result.output).toContain("panel recovery action")
+    expect(result.output).toContain("approve a fresh tab")
+    expect(wire.requests.map((request) => request.operation)).toEqual(["invoke"])
+  }),
+)
+
+for (const status of ["succeeded", "failed", "interrupted", "timed_out", "cancelled"] as const) {
+  it.live(`formats an honest ${status} outcome and empty evidence for only its owning chat`, () =>
+    Effect.gen(function* () {
+      const wire = relay()
+      const ctx = context()
+      yield* seed(ctx)
+      const updates: unknown[] = []
+      ctx.metadata = (value) =>
+        Effect.sync(() => {
+          updates.push(value)
+        })
+      const current = yield* tool
+      const pending = yield* current.execute(args, ctx).pipe(Effect.forkChild)
+      const request = yield* Effect.promise(wire.next)
+      if (request.operation !== "invoke") throw new Error("Expected run dispatch")
+      const owner = yield* BrowserOwner.open(ctx)
+      const intent = (yield* Effect.promise(() => owner.recover())).at(0)!
+      const handle: RemoteProtocol.BrowserJobHandle = {
+        providerId: provider,
+        browserTaskId: task,
+        jobId: `bj_${crypto.randomUUID()}`,
+        invocationId: request.invocationId,
+      }
+      wire.reply(request, { kind: "ack", operation: "invoke", ...handle })
+      const poll = yield* Effect.promise(wire.next)
+      expect(poll.operation).toBe("status")
+      expect(updates.at(0)).toMatchObject({
+        metadata: { status: "accepted", job_id: handle.jobId, browser_task_id: task },
+      })
+      const result = RemoteProtocol.BrowserResult.parse({
+        ...handle,
+        status,
+        reason: status === "succeeded" ? "completed" : status === "cancelled" ? "cancelled" : "runner_failed",
+        effectsUncertain: status === "interrupted",
+        summary: `Observed ${status} outcome`,
+        evidence: [],
+      })
+      const created = Number(request.invocationId.split(".").at(1))
+      const hash = (fields: string[]) => createHash("sha256").update(JSON.stringify(fields)).digest("hex")
+      const job = RemoteProtocol.BrowserJobSnapshot.parse({
+        ...handle,
+        generation: 1,
+        payloadFingerprint: hash([
+          "user_1",
+          request.owner.parentSessionId,
+          hash([request.owner.parentProof]),
+          request.providerId,
+          request.browserTaskId ?? "",
+          request.goal,
+        ]),
+        createdAt: new Date(created).toISOString(),
+        expiresAt: new Date(created + 604_800_000).toISOString(),
+        deadlines: { queue: new Date(created + 600_000).toISOString() },
+        status,
+        result,
+      })
+      expect(job.payloadFingerprint).not.toBe(intent.payloadFingerprint)
+      wire.reply(poll, { kind: "status", job })
+      const finished = yield* Fiber.join(pending)
+      expect(JSON.parse(finished.output)).toMatchObject({
+        status,
+        reason: result.reason,
+        summary: result.summary,
+        evidence: [],
+        effectsUncertain: result.effectsUncertain,
+        browser_task_id: task,
+        job_id: handle.jobId,
+      })
+      if (status === "interrupted") {
+        expect(finished.output).toContain("Close the affected bound tabs")
+        expect(finished.output).toContain("approve a fresh tab")
+      }
+      const foreign = context()
+      yield* seed(foreign)
+      const outsider = yield* BrowserOwner.open(foreign)
+      expect(yield* Effect.promise(() => outsider.approved(provider))).toBe(false)
+      expect(yield* Effect.promise(() => owner.approved(provider))).toBe(true)
+    }),
+  )
+}
+
+const registry = testEffect(
+  LayerNode.compile(ToolRegistry.node, [
+    [Config.node, TestConfig.layer({ directories: () => Effect.succeed([]) })],
+    [RuntimeFlags.node, RuntimeFlags.layer({})],
+  ]),
+)
+registry.instance("exposes browser_task through the real registry with its sandbox annotation", () =>
+  Effect.gen(function* () {
+    const service = yield* ToolRegistry.Service
+    const tools = yield* service.all()
+    const browser = tools.find((tool) => tool.id === "browser_task")
+    if (!browser) throw new Error("The browser tool is absent from the registry")
+    expect(Network.isBuiltin(browser)).toBe(true)
+    const boundary = yield* sandbox(denied, Network.tool(browser, Effect.succeed("dispatch"))).pipe(Effect.exit)
+    expect(Exit.isFailure(boundary)).toBe(true)
+    if (Exit.isFailure(boundary))
+      expect(Cause.pretty(boundary.cause)).toContain("Sandbox denied outbound network access")
+    const result = yield* browser.execute({ operation: "list" }, context())
+    expect(JSON.parse(result.output).reason).toBe("remote_disabled")
+  }),
+)

--- a/packages/opencode/test/kilocode/tool/browser-task.test.ts
+++ b/packages/opencode/test/kilocode/tool/browser-task.test.ts
@@ -300,6 +300,123 @@ describe("browser_task permission and schema", () => {
   )
 })
 
+it.live("formats accepted handle persistence failure as interrupted delivery with lookup-only recovery", () =>
+  Effect.gen(function* () {
+    const wire = relay()
+    const ctx = context()
+    yield* seed(ctx)
+    const current = yield* tool
+    const pending = yield* current.execute(args, ctx).pipe(Effect.forkChild)
+    const request = yield* Effect.promise(wire.next)
+    if (request.operation !== "invoke") throw new Error("Expected run dispatch")
+    const handle: RemoteProtocol.BrowserJobHandle = {
+      providerId: provider,
+      browserTaskId: task,
+      jobId: `bj_${crypto.randomUUID()}`,
+      invocationId: request.invocationId,
+    }
+    const dir = folder(ctx)
+    yield* Effect.acquireUseRelease(
+      Effect.promise(() => fs.rename(dir, `${dir}.unavailable`)),
+      () =>
+        Effect.gen(function* () {
+          wire.reply(request, { kind: "ack", operation: "invoke", ...handle })
+          const result = yield* Fiber.join(pending)
+          expect(result.title).toBe("Browser task: interrupted")
+          expect(JSON.parse(result.output)).toMatchObject({
+            status: "interrupted",
+            reason: "delivery_interrupted",
+            provider_id: provider,
+            browser_task_id: task,
+            job_id: handle.jobId,
+            invocation_id: handle.invocationId,
+            evidence: [],
+            effectsUncertain: true,
+            retryable: true,
+          })
+          expect(result.metadata).toMatchObject(JSON.parse(result.output))
+          expect(result.output).toContain("accepted")
+          expect(result.output).toContain("persistence failed")
+          expect(result.output).toContain("does not establish browser failure")
+          expect(result.output).toContain("Once private browser storage is available")
+          expect(result.output).toContain("operation=recover")
+          expect(result.output).toContain("without replay")
+          expect(result.output).toContain("Do not automatically repeat operation=run")
+          expect(result.output).not.toContain(request.owner.parentProof)
+          expect(wire.requests.map((request) => request.operation)).toEqual(["invoke"])
+        }),
+      () => Effect.promise(() => fs.rename(`${dir}.unavailable`, dir)),
+    )
+    const owner = yield* BrowserOwner.open(ctx)
+    expect((yield* Effect.promise(() => owner.recover())).at(0)?.handle).toBeUndefined()
+  }),
+)
+
+it.live("explains a busy continuation and checks its outstanding job only on an explicit status call", () =>
+  Effect.gen(function* () {
+    const wire = relay()
+    const ctx = context()
+    yield* seed(ctx)
+    const owner = yield* BrowserOwner.open(ctx)
+    const handle: RemoteProtocol.BrowserJobHandle = {
+      providerId: provider,
+      browserTaskId: task,
+      jobId: `bj_${crypto.randomUUID()}`,
+      invocationId: owner.invocationId,
+    }
+    yield* Effect.promise(async () => {
+      await owner.approve(provider)
+      await owner.prepare({ providerId: provider, goal: args.goal })
+      await owner.remember(handle)
+    })
+    const current = yield* tool
+    const pending = yield* current
+      .execute({ ...args, browser_task_id: task, goal: "Read the next page" }, { ...ctx, callID: "continue" })
+      .pipe(Effect.forkChild)
+    const request = yield* Effect.promise(wire.next)
+    expect(request).toMatchObject({ operation: "invoke", browserTaskId: task, goal: "Read the next page" })
+    wire.reply(request, { kind: "error", code: "conversation_busy", retryable: true, message: "Conversation busy" })
+    const result = yield* Fiber.join(pending)
+    expect(JSON.parse(result.output)).toMatchObject({
+      status: "rejected",
+      reason: "conversation_busy",
+      retryable: true,
+      effectsUncertain: false,
+    })
+    expect(result.output).toContain("outstanding job")
+    expect(result.output).toContain("operation=status")
+    expect(result.output).toContain("same browser_task_id")
+    expect(result.output).toContain("operation=cancel")
+    expect(result.output).toContain("Do not automatically retry the continuation")
+    expect(wire.requests.map((request) => request.operation)).toEqual(["invoke"])
+    const polling = yield* current
+      .execute({ operation: "status", browser_task_id: task }, { ...ctx, callID: "check-outstanding-job" })
+      .pipe(Effect.forkChild)
+    const status = yield* Effect.promise(wire.next)
+    expect(status).toMatchObject({ operation: "status", browserTaskId: task })
+    const created = Number(handle.invocationId.split(".").at(1))
+    wire.reply(status, {
+      kind: "status",
+      job: {
+        ...handle,
+        status: "queued",
+        generation: 1,
+        payloadFingerprint: "a".repeat(64),
+        createdAt: new Date(created).toISOString(),
+        expiresAt: new Date(created + 604_800_000).toISOString(),
+        deadlines: { queue: new Date(created + 600_000).toISOString() },
+      },
+    })
+    expect(JSON.parse((yield* Fiber.join(polling)).output)).toMatchObject({
+      status: "queued",
+      browser_task_id: task,
+      job_id: handle.jobId,
+      invocation_id: owner.invocationId,
+    })
+    expect(wire.requests.map((request) => request.operation)).toEqual(["invoke", "status"])
+  }),
+)
+
 it.live("requires panel recovery and fresh consent after an uncertain execution rejection", () =>
   Effect.gen(function* () {
     const wire = relay()


### PR DESCRIPTION
- The command-line interface (CLI) gains a dedicated browser task tool. With compatible browser support, it finds enabled profiles and requests work through your chosen profile.
- Each new task or continuation requires permission and an explicit profile choice. A continuation sends only the new goal, not the chat history.
- You can check status, request cancellation, or recover stored task status for the current conversation without replaying previous browser actions.
- Results distinguish browser failure, cancellation, interrupted delivery, and uncertain effects. Cancellation does not claim to undo actions already issued.
- If remote access or browser support is unavailable, the tool explains the requirement instead of silently enabling access.

---

## Context

CLI level 6 connects browser-task delegation to the existing relay while keeping recovery separate from browser execution. The extension provider and the full live browser path remain pending in later Cloud levels.

## Implementation

`BrowserTaskTool` registers `browser_task` by default through `KiloToolRegistry`; optional `browser` inputs preserve existing callers, and `BrowserTaskArguments` validates `list`, `run`, `status`, `cancel`, and `recover`. Every non-list operation requests `browser_task` permission; `run` requires explicit `provider_id` and `goal`, with an owned `browser_task_id` for continuation. `BrowserOwner` derives private authority from trusted `Tool.Context`, not model input; only the new goal travels, and `tool:browser_task` enforces network denial.

<details>
<summary>Files</summary>

- `packages/opencode/src/kilocode/tool/browser-task.ts` — added, 131 changed lines; advertises an object schema for model compatibility, a 16 KiB goal limit, and sanitized validation errors. Status and cancellation require `browser_task_id`; optional `job_id` selects a job, otherwise the relay selects the latest owned job. Recovery takes no identifiers; progress and results use structured metadata, and the tool description requires fresh tab consent.
- `packages/opencode/src/kilocode/tool/registry.ts` — modified, 26 changed lines; initializes and registers browser tasks with or without notebook support.
- `packages/opencode/src/kilocode/sandbox/network-tools.ts` — modified, 1 changed line; classifies browser tasks as opaque network access.

</details>

`BrowserClient` uses private `BrowserOwner` intents for durable recovery; the authenticated relay checks its fingerprint separately from the immutable local intent hash. Only authoritative `not_found` permits the original unchanged invocation to resend; `recover` submits no work, and `recovery_required` stops new goals behind unresolved intents. `BrowserClient.Output` preserves terminal status, evidence, and `effectsUncertain`; bounded recovery and cancellation use `BrowserClientError` to distinguish lost delivery from browser failure.

<details>
<summary>Files</summary>

- `packages/opencode/src/kilocode/browser-task/client.ts` — added, 577 changed lines; persists intent before dispatch and adds paginated discovery, correlated progress, owned-handle validation, durable acknowledgement storage, and terminal-event precedence. Negotiation waits five seconds; replies wait ten seconds; discovery, submission recovery, and lost-delivery recovery use 30-second bounds. One-second status polling follows relay deadlines plus 30 seconds; cancellation allows ten seconds for confirmation, not just acknowledgement. It explains unavailable providers, full queues, empty recovery, missing accepted jobs, and panel recovery after uncertain effects.

</details>

`KiloSessions.browser` uses the existing authenticated `RemoteWS` socket without enabling remote access or uploading a session. `RemoteWS.Options.onBrowserMessage` negotiates `browserJobsV1` on each connection; `RemoteWS.Connection.send` adds a boolean `connectedOnly` overload, while legacy callers retain buffering. Browser frames require fresh negotiation; missing capability support fails closed, and parse-failure logs expose byte counts rather than validation details.

<details>
<summary>Files</summary>

- `packages/opencode/src/kilo-sessions/kilo-sessions.ts` — modified, 46 changed lines; creates and closes the browser client with remote access, including superseded connections. It routes browser messages separately, preserves legacy context, and sends the immediate negotiation heartbeat on every connection.
- `packages/opencode/src/kilo-sessions/remote-ws.ts` — modified, 47 changed lines; advertises browser support only for opted-in consumers and separates browser callbacks from legacy messages. It resets negotiation on reconnect, never buffers browser requests, and sanitizes parse errors.

</details>

The `kilo-code` changeset declares a minor release for browser-task delegation. The release note includes profile selection, an open signed-in panel, fresh tab consent, and recovery without replay.

<details>
<summary>Files</summary>

- `.changeset/browser-task.md` — added, 5 changed lines; documents the minor feature release and its consent and recovery requirements.

</details>

Tests: 4 files changed, with 1,588 changed lines. Added `packages/opencode/test/kilocode/browser-task/client.test.ts` (957 lines) and `packages/opencode/test/kilocode/tool/browser-task.test.ts` (433 lines). Modified `packages/opencode/test/kilocode/sessions/remote-ws.test.ts` (180 changed lines) and `packages/opencode/test/kilocode/sandbox/network.test.ts` (18 changed lines).
Generated: 0 files changed.

---

## Issue

Feature-request exception: no issue link was supplied for this browser-task feature.

## Screenshots / Video

Visual Changes: N/A

## How to Test

### Verification

No end-to-end (E2E) report is attached. Bot E2E waits for both stack tips to land.

### Manual/local verification

- The implementer agent reported 123 passing repository tests across the browser client, browser tool, RemoteWS, and sandbox suites.
- The implementer agent reported three passing scratch integration tests against the real relay store.
- Captured implementer evidence records nine successful commands, including scoped Prettier checks, type-aware Oxlint, the five test runs, and whitespace validation.
- This description round did not rerun product checks. No human manual verification was supplied.

### Reviewer test steps

1. Use the CLI repository root at the reviewed head, `browser-task-0787-s6`.
2. Run each scoped suite separately:

```sh
npx --yes bun@1.3.14 test --cwd packages/opencode --timeout 60000 ./test/kilocode/browser-task/client.test.ts
npx --yes bun@1.3.14 test --cwd packages/opencode --timeout 60000 ./test/kilocode/tool/browser-task.test.ts
npx --yes bun@1.3.14 test --cwd packages/opencode --timeout 60000 ./test/kilocode/sessions/remote-ws.test.ts
npx --yes bun@1.3.14 test --cwd packages/opencode --timeout 60000 ./test/kilocode/sandbox/network.test.ts
```

3. Confirm that all four commands exit successfully.

The three integration tests use a scratch fixture outside the branch; the commands cover the repository tests only.

### Blocked checks and substitute verification

Live CLI model calls, extension execution, and browser verification remain unverified. The extension provider is pending, so scoped repository tests and real relay-store integration tests provide substitute evidence, not live browser proof.

## Human steps

- before merge — **Confirm the author's personal-review checklist item.**
- after merge — **For live use, deploy a relay that supports `browserJobsV1` before enabling browser tasks.**
- after merge — **When browser-provider support is available, sign in with `kilo auth login`.**
- after merge — **Enable `/remote` explicitly.**
- after merge — **Enable CLI tasks for the selected browser profile.**
- after merge — **Keep the signed-in browser panel open.**
- after merge — **Approve a fresh browser tab for each task or continuation.**

The change requires no new environment value, secret, migration, or cache reset.

## Notes

Bot E2E remains pending until both stack tips land. Scoped relay-store integration tests do not prove the live browser path.

- The CLI base is [PR 13561](https://github.com/Kilo-Org/kilocode/pull/13561), which supplies private ownership and durable intent storage.
- The earlier CLI protocol contract is [PR 13535](https://github.com/Kilo-Org/kilocode/pull/13535).
- Cloud producer dependencies are [PR 5638](https://github.com/Kilo-Org/cloud/pull/5638), [PR 5644](https://github.com/Kilo-Org/cloud/pull/5644), [PR 5648](https://github.com/Kilo-Org/cloud/pull/5648), and [PR 5653](https://github.com/Kilo-Org/cloud/pull/5653).
- These cross-repository dependencies are links, not Git bases.

### Worktrees and review scope

- `Kilo-Org/kilocode`: `/Users/igor/Projects/.worktrees/browser-task-0787-kilocode`; review range `browser-task-0787-s5...browser-task-0787-s6`.
- `Kilo-Org/cloud`: `/Users/igor/Projects/.worktrees/browser-task-0787`, branch `browser-task-0787-s4`; dependency context only.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [ ] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

The handoff supplies no author attestation for the final checkbox.

## Get in Touch

No contact handle was supplied.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `browser-task-0787` — #13535
5. `browser-task-0787-s5` — #13561
6. `browser-task-0787-s6` — #13567 ← this PR (tip)
