### PR TITLE
fix(agent-manager): decode JSON-encoded task arrays

### DIFF
--- a/.changeset/agent-manager-json-tasks.md
+++ b/.changeset/agent-manager-json-tasks.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Allow Agent Manager to start sessions when a model returns the task list as a JSON-encoded array.

--- a/packages/opencode/src/kilocode/tool/agent-manager.ts
+++ b/packages/opencode/src/kilocode/tool/agent-manager.ts
@@ -128,7 +128,17 @@ const AnswerParams = Schema.Struct({
     }),
 })
 
-export const Params = Schema.Union([StartParams, ListParams, PromptParams, StopParams, MoveParams, AnswerParams])
+export const Params = Schema.Union([
+  Schema.Struct({
+    ...StartParams.fields,
+    tasks: Schema.Union([StartParams.fields.tasks, Schema.fromJsonString(StartParams.fields.tasks)]),
+  }),
+  ListParams,
+  PromptParams,
+  StopParams,
+  MoveParams,
+  AnswerParams,
+])
 
 // Anthropic rejects a top-level anyOf/oneOf/allOf, so the advertised schema has to
 // stay one flat object while Params keeps the real per-operation validation. That

--- a/packages/opencode/test/kilocode/agent-manager-tool.test.ts
+++ b/packages/opencode/test/kilocode/agent-manager-tool.test.ts
@@ -1,6 +1,6 @@
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { describe, expect, test } from "bun:test"
-import { Effect, Layer, ManagedRuntime, Queue, Schema } from "effect"
+import { Cause, Effect, Exit, Layer, ManagedRuntime, Queue, Schema } from "effect"
 import { MessageID, SessionID } from "../../src/session/schema"
 import { provideTmpdirInstance } from "../fixture/fixture"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
