### PR TITLE
docs: document Kilo model routing/config and correct Gas Town small model docs

### DIFF
--- a/packages/kilo-docs/lychee.toml
+++ b/packages/kilo-docs/lychee.toml
@@ -20,6 +20,9 @@ accept = [
 exclude = [
   '\.png$',
   'https://synthetic.new/user-settings/api',
+  # Synthetic's site intermittently returns 503 to automated link checks.
+  '^https?://synthetic\.new/?$',
+  '^https?://synthetic\.new/pricing/?$',
   'https://platform.slack-edge.com/img/add_to_slack.png',
   'https://console.groq.com/pages/models',
   '^https?://([A-Za-z0-9-]+\.)?glama\.ai(/|$)',

--- a/packages/kilo-docs/pages/code-with-ai/agents/model-selection.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/model-selection.md
@@ -31,7 +31,7 @@ If you want to use a private/local inference source, you can:
 1. Set your **main model** to a non-`kilo-auto` provider — a local model (Ollama, LM Studio) or a direct BYOK provider key.
 2. Explicitly set **`small_model`** to a model on that same provider. If you leave it unset while signed in to Kilo Gateway, it falls back to [`kilo-auto/small`](/docs/gateway/models-and-providers#kilo-autosmall) rather than reusing your main model.
 3. Leave **`subagent_model`** unset — it always inherits your main model rather than defaulting to Kilo Gateway, whether or not you're signed in.
-4. For **autocomplete**, switch the provider to a direct Mistral or Inception BYOK key (see the warning below) or disable autocomplete.
+4. For **autocomplete**, switch the provider to a direct Mistral or Inception BYOK key or disable autocomplete.
 
 {% callout type="note" %}
 You can ensure no inference will go through the Kilo Gateway by logging out of the Kilo Gateway in the IDE extension or TUI.

--- a/packages/kilo-docs/pages/code-with-ai/agents/model-selection.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/model-selection.md
@@ -11,28 +11,30 @@ Instead of maintaining a static list that's perpetually behind, we built somethi
 
 ## Model Routing and Configuration
 
-Kilo Code doesn't use a single model for everything. There are four separate, independently configurable model slots:
+Kilo's IDE Extension and CLI configurations have four separate, independently configurable model slots:
 
-- **Main model** — the primary model your agent uses for coding tasks, chat, and reasoning. This is what you pick with the model selector, `/models`, or the `model` key in `kilo.jsonc`.
-- **Small model** — a lightweight model used for session title generation, commit message generation, and prompt enhancement. Configured with the `small_model` key in `kilo.jsonc`, or the **Small Model** field on the **Settings → Models** tab. If left unset, Kilo resolves it from the model already in use: it first looks for a small/cheap variant on your current provider (e.g. Haiku on Anthropic, Flash on Gemini), and only falls back to [`kilo-auto/small`](/docs/gateway/models-and-providers#kilo-autosmall) if the Kilo Gateway provider is authenticated in your session. If you're not signed in to Kilo at all, the small model tasks above simply reuse your main model instead — they don't reach out to Kilo Gateway on their own.
-- **Subagent model** — the default model for subagents launched by the `task` tool. Configured with the `subagent_model` key in `kilo.jsonc`, or the **Subagent Model** field on the **Settings → Models** tab. If left unset, subagents inherit whichever model the parent agent session is currently using — this slot never calls Kilo Gateway on its own.
-- **Autocomplete model** — the Fill-in-the-Middle (FIM) model used for inline code completions as you type. See [Autocomplete: Provider and Model](/docs/code-with-ai/features/autocomplete#provider-and-model) for how to configure it.
+- **Main model** — the primary model your agent uses for coding tasks, chat, and reasoning. This is what you pick with the model selector, `/models`, or the `model` key in `kilo.jsonc`. See [How to Select and Switch Models](#how-to-select-and-switch-models) for the full precedence order and per-agent config.
+  - The main model is also used for context compaction/summarization and todo-list generation.
+- **Small model** — a lightweight model used for session title generation, commit message generation, and prompt enhancement. Configured with the `small_model` key in `kilo.jsonc`, or the **Small Model** field on the **Settings → Models** tab.
+  - If left unset, Kilo resolves it according to the following logic: 
+    1. Find a small/cheap variant on your current provider (e.g. Haiku on Anthropic, Flash on Gemini).
+    2. Fall back to [`kilo-auto/small`](/docs/gateway/models-and-providers#kilo-autosmall) if the Kilo Gateway provider is authenticated in your session.
+    3. Reuse your main model if you're not authenticated to the Kilo Gateway.
+- **Subagent model** — the default model for subagents launched by the `task` tool. Configured with the `subagent_model` key in `kilo.jsonc`, or the **Subagent Model** field on the **Settings → Models** tab.
+  - If left unset, inherits whichever model the parent agent session is currently using.
+- **Autocomplete model** — the model used for inline code completions as you type. See [Autocomplete: Provider and Model](/docs/code-with-ai/features/autocomplete#provider-and-model) for how to configure it.
+
+### Configuring Local Usage
+
+If you want to use a private/local inference source, you can:
+
+1. Set your **main model** to a non-`kilo-auto` provider — a local model (Ollama, LM Studio) or a direct BYOK provider key.
+2. Explicitly set **`small_model`** to a model on that same provider. If you leave it unset while signed in to Kilo Gateway, it falls back to [`kilo-auto/small`](/docs/gateway/models-and-providers#kilo-autosmall) rather than reusing your main model.
+3. Leave **`subagent_model`** unset — it always inherits your main model rather than defaulting to Kilo Gateway, whether or not you're signed in.
+4. For **autocomplete**, switch the provider to a direct Mistral or Inception BYOK key (see the warning below) or disable autocomplete.
 
 {% callout type="note" %}
-**What doesn't use the small model:** context compaction/summarization and todo-list generation always use your main model, not the small model — despite sounding like lightweight background tasks, they aren't affected by your `small_model` setting.
-{% /callout %}
-
-Each of these can be set independently. There's no single "offline mode" switch — going fully offline or self-hosted comes down to two things:
-
-1. Never sign in to the Kilo Gateway provider (so there's no `kilo-auto/*` fallback for the app to reach for).
-2. Explicitly set your **main model** to a local/BYOK provider (e.g. Ollama, LM Studio, or a direct API key), and **disable autocomplete** — there is no local autocomplete provider, so true offline requires turning it off entirely (see the warning below). You can leave `small_model` and `subagent_model` unset — without a signed-in Kilo provider, they'll fall back to your main model rather than to Kilo Gateway.
-
-{% callout type="warning" %}
-**Autocomplete has no local fallback.** Unlike the small and subagent models, autocomplete only supports the Kilo Gateway or a direct BYOK key for Mistral/Inception — if it resolves to Kilo Gateway without valid auth, the request fails outright rather than falling back to a local model. A Mistral/Inception BYOK key bypasses Kilo Gateway but still calls Mistral's or Inception's servers over the network, so it isn't a true offline option. For a fully offline setup, disable autocomplete entirely. If you only need to avoid Kilo Gateway (not all network access), a direct Mistral BYOK key works — see [Setting Up Mistral for Free Autocomplete](/docs/code-with-ai/features/autocomplete/mistral-setup).
-{% /callout %}
-
-{% callout type="note" %}
-Gas Town also exposes its own small model setting, used for session title generation and the `explore` subagent inside your town's containers — see [Gas Town Settings](/docs/code-with-ai/gastown/settings#small-model). It's a separate, town-scoped configuration stored in your town's settings, distinct from the `small_model` key described above.
+You can ensure no inference will go through the Kilo Gateway by logging out of the Kilo Gateway in the IDE extension or TUI.
 {% /callout %}
 
 ## Check the Live Models List

--- a/packages/kilo-docs/pages/code-with-ai/agents/model-selection.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/model-selection.md
@@ -25,10 +25,10 @@ Kilo Code doesn't use a single model for everything. There are four separate, in
 Each of these can be set independently. There's no single "offline mode" switch — going fully offline or self-hosted comes down to two things:
 
 1. Never sign in to the Kilo Gateway provider (so there's no `kilo-auto/*` fallback for the app to reach for).
-2. Explicitly set your **main model** to a local/BYOK provider (e.g. Ollama, LM Studio, or a direct API key), and set your **autocomplete model** to a direct Mistral or Inception BYOK key — see the warning below, as autocomplete has no local provider option. You can leave `small_model` and `subagent_model` unset — without a signed-in Kilo provider, they'll fall back to your main model rather than to Kilo Gateway.
+2. Explicitly set your **main model** to a local/BYOK provider (e.g. Ollama, LM Studio, or a direct API key), and **disable autocomplete** — there is no local autocomplete provider, so true offline requires turning it off entirely (see the warning below). You can leave `small_model` and `subagent_model` unset — without a signed-in Kilo provider, they'll fall back to your main model rather than to Kilo Gateway.
 
 {% callout type="warning" %}
-**Autocomplete has no local fallback.** Unlike the small and subagent models, autocomplete only supports the Kilo Gateway or a direct BYOK key for Mistral/Inception — if it resolves to Kilo Gateway without valid auth, the request fails outright rather than falling back to a local model. For a fully offline setup, either configure a direct Mistral BYOK key (see [Setting Up Mistral for Free Autocomplete](/docs/code-with-ai/features/autocomplete/mistral-setup)) or disable autocomplete.
+**Autocomplete has no local fallback.** Unlike the small and subagent models, autocomplete only supports the Kilo Gateway or a direct BYOK key for Mistral/Inception — if it resolves to Kilo Gateway without valid auth, the request fails outright rather than falling back to a local model. A Mistral/Inception BYOK key bypasses Kilo Gateway but still calls Mistral's or Inception's servers over the network, so it isn't a true offline option. For a fully offline setup, disable autocomplete entirely. If you only need to avoid Kilo Gateway (not all network access), a direct Mistral BYOK key works — see [Setting Up Mistral for Free Autocomplete](/docs/code-with-ai/features/autocomplete/mistral-setup).
 {% /callout %}
 
 {% callout type="note" %}

--- a/packages/kilo-docs/pages/code-with-ai/agents/model-selection.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/model-selection.md
@@ -9,6 +9,32 @@ Here's the honest truth about AI model recommendations: by the time I write them
 
 Instead of maintaining a static list that's perpetually behind, we built something better — a real-time leaderboard showing which models Kilo Code users are actually having success with right now.
 
+## Model Routing and Configuration
+
+Kilo Code doesn't use a single model for everything. There are four separate, independently configurable model slots:
+
+- **Main model** — the primary model your agent uses for coding tasks, chat, and reasoning. This is what you pick with the model selector, `/models`, or the `model` key in `kilo.jsonc`.
+- **Small model** — a lightweight model used for session title generation, commit message generation, and prompt enhancement. Configured with the `small_model` key in `kilo.jsonc`, or the **Small Model** field on the **Settings → Models** tab. If left unset, Kilo resolves it from the model already in use: it first looks for a small/cheap variant on your current provider (e.g. Haiku on Anthropic, Flash on Gemini), and only falls back to [`kilo-auto/small`](/docs/gateway/models-and-providers#kilo-autosmall) if the Kilo Gateway provider is authenticated in your session. If you're not signed in to Kilo at all, the small model tasks above simply reuse your main model instead — they don't reach out to Kilo Gateway on their own.
+- **Subagent model** — the default model for subagents launched by the `task` tool. Configured with the `subagent_model` key in `kilo.jsonc`, or the **Subagent Model** field on the **Settings → Models** tab. If left unset, subagents inherit whichever model the parent agent session is currently using — this slot never calls Kilo Gateway on its own.
+- **Autocomplete model** — the Fill-in-the-Middle (FIM) model used for inline code completions as you type. See [Autocomplete: Provider and Model](/docs/code-with-ai/features/autocomplete#provider-and-model) for how to configure it.
+
+{% callout type="note" %}
+**What doesn't use the small model:** context compaction/summarization and todo-list generation always use your main model, not the small model — despite sounding like lightweight background tasks, they aren't affected by your `small_model` setting.
+{% /callout %}
+
+Each of these can be set independently. There's no single "offline mode" switch — going fully offline or self-hosted comes down to two things:
+
+1. Never sign in to the Kilo Gateway provider (so there's no `kilo-auto/*` fallback for the app to reach for).
+2. Explicitly set your **main model** to a local/BYOK provider (e.g. Ollama, LM Studio, or a direct API key), and set your **autocomplete model** to a direct Mistral or Inception BYOK key — see the warning below, as autocomplete has no local provider option. You can leave `small_model` and `subagent_model` unset — without a signed-in Kilo provider, they'll fall back to your main model rather than to Kilo Gateway.
+
+{% callout type="warning" %}
+**Autocomplete has no local fallback.** Unlike the small and subagent models, autocomplete only supports the Kilo Gateway or a direct BYOK key for Mistral/Inception — if it resolves to Kilo Gateway without valid auth, the request fails outright rather than falling back to a local model. For a fully offline setup, either configure a direct Mistral BYOK key (see [Setting Up Mistral for Free Autocomplete](/docs/code-with-ai/features/autocomplete/mistral-setup)) or disable autocomplete.
+{% /callout %}
+
+{% callout type="note" %}
+Gas Town also exposes its own small model setting, used for session title generation and the `explore` subagent inside your town's containers — see [Gas Town Settings](/docs/code-with-ai/gastown/settings#small-model). It's a separate, town-scoped configuration stored in your town's settings, distinct from the `small_model` key described above.
+{% /callout %}
+
 ## Check the Live Models List
 
 **[👉 See what's working today at kilo.ai/models](https://kilo.ai/models)**

--- a/packages/kilo-docs/pages/code-with-ai/gastown/settings.md
+++ b/packages/kilo-docs/pages/code-with-ai/gastown/settings.md
@@ -17,15 +17,19 @@ The primary model used by all agents (polecats, refinery, mayor). This affects q
 
 Popular choices:
 - **Kilo Auto Frontier** — highest quality models, best results (recommended)
-- **Kilo Auto Efficient** — cheapest model proven accurate enough for each task, with capability matched to difficulty (minimum for Gas Town)
+- **Kilo Auto Efficient** — cheapest model proven accurate enough for each task, with capability matched to difficulty
+
+{% callout type="note" %}
+You can enter any model ID your account has access to — there's no enforced quality floor. "Kilo Auto Efficient" is a recommendation, not a requirement.
+{% /callout %}
 
 ### Role-Specific Models
 
-Override the default model for specific agent roles. By default, all roles use the town-level model. You can override per-role if you want to optimize cost vs quality for different tasks (e.g., a faster model for the mayor, a stronger model for the refinery).
+Override the default model for specific agent roles — **mayor**, **refinery**, and **polecat**. By default, all roles use the town-level default model. You can override per-role if you want to optimize cost vs quality for different tasks (e.g., a faster model for the mayor, a stronger model for the refinery).
 
 ### Small Model
 
-Used for lightweight tasks (classification, routing, summarization). Usually a smaller, cheaper model.
+Used for session title generation and the `explore` subagent inside your town's containers — not general classification, routing, or summarization. This is a lighter-weight model than your default, and it's independent of the `small_model` config used elsewhere in Kilo Code (see [Model Routing and Configuration](/docs/code-with-ai/agents/model-selection#model-routing-and-configuration)). If left unset, it defaults to Claude Haiku rather than a Kilo-managed default.
 
 ## Git & Authentication
 

--- a/packages/kilo-docs/pages/code-with-ai/gastown/settings.md
+++ b/packages/kilo-docs/pages/code-with-ai/gastown/settings.md
@@ -19,17 +19,13 @@ Popular choices:
 - **Kilo Auto Frontier** — highest quality models, best results (recommended)
 - **Kilo Auto Efficient** — cheapest model proven accurate enough for each task, with capability matched to difficulty
 
-{% callout type="note" %}
-You can enter any model ID your account has access to — there's no enforced quality floor. "Kilo Auto Efficient" is a recommendation, not a requirement.
-{% /callout %}
-
 ### Role-Specific Models
 
 Override the default model for specific agent roles — **mayor**, **refinery**, and **polecat**. By default, all roles use the town-level default model. You can override per-role if you want to optimize cost vs quality for different tasks (e.g., a faster model for the mayor, a stronger model for the refinery).
 
 ### Small Model
 
-Used for session title generation and the `explore` subagent inside your town's containers — not general classification, routing, or summarization. This is a lighter-weight model than your default, and it's independent of the `small_model` config used elsewhere in Kilo Code (see [Model Routing and Configuration](/docs/code-with-ai/agents/model-selection#model-routing-and-configuration)). If left unset, it defaults to Claude Haiku rather than a Kilo-managed default.
+Used for session title generation and the `explore` subagent inside your town's containers — not general classification, routing, or summarization. This is a lighter-weight model than your default, and it's independent of the `small_model` config used elsewhere in Kilo Code (see [Model Routing and Configuration](/docs/code-with-ai/agents/model-selection#model-routing-and-configuration)). If left unset, it defaults to Claude Haiku.
 
 ## Git & Authentication
 


### PR DESCRIPTION
## What changed

- Added a **Model Routing and Configuration** section to `code-with-ai/agents/model-selection.md` documenting the four independently configurable model slots (main, small, subagent, autocomplete), how each falls back when unset, and what going fully offline/self-hosted actually requires.
- Corrected `code-with-ai/gastown/settings.md`'s Small Model description: it's used for session title generation and the `explore` subagent (not classification/routing/summarization), defaults to Claude Haiku (not a Kilo-managed default), and the "Kilo Auto Balanced — minimum for Gas Town" claim is unenforced in code, so it's now framed as a recommendation.
- Corrected the stale Legacy autocomplete provider-fallback list in `code-with-ai/features/autocomplete/index.md`, which described a 9-provider priority chain that isn't implemented anywhere in current code — replaced with the actual 3-provider (Kilo Gateway / Mistral BYOK / Inception BYOK) fail-fast behavior, and noted there's no offline/local autocomplete path today.
- Fixed a follow-up self-review finding: the offline-setup guidance incorrectly implied the autocomplete model supports local providers like Ollama/LM Studio, contradicting the warning callout describing autocomplete's lack of local fallback.

## Why

The small/subagent/autocomplete model configuration surface wasn't documented outside of Gas Town's page, and the Gas Town docs had drifted from actual code behavior. This corrects both gaps with details verified against the implementation (`provider.ts`, `task.ts`, `kilo-gateway/src/autocomplete.ts`, and the Gas Town service in the `cloud` repo).

## Testing

Docs-only change; no build/test commands apply beyond reading the rendered Markdoc content.