### PR TITLE
refactor(vscode): share marketplace type contracts

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/types/marketplace.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/marketplace.ts
@@ -1,79 +1,18 @@
-export interface McpParameter {
-  name: string
-  key: string
-  placeholder?: string
-  optional?: boolean
-}
-
-export interface McpInstallationMethod {
-  name: string
-  content: string
-  parameters?: McpParameter[]
-  prerequisites?: string[]
-}
-
-export interface MarketplaceSuggestFor {
-  filename?: string[]
-  vscode_extension?: string[]
-}
-
-export interface MarketplaceItemBase {
-  id: string
-  name: string
-  description: string
-  category: string
-  author?: string
-  authorUrl?: string
-  prerequisites?: string[]
-  suggest_for?: MarketplaceSuggestFor
-}
-
-export interface McpMarketplaceItem extends MarketplaceItemBase {
-  type: "mcp"
-  url: string
-  content: string | McpInstallationMethod[]
-  parameters?: McpParameter[]
-}
-
-export interface AgentContent {
-  mode: "primary" | "subagent" | "all"
-  description: string
-  prompt: string
-  options?: Record<string, unknown>
-  permission?: Record<string, unknown>
-}
-
-export interface AgentMarketplaceItem extends MarketplaceItemBase {
-  type: "agent"
-  content: AgentContent
-}
-
-export interface SkillMarketplaceItem extends MarketplaceItemBase {
-  type: "skill"
-  githubUrl: string
-  content: string
-  displayName: string
-  displayCategory: string
-}
-
-export type MarketplaceItem = McpMarketplaceItem | AgentMarketplaceItem | SkillMarketplaceItem
-
-export interface InstallMarketplaceItemOptions {
-  target?: "global" | "project"
-  parameters?: Record<string, unknown>
-}
-
-export interface MarketplaceInstalledMetadata {
-  project: Record<string, { type: string }>
-  global: Record<string, { type: string }>
-}
-
-export interface MarketplaceRelevance {
-  filename?: string[]
-  vscodeExtension?: string[]
-}
-
-export type MarketplaceRelevanceMetadata = Record<string, MarketplaceRelevance>
+export type {
+  McpParameter,
+  McpInstallationMethod,
+  MarketplaceSuggestFor,
+  MarketplaceItemBase,
+  McpMarketplaceItem,
+  AgentContent,
+  AgentMarketplaceItem,
+  SkillMarketplaceItem,
+  MarketplaceItem,
+  InstallMarketplaceItemOptions,
+  MarketplaceInstalledMetadata,
+  MarketplaceRelevance,
+  MarketplaceRelevanceMetadata,
+} from "../../../src/services/marketplace/types"
 
 export interface MarketplaceFilters {
   type?: string

--- a/script/kilocode-duplication-allowlist.json
+++ b/script/kilocode-duplication-allowlist.json
@@ -259,18 +259,6 @@
     },
     {
       "files": [
-        "packages/kilo-vscode/src/services/marketplace/types.ts",
-        "packages/kilo-vscode/webview-ui/src/types/marketplace.ts"
-      ],
-      "fingerprint": "96a848236212dea1",
-      "maxMatches": 1,
-      "maxTokens": 171,
-      "kind": "legacy",
-      "owner": "kilo-vscode",
-      "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
-    },
-    {
-      "files": [
         "packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css",
         "packages/kilo-vscode/webview-ui/src/styles/session-tabs.css"
       ],


### PR DESCRIPTION
## What Problem This Solves
Marketplace contracts were declared separately in the extension host and webview, so their wire types could drift.

## Why This Change Was Made
Use the existing, import-free host declarations as the canonical source through explicit type-only re-exports. Keep MarketplaceFilters webview-only and leave RawSkill and host result contracts unchanged. Remove only resolved duplication fingerprint `96a848236212dea1`; all other ratchet bounds remain unchanged.

## User Impact
No runtime behavior or wire-shape changes. Field optionality and discriminated unions are preserved. This removes 61 production lines without adding a shared module or runtime browser dependency.

## Evidence
- Duplication report before/after: 38 to 37 pairs, 779 to 729 duplicated lines, 5201 to 5030 duplicated tokens. Prune and normal ratchet checks pass.
- All 29 existing marketplace tests pass. Package typecheck, lint, knip, compile (host and browser bundles), marker guard, formatting, and diff checks pass.
- Fresh visible isolated VS Code smoke loaded 323 public catalogue items. Category filtering returned 9 Business and 159 Data items; MCP filtering returned 126 items. Matching search, empty search results, filter reset, and full skill-description expand/collapse worked.
- Both local screenshots were visually reviewed. No installation/removal, credentials, or model prompts were used. Installation dialogs were not exercised. The console showed only a url.parse deprecation warning.
- Missing local dependencies were installed from the frozen lockfile before successful checks. An initial isolated launch failed; retry with shorter temporary paths succeeded. Isolated VS Code and its daemon were stopped, and their profiles were removed.