### PR TITLE
refactor(vscode): reuse Agent Manager diff scope helpers

### DIFF
--- a/packages/kilo-vscode/tests/unit/agent-manager-diff-scope-state.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-diff-scope-state.test.ts
@@ -22,6 +22,14 @@ describe("agent-manager webview diff scope descriptors", () => {
     expect(descriptors[3]!.id).toBe("local#session:ses_abc")
   })
 
+  it("preserves legacy and malformed ids and parses the final separator", () => {
+    expect(parseDiffId("local")).toEqual({ ctx: "local", scope: "branch" })
+    expect(parseDiffId("wt_1#bogus")).toEqual({ ctx: "wt_1#bogus", scope: "branch" })
+    expect(parseDiffId("wt_1#")).toEqual({ ctx: "wt_1#", scope: "branch" })
+    expect(parseDiffId("wt#1#staged")).toEqual({ ctx: "wt#1", scope: "staged" })
+    expect(parseDiffId("local#session:")).toEqual({ ctx: "local", scope: "session", sessionId: "" })
+  })
+
   it("round-trips the session descriptor id", () => {
     expect(parseDiffId(composeDiffId("wt_1", "session", "ses_abc"))).toEqual({
       ctx: "wt_1",

--- a/packages/kilo-vscode/webview-ui/agent-manager/diff-scope-state.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/diff-scope-state.ts
@@ -13,31 +13,15 @@
 import { createMemo, createSignal, type Accessor } from "solid-js"
 import type { DiffSourceDescriptor } from "../../src/diff/sources/types"
 
-export type DiffScope = "branch" | "staged" | "unstaged" | "session"
+import { composeDiffId, DEFAULT_DIFF_SCOPE, type DiffScope } from "../../src/agent-manager/diff-scope"
 
-export const DEFAULT_DIFF_SCOPE: DiffScope = "branch"
-
-const SEP = "#"
-const SESSION_TOKEN = "session:"
-
-export function composeDiffId(ctx: string, scope: DiffScope, sessionId?: string): string {
-  if (scope === "session" && sessionId) return `${ctx}${SEP}${SESSION_TOKEN}${sessionId}`
-  return `${ctx}${SEP}${scope}`
-}
-
-export function parseDiffId(id: string): { ctx: string; scope: DiffScope; sessionId?: string } {
-  const idx = id.lastIndexOf(SEP)
-  if (idx === -1) return { ctx: id, scope: DEFAULT_DIFF_SCOPE }
-  const token = id.slice(idx + SEP.length)
-  const ctx = id.slice(0, idx)
-  if (token.startsWith(SESSION_TOKEN)) return { ctx, scope: "session", sessionId: token.slice(SESSION_TOKEN.length) }
-  if (isDiffScope(token)) return { ctx, scope: token }
-  return { ctx: id, scope: DEFAULT_DIFF_SCOPE }
-}
-
-export function isDiffScope(value: string): value is DiffScope {
-  return value === "branch" || value === "staged" || value === "unstaged" || value === "session"
-}
+export {
+  composeDiffId,
+  parseDiffId,
+  isDiffScope,
+  DEFAULT_DIFF_SCOPE,
+  type DiffScope,
+} from "../../src/agent-manager/diff-scope"
 
 /**
  * The fixed scope descriptors for a context. `workspace` maps to the Branch

--- a/script/kilocode-duplication-allowlist.json
+++ b/script/kilocode-duplication-allowlist.json
@@ -181,18 +181,6 @@
     },
     {
       "files": [
-        "packages/kilo-vscode/src/agent-manager/diff-scope.ts",
-        "packages/kilo-vscode/webview-ui/agent-manager/diff-scope-state.ts"
-      ],
-      "fingerprint": "b4d0b555891237a8",
-      "maxMatches": 1,
-      "maxTokens": 233,
-      "kind": "legacy",
-      "owner": "kilo-vscode",
-      "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
-    },
-    {
-      "files": [
         "packages/kilo-vscode/src/agent-manager/orchestration-bridge.ts",
         "packages/kilo-vscode/src/services/notebook/bridge.ts"
       ],


### PR DESCRIPTION
## What Problem This Solves
Agent Manager duplicated its diff-scope type, default, ID composition, parsing, and validation between the extension and webview. Future changes could make the two sides disagree.

## Why This Change Was Made
Reuse the existing dependency-free host module and retain the webview import API through explicit re-exports. No new helper, runtime dependency, scanner exclusion, or scope-state abstraction is needed. Remove only the resolved duplication exception `b4d0b555891237a8`.

## User Impact
No intended behavior change. Bare and malformed context fallback, final-`#` parsing, session IDs, Branch defaults, per-context state, and capabilities retain the same implementation. Production source decreases by 16 lines; the focused regression adds 8 test lines.

## Evidence
- Duplication report: 38 to 37 block pairs, 779 to 748 duplicated lines, 5,201 to 4,968 duplicated tokens. Prune removes only the target exception.
- Both focused diff-scope suites pass: 13 tests, 40 assertions.
- Package typecheck, lint, knip, compile, build:check, marker guard, and diff whitespace check pass.
- Real visible isolated VS Code fixture: Branch shows all three changes, Staged only staged.txt, Unstaged only unstaged.txt, and returning to Branch restores all three. Revert controls appear only for Branch; fixture contents remain unchanged.
- Cross-context retention was not manually exercised because the fresh fixture had no second context. The first launch inherited account state and was stopped without a prompt; the successful retry used explicit isolated HOME/XDG state. Both profiles and daemons were stopped and cleaned. No model requests or apply/revert actions were made.
- Screenshots remain local and are not published. This is a separate small follow-up, not a modification of the completed duplication-ratchet PR.