### PR TITLE
fix(agent-manager): show live subagent tab activity

### DIFF
--- a/.changeset/fix-subagent-tab-activity.md
+++ b/.changeset/fix-subagent-tab-activity.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show live activity indicators for subagent tabs in Agent Manager, including running, retrying, waiting for input, completed, and error states.

--- a/packages/kilo-vscode/tests/fixtures/session-provider-activity.tsx
+++ b/packages/kilo-vscode/tests/fixtures/session-provider-activity.tsx
@@ -13,9 +13,11 @@ Object.assign(globalThis, {
   window,
   document: window.document,
   navigator: window.navigator,
+  localStorage: window.localStorage,
   Node: window.Node,
   Element: window.Element,
   HTMLElement: window.HTMLElement,
+  HTMLHeadElement: window.HTMLHeadElement,
   HTMLInputElement: window.HTMLInputElement,
   HTMLTextAreaElement: window.HTMLTextAreaElement,
   SVGElement: window.SVGElement,
@@ -23,6 +25,7 @@ Object.assign(globalThis, {
   IntersectionObserver: window.IntersectionObserver,
   ResizeObserver: window.ResizeObserver,
   CustomEvent: window.CustomEvent,
+  customElements: window.customElements,
   Event: window.Event,
   MessageEvent: window.MessageEvent,
   requestAnimationFrame: window.requestAnimationFrame.bind(window),
@@ -32,14 +35,16 @@ Object.assign(globalThis, {
 })
 
 const { render } = await import("solid-js/web")
-const { For, createSignal } = await import("solid-js")
+const { For, Show, createSignal } = await import("solid-js")
 const { WorktreeItem } = await import("../../webview-ui/agent-manager/WorktreeItem")
+const { SubagentPanel } = await import("../../webview-ui/agent-manager/SubagentPanel")
 const { DragDropProvider, SortableProvider } = await import("@thisbeyond/solid-dnd")
 const { renderTab } = await import("../../webview-ui/agent-manager/tab-rendering")
 const { VSCodeProvider } = await import("../../webview-ui/src/context/vscode")
 const { ServerProvider } = await import("../../webview-ui/src/context/server")
 const { ConfigContext } = await import("../../webview-ui/src/context/config")
 const { LanguageContext } = await import("../../webview-ui/src/context/language")
+const { NotificationsProvider } = await import("../../webview-ui/src/context/notifications")
 const { ProviderContext } = await import("../../webview-ui/src/context/provider")
 const { SessionProvider, useSession } = await import("../../webview-ui/src/context/session")
 const { terminal } = await import("../../webview-ui/src/context/session-outcome")
@@ -85,6 +90,8 @@ const language = {
 const ref = { value: undefined as ReturnType<typeof useSession> | undefined }
 const [operation, setOperation] = createSignal(false)
 const [run, setRun] = createSignal(false)
+const [inspector, setInspector] = createSignal(false)
+const [active, setActive] = createSignal("task-child")
 const Probe = () => {
   const session = useSession()
   ref.value = session
@@ -143,6 +150,20 @@ const Probe = () => {
         onCopyPath={() => {}}
         onOpen={() => {}}
       />
+      <Show when={inspector()}>
+        <SubagentPanel
+          tabs={() => ["task-child", "task-grand"].map((id) => ({ id, title: id }))}
+          active={active}
+          visible={() => true}
+          nextKeybind=""
+          closeKeybind=""
+          onSelect={setActive}
+          onClose={() => {}}
+          onCloseOthers={() => {}}
+          onReorder={() => {}}
+          onClosePanel={() => setInspector(false)}
+        />
+      </Show>
     </DragDropProvider>
   )
 }
@@ -158,9 +179,11 @@ const dispose = render(
         <ProviderContext.Provider value={provider as never}>
           <ConfigContext.Provider value={config as never}>
             <LanguageContext.Provider value={language as never}>
-              <SessionProvider>
-                <Probe />
-              </SessionProvider>
+              <NotificationsProvider>
+                <SessionProvider>
+                  <Probe />
+                </SessionProvider>
+              </NotificationsProvider>
             </LanguageContext.Provider>
           </ConfigContext.Provider>
         </ProviderContext.Provider>
@@ -197,7 +220,18 @@ const check = async (id: string, expected: string) => {
   const actual = state(id)
   if (id === "root") card(expected)
   const tab = host.querySelector(`[data-tab-id="${id}"] [data-activity]`)
-  if (id === "root" || id === "background") assert(tab, `Missing rendered tab for ${id}`)
+  if (id === "root" || id === "background" || (inspector() && (id === "task-child" || id === "task-grand"))) {
+    assert(tab, `Missing rendered tab for ${id}`)
+    assert.equal(!!tab.querySelector('[data-component="spinner"]'), expected === "busy" || expected === "retry")
+  }
+  if (tab && (id === "task-child" || id === "task-grand")) {
+    assert.equal(tab.querySelector(".am-tab-icon")?.getAttribute("data-activity"), expected)
+    assert.equal(!!tab.querySelector(".am-tab-icon")?.getAttribute("aria-label"), expected !== "idle")
+    assert.equal(
+      tab.querySelector('[role="tab"]')?.getAttribute("aria-label"),
+      expected === "idle" ? id : `${id}: session.activity.${expected}`,
+    )
+  }
   if (tab && tab.getAttribute("data-activity") !== expected) {
     failures.push(
       `step ${step.value} ${id}: rendered tab expected ${expected}, got ${tab.getAttribute("data-activity")}`,
@@ -267,8 +301,15 @@ try {
   await emit({ type: "sessionStatus", sessionID: "durable-grand", status: "idle" })
 
   await emit({ type: "sessionStatus", sessionID: "task-child", status: "busy" })
+  setInspector(true)
   await check("root", "busy")
   await check("task-child", "busy")
+  await check("task-grand", "idle")
+  assert.equal(value.currentSessionID(), "root")
+  host.querySelector<HTMLElement>('[data-tab-id="task-grand"] [role="tab"]')!.click()
+  await settle()
+  assert.equal(active(), "task-grand")
+  assert.equal(value.currentSessionID(), "root")
   await emit({ type: "sessionStatus", sessionID: "task-child", status: "retry", attempt: 1, message: "retry", next: 1 })
   await check("root", "retry")
   await check("task-child", "retry")
@@ -359,6 +400,11 @@ try {
   await emit({ type: "sessionTurnClosed", sessionID: "task-child", reason: "completed", parentID: "root" })
   await check("task-child", "done")
   await check("root", "idle")
+  setInspector(false)
+  await settle()
+  setInspector(true)
+  await check("task-child", "done")
+  assert.equal(value.currentSessionID(), "root")
   await emit({ type: "sessionTurnClosed", sessionID: "task-child", reason: "error", parentID: "root" })
   await check("task-child", "error")
   await check("root", "idle")

--- a/packages/kilo-vscode/tests/unit/session-provider-activity.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-provider-activity.test.ts
@@ -20,6 +20,11 @@ describe("SessionProvider activity", () => {
       name: "solid-dedupe",
       setup(ctx: Parameters<NonNullable<Parameters<typeof build>[0]["plugins"]>[number]["setup"]>[0]) {
         ctx.onResolve({ filter: /^solid-js(\/web|\/store)?$/ }, (args) => ({ path: aliases[args.path] }))
+        ctx.onResolve({ filter: /\?worker&url$/ }, (args) => ({ path: args.path, namespace: "worker-url" }))
+        ctx.onLoad({ filter: /.*/, namespace: "worker-url" }, () => ({
+          contents: "export default undefined",
+          loader: "js",
+        }))
       },
     }
     const result = await build({
@@ -29,7 +34,7 @@ describe("SessionProvider activity", () => {
       external: ["happy-dom"],
       format: "esm",
       logLevel: "silent",
-      loader: { ".css": "empty" },
+      loader: { ".css": "empty", ".svg": "dataurl" },
       platform: "node",
       plugins: [dedupe, solidPlugin()],
       target: "es2022",

--- a/packages/kilo-vscode/webview-ui/agent-manager/ClosableTab.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ClosableTab.tsx
@@ -7,6 +7,7 @@ import { Show, type Component, type JSX } from "solid-js"
 import { SessionTabMenu } from "../src/components/chat/SessionTabMenu"
 import { SortableTabContainer } from "../src/components/chat/TabDnd"
 import { useLanguage } from "../src/context/language"
+import type { Activity } from "../src/utils/session-activity"
 import { parseBindingTokens } from "./keybind-tokens"
 
 type TabIcon = IconProps["name"] | "spinner"
@@ -24,6 +25,8 @@ export interface ClosableTabProps {
   /** Renders instead of `icon`, for tabs that need a per-filetype glyph. */
   iconNode?: Value<JSX.Element>
   iconStatus?: Value<"success" | "failure" | undefined>
+  state?: Activity
+  stateLabel?: string
   class?: string
   focused?: boolean
   active: boolean
@@ -52,6 +55,7 @@ export const ClosableTabChrome: Component<ClosableTabProps> = (props) => {
   return (
     <div
       class={`am-tab am-tab-closable ${props.active ? "am-tab-active" : ""} ${props.focused ? "am-tab-focused" : ""} ${props.class ?? ""}`}
+      data-activity={props.state}
     >
       <div
         class="am-tab-target"
@@ -72,7 +76,12 @@ export const ClosableTabChrome: Component<ClosableTabProps> = (props) => {
           openDelay={0}
         >
           <span class="am-tab-title">
-            <span class="am-tab-icon" data-run-status={status()}>
+            <span
+              class="am-tab-icon"
+              data-run-status={status()}
+              data-activity={props.state}
+              aria-label={props.stateLabel}
+            >
               <Show
                 when={props.iconNode}
                 fallback={
@@ -144,6 +153,8 @@ export const SortableClosableTab: Component<
         icon={props.icon}
         iconNode={props.iconNode}
         iconStatus={props.iconStatus}
+        state={props.state}
+        stateLabel={props.stateLabel}
         class={props.class}
         focused={props.focused}
         active={props.active}

--- a/packages/kilo-vscode/webview-ui/agent-manager/SubagentPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/SubagentPanel.tsx
@@ -7,10 +7,13 @@
 
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
-import { createEffect, type Accessor, type Component } from "solid-js"
+import { createEffect, createMemo, type Accessor, type Component } from "solid-js"
 import { DataBridge } from "../src/App"
 import { ChatView } from "../src/components/chat"
+import { ActivityIcon } from "../src/components/shared/ActivityIcon"
+import { useLanguage } from "../src/context/language"
 import { SessionProvider, useSession } from "../src/context/session"
+import { description, label, type Activity } from "../src/utils/session-activity"
 import { SortableClosableTab } from "./ClosableTab"
 import { InspectorTabStrip } from "./InspectorTabStrip"
 import type { SubagentTab } from "./subagent-tabs"
@@ -44,8 +47,9 @@ const SubagentChat: Component<{ active: Accessor<string | undefined> }> = (props
   )
 }
 
-const SubagentContent: Component<Props> = (props) => {
+const SubagentContent: Component<Props & { activity: (id: string) => Activity }> = (props) => {
   const session = useSession()
+  const language = useLanguage()
   const ids = () => props.tabs().map((tab) => tab.id)
   const title = (id: string) => props.tabs().find((tab) => tab.id === id)?.title ?? "Sub-agent"
   const close = (id: string, focus: { restore: () => void }) => {
@@ -89,13 +93,19 @@ const SubagentContent: Component<Props> = (props) => {
         onSelect={props.onSelect}
         onReorder={props.onReorder}
         renderTab={(id, api) => {
-          const label = title(id)
+          const name = title(id)
+          const state = createMemo(() => props.activity(id))
           return (
             <SortableClosableTab
               id={id}
-              label={label}
-              tooltip={label}
+              label={name}
+              tooltip={() => (state() === "idle" ? name : `${name}: ${language.t(description(state()))}`)}
               icon="task"
+              iconNode={
+                <ActivityIcon state={state()} idle={<Icon name="task" size="small" />} spinner="am-tab-spinner" />
+              }
+              state={state()}
+              stateLabel={state() === "idle" ? undefined : language.t(label(state()))}
               showKeybind={false}
               keybind={props.active() === id ? "" : props.nextKeybind}
               closeKeybind={props.closeKeybind}
@@ -124,8 +134,11 @@ const SubagentContent: Component<Props> = (props) => {
   )
 }
 
-export const SubagentPanel: Component<Props> = (props) => (
-  <SessionProvider>
-    <SubagentContent {...props} />
-  </SessionProvider>
-)
+export const SubagentPanel: Component<Props> = (props) => {
+  const session = useSession()
+  return (
+    <SessionProvider>
+      <SubagentContent {...props} activity={session.activityFor} />
+    </SessionProvider>
+  )
+}


### PR DESCRIPTION
## What Problem This Solves

Subagent tabs in Agent Manager kept a fixed task icon while the session was running, retrying, or waiting for input. This also affected async subagents opened from the background-agent strip, so their tabs did not provide the same progress and outcome signals as normal session tabs.

## Why This Change Was Made

Use the existing activity resolver, icons, colors, and translated labels. Read activity from the parent session provider so events received before the inspector opens are not lost. Keep the inspector's separate chat provider so selecting a subagent does not replace the parent conversation.

## User Impact

- Show animated spinners for running and retrying subagents.
- Show the normal needs-input, completed, and error indicators, with matching tooltips.
- Update inactive tabs and preserve the idle task icon.
- Keep tab selection, closing, and reopening independent of the parent chat.

## Evidence

- Extension build, type checks, lint, Knip, formatting, and the Kilo marker guard passed.
- All 36 focused tests passed, including the real subagent panel mounted after activity events and reopened after completion.
- All 4,494 extension unit tests passed on rerun without code changes. The first full run hit the existing PR-comment render test's 5-second timeout; that test also passed in isolation.
- Isolated VS Code checks passed for all six states, inactive-tab updates, blocking versus nonblocking questions, disconnect/reconnect, async-agent opening, spinner animation, and closing/switching tabs.
- UI checks used deterministic session events, not live model requests. The screenshots contain only test labels.

Running, retrying, and waiting for input:

<img width="700" alt="Subagent tabs show running and retrying spinners and a needs-input warning" src="https://marius-kilocode.github.io/pr-assets/20260831-subagent-tabs-running-22da7021.png" />

Completed, error, and idle states after reopening the tabs:

<img width="700" alt="Subagent tabs show a completed check, an error warning, and the idle task icon" src="https://marius-kilocode.github.io/pr-assets/20260831-subagent-tabs-outcomes-22da7021.png" />
