### PR TITLE
refactor(vscode): share prompt dropdown container styles

### DIFF
--- a/packages/kilo-vscode/webview-ui/src/styles/prompt-dropdowns.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/prompt-dropdowns.css
@@ -2,7 +2,8 @@
    File Mention Dropdown
    ============================================ */
 
-.file-mention-dropdown {
+.file-mention-dropdown,
+.slash-command-dropdown {
   position: absolute;
   bottom: calc(100% + 4px);
   left: 0;
@@ -155,20 +156,6 @@
 /* ============================================
    Slash Command Dropdown
    ============================================ */
-
-.slash-command-dropdown {
-  position: absolute;
-  bottom: calc(100% + 4px);
-  left: 0;
-  right: 0;
-  z-index: 10;
-  background: var(--vscode-editorWidget-background, var(--vscode-input-background));
-  border: 1px solid var(--vscode-editorWidget-border, var(--vscode-input-border));
-  border-radius: 4px;
-  overflow: hidden;
-  max-height: 200px;
-  overflow-y: auto;
-}
 
 .slash-command-item {
   display: flex;

--- a/script/kilocode-duplication-allowlist.json
+++ b/script/kilocode-duplication-allowlist.json
@@ -342,18 +342,6 @@
       "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
     },
     {
-      "files": [
-        "packages/kilo-vscode/webview-ui/src/styles/prompt-dropdowns.css",
-        "packages/kilo-vscode/webview-ui/src/styles/prompt-dropdowns.css"
-      ],
-      "fingerprint": "aee459acfb62435f",
-      "maxMatches": 1,
-      "maxTokens": 109,
-      "kind": "legacy",
-      "owner": "kilo-vscode",
-      "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
-    },
-    {
       "files": ["packages/opencode/src/kilocode/agent/index.ts", "packages/opencode/src/kilocode/agent/index.ts"],
       "fingerprint": "9044b540f896a694",
       "maxMatches": 1,


### PR DESCRIPTION
## What Problem This Solves
The file-mention and slash-command dropdown containers repeat the same CSS declarations, recorded as duplication fingerprint `aee459acfb62435f`.

## Why This Change Was Made
Group the two existing class selectors into one rule and prune only the resolved ratchet exception. This removes 13 net production lines without adding classes or abstractions. Item styles, selector specificity, import order, and the later session-mention scrolling override remain unchanged.

## User Impact
No intended visual or behavior change. Both dropdowns keep their placement, width, 200px scroll cap, selection styling, and keyboard behavior.

## Evidence
- Duplication report: 38 to 37 pairs, 779 to 765 duplicate lines, 5201 to 5092 duplicate tokens. The final ratchet passes with no new findings or relaxed bounds.
- 327 existing prompt, mention, slash-command, and CSS architecture tests pass. Typecheck, lint, extension rebuild, formatting, and the change-marker guard pass.
- Before/after verification in visible isolated VS Code profiles used the actual sidebar `@` and `/` dropdowns. Computed styles, geometry, selection colors, arrow-key scrolling, and Escape dismissal matched. Screenshots were inspected; no command was executed or model prompt sent.
- The session-picker wrapper remained uncapped and its inner list retained its own 240px scrolling cap. Populated-session scrolling was not exercised because the isolated profile had no past chats. File-search ties changed order between launches; styles matched per file.
- Temporary profiles were cleaned and the self-test daemon stopped. No screenshots were uploaded.