### PR TITLE
test(cli): catch blank TUI in release smoke checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Run cross-platform PTY service tests
         if: matrix.settings.run && matrix.settings.pty
         working-directory: packages/core
-        run: bun test test/kilocode/pty-platform.test.ts --timeout 60000
+        run: bun test test/kilocode/pty-platform.test.ts test/kilocode/pty-smoke.test.ts --timeout 60000
 
       - name: Run cross-platform PTY route tests
         if: matrix.settings.run && matrix.settings.pty

--- a/packages/core/src/kilocode/pty/smoke.ts
+++ b/packages/core/src/kilocode/pty/smoke.ts
@@ -55,7 +55,8 @@ export async function render(file: string, args: string[] = ["--pure"], timeout 
         ready.reject(new Error(`TUI diagnostic during ${state.phase}: ${JSON.stringify(state.output)}`))
         return
       }
-      if (state.phase === "prompt" && text.includes("Ask anything...")) {
+      const visible = text.replace(/[\r\n]/g, "")
+      if (state.phase === "prompt" && visible.includes("Ask anything...")) {
         state.phase = "palette"
         state.output = ""
         try {
@@ -65,7 +66,7 @@ export async function render(file: string, args: string[] = ["--pure"], timeout 
         }
         return
       }
-      if (state.phase === "palette" && text.includes("Commands")) ready.resolve()
+      if (state.phase === "palette" && visible.includes("Commands")) ready.resolve()
     })
     const exit = proc.onExit((event) => {
       ready.reject(

--- a/packages/core/src/kilocode/pty/smoke.ts
+++ b/packages/core/src/kilocode/pty/smoke.ts
@@ -1,8 +1,98 @@
 import { Shell } from "../../shell"
 import { KiloPtyTermination } from "./termination"
 import { spawn } from "#pty"
+import { mkdtemp, rm } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { stripVTControlCharacters } from "node:util"
 
 const TIMEOUT = 15_000
+const OUTPUT_LIMIT = 20_000
+const DIAGNOSTIC =
+  /(?:TUI worker error\b|(?:^|[\r\n])\s*(?:panic|fatal(?: error)?|unhandled exception|uncaught exception)\b)/i
+
+export async function render(file: string, args: string[] = ["--pure"], timeout = 60_000) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "kilo-pty-render-"))
+  const env: Record<string, string> = {}
+  for (const key of ["PATH", "SystemRoot", "SYSTEMROOT", "ComSpec", "LANG", "LC_ALL", "LC_CTYPE", "LANGUAGE"]) {
+    const value = process.env[key]
+    if (value !== undefined) env[key] = value
+  }
+  Object.assign(env, {
+    TERM: "xterm-256color",
+    KILO_TERMINAL: "1",
+    KILO_TEST_HOME: dir,
+    KILO_NO_DAEMON: "1",
+    KILO_DISABLE_AUTOUPDATE: "1",
+    KILO_DISABLE_MODELS_FETCH: "1",
+    KILO_DISABLE_PROJECT_CONFIG: "1",
+    KILO_DISABLE_DEFAULT_PLUGINS: "1",
+    KILO_PURE: "1",
+    KILO_CONFIG_CONTENT: JSON.stringify({ enabled_providers: [], experimental: { openTelemetry: false } }),
+    KILO_AUTH_CONTENT: "{}",
+    HOME: dir,
+    USERPROFILE: dir,
+    APPDATA: path.join(dir, "AppData", "Roaming"),
+    LOCALAPPDATA: path.join(dir, "AppData", "Local"),
+    XDG_DATA_HOME: path.join(dir, ".local", "share"),
+    XDG_CACHE_HOME: path.join(dir, ".cache"),
+    XDG_CONFIG_HOME: path.join(dir, ".config"),
+    XDG_STATE_HOME: path.join(dir, ".local", "state"),
+    TMPDIR: dir,
+    TMP: dir,
+    TEMP: dir,
+  })
+
+  try {
+    const proc = spawn(file, args, { name: "xterm-256color", cwd: dir, env, cols: 100, rows: 40 })
+    const state = { output: "", phase: "prompt" }
+    const ready = Promise.withResolvers<void>()
+    const data = proc.onData((chunk) => {
+      const raw = state.output + chunk
+      const text = stripVTControlCharacters(raw)
+      state.output = raw.slice(-OUTPUT_LIMIT)
+      if (DIAGNOSTIC.test(text)) {
+        ready.reject(new Error(`TUI diagnostic during ${state.phase}: ${JSON.stringify(state.output)}`))
+        return
+      }
+      if (state.phase === "prompt" && text.includes("Ask anything...")) {
+        state.phase = "palette"
+        state.output = ""
+        try {
+          proc.write("\x10")
+        } catch (err) {
+          ready.reject(err)
+        }
+        return
+      }
+      if (state.phase === "palette" && text.includes("Commands")) ready.resolve()
+    })
+    const exit = proc.onExit((event) => {
+      ready.reject(
+        new Error(
+          `TUI exited during ${state.phase} (code ${event.exitCode}, signal ${event.signal ?? "none"}): ${JSON.stringify(state.output)}`,
+        ),
+      )
+    })
+    const timer = setTimeout(
+      () =>
+        ready.reject(
+          new Error(`TUI timed out during ${state.phase} after ${timeout}ms: ${JSON.stringify(state.output)}`),
+        ),
+      timeout,
+    )
+    try {
+      await ready.promise
+    } finally {
+      clearTimeout(timer)
+      data.dispose()
+      exit.dispose()
+      await KiloPtyTermination.terminate(proc)
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
 
 export async function smoke() {
   const proc = spawn(Shell.preferred(), [], {

--- a/packages/core/test/kilocode/pty-smoke.test.ts
+++ b/packages/core/test/kilocode/pty-smoke.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test"
+import { render } from "../../src/kilocode/pty/smoke"
+
+const run = (source: string, timeout = 3_000) => render(process.execPath, ["-e", source], timeout)
+
+describe("rendered PTY smoke", () => {
+  test("accepts a chunked prompt and responsive command palette", async () => {
+    const source = [
+      "if (process.stdin.isTTY && process.stdin.setRawMode) process.stdin.setRawMode(true)",
+      'process.stdout.write("\\x1b[2J\\x1b[HAsk ")',
+      'setTimeout(() => process.stdout.write("anything..."), 20)',
+      'process.stdin.on("data", (data) => {',
+      '  if (!data.toString().includes("\\x10")) return',
+      '  process.stdout.write("\\x1b[2JCom")',
+      '  setTimeout(() => process.stdout.write("mands"), 20)',
+      "})",
+      "setInterval(() => {}, 1000)",
+    ].join("\n")
+
+    await expect(run(source)).resolves.toBeUndefined()
+  })
+
+  test("times out when output has no visible prompt", async () => {
+    const source = 'process.stdout.write("\\x1b[2J\\x1b[H\\x1b[?25l\\r\\n"); setInterval(() => {}, 1000)'
+
+    await expect(run(source)).rejects.toThrow(/timed out during prompt/)
+  })
+
+  test("rejects a zero exit before the prompt", async () => {
+    const source = 'process.stdout.write("started"); setTimeout(() => process.exit(0), 20)'
+
+    await expect(run(source)).rejects.toThrow(/exited during prompt \(code 0,/)
+  })
+
+  test("rejects a nonzero exit before the prompt", async () => {
+    const source = 'process.stdout.write("started"); setTimeout(() => process.exit(7), 20)'
+
+    await expect(run(source)).rejects.toThrow(/exited during prompt \(code 7,/)
+  })
+
+  test("times out when the prompt ignores the palette key", async () => {
+    const source = 'process.stdout.write("\\x1b[2J\\x1b[HAsk anything..."); setInterval(() => {}, 1000)'
+
+    await expect(run(source)).rejects.toThrow(/timed out during palette/)
+  })
+
+  test("rejects a TUI worker diagnostic before bundled source text", async () => {
+    const source =
+      'process.stdout.write("rendered: TUI worker error Error: Ask anything...\\nconst source = \\\"Commands\\\"\\n"); setInterval(() => {}, 1000)'
+
+    await expect(run(source)).rejects.toThrow(/TUI diagnostic during prompt/)
+  })
+})

--- a/packages/core/test/kilocode/pty-smoke.test.ts
+++ b/packages/core/test/kilocode/pty-smoke.test.ts
@@ -4,14 +4,14 @@ import { render } from "../../src/kilocode/pty/smoke"
 const run = (source: string, timeout = 3_000) => render(process.execPath, ["-e", source], timeout)
 
 describe("rendered PTY smoke", () => {
-  test("accepts a chunked prompt and responsive command palette", async () => {
+  test("accepts chunked terminal redraws and a responsive command palette", async () => {
     const source = [
       "if (process.stdin.isTTY && process.stdin.setRawMode) process.stdin.setRawMode(true)",
-      'process.stdout.write("\\x1b[2J\\x1b[HAsk any")',
+      'process.stdout.write("\\x1b[2J\\x1b[HAsk any" + "\\r\\n".repeat(39) + "\\x1b[1;8H")',
       'setTimeout(() => process.stdout.write("thing..."), 20)',
       'process.stdin.on("data", (data) => {',
       '  if (!data.toString().includes("\\x10")) return',
-      '  process.stdout.write("\\x1b[2JCom")',
+      '  process.stdout.write("\\x1b[2J\\x1b[HCom" + "\\r\\n".repeat(39) + "\\x1b[1;4H")',
       '  setTimeout(() => process.stdout.write("mands"), 20)',
       "})",
       "setInterval(() => {}, 1000)",

--- a/packages/core/test/kilocode/pty-smoke.test.ts
+++ b/packages/core/test/kilocode/pty-smoke.test.ts
@@ -7,8 +7,8 @@ describe("rendered PTY smoke", () => {
   test("accepts a chunked prompt and responsive command palette", async () => {
     const source = [
       "if (process.stdin.isTTY && process.stdin.setRawMode) process.stdin.setRawMode(true)",
-      'process.stdout.write("\\x1b[2J\\x1b[HAsk ")',
-      'setTimeout(() => process.stdout.write("anything..."), 20)',
+      'process.stdout.write("\\x1b[2J\\x1b[HAsk any")',
+      'setTimeout(() => process.stdout.write("thing..."), 20)',
       'process.stdin.on("data", (data) => {',
       '  if (!data.toString().includes("\\x10")) return',
       '  process.stdout.write("\\x1b[2JCom")',
@@ -17,7 +17,7 @@ describe("rendered PTY smoke", () => {
       "setInterval(() => {}, 1000)",
     ].join("\n")
 
-    await expect(run(source)).resolves.toBeUndefined()
+    await run(source)
   })
 
   test("times out when output has no visible prompt", async () => {

--- a/packages/opencode/src/kilocode/cli/cmd/pty-smoke.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/pty-smoke.ts
@@ -7,5 +7,7 @@ export const PtySmokeCommand = cmd({
     if (process.env.KILO_PTY_SMOKE !== "1") throw new Error("PTY smoke command is release-only")
     const { PtySmoke } = await import("@opencode-ai/core/kilocode/pty/smoke")
     await PtySmoke.smoke()
+    await PtySmoke.render(process.execPath)
+    console.log("Compiled TUI startup smoke test passed")
   },
 })


### PR DESCRIPTION
## What Problem This Solves

The release PTY smoke only started a shell. It and the headless benchmarks could pass while the interactive CLI opened to a blank screen, as reported in #13473.

## Why This Change Was Made

Extend the existing gated `__pty-smoke` command instead of changing the release pipeline or Bun version. Require the compiled CLI to render `Ask anything...` and open `Commands` with Ctrl+P within 60 seconds. Fail on blank output, early exit, or startup diagnostics, and clean up the isolated child process.

## User Impact

A blank or unresponsive TUI now fails the existing release validation on supported PTY targets. No release-matrix or normal CLI behavior changes. Existing Alpine and Windows ARM64 PTY exclusions remain.

## Evidence

- Eight real-PTY tests passed with Bun 1.3.14, including blank output, early exits, an unresponsive prompt, and worker errors.
- Repository typecheck, lint (no errors), formatting, and affected workflow guards passed.
- Rebuilt the macOS ARM64 CLI and ran `KILO_PTY_SMOKE=1 <compiled-cli> --pure __pty-smoke`; prompt rendering and the command palette passed.
- Replayed the Windows terminal redraw failure locally: the test failed before newline normalization and passed afterward. [CI is now green on Linux, macOS, and Windows](https://github.com/Kilo-Org/kilocode/actions/runs/33381810614).
- The downloaded 7.5.0 macOS ARM64 artifact also passed the isolated probe. The historical blank screen did not reproduce locally; the failure-mode tests verify rejection of that symptom.