### PR TITLE
fix(cli): prevent custom agents from inheriting plan mode

### DIFF
--- a/.changeset/custom-agent-plan-inheritance.md
+++ b/.changeset/custom-agent-plan-inheritance.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep custom agents writable unless they accept Plan restrictions.

--- a/packages/opencode/src/kilocode/tool/task.ts
+++ b/packages/opencode/src/kilocode/tool/task.ts
@@ -65,9 +65,19 @@ export namespace KiloTask {
    */
   export function inherited(input: {
     caller: Agent.Info
+    target: Agent.Info
     session: Pick<Session.Info, "permission">
     mcp: Config.Info["mcp"]
   }): Permission.Ruleset {
+    const id = typeof input.caller.options.id === "string" ? input.caller.options.id.toLowerCase() : undefined
+    const name = input.caller.name.toLowerCase()
+    const plan = id === "architect" || name === "plan" || name === "architect"
+    if (
+      plan &&
+      !input.target.native &&
+      input.target.permission.findLast((rule) => rule.permission === "plan")?.action !== "allow"
+    )
+      return []
     const rules = Permission.merge(input.caller.permission ?? [], input.session.permission ?? [])
     const prefixes = Object.keys(input.mcp ?? {}).map((k) => k.replace(/[^a-zA-Z0-9_-]/g, "_") + "_")
     const isMcp = (p: string) => prefixes.some((prefix) => p.startsWith(prefix))

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -166,7 +166,7 @@ export const TaskTool = Tool.define(
       }
       // kilocode_change start — inherit edit/bash/MCP restrictions from calling agent
       const caller = yield* agent.get(ctx.agent)
-      const rules = KiloTask.inherited({ caller, session: parent, mcp: cfg.mcp })
+      const rules = KiloTask.inherited({ caller, target: next, session: parent, mcp: cfg.mcp })
       const childPermission = KiloTask.merge(
         deriveSubagentSessionPermission({
           parentSessionPermission: parent.permission ?? [],

--- a/packages/opencode/test/agent/plan-mode-subagent-bypass.test.ts
+++ b/packages/opencode/test/agent/plan-mode-subagent-bypass.test.ts
@@ -165,9 +165,12 @@ it.effect("subagent inherits parent session deny rules as hard runtime ceilings"
 it.instance("Plan delegation preserves notebook ceilings without projecting bash denies", () =>
   Effect.gen(function* () {
     const caller = yield* Agent.use.get("plan")
+    const target = yield* Agent.use.get("explore")
     expect(caller).toBeDefined()
+    expect(target).toBeDefined()
     const rules = KiloTask.inherited({
       caller: caller!,
+      target: target!,
       session: { permission: [] } as unknown as Parameters<typeof KiloTask.inherited>[0]["session"],
       mcp: {},
     })
@@ -192,6 +195,7 @@ it.instance(
       const inherited = (caller: Agent.Info) =>
         KiloTask.inherited({
           caller,
+          target: explore!,
           session: { permission: [] } as unknown as Parameters<typeof KiloTask.inherited>[0]["session"],
           mcp: {},
         })
@@ -246,6 +250,7 @@ it.instance(
 
       const rules = KiloTask.inherited({
         caller: caller!,
+        target: worker!,
         session: { permission: [] } as unknown as Parameters<typeof KiloTask.inherited>[0]["session"],
         mcp: {},
       })

--- a/packages/opencode/test/kilocode/agent-permission-overrides.test.ts
+++ b/packages/opencode/test/kilocode/agent-permission-overrides.test.ts
@@ -421,13 +421,66 @@ test("plan carries guarded denies into delegated sessions under a global catch-a
       const explore = await load(tmp.path, (svc) => svc.get("explore"))
       const child = KiloTask.merge(
         deriveSubagentSessionPermission({ parentSessionPermission: [], subagent: explore! }),
-        KiloTask.permissions(KiloTask.inherited({ caller: plan!, session: { permission: [] }, mcp: undefined })),
+        KiloTask.permissions(
+          KiloTask.inherited({ caller: plan!, target: explore!, session: { permission: [] }, mcp: undefined }),
+        ),
       )
       // A subagent session is evaluated as merge(agent, session), so session rules win.
       const runtime = Permission.merge(explore!.permission, child)
       for (const permission of ["agent_manager", "repo_clone", "write", "interactive_terminal", "bash", "edit"]) {
         expect(Permission.evaluate(permission, "*", runtime).action).toBe("deny")
       }
+    },
+  })
+})
+
+test("custom agents opt in to Plan restriction inheritance with an exact allow", async () => {
+  await using tmp = await tmpdir({
+    config: {
+      agent: {
+        implicit: {
+          description: "A custom agent with only a wildcard allow",
+          mode: "subagent",
+          permission: { "*": "allow" },
+        },
+        denied: {
+          description: "A custom agent that rejects Plan restrictions",
+          mode: "subagent",
+          permission: { plan: "deny" },
+        },
+        asked: {
+          description: "A custom agent that asks for Plan restrictions",
+          mode: "subagent",
+          permission: { plan: "ask" },
+        },
+        allowed: {
+          description: "A custom agent that accepts Plan restrictions",
+          mode: "subagent",
+          permission: { plan: "allow" },
+        },
+      },
+    },
+  })
+
+  await provideTestInstance({
+    directory: tmp.path,
+    fn: async () => {
+      const plan = await load(tmp.path, (svc) => svc.get("plan"))
+      const explore = await load(tmp.path, (svc) => svc.get("explore"))
+      const implicit = await load(tmp.path, (svc) => svc.get("implicit"))
+      const denied = await load(tmp.path, (svc) => svc.get("denied"))
+      const asked = await load(tmp.path, (svc) => svc.get("asked"))
+      const allowed = await load(tmp.path, (svc) => svc.get("allowed"))
+      const inherited = (target: Agent.Info) =>
+        KiloTask.inherited({ caller: plan!, target, session: { permission: [] }, mcp: undefined })
+
+      for (const target of [implicit!, denied!, asked!]) {
+        expect(Permission.evaluate("edit", "src/output.ts", inherited(target)).action).not.toBe("deny")
+        expect(Permission.evaluate("write", "src/output.ts", inherited(target)).action).not.toBe("deny")
+      }
+      expect(Permission.evaluate("edit", "src/output.ts", inherited(allowed!)).action).toBe("deny")
+      expect(Permission.evaluate("write", "src/output.ts", inherited(allowed!)).action).toBe("deny")
+      expect(Permission.evaluate("edit", "src/output.ts", inherited(explore!)).action).toBe("deny")
     },
   })
 })


### PR DESCRIPTION
## What changed

- Keep custom agents writable unless they explicitly set `plan: allow`.
- Make `plan: deny` and `plan: ask` prevent Plan restriction inheritance.
- Preserve Plan restriction inheritance for native agents.

## Why

Custom agents inherited Plan restrictions from Plan mode without opting in. This behavior blocked edits outside `.kilo/plan`.

## Verification

- Driver slice checks passed for the Plan mode inheritance regression tests.
- CLI `test:ci`: 248 of 251 files passed.
- The three failures matched clean `main` and were unrelated to this change.