### PR TITLE
docs: enforce Promise.withResolvers() more explicitly.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ Examples: `fix(tui): simplify thinking toggle styling`, `docs: update contributi
 - Prefer single word variable names where possible
 - Use Bun APIs when possible, like `Bun.file()`
 - Rely on type inference when possible; avoid explicit type annotations or interfaces unless necessary for exports or clarity
-- Prefer `Promise.withResolvers<T>()` for deferreds when runtime/types support it; allow callback/event executors, not async executors or redundant Promise wrapping.
+- Always use `Promise.withResolvers<T>()` to create deferred promises; all supported runtimes provide it. Never capture `resolve` and `reject` from a `new Promise` executor in external variables or object properties.
 
 ### Avoid let statements
 


### PR DESCRIPTION
## Issue

We keep seeing patterns like this:

```ts
const ended: { resolve?: () => void; reject?: (error: Error) => void } = {}
const exit = new Promise<void>((resolve, reject) => {
  ended.resolve = resolve
  ended.reject = reject
})
```

as opposite of having just this:

```ts
const ended = Promise.withResolvers()
```

which is more explicit and available since 2024 in all runtimes: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers#browser_compatibility

Fixes #

## Context

This MR makes the wording around preferring `Promise.withResolvers()` more explicit, hoping that will lead to less LOC shipped for no reason with also flaky guards around (see both `resolve?` and `reject?` instantly attached after so that these are a certainity, not a *maybe*).

## Implementation

The wording has been changed to explicitly avoid the mentioned case, hoping we won't see that pattern with runtime created no-ops around.