@@ -220,8 +220,58 @@ describe("agent_manager tool", () => {
     // The advertised bounds on tasks must survive being made nullable.
     const tasks = schema.properties?.tasks
     expect(typeof tasks === "object" ? tasks.anyOf?.[0] : undefined).toEqual(
-      expect.objectContaining({ minItems: 1, maxItems: 20 }),
+      expect.objectContaining({ type: "array", minItems: 1, maxItems: 20 }),
     )
+    expect(typeof tasks === "object" ? tasks.anyOf : undefined).toHaveLength(2)
+  })
+
+  test.each(["local", "worktree"])("decodes JSON-encoded tasks for %s sessions", (mode) => {
+    const tasks = [
+      { prompt: 'Check "quoted" text\nC:\\repo', name: "Encoded" },
+      { name: "Prepared", model: null },
+    ]
+    expect(Schema.decodeUnknownSync(Params)({ mode, tasks: JSON.stringify(tasks), action: null })).toEqual({
+      mode,
+      tasks,
+    })
+  })
+
+  test("rejects invalid JSON-encoded tasks before permission or event publication", async () => {
+    const tool: Tool.Def = await init()
+    const permissions: unknown[] = []
+    const events: AgentManagerStart[] = []
+    await runtime.runPromise(
+      provideTmpdirInstance(() =>
+        Effect.gen(function* () {
+          const bus = yield* Bus.Service
+          const off = yield* bus.subscribeCallback(AgentManagerEvent.Start, (item) => events.push(item.properties))
+          yield* Effect.addFinalizer(() => Effect.sync(off))
+          for (const tasks of [
+            "[",
+            "null",
+            "{}",
+            '"[]"',
+            "[]",
+            "[null]",
+            "[{}]",
+            JSON.stringify([{ prompt: 42 }]),
+            JSON.stringify([{ name: "Prepared", model: "test/reasoning/model" }]),
+            JSON.stringify(Array.from({ length: 21 }, () => ({ prompt: "Fix" }))),
+          ]) {
+            const result = yield* tool
+              .execute(
+                { mode: "local", tasks },
+                { ...ctx, ask: (input: unknown) => Effect.sync(() => permissions.push(input)) },
+              )
+              .pipe(Effect.exit)
+            expect(Exit.isFailure(result)).toBe(true)
+            if (Exit.isFailure(result)) expect(Cause.squash(result.cause)).toBeInstanceOf(Tool.InvalidArgumentsError)
+          }
+        }),
+      ).pipe(Effect.scoped),
+    )
+    expect(permissions).toEqual([])
+    expect(events).toEqual([])
   })
 
   test("keeps session ID validation local", () => {
@@ -644,8 +694,9 @@ describe("agent_manager tool", () => {
     expect(task?.variant).toBe("high")
   })
 
-  test("publishes validated model and variant selections", async () => {
-    const tool = await init()
+  test.each(["array", "JSON-encoded"])("publishes validated selections from %s tasks", async (encoding) => {
+    const tool: Tool.Def = await init()
+    const tasks = [{ prompt: "Fix issue", model: "test/reasoning/model", variant: "high" }]
 
     const event = await runtime.runPromise(
       provideTmpdirInstance(() =>
@@ -660,7 +711,7 @@ describe("agent_manager tool", () => {
           yield* tool.execute(
             {
               mode: "local",
-              tasks: [{ prompt: "Fix issue", model: "test/reasoning/model", variant: "high" }],
+              tasks: encoding === "array" ? tasks : JSON.stringify(tasks),
             },
             { ...ctx, ask: () => Effect.void },
           )


### PR DESCRIPTION
## What Problem This Solves

Agent Manager rejects a start request when a model returns `tasks` as a JSON-encoded array instead of an array. The outer tool arguments parse successfully, but CLI validation rejects the nested string before permission checks or the extension start event, so no session is created.

Fixes #13596.

## Why This Change Was Made

The advertised schema already correctly describes `tasks` as array-or-null. Provider adapters parse the outer arguments but do not decode nested JSON strings. Changing the advertised schema would encourage the incorrect format and could disturb the existing flat, nullable schema used for provider compatibility.

Decode one JSON layer only for the runtime start operation, then validate the result with the existing task schema and 1–20 item bounds. Keep native arrays, management actions, permission checks, and the extension event contract unchanged. Malformed JSON, decoded non-arrays, double-encoded strings, invalid task objects, empty arrays, and oversized arrays still fail before permission or event publication.

This is a defensive compatibility fix. It does not establish that MiMo generated the reported payload or that an SDK change caused the reported version regression.

## User Impact

Local and worktree session requests can proceed when the task list is otherwise valid but JSON-encoded. Models still receive the array-based schema, and genuinely invalid task lists remain rejected. A patch changeset is included.

## Evidence

- New regression cases failed on the original decoder and passed after the change. They exercise the actual runtime schema and initialized tool, including normalized task arrays in the published event and zero permission/event side effects for invalid input.
- 49 focused CLI tests and 13 extension boundary tests passed. CLI typecheck, extension compile (including host/webview typechecks and lint), formatting, and the worktree annotation guard passed. Focused lint retained its seven pre-existing warnings with no new warnings.
- `vscode-self-test` used a credential-free scripted OpenAI-compatible provider and the real extension/backend flow. Before the fix, encoded tasks failed. After the fix, the same payload created a session; native arrays still created sessions; invalid encoded tasks created none. The captured advertised task schema was identical before and after. The isolated test processes were stopped afterward.
- Live MiMo and Windows were not tested. The extension rebuild completed through its installed-Bun fallback after the pinned Bun launcher failed.

Before, the encoded task array is rejected:

<img width="700" alt="Agent Manager rejects a JSON-encoded task array before the fix" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260831-agent-manager-json-tasks-before-1245.png" />

After, the same encoded task array succeeds and the extension creates a session:

<img width="700" alt="Agent Manager accepts the encoded task array and creates a session after the fix" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260831-agent-manager-json-tasks-after-1245.png" />
