### PR TITLE
fix: select an available default model

### DIFF
--- a/.changeset/available-default-model.md
+++ b/.changeset/available-default-model.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/kilo-jetbrains": patch
+---
+
+Use Kilo Auto Efficient when Auto Free is unavailable, or the first available model when neither is listed.

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/controller/SessionController.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/controller/SessionController.kt
@@ -2903,13 +2903,17 @@ private fun resolveModelSelection(
     valid(providers, mode)?.let { return it }
     valid(providers, global)?.let { return it }
     recent.firstNotNullOfOrNull { valid(providers, it) }?.let { return it }
-    return fallback
+    if (fallback == null) return null
+    valid(providers, fallback)?.let { return it }
+    valid(providers, ModelSelectionDto(KILO_PROVIDER, "kilo-auto/efficient"))?.let { return it }
+    return providers?.providers?.firstNotNullOfOrNull { provider ->
+        provider.models.keys.firstOrNull()?.let { valid(providers, ModelSelectionDto(provider.id, it)) }
+    }
 }
 
 private fun valid(providers: ProvidersDto?, item: ModelSelectionDto?): ModelSelectionDto? {
     if (item == null) return null
     val list = providers?.providers ?: return item
-    if (list.isEmpty()) return item
     val provider = list.firstOrNull { it.id == item.providerID } ?: return null
     if (item.providerID != KILO_PROVIDER && item.providerID !in providers.connected) return null
     if (item.modelID !in provider.models) return null

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/controller/ConfigSelectionTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/session/controller/ConfigSelectionTest.kt
@@ -230,7 +230,7 @@ class ConfigSelectionTest : SessionControllerTestBase() {
         assertEquals("anthropic/claude", m.model.model)
     }
 
-    fun `test no valid candidates falls back to kilo auto`() {
+    fun `test no valid candidates prefers free when present in the catalog`() {
         appRpc.models = ModelStateDto(recent = listOf(ModelSelectionDto("openai", "gpt")))
         appRpc.state.value = KiloAppStateDto(
             KiloAppStatusDto.READY,
@@ -238,19 +238,10 @@ class ConfigSelectionTest : SessionControllerTestBase() {
         )
         projectRpc.state.value = workspaceReady(
             providers = listOf(
-                ProviderDto(
-                    id = "kilo",
-                    name = "Kilo",
-                    models = mapOf("kilo-auto/free" to ModelDto(id = "kilo-auto/free", name = "Auto")),
-                ),
-                ProviderDto(
-                    id = "openai",
-                    name = "OpenAI",
-                    models = mapOf("gpt" to ModelDto(id = "gpt", name = "GPT")),
-                ),
+                provider("kilo", "gpt-5", "kilo-auto/efficient", "kilo-auto/free"),
+                provider("openai", "gpt"),
             ),
-            connected = listOf("kilo"),
-            defaults = emptyMap(),
+            connected = emptyList(),
         )
         val m = controller()
         collect(m)
@@ -258,6 +249,194 @@ class ConfigSelectionTest : SessionControllerTestBase() {
 
         assertEquals("kilo/kilo-auto/free", m.model.defaultModel)
         assertEquals("kilo/kilo-auto/free", m.model.model)
+        assertFalse(m.model.modelOverride)
+    }
+
+    fun `test missing free prefers efficient over the first selectable model`() {
+        appRpc.state.value = KiloAppStateDto(KiloAppStatusDto.READY)
+        projectRpc.state.value = workspaceReady(
+            providers = listOf(
+                provider("openai", "gpt"),
+                provider("kilo", "gpt-5", "kilo-auto/efficient"),
+            ),
+            connected = listOf("openai"),
+        )
+        val m = controller()
+        collect(m)
+        flush()
+
+        assertEquals("kilo/kilo-auto/efficient", m.model.defaultModel)
+        assertEquals("kilo/kilo-auto/efficient", m.model.model)
+        assertFalse(m.model.modelOverride)
+    }
+
+    fun `test stale free selections fall back to efficient`() {
+        appRpc.models = ModelStateDto(
+            model = mapOf("code" to ModelSelectionDto("kilo", "kilo-auto/free")),
+            recent = listOf(ModelSelectionDto("kilo", "kilo-auto/free")),
+        )
+        appRpc.state.value = KiloAppStateDto(
+            KiloAppStatusDto.READY,
+            config = ConfigDto(
+                model = "kilo/kilo-auto/free",
+                agent = mapOf("code" to AgentConfigDto(model = "kilo/kilo-auto/free")),
+            ),
+        )
+        projectRpc.state.value = workspaceReady(
+            providers = listOf(provider("kilo", "gpt-5", "kilo-auto/efficient")),
+            defaults = mapOf("code" to "kilo/kilo-auto/free"),
+        )
+        val m = controller()
+        collect(m)
+        flush()
+
+        assertEquals("kilo/kilo-auto/efficient", m.model.defaultModel)
+        assertEquals("kilo/kilo-auto/efficient", m.model.model)
+        assertFalse(m.model.modelOverride)
+    }
+
+    fun `test missing auto models falls back to the first selectable model`() {
+        appRpc.state.value = KiloAppStateDto(KiloAppStatusDto.READY, config = ConfigDto())
+        projectRpc.state.value = workspaceReady(
+            providers = listOf(
+                provider("openai", "gpt", "gpt-2"),
+                provider("kilo", "gpt-5"),
+            ),
+            connected = listOf("openai"),
+        )
+        val m = controller()
+        collect(m)
+        flush()
+
+        assertEquals("openai/gpt", m.model.defaultModel)
+        assertEquals("openai/gpt", m.model.model)
+        assertFalse(m.model.modelOverride)
+    }
+
+    fun `test fallback skips disconnected providers and providers without models`() {
+        appRpc.state.value = KiloAppStateDto(
+            KiloAppStatusDto.READY,
+            config = ConfigDto(model = "anthropic/claude"),
+        )
+        projectRpc.state.value = workspaceReady(
+            providers = listOf(
+                provider("anthropic", "claude"),
+                provider("kilo"),
+                provider("openai", "gpt"),
+            ),
+            connected = listOf("openai"),
+        )
+        val m = controller()
+        collect(m)
+        flush()
+
+        assertEquals("openai/gpt", m.model.defaultModel)
+        assertEquals("openai/gpt", m.model.model)
+        assertFalse(m.model.modelOverride)
+    }
+
+    fun `test no selectable models leaves selection null`() {
+        appRpc.models = ModelStateDto(model = mapOf("code" to ModelSelectionDto("openai", "gpt")))
+        appRpc.state.value = KiloAppStateDto(
+            KiloAppStatusDto.READY,
+            config = ConfigDto(model = "kilo/kilo-auto/free"),
+        )
+        projectRpc.state.value = workspaceReady(
+            providers = listOf(provider("kilo"), provider("openai", "gpt")),
+            connected = emptyList(),
+            defaults = mapOf("code" to "kilo/kilo-auto/free"),
+        )
+        val m = controller()
+        collect(m)
+        flush()
+
+        assertNull(m.model.defaultModel)
+        assertNull(m.model.model)
+        assertFalse(m.model.modelOverride)
+    }
+
+    fun `test loaded empty catalog rejects stale selections`() {
+        appRpc.models = ModelStateDto(
+            model = mapOf("code" to ModelSelectionDto("kilo", "kilo-auto/free")),
+            recent = listOf(ModelSelectionDto("kilo", "kilo-auto/free")),
+        )
+        appRpc.state.value = KiloAppStateDto(
+            KiloAppStatusDto.READY,
+            config = ConfigDto(
+                model = "kilo/kilo-auto/free",
+                agent = mapOf("code" to AgentConfigDto(model = "kilo/kilo-auto/free")),
+            ),
+        )
+        projectRpc.state.value = workspaceReady(
+            providers = emptyList(),
+            connected = emptyList(),
+            defaults = mapOf("code" to "kilo/kilo-auto/free"),
+        )
+        val m = controller()
+        collect(m)
+        flush()
+
+        assertNull(m.model.defaultModel)
+        assertNull(m.model.model)
+        assertFalse(m.model.modelOverride)
+    }
+
+    fun `test unloaded catalog keeps free until catalog arrives`() {
+        appRpc.state.value = KiloAppStateDto(KiloAppStatusDto.READY)
+        val m = controller()
+        collect(m)
+        flush()
+        edt { m.selectAgent("code") }
+        flush()
+
+        assertNull(m.model.workspace.providers)
+        assertEquals("kilo/kilo-auto/free", m.model.defaultModel)
+        assertEquals("kilo/kilo-auto/free", m.model.model)
+        assertFalse(m.model.modelOverride)
+
+        projectRpc.state.value = workspaceReady(
+            providers = listOf(provider("kilo", "gpt-5", "kilo-auto/efficient")),
+        )
+        flush()
+
+        assertEquals("kilo/kilo-auto/efficient", m.model.defaultModel)
+        assertEquals("kilo/kilo-auto/efficient", m.model.model)
+        assertFalse(m.model.modelOverride)
+    }
+
+    fun `test unloaded catalog preserves configured and saved selections`() {
+        appRpc.models = ModelStateDto(model = mapOf("code" to ModelSelectionDto("openai", "gpt")))
+        appRpc.state.value = KiloAppStateDto(
+            KiloAppStatusDto.READY,
+            config = ConfigDto(model = "anthropic/claude"),
+        )
+        val m = controller()
+        collect(m)
+        flush()
+        edt { m.selectAgent("code") }
+        flush()
+
+        assertNull(m.model.workspace.providers)
+        assertEquals("anthropic/claude", m.model.defaultModel)
+        assertEquals("openai/gpt", m.model.model)
+        assertTrue(m.model.modelOverride)
+    }
+
+    fun `test provider defaults retain priority before app config loads`() {
+        projectRpc.state.value = workspaceReady(
+            providers = listOf(
+                provider("kilo", "kilo-auto/free", "kilo-auto/efficient"),
+                provider("openai", "gpt"),
+            ),
+            connected = listOf("openai"),
+            defaults = mapOf("code" to "openai/gpt"),
+        )
+        val m = controller()
+        collect(m)
+        flush()
+
+        assertEquals("openai/gpt", m.model.defaultModel)
+        assertEquals("openai/gpt", m.model.model)
         assertFalse(m.model.modelOverride)
     }
 
@@ -358,4 +537,10 @@ class ConfigSelectionTest : SessionControllerTestBase() {
         assertEquals("kilo/gpt-5", appRpc.variants.single().key)
         assertEquals("high", appRpc.variants.single().value)
     }
+
+    private fun provider(id: String, vararg models: String) = ProviderDto(
+        id = id,
+        name = id,
+        models = models.associateWith { ModelDto(id = it, name = it) },
+    )
 }

--- a/packages/kilo-vscode/tests/unit/model-selection.test.ts
+++ b/packages/kilo-vscode/tests/unit/model-selection.test.ts
@@ -12,7 +12,7 @@ function makeProvider(id: string, name: string, modelIds: string[]): Provider {
 }
 
 const providers = {
-  kilo: makeProvider("kilo", "Kilo Gateway", ["kilo-auto/free"]),
+  kilo: makeProvider("kilo", "Kilo Gateway", ["kilo-auto/efficient", "kilo-auto/free"]),
   anthropic: makeProvider("anthropic", "Anthropic", ["claude-sonnet-4"]),
   openai: makeProvider("openai", "OpenAI", ["gpt-4.1"]),
 }
@@ -84,13 +84,101 @@ describe("resolveModelSelection", () => {
     expect(result).toEqual(KILO_AUTO)
   })
 
-  it("keeps the explicit fallback even when kilo is missing from the loaded catalog", () => {
+  it("prefers efficient over the first available model when free is missing", () => {
+    const result = resolveModelSelection({
+      providers: {
+        openai: providers.openai,
+        kilo: makeProvider("kilo", "Kilo Gateway", ["anthropic/claude-sonnet-4", "kilo-auto/efficient"]),
+      },
+      connected: ["openai"],
+      fallback: KILO_AUTO,
+    })
+    expect(result).toEqual({ providerID: "kilo", modelID: "kilo-auto/efficient" })
+  })
+
+  it("ignores stale free preferences when efficient is available", () => {
+    const result = resolveModelSelection({
+      providers: { kilo: makeProvider("kilo", "Kilo Gateway", ["kilo-auto/efficient"]) },
+      connected: [],
+      override: KILO_AUTO,
+      mode: KILO_AUTO,
+      global: KILO_AUTO,
+      recent: [KILO_AUTO],
+      fallback: KILO_AUTO,
+    })
+    expect(result).toEqual({ providerID: "kilo", modelID: "kilo-auto/efficient" })
+  })
+
+  it("preserves valid preferences when free is missing", () => {
+    const catalog = {
+      kilo: makeProvider("kilo", "Kilo Gateway", ["kilo-auto/efficient"]),
+      openai: providers.openai,
+    }
+    const selection = { providerID: "openai", modelID: "gpt-4.1" }
+    for (const preference of [
+      { override: selection },
+      { mode: selection },
+      { global: selection },
+      { recent: [selection] },
+      { fallback: selection },
+    ]) {
+      expect(
+        resolveModelSelection({ providers: catalog, connected: ["openai"], fallback: KILO_AUTO, ...preference }),
+      ).toEqual(selection)
+    }
+  })
+
+  it("uses the first available model when both auto models are missing", () => {
+    const result = resolveModelSelection({
+      providers: {
+        kilo: makeProvider("kilo", "Kilo Gateway", ["openai/gpt-4.1", "anthropic/claude-sonnet-4"]),
+        openai: providers.openai,
+      },
+      connected: ["openai"],
+      fallback: KILO_AUTO,
+    })
+    expect(result).toEqual({ providerID: "kilo", modelID: "openai/gpt-4.1" })
+  })
+
+  it("uses the first connected model when kilo is missing", () => {
     const result = resolveModelSelection({
       providers: { openai: providers.openai },
+      connected: ["openai"],
+      fallback: KILO_AUTO,
+    })
+    expect(result).toEqual({ providerID: "openai", modelID: "gpt-4.1" })
+  })
+
+  it("skips disconnected providers and providers without models", () => {
+    const result = resolveModelSelection({
+      providers: {
+        anthropic: providers.anthropic,
+        kilo: makeProvider("kilo", "Kilo Gateway", []),
+        openai: providers.openai,
+      },
+      connected: ["openai"],
+      fallback: KILO_AUTO,
+    })
+    expect(result).toEqual({ providerID: "openai", modelID: "gpt-4.1" })
+  })
+
+  it("returns null when no loaded models are selectable", () => {
+    const result = resolveModelSelection({
+      providers: { kilo: makeProvider("kilo", "Kilo Gateway", []), openai: providers.openai },
       connected: [],
       fallback: KILO_AUTO,
     })
-    expect(result).toEqual(KILO_AUTO)
+    expect(result).toBeNull()
+  })
+
+  it("does not choose an automatic fallback when none is requested", () => {
+    for (const fallback of [undefined, null]) {
+      expect(resolveModelSelection({ providers, connected: ["openai"], fallback })).toBeNull()
+    }
+  })
+
+  it("keeps the explicit fallback before providers load", () => {
+    expect(resolveModelSelection({ providers: {}, connected: [], fallback: KILO_AUTO })).toEqual(KILO_AUTO)
   })
 
   it("keeps the raw preference order before providers load", () => {

--- a/packages/kilo-vscode/webview-ui/src/context/model-selection.ts
+++ b/packages/kilo-vscode/webview-ui/src/context/model-selection.ts
@@ -32,12 +32,23 @@ export function resolveModelSelection(input: {
   recent?: ModelSelection[]
   fallback?: ModelSelection | null
 }): ModelSelection | null {
-  return (
+  const preferred =
     validate(input.providers, input.connected, input.override) ??
     validate(input.providers, input.connected, input.mode) ??
     validate(input.providers, input.connected, input.global) ??
     recent(input.providers, input.connected, input.recent) ??
-    input.fallback ??
-    null
-  )
+    validate(input.providers, input.connected, input.fallback)
+  if (preferred) return preferred
+  if (!input.fallback) return null
+
+  const efficient = validate(input.providers, input.connected, { providerID: "kilo", modelID: "kilo-auto/efficient" })
+  if (efficient) return efficient
+
+  for (const [providerID, provider] of Object.entries(input.providers)) {
+    const modelID = Object.keys(provider.models).at(0)
+    if (!modelID) continue
+    const selection = validate(input.providers, input.connected, { providerID, modelID })
+    if (selection) return selection
+  }
+  return null
 }


### PR DESCRIPTION
Prevent VS Code and JetBrains from defaulting to `kilo-auto/free` when the loaded model catalog does not offer it. Prefer `kilo-auto/efficient` in that case, then the first selectable catalog model; leave selection empty if none are available.

Keep valid configured, remembered, and recent choices ahead of the automatic fallback, and preserve startup behavior before the catalog loads. Explicit session selections are unchanged.