### PR TITLE
fix(vscode): preserve background agent spinner animation

### DIFF
--- a/.changeset/smooth-background-agent-spinner.md
+++ b/.changeset/smooth-background-agent-spinner.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep background agent spinners animating smoothly during status updates.

--- a/packages/kilo-vscode/tests/accessibility.spec.ts
+++ b/packages/kilo-vscode/tests/accessibility.spec.ts
@@ -73,6 +73,62 @@ test.describe("webview accessibility ratchet", () => {
     await expect(list).toBeHidden()
   })
 
+  test("Background agent spinners survive polling updates", async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "no-preference" })
+    await page.clock.install()
+    await page.clock.pauseAt(new Date())
+    await page.addInitScript(() => {
+      let revision = 0
+      Object.defineProperty(window, "acquireVsCodeApi", {
+        value: () => ({
+          getState: () => undefined,
+          setState: () => {},
+          postMessage: (message: { type: string; sessionID?: string; requestID?: string }) => {
+            if (message.type !== "requestBackgroundJobs") return
+            revision += 1
+            window.postMessage(
+              {
+                type: "backgroundJobsLoaded",
+                sessionID: message.sessionID,
+                requestID: message.requestID,
+                jobs: [
+                  {
+                    id: "job-spinner",
+                    type: "task",
+                    title: `Agent ${revision}`,
+                    status: revision < 4 ? "running" : "completed",
+                    started_at: 1,
+                    metadata: { parentSessionId: message.sessionID, sessionId: "child-spinner", background: true },
+                  },
+                ],
+              },
+              "*",
+            )
+          },
+        }),
+      })
+    })
+    await open(page, "chat--task-header-background-agents-420")
+    await page.locator('[data-slot="task-header-agents-toggle"]').click()
+    const row = page.locator('[data-slot="task-header-agent"]')
+    await expect(row).toContainText("Agent 1")
+    const node = await row.elementHandle()
+    const spinner = await row.locator('[data-component="spinner"]').elementHandle()
+    expect(spinner).not.toBeNull()
+
+    for (const revision of [2, 3]) {
+      await page.clock.runFor(1000)
+      await expect(row).toContainText(`Agent ${revision}`)
+      expect(await spinner!.evaluate((node) => node.isConnected)).toBe(true)
+    }
+
+    await page.clock.runFor(1000)
+    await expect(row).toHaveAttribute("data-status", "completed")
+    expect(await node!.evaluate((node) => node.isConnected)).toBe(true)
+    await expect(row.locator('[data-component="spinner"]')).toHaveCount(0)
+    await expect(row.getByRole("button", { name: "Dismiss: Agent 4" })).toBeVisible()
+  })
+
   test("Agent Manager keeps virtualized transcript fragments laid out", async ({ page }) => {
     await open(page, "agentmanager--sidebar-search-open")
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
@@ -297,58 +297,62 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
                 <span>{language.t("task.backgroundAgents.waiting")}</span>
               </div>
             </Show>
-            <For each={visible()}>
-              {(agent) => (
-                <div data-slot="task-header-agent" data-status={agent.status}>
-                  <Show when={icon(agent)} fallback={<Spinner />}>
-                    {(name) => <Icon name={name()} size="small" data-slot="task-header-agent-status" />}
-                  </Show>
-                  <button
-                    data-slot="task-header-agent-main"
-                    title={`${language.t("task.backgroundAgents.open")}: ${label(agent)}`}
-                    aria-label={`${language.t("task.backgroundAgents.open")}: ${label(agent)}`}
-                    onClick={() => openAgent(agent)}
-                  >
-                    <span data-slot="task-header-agent-label" dir="auto">
-                      {label(agent)}
-                    </span>
-                    <span data-slot="task-header-agent-status-label">{status(agent)}</span>
-                    <Show when={agent.permission || agent.question}>
-                      <span data-slot="task-header-agent-attention-label">
-                        {language.t("task.backgroundAgents.needsInput")}
-                      </span>
-                    </Show>
-                  </button>
-                  <Show when={!props.readonly && agent.status === "running"}>
-                    <Button
-                      icon="stop"
-                      variant="ghost"
-                      size="small"
-                      aria-label={`${language.t("task.backgroundAgents.cancel")}: ${label(agent)}`}
-                      onClick={(event: MouseEvent) => cancelAgent(event, agent)}
-                    >
-                      <span data-slot="task-header-agent-action-label">
-                        {language.t("task.backgroundAgents.cancel")}
-                      </span>
-                    </Button>
-                  </Show>
-                  <Show when={!props.readonly && agent.status !== "running"}>
-                    <Button
-                      icon="close-small"
-                      variant="ghost"
-                      size="small"
-                      aria-label={`${language.t("task.backgroundAgents.dismiss")}: ${label(agent)}`}
-                      onClick={(event: MouseEvent) => {
-                        event.stopPropagation()
-                        hide([agent.jobID])
-                      }}
-                    >
-                      <span data-slot="task-header-agent-action-label">
-                        {language.t("task.backgroundAgents.dismiss")}
-                      </span>
-                    </Button>
-                  </Show>
-                </div>
+            <For each={visible().map((agent) => agent.jobID)}>
+              {(id) => (
+                <Show when={visible().find((agent) => agent.jobID === id)}>
+                  {(agent) => (
+                    <div data-slot="task-header-agent" data-status={agent().status}>
+                      <Show when={icon(agent())} fallback={<Spinner />}>
+                        {(name) => <Icon name={name()} size="small" data-slot="task-header-agent-status" />}
+                      </Show>
+                      <button
+                        data-slot="task-header-agent-main"
+                        title={`${language.t("task.backgroundAgents.open")}: ${label(agent())}`}
+                        aria-label={`${language.t("task.backgroundAgents.open")}: ${label(agent())}`}
+                        onClick={() => openAgent(agent())}
+                      >
+                        <span data-slot="task-header-agent-label" dir="auto">
+                          {label(agent())}
+                        </span>
+                        <span data-slot="task-header-agent-status-label">{status(agent())}</span>
+                        <Show when={agent().permission || agent().question}>
+                          <span data-slot="task-header-agent-attention-label">
+                            {language.t("task.backgroundAgents.needsInput")}
+                          </span>
+                        </Show>
+                      </button>
+                      <Show when={!props.readonly && agent().status === "running"}>
+                        <Button
+                          icon="stop"
+                          variant="ghost"
+                          size="small"
+                          aria-label={`${language.t("task.backgroundAgents.cancel")}: ${label(agent())}`}
+                          onClick={(event: MouseEvent) => cancelAgent(event, agent())}
+                        >
+                          <span data-slot="task-header-agent-action-label">
+                            {language.t("task.backgroundAgents.cancel")}
+                          </span>
+                        </Button>
+                      </Show>
+                      <Show when={!props.readonly && agent().status !== "running"}>
+                        <Button
+                          icon="close-small"
+                          variant="ghost"
+                          size="small"
+                          aria-label={`${language.t("task.backgroundAgents.dismiss")}: ${label(agent())}`}
+                          onClick={(event: MouseEvent) => {
+                            event.stopPropagation()
+                            hide([agent().jobID])
+                          }}
+                        >
+                          <span data-slot="task-header-agent-action-label">
+                            {language.t("task.backgroundAgents.dismiss")}
+                          </span>
+                        </Button>
+                      </Show>
+                    </div>
+                  )}
+                </Show>
               )}
             </For>
           </div>


### PR DESCRIPTION
## What Problem This Solves

Expanded background-agent spinners restarted on every one-second job refresh. The shared spinner animation was correct, but the list used newly created agent objects as Solid list identities, replacing the rows and SVGs each time.

## Why This Change Was Made

Key expanded rows by job ID and read current job data through a non-keyed `Show`, matching the existing collapsed preview. This preserves the spinner without changing shared animation styles or polling frequency. Titles, status, and row actions still use the latest snapshot.

## User Impact

Background-agent spinners animate continuously while the list is expanded. Completed agents still show their final status and Dismiss control.

## Evidence

- The browser regression failed before the fix because the first refresh detached the original SVG. It passes after the fix, including three repeated runs, and verifies updated titles and completion state.
- Extension compilation, host/webview typechecks, lint, 22 focused unit tests, both background-agent browser tests, Knip, and the change-marker guard pass.
- Isolated VS Code verification preserved the original SVGs and animation objects through four one-second refreshes. Completing one job updated its icon, status, and controls while the other spinner continued.
- UI verification used synthetic responses matched to real outgoing request IDs, with no model requests or credentials. Backend job execution was not tested. The screenshot shows the completion state; animation continuity was measured separately because screenshot capture temporarily disables animations.

<img width="360" alt="Expanded background agents showing one running agent and one completed agent" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260831-background-spinner-completion-1036.png" />
