### PR TITLE
fix(cli): support Fish PTY smoke output

### DIFF
--- a/.changeset/fish-pty-smoke-output.md
+++ b/.changeset/fish-pty-smoke-output.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Support Fish shell output in the packaged PTY startup check.

--- a/packages/core/src/kilocode/pty/smoke-output.ts
+++ b/packages/core/src/kilocode/pty/smoke-output.ts
@@ -1,0 +1,7 @@
+export function hasReadyMarker(output: string) {
+  const lines = output
+    .replace(/\x1b\][\s\S]*?(?:\x07|\x1b\\)/g, "")
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "")
+    .split(/\r?\n/)
+  return lines.some((line) => line.trim() === "KILO_PTY_READY")
+}

--- a/packages/core/src/kilocode/pty/smoke.ts
+++ b/packages/core/src/kilocode/pty/smoke.ts
@@ -1,5 +1,6 @@
 import { Shell } from "../../shell"
 import { KiloPtyTermination } from "./termination"
+import { hasReadyMarker } from "./smoke-output"
 import { spawn } from "#pty"
 
 const TIMEOUT = 15_000
@@ -17,8 +18,7 @@ export async function smoke() {
   const exited = Promise.withResolvers<number>()
   const data = proc.onData((chunk) => {
     state.output += chunk
-    const lines = state.output.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "").split(/\r?\n/)
-    if (lines.some((line) => line.trim() === "KILO_PTY_READY")) output.resolve()
+    if (hasReadyMarker(state.output)) output.resolve()
   })
   const exit = proc.onExit((event) => {
     state.exited = true

--- a/packages/core/test/kilocode/pty-smoke-output.test.ts
+++ b/packages/core/test/kilocode/pty-smoke-output.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test"
+import { hasReadyMarker } from "../../src/kilocode/pty/smoke-output"
+
+test("detects the PTY marker after Fish title control sequences", () => {
+  const output = [
+    "\x1b]0;user@host ~/project\x07",
+    "\x1b]7;file://host/project\x1b\\",
+    "\x1b[?2004hKILO_PTY_READY\x1b[?2004l\r\n",
+  ].join("")
+
+  expect(hasReadyMarker(output)).toBe(true)
+})
+
+test("does not accept the marker as part of another line", () => {
+  expect(hasReadyMarker("prefix KILO_PTY_READY suffix\r\n")).toBe(false)
+})


### PR DESCRIPTION
## Issue

Fixes the Fish smoke-marker parsing subtask in #13451.

## Context

Fish can emit OSC title and working-directory controls around the expected PTY marker. The smoke check only removed CSI controls, so it could time out even after `KILO_PTY_READY` was printed.

## Implementation

Normalize complete BEL- or ST-terminated OSC sequences and CSI sequences before checking for an exact marker line. The parser remains strict about surrounding text so unrelated output cannot satisfy the smoke check.

## Screenshots / Video

N/A - no visual UI change.

## How to Test

### Manual/local verification

- Agent: `bun test test/kilocode/pty-smoke-output.test.ts` from `packages/core` with isolated XDG directories: 2 passed, 0 failed.
- Agent: `bun run --cwd packages/core typecheck`: passed.
- Agent: targeted Bun bundle of `packages/core/src/kilocode/pty/smoke.ts`: passed.
- Agent: Prettier check on the four changed files: passed.
- Agent: Oxlint on the changed TypeScript files: 0 errors; one existing warning in unchanged `smoke.ts` code.

### Reviewer test steps

1. From `packages/core`, run `bun test test/kilocode/pty-smoke-output.test.ts`.
2. Confirm BEL- and ST-terminated Fish controls are accepted while a marker embedded in another line is rejected.

### Blocked checks and substitute verification

- Fish is not installed on the verification host, so the real Fish PTY process was not executed. The focused parser test uses captured Fish-shaped OSC/CSI output for both OSC terminators.
- The existing `pty-platform.test.ts` default-shell exit assertion returns `1` instead of `0` on this host. That file does not import the changed parser; its process-tree termination case passes. Focused parser tests, typecheck, bundle, formatting, and lint were used as substitute verification.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [ ] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

GitHub: @cyq1017
