### PR TITLE
fix(jetbrains): rescale Agent Manager list rows on IDE zoom

### DIFF
--- a/.changeset/jetbrains-agent-manager-zoom-scaling.md
+++ b/.changeset/jetbrains-agent-manager-zoom-scaling.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-jetbrains": patch
+---
+
+Fix Agent Manager and history list rows not resizing correctly when zooming the IDE interface in or out

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/AgentManagerPanel.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/AgentManagerPanel.kt
@@ -176,7 +176,7 @@ class AgentManagerPanel(
         return object : BorderLayoutPanel() {
             override fun getBackground(): Color = activeListToolWindowBackground()
         }.apply {
-            border = JBUI.Borders.empty(UiStyle.Gap.sm())
+            border = JBUI.Borders.empty(UiStyle.Gap.SM)
             addToCenter(list)
         }
     }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/diff/KiloDiffEditorContent.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/diff/KiloDiffEditorContent.kt
@@ -113,7 +113,7 @@ internal class DiffEditorView(
     private val outdated = AtomicBoolean(false)
     private val refreshing = AtomicBoolean(false)
     private val tree = buildFileTree(start)
-    private val badge = DiffStatBadge(0, 0, inset = UiStyle.Gap.pad())
+    private val badge = DiffStatBadge(0, 0, inset = UiStyle.Gap.PAD)
     private val splitter = OnePixelSplitter(false, 0.25f)
     private val select = Debouncer<Int>(scope, parent) { show(it) }
     private val banner = EditorNotificationPanel(EditorNotificationPanel.Status.Warning).apply {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/ChangesPanel.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/ChangesPanel.kt
@@ -52,6 +52,9 @@ internal class ChangesPanel @RequiresEdt constructor(
     private val behind = if (mode == Mode.FULL) counter("/icons/arrow-down-to-line.svg", "worktree.stats.behind.tooltip") else null
     private val separator = if (mode == Mode.FULL) JSeparator(SwingConstants.VERTICAL) else null
     private var state: State? = null
+    private var row: Stack? = null
+    // JPanel's constructor calls updateUI() before any field above exists, so guard the refresh.
+    private var wired = false
 
     init {
         isOpaque = false
@@ -61,12 +64,37 @@ internal class ChangesPanel @RequiresEdt constructor(
             add(base, BorderLayout.CENTER)
             addMouseListener(base.listener)
         } else {
-            add(Stack.horizontal(UiStyle.Gap.md()).next(local!!).next(separator!!).next(ahead!!).next(behind!!).next(base))
+            row = Stack.horizontal(UiStyle.Gap.md()).next(local!!).next(separator!!).next(ahead!!).next(behind!!).next(base)
+            add(row)
         }
         visit(this) { it.isFocusable = false }
+        // JBFont rescales itself when the IDE font changes, and the lazy colour re-reads the theme,
+        // so neither needs re-applying on a Look-and-Feel change — and re-applying them would clobber
+        // the font a host pushes in through [setFont].
         font = JBFont.small()
         foreground = JBColor.lazy { UiStyle.Colors.weak() }
+        wired = true
+        syncScale()
         setActions(onBase, onLocal)
+    }
+
+    @RequiresEdt
+    override fun updateUI() {
+        super.updateUI()
+        if (!wired) return
+        syncScale()
+    }
+
+    /**
+     * Re-derives the spacing for the current scale. A layout manager captures its gap and
+     * [JBLabel.setIconTextGap] its pixel value when they are set, so an IDE zoom would otherwise leave
+     * the stats strip with its pre-zoom gaps.
+     */
+    @RequiresEdt
+    private fun syncScale() {
+        row?.space = UiStyle.Gap.md()
+        ahead?.iconTextGap = UiStyle.Gap.xs()
+        behind?.iconTextGap = UiStyle.Gap.xs()
     }
 
     @RequiresEdt
@@ -175,6 +203,7 @@ internal class ChangesPanel @RequiresEdt constructor(
     private inner class Group @RequiresEdt constructor(fill: Boolean) : JPanel(BorderLayout()) {
         private val count = JBLabel().apply { foreground = JBColor.lazy { UiStyle.Colors.weak() } }
         private val stat = DiffStatBadge(0, 0, DiffStatBadge.Variant.COMPACT, fill = fill)
+        private lateinit var row: Stack
         private var over = false
         var action: (() -> Unit)? = null
         val listener = object : MouseAdapter() {
@@ -203,7 +232,8 @@ internal class ChangesPanel @RequiresEdt constructor(
             isOpaque = false
             isVisible = false
             stat.isVisible = false
-            add(Stack.horizontal(UiStyle.Gap.sm()).next(count).next(stat).align(HAlign.LEFT, VAlign.CENTER))
+            row = Stack.horizontal(UiStyle.Gap.sm()).next(count).next(stat)
+            add(row.align(HAlign.LEFT, VAlign.CENTER))
             visit(this) {
                 it.isFocusable = false
                 it.addMouseListener(listener)
@@ -226,7 +256,9 @@ internal class ChangesPanel @RequiresEdt constructor(
         @RequiresEdt
         override fun updateUI() {
             super.updateUI()
-            border = JBUI.Borders.empty(0, UiStyle.Gap.sm())
+            border = JBUI.Borders.empty(0, UiStyle.Gap.SM)
+            // JPanel's constructor runs updateUI() before the row exists.
+            if (this::row.isInitialized) row.space = UiStyle.Gap.sm()
         }
 
         @RequiresEdt

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/DiffStatBadge.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/DiffStatBadge.kt
@@ -17,6 +17,7 @@ internal class DiffStatBadge(
     additions: Int,
     deletions: Int,
     private val variant: Variant = Variant.REGULAR,
+    /** Extra trailing padding, as an unscaled [UiStyle.Gap] step. */
     private val inset: Int = 0,
     // When false the badge paints only its text, without the rounded background pill or padding.
     private val fill: Boolean = true,
@@ -37,12 +38,11 @@ internal class DiffStatBadge(
             COMPACT -> UiStyle.Gap.xs()
         }
 
-        fun pad() = when (this) {
-            REGULAR -> UiStyle.Gap.sm()
-            COMPACT -> UiStyle.Gap.sm()
-        }
+        /** Unscaled horizontal padding step; [JBUI.Borders] scales what it is handed. */
+        fun pad() = UiStyle.Gap.SM
     }
 
+    // JBFont rescales itself when the IDE font changes, so assigning it once is enough for the text.
     private val removed = JBLabel().apply {
         foreground = UiStyle.Colors.removedForeground()
         font = JBFont.small()
@@ -51,16 +51,26 @@ internal class DiffStatBadge(
         foreground = UiStyle.Colors.addedForeground()
         font = JBFont.small()
     }
+    private lateinit var row: Stack
 
     init {
         isOpaque = false
-        border = if (fill) JBUI.Borders.empty(0, variant.pad(), 0, variant.pad() + inset) else JBUI.Borders.empty()
-        add(
-            Stack.horizontal(variant.gap())
-                .next(removed)
-                .next(added),
-        )
+        row = Stack.horizontal(variant.gap()).next(removed).next(added)
+        add(row)
+        syncScale()
         update(additions, deletions)
+    }
+
+    override fun updateUI() {
+        super.updateUI()
+        // JPanel's constructor runs updateUI() before the fields above exist.
+        if (this::row.isInitialized) syncScale()
+    }
+
+    /** A layout manager captures its gap once, so re-derive the spacing for the current scale. */
+    private fun syncScale() {
+        border = if (fill) JBUI.Borders.empty(0, variant.pad(), 0, variant.pad() + inset) else JBUI.Borders.empty()
+        row.space = variant.gap()
     }
 
     override fun getPreferredSize(): Dimension {
@@ -82,7 +92,7 @@ internal class DiffStatBadge(
         }
         val g2 = g.create() as Graphics2D
         try {
-            val w = maxOf(0, width - inset)
+            val w = maxOf(0, width - JBUI.scale(inset))
             val h = minOf(height, variant.height())
             val y = (height - h) / 2
             g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/FilledBadgeIcon.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/FilledBadgeIcon.kt
@@ -10,11 +10,19 @@ import java.awt.RenderingHints
 import java.awt.font.FontRenderContext
 import javax.swing.Icon
 
+/**
+ * A filled pill drawn as an icon so it can sit inside a label or a list-cell renderer.
+ *
+ * Owners keep an instance for as long as its text and style hold, so it has to stay correct across an
+ * IDE zoom. The geometry is measured per call, and [JBFont] re-derives its size from "Label.font" on
+ * read, so the pill and its text grow together.
+ */
 internal class FilledBadgeIcon(
     internal val text: String,
     internal val style: UiStyle.Badge.Style,
     private val font: Font = JBFont.small(),
 ) : Icon {
+
     override fun getIconWidth(): Int {
         val width = font.getStringBounds(text, FontRenderContext(null, true, true)).width.toInt()
         return width + UiStyle.Gap.lg() * 2

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/UiStyle.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/UiStyle.kt
@@ -17,19 +17,39 @@ import javax.swing.UIManager
 /** Shared Swing style tokens that are not tied to one session component. */
 object UiStyle {
 
-    /** DPI-aware spacing primitives used across custom Swing layouts. */
+    /**
+     * DPI-aware spacing primitives used across custom Swing layouts.
+     *
+     * The functions return pixels for the current scale and suit manual layout and painting. The
+     * constants are the raw steps and belong in APIs that scale what they are handed — notably
+     * [JBUI.Borders] and [JBUI.insets], whose `JBInsets` re-applies the user scale on every read.
+     * Passing a function result there scales twice, which stays invisible at 100% and drifts as
+     * soon as the IDE is zoomed.
+     */
     object Gap {
-        fun xs() = JBUI.scale(2)
+        const val XS = 2
 
-        fun sm() = JBUI.scale(4)
+        const val SM = 4
 
-        fun md() = JBUI.scale(6)
+        const val MD = 6
 
-        fun lg() = JBUI.scale(8)
+        const val LG = 8
 
-        fun pad() = JBUI.scale(12)
+        const val PAD = 12
 
-        fun xl() = JBUI.scale(16)
+        const val XL = 16
+
+        fun xs() = JBUI.scale(XS)
+
+        fun sm() = JBUI.scale(SM)
+
+        fun md() = JBUI.scale(MD)
+
+        fun lg() = JBUI.scale(LG)
+
+        fun pad() = JBUI.scale(PAD)
+
+        fun xl() = JBUI.scale(XL)
     }
 
     /** Theme-aware component geometry tokens. */

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/layout/Stack.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/layout/Stack.kt
@@ -25,12 +25,27 @@ class StackAxis private constructor(val vertical: Boolean) {
  */
 open class Stack(
     private val axis: StackAxis,
-    private val space: Int = 0,
+    space: Int = 0,
 ) : JPanel(Layout(axis, space)) {
 
     init {
         isOpaque = false
     }
+
+    /**
+     * Base spacing between adjacent visible children.
+     *
+     * A layout manager captures its gap once, so a DPI-derived value (e.g. [ai.kilocode.client.ui.UiStyle.Gap])
+     * would keep its pre-zoom pixel width forever. Reassign this from `updateUI()` on components whose
+     * spacing has to follow the IDE zoom or the active theme.
+     */
+    var space: Int
+        get() = mgr.base
+        set(value) {
+            if (mgr.base == value) return
+            mgr.base = value
+            revalidate()
+        }
 
     fun next(child: Component): Stack {
         add(child)
@@ -64,7 +79,7 @@ open class Stack(
 
     private class Layout(
         private val axis: StackAxis,
-        private val gap: Int,
+        var base: Int,
     ) : LayoutManager2 {
 
         var fit = false
@@ -117,7 +132,7 @@ open class Stack(
                         ready = false
                         if (entry.comp.isVisible) {
                             if (seen) {
-                                val gap = space ?: gap
+                                val gap = space ?: base
                                 if (axis.vertical) y += gap else x += gap
                             }
                             seen = true
@@ -180,7 +195,7 @@ open class Stack(
                             val pref = entry.comp.preferredSize
                             val min = entry.comp.minimumSize
                             val max = entry.comp.maximumSize
-                            items.add(Item(entry.comp, if (seen) space ?: gap else 0, bound(pref.width, min.width, max.width)))
+                            items.add(Item(entry.comp, if (seen) space ?: base else 0, bound(pref.width, min.width, max.width)))
                             seen = true
                             ready = true
                         }
@@ -215,7 +230,7 @@ open class Stack(
                         pending = null
                         ready = false
                         if (entry.comp.isVisible) {
-                            if (seen) main = safe(main, space ?: gap)
+                            if (seen) main = safe(main, space ?: base)
                             seen = true
                             ready = true
                             val dim = dim(entry.comp, kind)

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/list/ActiveList.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/list/ActiveList.kt
@@ -69,7 +69,7 @@ internal class ActiveList(
             it.textEditor.emptyText.text = placeholder
             wireActiveListSearch(it, view)
             addToTop(it)
-            scroll.border = JBUI.Borders.emptyTop(UiStyle.Gap.sm())
+            scroll.border = JBUI.Borders.emptyTop(UiStyle.Gap.SM)
         } ?: run { scroll.border = JBUI.Borders.empty() }
         addToCenter(scroll)
     }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/list/ActiveListRenderer.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/list/ActiveListRenderer.kt
@@ -19,6 +19,7 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.util.IconUtil
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.util.ui.EmptyIcon
+import com.intellij.util.ui.JBInsets
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import java.awt.AlphaComposite
@@ -37,6 +38,15 @@ import javax.swing.JPanel
 import javax.swing.ListCellRenderer
 import javax.swing.SwingConstants
 
+/**
+ * Unscaled gap around a row's badge columns.
+ *
+ * Read from the same theme key as [JBUI.CurrentTheme.ActionsList.elementIconGap] but left unscaled, so
+ * one value can feed both the layout gaps (which need pixels) and [JBUI.Borders] (which scales what it
+ * is handed).
+ */
+private fun activeListIconGap() = JBUI.getInt("ActionsList.icon.gap", UiStyle.Gap.MD)
+
 internal class ActiveListRenderer(
     private val model: CollectionListModel<ActiveListItem>,
     private val cfg: ActiveListConfig = ActiveListConfig.Equal,
@@ -50,12 +60,6 @@ internal class ActiveListRenderer(
         if (menu == null) return
         glyph.update(activeListMenuCell())
         glyph.isVisible = false
-        // Mirror the flush leading icon: drop the row's trailing inset and let the empty-icon spacer
-        // hold a dedicated menu column at the content edge. The overlay glyph then floats over that
-        // same slot, revealed on hover.
-        row.border = JBUI.Borders.empty(UiStyle.Gap.md(), 0, UiStyle.Gap.md(), 0)
-        (row.layout as BorderLayout).hgap = 0
-        mark.border = JBUI.Borders.emptyRight(UiStyle.Gap.md())
         val tail = JPanel(BorderLayout())
         UiStyle.Components.transparent(tail)
         tail.add(endPane, BorderLayout.CENTER)
@@ -69,6 +73,9 @@ internal class ActiveListRenderer(
             val width = child.preferredSize.width.coerceAtMost(host.width)
             Rectangle((host.width - width).coerceAtLeast(0), 0, width, host.height)
         }
+        // The menu column changes the row's own padding, so re-derive the scaled geometry now that
+        // [menu] is known.
+        syncScale()
     }
 
     private var menu: ActiveListMenu<*>? = null
@@ -83,8 +90,8 @@ internal class ActiveListRenderer(
     private val icon = JBLabel().apply { verticalAlignment = SwingConstants.TOP }
     private val mark = icon.align(HAlign.CENTER, VAlign.CENTER)
     private val title = SimpleColoredComponent()
-    private val leading = Stack.horizontal(JBUI.CurrentTheme.ActionsList.elementIconGap())
-    private val badges = Stack.horizontal(JBUI.CurrentTheme.ActionsList.elementIconGap())
+    private val leading = Stack.horizontal(JBUI.scale(activeListIconGap()))
+    private val badges = Stack.horizontal(JBUI.scale(activeListIconGap()))
     private val secondary = Stack.horizontal(UiStyle.Gap.md())
     // Title in CENTER clips when the group is narrow; tags in WEST/EAST keep their full preferred
     // width. A squeezed row sacrifices the title text but never drops the tags.
@@ -114,7 +121,6 @@ internal class ActiveListRenderer(
     private val cells = Stack.horizontal(activeListCellGap())
     private val cellPane = cells.align(HAlign.RIGHT, VAlign.CENTER)
     private val pill = JPanel(BorderLayout()).apply {
-        border = JBUI.Borders.empty(UiStyle.Gap.sm())
         add(cellPane, BorderLayout.CENTER)
     }
     // The dropdown button keeps the overlay approach: a real empty-icon [spacer] holds the trailing
@@ -123,8 +129,6 @@ internal class ActiveListRenderer(
     // the icon sits flush against the content edge, mirroring the flush leading icon.
     private val glyph = ActiveListActionCell()
     private val spacer = JBLabel(EmptyIcon.create(AllIcons.Actions.More))
-    // Width of the dropdown column, used to offset the action pill when a list opts into both.
-    private val reserve: Int by lazy { glyph.preferredSize.width }
     private val row = JPanel(BorderLayout(UiStyle.Gap.md(), 0)).apply {
         add(mark, BorderLayout.WEST)
         add(textPane, BorderLayout.CENTER)
@@ -136,6 +140,8 @@ internal class ActiveListRenderer(
     private val wrap = PickerRow()
     private var bodyHeight: Int? = null
     private var gap = false
+    // JPanel's constructor calls updateUI() before any field below exists, so guard the refresh.
+    private var wired = false
 
     init {
         isOpaque = true
@@ -167,15 +173,10 @@ internal class ActiveListRenderer(
             glyph,
             spacer,
         )
-        row.border = JBUI.Borders.empty(
-            UiStyle.Gap.md(),
-            0,
-            UiStyle.Gap.md(),
-            UiStyle.Gap.pad(),
-        )
         layers.addOverlay(pill) { host, child ->
             val size = child.preferredSize
-            val gap = if (menu != null) reserve else 0
+            // The dropdown column, so the pill clears it when a list opts into both.
+            val gap = if (menu != null) glyph.preferredSize.width else 0
             Rectangle(
                 (host.width - size.width - UiStyle.Gap.pad() - gap).coerceAtLeast(0),
                 ((host.height - size.height) / 2).coerceAtLeast(0),
@@ -186,6 +187,49 @@ internal class ActiveListRenderer(
         wrap.setContent(layers)
         add(top, BorderLayout.NORTH)
         add(wrap, BorderLayout.CENTER)
+        wired = true
+        syncScale()
+    }
+
+    /**
+     * Re-derives every scale-dependent value in the stamp.
+     *
+     * The renderer is one long-lived component reused for every row, and both a layout manager's gap
+     * and an assigned border capture their pixel width when they are created. An IDE zoom moves the
+     * JBUI user scale without touching row data, so anything captured in a constructor would keep its
+     * pre-zoom size while the fonts and icons around it grow. Everything DPI-derived therefore lives
+     * here and is re-applied from [updateUI].
+     */
+    private fun syncScale() {
+        // Shared with [sep], which holds this exact instance, so one update covers the header band too.
+        (insets as? JBInsets)?.update()
+        // [sep]'s own font is left alone on purpose: GroupHeaderSeparator builds it from JBFont, and a
+        // JBFont re-derives its size from "Label.font" on read, so it already follows an IDE zoom.
+        val iconGap = JBUI.scale(activeListIconGap())
+        leading.space = iconGap
+        badges.space = iconGap
+        secondary.space = UiStyle.Gap.md()
+        details.space = UiStyle.Gap.md()
+        cells.space = activeListCellGap()
+        (titleGroup.layout as BorderLayout).hgap = UiStyle.Gap.xs()
+        (descLine.layout as BorderLayout).hgap = UiStyle.Gap.md()
+        pill.border = JBUI.Borders.empty(UiStyle.Gap.SM)
+        // Mirror the flush leading icon when a menu column is present: drop the row's trailing inset
+        // and let the empty-icon spacer hold a dedicated column at the content edge. The overlay glyph
+        // then floats over that same slot, revealed on hover.
+        (row.layout as BorderLayout).hgap = if (menu == null) UiStyle.Gap.md() else 0
+        row.border = if (menu == null) {
+            JBUI.Borders.empty(UiStyle.Gap.MD, 0, UiStyle.Gap.MD, UiStyle.Gap.PAD)
+        } else {
+            JBUI.Borders.empty(UiStyle.Gap.MD, 0, UiStyle.Gap.MD, 0)
+        }
+        mark.border = if (menu == null) JBUI.Borders.empty() else JBUI.Borders.emptyRight(UiStyle.Gap.MD)
+    }
+
+    override fun updateUI() {
+        super.updateUI()
+        if (!wired) return
+        syncScale()
     }
 
     @RequiresEdt
@@ -238,7 +282,7 @@ internal class ActiveListRenderer(
         desc.text = note
         desc.isVisible = note.isNotBlank()
         desc.border = if (cfg.descriptionIndent && desc.isVisible) {
-            JBUI.Borders.emptyLeft(UiStyle.Gap.sm())
+            JBUI.Borders.emptyLeft(UiStyle.Gap.SM)
         } else {
             JBUI.Borders.empty()
         }
@@ -368,7 +412,7 @@ internal class ActiveListRenderer(
 
     private fun syncBadges(item: ActiveListItem) {
         val hidden = item.progress != null
-        val gap = JBUI.CurrentTheme.ActionsList.elementIconGap()
+        val gap = activeListIconGap()
         leading.border = JBUI.Borders.emptyRight(gap)
         badges.border = JBUI.Borders.emptyLeft(gap)
         syncBadges(leading, if (hidden) emptyList() else item.leading)

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/list/ActiveListView.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/list/ActiveListView.kt
@@ -4,6 +4,7 @@ import ai.kilocode.client.ui.UiStyle
 import ai.kilocode.client.ui.layout.Stack
 import ai.kilocode.client.ui.layout.StackAxis
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupListener
@@ -35,6 +36,7 @@ import javax.swing.JViewport
 import javax.swing.ListSelectionModel
 import javax.swing.Scrollable
 import javax.swing.SwingConstants
+import javax.swing.SwingUtilities
 import javax.swing.event.ListSelectionEvent
 
 internal class ActiveListView(
@@ -69,6 +71,13 @@ internal class ActiveListView(
         override fun getBackground(): Color {
             if (surface == ActiveListSurface.ToolWindow) return activeListToolWindowBackground()
             return super.getBackground() ?: UIUtil.getListBackground(false, false)
+        }
+
+        // The platform's Look-and-Feel pass reaches the list but never the renderer stamp, so [rescale]
+        // refreshes and re-measures it here.
+        override fun updateUI() {
+            super.updateUI()
+            rescale()
         }
 
         override fun getToolTipText(event: MouseEvent): String? {
@@ -106,6 +115,8 @@ internal class ActiveListView(
     private var restoring = false
     // Cursor for the row body; buttons override it on hover via [cursorAt].
     private var baseCursor: Cursor = Cursor.getDefaultCursor()
+    // JBList's constructor calls updateUI() before the fields above exist, so guard the re-measure.
+    private var wired = false
     internal var onSelect: (() -> Unit)? = null
 
     fun setEmptyText(text: String) {
@@ -214,6 +225,47 @@ internal class ActiveListView(
         reorder?.let { installActiveListReorder(this, list, it) }
         ScrollingUtil.installActions(list)
         next(list)
+        wired = true
+    }
+
+    /**
+     * Refreshes and re-measures the rows after a Look-and-Feel or IDE-zoom change.
+     *
+     * The renderer stamp has to be refreshed by hand. [javax.swing.JList.updateUI] only forwards to its
+     * renderer `if (renderer instanceof Component)`, and [JBList.setCellRenderer] wraps whatever it is
+     * given in a non-Component adapter, so the stamp is never reached by the platform's own
+     * Look-and-Feel pass. Fonts still follow a zoom on their own — a [com.intellij.util.ui.JBFont]
+     * re-derives its size from "Label.font" whenever it is read — but every inset, border and layout gap
+     * resolved through [JBUI.scale] is a plain pixel count that has to be recomputed.
+     *
+     * Re-measuring then needs [heightKey] dropped: zoom moves the scale and the label font without
+     * touching row data or the list width, so the key compares equal and [syncCellHeight] would keep
+     * `fixedCellHeight` at its pre-zoom value while the row content around it changes size.
+     *
+     * The measure itself is deferred. `LafManagerImpl` walks the window with
+     * `IJSwingUtilities.updateComponentTreeUI`, which visits children before their parents, so when this
+     * runs the list's own ancestors — and any theme value they still hold from before the zoom — have not
+     * been re-initialized yet. Measuring on the next EDT pass instead lets the whole tree settle at the
+     * new scale first, the same ordering [ai.kilocode.client.session.history.HistoryPanel] relies on.
+     */
+    @RequiresEdt
+    private fun rescale() {
+        if (!wired) return
+        SwingUtilities.updateComponentTreeUI(renderer)
+        heightKey = null
+        renderer.setBodyHeight(null)
+        sync()
+        val app = ApplicationManager.getApplication() ?: return
+        app.invokeLater({ remeasure() }, ModalityState.any())
+    }
+
+    /** Second, settled pass of [rescale]; safe to run when the list has since been detached. */
+    @RequiresEdt
+    private fun remeasure() {
+        if (!wired) return
+        heightKey = null
+        renderer.setBodyHeight(null)
+        sync()
     }
 
     @RequiresEdt

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/AgentManagerPanelTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/AgentManagerPanelTest.kt
@@ -65,6 +65,9 @@ import com.intellij.ui.SimpleTextAttributes
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBList
 import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.ExpandedItemListCellRendererWrapper
+import com.intellij.ui.scale.JBUIScale
+import com.intellij.util.IJSwingUtilities
 import com.intellij.util.ui.UIUtil
 import java.awt.Component
 import java.awt.Container
@@ -74,6 +77,7 @@ import java.awt.event.MouseEvent
 import java.awt.Point
 import javax.swing.JComponent
 import javax.swing.SwingUtilities
+import javax.swing.UIManager
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
 
@@ -252,6 +256,47 @@ class AgentManagerPanelTest : BasePlatformTestCase() {
         iter.next()
 
         assertEquals(SimpleTextAttributes.STYLE_PLAIN, iter.textAttributes.style)
+    }
+
+    /**
+     * End-to-end cover for an IDE interface zoom on the real panel. Only the platform's own refresh is
+     * applied — raise the `*.font` defaults and the user scale like `LafManagerImpl.patchLafFonts`, then
+     * walk the tree — because that walk never reaches the shared row renderer and the list is what has
+     * to refresh it. See `ActiveListScaleTest` for the unit-level detail.
+     */
+    fun `test worktree row height grows after an IDE zoom instead of staying at the pre zoom size`() {
+        rpc.listed += worktree("aardvark")
+        val controller = WorktreeController(service, project.basePath!!, coroutines.scope)
+        val panel = edt { AgentManagerPanel(testRootDisposable, controller, project) }
+        edt { controller.reload() }
+        flush()
+
+        // Worktree rows carry a "Local worktrees" section, so the list keeps fixedCellHeight at -1 and
+        // BasicListUI measures each row from the renderer instead — this is the exact call it makes.
+        val list = edt { UIUtil.findComponentOfType(panel, JBList::class.java)!! }
+        assertEquals(-1, edt { list.fixedCellHeight })
+        val before = edt { rowHeight(list) }
+        assertTrue("expected a real row height, got $before", before > 0)
+
+        val label = UIManager.getFont("Label.font")
+        val scale = JBUIScale.scale(1f)
+        val keys = UIManager.getDefaults().keys.toList().filterIsInstance<String>().filter { it.endsWith(".font") }
+        val fonts = keys.associateWith { UIManager.getFont(it) }
+        try {
+            edt {
+                keys.forEach { UIManager.put(it, label.deriveFont(label.size2D * 2f)) }
+                JBUIScale.setUserScaleFactorForTest(scale * 2f)
+                IJSwingUtilities.updateComponentTreeUI(panel)
+            }
+
+            val after = edt { rowHeight(list) }
+            assertTrue("expected the row height to grow with the zoom, was $before then $after", after > before)
+        } finally {
+            edt {
+                JBUIScale.setUserScaleFactorForTest(scale)
+                fonts.forEach { (key, font) -> UIManager.put(key, font) }
+            }
+        }
     }
 
     fun `test clicking a worktree opens the worktree session editor`() {
@@ -638,6 +683,65 @@ class AgentManagerPanelTest : BasePlatformTestCase() {
         flush()
 
         assertSame(WorktreeIcons.locked, row(panel, 0).icon)
+    }
+
+    /**
+     * Zooming in and back out repeatedly must land on exactly the original row height. Rows carrying
+     * diff metrics and a PR badge are the tallest shape the panel renders, and the row height is the
+     * maximum across rows, so a single value that latches instead of being re-derived shows up here as
+     * padding that never shrinks back.
+     */
+    fun `test worktree row height round trips through repeated IDE zoom changes`() {
+        val item = WorktreeDto("${project.basePath!!}/.kilo/worktrees/feature-x", "feature-x", "feature/x", "${project.basePath!!}/.kilo/worktrees/feature-x")
+        rpc.listed += main()
+        rpc.listed += item
+        rpc.statsResult = WorktreeStatsListDto(
+            listOf(WorktreeStatsDto(item.path, additions = 742, deletions = 169, ahead = 2, behind = 41, files = 14, base = "origin/main")),
+        )
+        val timers = TestUiTimers()
+        ApplicationManager.getApplication().replaceService(KiloWorktreeService::class.java, service, testRootDisposable)
+        project.replaceService(WorktreeStatusService::class.java, WorktreeStatusService(project, coroutines.scope, timers), testRootDisposable)
+        val controller = WorktreeController(service, project.basePath!!, coroutines.scope)
+        val panel = edt { AgentManagerPanel(testRootDisposable, controller, project) }
+        edt { controller.reload() }
+        timers.advanceBy(300)
+        waitUntil { row(panel, 0).metrics != null || row(panel, 1).metrics != null }
+
+        val list = edt { UIUtil.findComponentOfType(panel, JBList::class.java)!! }
+        edt {
+            list.setSize(360, 600)
+            list.doLayout()
+        }
+        val label = UIManager.getFont("Label.font")
+        val scale = JBUIScale.scale(1f)
+        val keys = UIManager.getDefaults().keys.toList().filterIsInstance<String>().filter { it.endsWith(".font") }
+        val fonts = keys.associateWith { UIManager.getFont(it) }
+        // Applies a real IDE zoom — the *.font defaults and the user scale — then refreshes the tree.
+        val zoom = { factor: Float ->
+            edt {
+                keys.forEach { UIManager.put(it, label.deriveFont(label.size2D * factor)) }
+                JBUIScale.setUserScaleFactorForTest(scale * factor)
+                IJSwingUtilities.updateComponentTreeUI(panel)
+            }
+            edt { rowHeight(list) }
+        }
+        try {
+            val base = edt { rowHeight(list) }
+            assertTrue("expected a real row height, got $base", base > 0)
+
+            val zoomed = zoom(1.25f)
+            assertTrue("expected the row height to grow when zooming in, was $base then $zoomed", zoomed > base)
+
+            // Two full round trips, so a value that grows per zoom event cannot hide behind a single one.
+            assertEquals(base, zoom(1f))
+            assertEquals(zoomed, zoom(1.25f))
+            assertEquals(base, zoom(1f))
+        } finally {
+            edt {
+                JBUIScale.setUserScaleFactorForTest(scale)
+                fonts.forEach { (key, font) -> UIManager.put(key, font) }
+            }
+        }
     }
 
     fun `test worktree row shows metrics from status service`() {
@@ -1171,6 +1275,14 @@ class AgentManagerPanelTest : BasePlatformTestCase() {
     private fun main(): WorktreeDto {
         val base = project.basePath!!
         return WorktreeDto(base, "repo", "main", base, main = true)
+    }
+
+    /** The preferred height BasicListUI itself measures for row 0 when fixedCellHeight is -1. */
+    @Suppress("UNCHECKED_CAST")
+    private fun rowHeight(rawList: JBList<*>): Int {
+        val list = rawList as JBList<Any?>
+        val renderer = ExpandedItemListCellRendererWrapper.unwrap(list.cellRenderer)
+        return renderer.getListCellRendererComponent(list, list.model.getElementAt(0), 0, false, false).preferredSize.height
     }
 
     private fun worktree(name: String): WorktreeDto {

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/AgentManagerPanelTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/AgentManagerPanelTest.kt
@@ -78,6 +78,7 @@ import java.awt.Point
 import javax.swing.JComponent
 import javax.swing.SwingUtilities
 import javax.swing.UIManager
+import javax.swing.plaf.FontUIResource
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
 
@@ -284,7 +285,7 @@ class AgentManagerPanelTest : BasePlatformTestCase() {
         val fonts = keys.associateWith { UIManager.getFont(it) }
         try {
             edt {
-                keys.forEach { UIManager.put(it, label.deriveFont(label.size2D * 2f)) }
+                keys.forEach { UIManager.put(it, FontUIResource(label.deriveFont(label.size2D * 2f))) }
                 JBUIScale.setUserScaleFactorForTest(scale * 2f)
                 IJSwingUtilities.updateComponentTreeUI(panel)
             }
@@ -294,7 +295,7 @@ class AgentManagerPanelTest : BasePlatformTestCase() {
         } finally {
             edt {
                 JBUIScale.setUserScaleFactorForTest(scale)
-                fonts.forEach { (key, font) -> UIManager.put(key, font) }
+                fonts.forEach { (key, font) -> UIManager.put(key, FontUIResource(font)) }
             }
         }
     }
@@ -717,9 +718,11 @@ class AgentManagerPanelTest : BasePlatformTestCase() {
         val keys = UIManager.getDefaults().keys.toList().filterIsInstance<String>().filter { it.endsWith(".font") }
         val fonts = keys.associateWith { UIManager.getFont(it) }
         // Applies a real IDE zoom — the *.font defaults and the user scale — then refreshes the tree.
+        // The font has to be a FontUIResource like LafManagerImpl.patchLafFonts installs, because
+        // LookAndFeel.installColorsAndFont only replaces a component font that is null or a UIResource.
         val zoom = { factor: Float ->
             edt {
-                keys.forEach { UIManager.put(it, label.deriveFont(label.size2D * factor)) }
+                keys.forEach { UIManager.put(it, FontUIResource(label.deriveFont(label.size2D * factor))) }
                 JBUIScale.setUserScaleFactorForTest(scale * factor)
                 IJSwingUtilities.updateComponentTreeUI(panel)
             }
@@ -739,7 +742,7 @@ class AgentManagerPanelTest : BasePlatformTestCase() {
         } finally {
             edt {
                 JBUIScale.setUserScaleFactorForTest(scale)
-                fonts.forEach { (key, font) -> UIManager.put(key, font) }
+                fonts.forEach { (key, font) -> UIManager.put(key, FontUIResource(font)) }
             }
         }
     }

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/ui/FilledBadgeIconTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/ui/FilledBadgeIconTest.kt
@@ -1,0 +1,30 @@
+package ai.kilocode.client.ui
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.ui.scale.JBUIScale
+
+/**
+ * A [FilledBadgeIcon] instance is retained by its owning label across an IDE zoom — callers only
+ * recreate it when the badge text or style changes, see `ActiveListBadgeCell.update` — so its geometry
+ * has to be measured per call rather than captured once.
+ */
+@Suppress("UnstableApiUsage")
+class FilledBadgeIconTest : BasePlatformTestCase() {
+
+    fun `test icon geometry grows after a zoom without recreating the icon`() {
+        val original = JBUIScale.scale(1f)
+        try {
+            JBUIScale.setUserScaleFactorForTest(1f)
+            val icon = FilledBadgeIcon("12", UiStyle.Badge.Secondary)
+            val width = icon.iconWidth
+            val height = icon.iconHeight
+
+            JBUIScale.setUserScaleFactorForTest(2f)
+
+            assertTrue("expected a wider badge after the zoom, was $width then ${icon.iconWidth}", icon.iconWidth > width)
+            assertEquals("expected the badge height to scale exactly once", height * 2, icon.iconHeight)
+        } finally {
+            JBUIScale.setUserScaleFactorForTest(original)
+        }
+    }
+}

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/ui/UiStyleTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/ui/UiStyleTest.kt
@@ -4,11 +4,46 @@ import ai.kilocode.client.session.SessionActivityKind
 import ai.kilocode.client.session.ui.style.SessionUiStyle
 import ai.kilocode.rpc.dto.GhState
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.ui.scale.JBUIScale
 import com.intellij.util.ui.JBUI
 import java.awt.Color
 
 @Suppress("UnstableApiUsage")
 class UiStyleTest : BasePlatformTestCase() {
+
+    /**
+     * [UiStyle.Gap]'s unscaled constants exist for APIs that scale what they are handed (notably
+     * [JBUI.Borders]) — feeding them the scaled function result instead double-scales the value. This
+     * pins each constant to the pixel count its matching function reports at 1x, so the two can never
+     * silently drift apart.
+     */
+    fun `test gap constants match their scaled functions at 1x`() {
+        val original = JBUIScale.scale(1f)
+        try {
+            JBUIScale.setUserScaleFactorForTest(1f)
+
+            assertEquals(UiStyle.Gap.XS, UiStyle.Gap.xs())
+            assertEquals(UiStyle.Gap.SM, UiStyle.Gap.sm())
+            assertEquals(UiStyle.Gap.MD, UiStyle.Gap.md())
+            assertEquals(UiStyle.Gap.LG, UiStyle.Gap.lg())
+            assertEquals(UiStyle.Gap.PAD, UiStyle.Gap.pad())
+            assertEquals(UiStyle.Gap.XL, UiStyle.Gap.xl())
+        } finally {
+            JBUIScale.setUserScaleFactorForTest(original)
+        }
+    }
+
+    fun `test gap constants scale exactly once through JBUI scale`() {
+        val original = JBUIScale.scale(1f)
+        try {
+            JBUIScale.setUserScaleFactorForTest(2f)
+
+            assertEquals(UiStyle.Gap.md(), JBUI.scale(UiStyle.Gap.MD))
+            assertEquals(UiStyle.Gap.pad(), JBUI.scale(UiStyle.Gap.PAD))
+        } finally {
+            JBUIScale.setUserScaleFactorForTest(original)
+        }
+    }
 
     fun `test border is lighter than dark panel`() {
         val panel = Color(0, 0, 0)

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/ui/layout/StackTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/ui/layout/StackTest.kt
@@ -107,6 +107,34 @@ class StackTest : BasePlatformTestCase() {
         assertEquals(10 x 5, stack.preferredSize)
     }
 
+    fun `test space setter re derives the base gap without recreating children`() {
+        val a = child(pref = 10 x 5)
+        val b = child(pref = 20 x 7)
+        val stack = Stack.vertical(gap = 3).apply {
+            next(a)
+            next(b)
+        }
+
+        stack.setBounds(0, 0, 100, 50)
+        stack.doLayout()
+        assertBounds(0, 8, 100, 7, b)
+
+        // A DPI-derived gap (see ai.kilocode.client.ui.UiStyle.Gap) is only known at construction
+        // time; an IDE zoom must be able to widen it later on the same retained Stack instance.
+        stack.space = 11
+        stack.doLayout()
+
+        assertSame(a, stack.getComponent(0))
+        assertSame(b, stack.getComponent(1))
+        assertBounds(0, 16, 100, 7, b)
+    }
+
+    fun `test space getter reflects the constructor gap`() {
+        val stack = Stack.horizontal(gap = 9)
+
+        assertEquals(9, stack.space)
+    }
+
     fun `test removeAll clears explicit gaps`() {
         val a = child(pref = 10 x 5)
         val b = child(pref = 20 x 7)

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/ui/list/ActiveListScaleTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/ui/list/ActiveListScaleTest.kt
@@ -1,0 +1,197 @@
+package ai.kilocode.client.ui.list
+
+import ai.kilocode.client.ui.UiStyle
+import ai.kilocode.client.ui.layout.Stack
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.ui.ExpandedItemListCellRendererWrapper
+import com.intellij.ui.GroupHeaderSeparator
+import com.intellij.ui.scale.JBUIScale
+import com.intellij.util.IJSwingUtilities
+import com.intellij.util.ui.UIUtil
+import javax.swing.UIManager
+
+/**
+ * Regression coverage for the Agent Manager / session-history list not re-scaling when the global
+ * IntelliJ interface zoom changes (`View | Appearance | Zoom IDE In/Out`).
+ *
+ * [zoom] plus [refresh] reproduce what the platform actually does, so these tests fail if the production
+ * refresh path breaks: `LafManagerImpl.patchLafFonts` raises the `*.font` UI defaults and the JBUI user
+ * scale factor, then `IJSwingUtilities.updateComponentTreeUI` walks the window. That walk reaches the
+ * list but *not* the shared renderer stamp — `JList.updateUI` only forwards to a renderer that is itself
+ * a `Component`, and `JBList` wraps ours in a non-`Component` adapter — so the list has to refresh the
+ * stamp itself. Nothing here refreshes the stamp directly, on purpose.
+ *
+ * Both halves of a zoom matter. Fonts follow the `*.font` defaults on their own, because a `JBFont`
+ * re-derives its size from "Label.font" whenever it is read. Everything resolved through `JBUI.scale`
+ * (theme insets, layout gaps, measured row heights) is a plain pixel count that changes only when it is
+ * recomputed, which is what these tests pin down.
+ */
+@Suppress("UnstableApiUsage")
+class ActiveListScaleTest : BasePlatformTestCase() {
+
+    fun `test row height is re measured after a zoom instead of staying at the pre zoom size`() {
+        val view = ActiveListView("") { _, _ -> }
+        view.update(rows("a", "b"))
+        val before = view.list.fixedCellHeight
+        assertTrue("expected a real fixed row height, got $before", before > 0)
+
+        zoom(2f) {
+            refresh(view)
+
+            val after = view.list.fixedCellHeight
+            assertTrue("expected the row height to grow with the zoom, was $before then $after", after > before)
+        }
+    }
+
+    fun `test row height shrinks back after zooming out again`() {
+        val view = ActiveListView("") { _, _ -> }
+        view.update(rows("a"))
+        val base = view.list.fixedCellHeight
+
+        zoom(2f) {
+            refresh(view)
+            assertTrue("expected the row height to grow first", view.list.fixedCellHeight > base)
+        }
+        refresh(view)
+
+        assertEquals(base, view.list.fixedCellHeight)
+    }
+
+    /**
+     * Sectioned rows are what the Agent Manager renders, and they take the other branch of the height
+     * sync: `fixedCellHeight` stays at -1 and the measured body height is pushed onto the renderer
+     * instead. Zooming out has to bring that body height back down.
+     */
+    fun `test sectioned row body height shrinks back after zooming out again`() {
+        val view = ActiveListView("") { _, _ -> }
+        view.update(listOf(row("a", section = "Local"), row("b", section = "Local")))
+        val base = body(view)
+        assertTrue("expected a real body height, got $base", base > 0)
+
+        zoom(2f) {
+            refresh(view)
+            assertTrue("expected the body height to grow first, was $base then ${body(view)}", body(view) > base)
+        }
+        refresh(view)
+
+        assertEquals(base, body(view))
+    }
+
+    /**
+     * The Agent Manager's own row shape: a section, diff metrics and a PR badge. The metrics strip
+     * carries its own nested layout gaps and a minimum height, so it dominates the measured row height
+     * and is where a stuck pre-zoom size actually shows up.
+     */
+    fun `test sectioned row with metrics and badge shrinks back after zooming out again`() {
+        val view = ActiveListView("") { _, _ -> }
+        view.update(
+            listOf(
+                row("a", section = "Local", metrics = ActiveListMetrics(files = 14, additions = 742, deletions = 169), badge = "#12967"),
+                row("b", section = "Local"),
+            ),
+        )
+        val base = body(view)
+        assertTrue("expected a real body height, got $base", base > 0)
+
+        zoom(2f) {
+            refresh(view)
+            assertTrue("expected the body height to grow first, was $base then ${body(view)}", body(view) > base)
+        }
+        refresh(view)
+
+        assertEquals(base, body(view))
+    }
+
+    /**
+     * Proves the list refreshes the renderer stamp, using a value that only [JBUI.scale] feeds: a
+     * layout gap. A layout manager captures its gap as a plain pixel count when it is created, so unlike
+     * the fonts around it, the stamp's internal spacing stays at its pre-zoom size unless the stamp is
+     * re-initialized — which is what left the section header and the row metrics misaligned against
+     * text that had grown.
+     */
+    fun `test renderer layout gaps are re derived after a zoom`() {
+        val view = ActiveListView("") { _, _ -> }
+        view.update(listOf(row("a", section = "Local")))
+        val before = gaps(view)
+        assertTrue("expected real layout gaps, got $before", before > 0)
+
+        zoom(2f) {
+            refresh(view)
+
+            val after = gaps(view)
+            assertTrue("expected the layout gaps to grow with the zoom, was $before then $after", after > before)
+        }
+    }
+
+    fun `test section header band grows after a zoom`() {
+        val view = ActiveListView("") { _, _ -> }
+        view.update(listOf(row("a", section = "Local")))
+        val before = band(view)
+        assertTrue("expected a real section band height, got $before", before > 0)
+
+        zoom(2f) {
+            refresh(view)
+
+            val after = band(view)
+            assertTrue("expected the section band to grow with the zoom, was $before then $after", after > before)
+        }
+    }
+
+    /** Applies a real IDE zoom for the duration of [block]: the font defaults and the user scale. */
+    private fun zoom(factor: Float, block: () -> Unit) {
+        val label = UIManager.getFont("Label.font")
+        val scale = JBUIScale.scale(1f)
+        val keys = UIManager.getDefaults().keys.toList().filterIsInstance<String>().filter { it.endsWith(".font") }
+        val fonts = keys.associateWith { UIManager.getFont(it) }
+        try {
+            val bigger = label.deriveFont(label.size2D * factor)
+            keys.forEach { UIManager.put(it, bigger) }
+            JBUIScale.setUserScaleFactorForTest(scale * factor)
+            block()
+        } finally {
+            JBUIScale.setUserScaleFactorForTest(scale)
+            fonts.forEach { (key, font) -> UIManager.put(key, font) }
+        }
+    }
+
+    /** The platform's own Look-and-Feel pass over the list, which never reaches the renderer stamp. */
+    private fun refresh(view: ActiveListView) = IJSwingUtilities.updateComponentTreeUI(view)
+
+    /** Height the stamp gives a row body, which is what sectioned lists size their rows with. */
+    private fun body(view: ActiveListView): Int {
+        return stamp(view).bodyPreferredHeight(view.list, view.list.model.getElementAt(0), 0, true, true)
+    }
+
+    /** Widest spacing any row in the stamp lays its children out with. */
+    private fun gaps(view: ActiveListView): Int {
+        return UIUtil.uiTraverser(stamp(view)).filterIsInstance(Stack::class.java).maxOf { it.space }
+    }
+
+    /** Height the stamp gives the section band while rendering the first row. */
+    private fun band(view: ActiveListView): Int {
+        val stamp = stamp(view)
+        stamp.getListCellRendererComponent(view.list, view.list.model.getElementAt(0), 0, false, false)
+        return UIUtil.findComponentOfType(stamp, GroupHeaderSeparator::class.java)!!.preferredSize.height
+    }
+
+    /** [JBList.setCellRenderer] wraps whatever renderer is assigned, so unwrap it back. */
+    private fun stamp(view: ActiveListView): ActiveListRenderer {
+        return ExpandedItemListCellRendererWrapper.unwrap(view.list.cellRenderer) as ActiveListRenderer
+    }
+
+    private fun rows(vararg keys: String): List<ActiveListItem> = keys.map { row(it) }
+
+    private fun row(
+        key: String,
+        section: String? = null,
+        metrics: ActiveListMetrics? = null,
+        badge: String? = null,
+    ): ActiveListItem = object : ActiveListItem {
+        override val key = key
+        override val title = key
+        override val description = "desc"
+        override val section = section
+        override val metrics = metrics
+        override val secondaryBadges = badge?.let { listOf(ActiveListBadge(it, UiStyle.Badge.Secondary)) }.orEmpty()
+    }
+}

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/ui/list/ActiveListScaleTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/ui/list/ActiveListScaleTest.kt
@@ -9,6 +9,7 @@ import com.intellij.ui.scale.JBUIScale
 import com.intellij.util.IJSwingUtilities
 import com.intellij.util.ui.UIUtil
 import javax.swing.UIManager
+import javax.swing.plaf.FontUIResource
 
 /**
  * Regression coverage for the Agent Manager / session-history list not re-scaling when the global
@@ -137,20 +138,28 @@ class ActiveListScaleTest : BasePlatformTestCase() {
         }
     }
 
-    /** Applies a real IDE zoom for the duration of [block]: the font defaults and the user scale. */
+    /**
+     * Applies a real IDE zoom for the duration of [block]: the font defaults and the user scale.
+     *
+     * The installed font must be a [FontUIResource], exactly as `LafManagerImpl.patchLafFonts` installs
+     * it. [javax.swing.LookAndFeel.installColorsAndFont] only replaces a component's font when the
+     * current one is `null` or a `UIResource`, so handing the defaults a plain font would let components
+     * adopt it once and then refuse every later update — the zoom would appear to stick permanently, in
+     * the test rather than in the product.
+     */
     private fun zoom(factor: Float, block: () -> Unit) {
         val label = UIManager.getFont("Label.font")
         val scale = JBUIScale.scale(1f)
         val keys = UIManager.getDefaults().keys.toList().filterIsInstance<String>().filter { it.endsWith(".font") }
         val fonts = keys.associateWith { UIManager.getFont(it) }
         try {
-            val bigger = label.deriveFont(label.size2D * factor)
+            val bigger = FontUIResource(label.deriveFont(label.size2D * factor))
             keys.forEach { UIManager.put(it, bigger) }
             JBUIScale.setUserScaleFactorForTest(scale * factor)
             block()
         } finally {
             JBUIScale.setUserScaleFactorForTest(scale)
-            fonts.forEach { (key, font) -> UIManager.put(key, font) }
+            fonts.forEach { (key, font) -> UIManager.put(key, FontUIResource(font)) }
         }
     }
 


### PR DESCRIPTION
## Issue

<!-- No existing issue; reported directly during JetBrains plugin testing. -->

Fixes # — no filed issue. Reported directly while testing the JetBrains plugin: the Agent Manager list does not scale correctly when using the global IntelliJ interface zoom.

## Context

Changing the global IntelliJ interface zoom (`View | Appearance | Zoom IDE In/Out`) left the Agent Manager and session-history lists with their pre-zoom geometry.

The text did scale, which made the breakage look partial rather than total: a `JBFont` re-derives its size from `Label.font` on every read (`JBFont.getSize()` → `refreshScaledFont()`), so fonts follow a zoom on their own. Everything else in a row — theme insets, layout gaps, `BorderLayout.hgap`, and the measured row height — is a plain pixel count resolved once through `JBUI.scale`. Those stayed put, so the section header band and the row metrics drifted out of alignment with text that had grown.

## Implementation

**Root cause: the shared row renderer never received the platform's Look-and-Feel pass.**

`javax.swing.JList.updateUI` only forwards to its renderer when the renderer is itself a `Component`:

```java
// JList.java:573
ListCellRenderer<? super E> renderer = getCellRenderer();
if (renderer instanceof Component) {
    SwingUtilities.updateComponentTreeUI((Component)renderer);
}
```

`JBList.setCellRenderer` wraps whatever it is given in `ExpandedItemListCellRendererWrapper`, which implements `ListCellRenderer` but is **not** a `Component`. The renderer is also not a child of the list, so `IJSwingUtilities.updateComponentTreeUI(frame)` never reaches it either. `ActiveListRenderer.updateUI()` was therefore never called on a zoom.

`ActiveListView` now refreshes the stamp itself and drops its measured-height cache. That cache is keyed on `(config, list.width, rows)` — a zoom changes none of those, so it compared equal and `syncCellHeight` kept the pre-zoom height.

All DPI-derived values in the renderer moved into one `syncScale()` applied from both the constructors and `updateUI()`, since a layout manager captures its gap and an assigned border its insets at creation time.

**Also fixes double scaling on these paths.** `JBUI.Borders` scales what it is handed (`JBEmptyBorder` → `JBInsets`, whose javadoc says *"You should pass unscaled values only!"*), so passing an already-scaled `UiStyle.Gap.md()` applied the factor twice — invisible at 100%, drifting as soon as the IDE is zoomed. `UiStyle.Gap` gains unscaled constants for those call sites, and `DiffStatBadge`'s `inset` parameter becomes an unscaled step.

Two supporting changes reviewers may want to look at:

- `Stack` gains a settable `space`, so a DPI-derived gap captured by its layout manager can be re-derived rather than frozen.
- `rescale()` measures twice: once inline and once via `invokeLater`. `IJSwingUtilities.updateComponentTreeUI` visits children before parents, so when `list.updateUI()` runs the list's ancestors still hold pre-zoom theme values. The deferred pass lets the tree settle at the new scale first — the same ordering `HistoryPanel.bindTheme()` already relies on.

**Scope note:** the same `JBUI.Borders.empty(UiStyle.Gap.xx())` double-scaling pattern exists at ~90 other call sites across the plugin. Only the ones on the list/Agent Manager path are fixed here; the plugin-wide sweep is mechanical, carries real visual-regression risk, and belongs in its own PR.

**Things I got wrong while investigating,** in case it saves a reviewer the same detour: I initially assumed `font = JBFont.small()` was frozen in `ChangesPanel`, `DiffStatBadge`, and `FilledBadgeIcon`. It is not — `JBFont` self-rescales, and re-applying the font in `updateUI()` would also have clobbered the font hosts push in through `PrHeaderView.applyStyle`. Those files therefore only get their genuinely-frozen parts fixed: layout gaps, `iconTextGap`, and the double-scaled borders.

## Screenshots / Video

### Before

<img width="1374" height="884" alt="Screen Shot 2026-09-01 at 8 20 58 AM" src="https://github.com/user-attachments/assets/abdce10b-d31e-4641-88de-0506f9faba8a" />


### After 

<img width="1400" height="1000" alt="Screen Shot 2026-08-31 at 10 30 28 PM" src="https://github.com/user-attachments/assets/4caf0f5b-eb14-4940-82e0-2019ced5f396" />


## How to Test

### Manual/local verification

- `./gradlew typecheck test --rerun-tasks` from `packages/kilo-jetbrains/` — green across `shared`, `frontend`, and `backend`. Agent-executed.
- CI green on this branch, including `jetbrains / jetbrains` (4593 tests). One unrelated flake, `SessionUpdateQueueTest > test update hooks run on EDT around history and recovery`, failed once and then passed on re-run with no code change; it does not touch this diff. The `--rerun-tasks` matters: Gradle served a stale instrumented jar during intermediate runs and briefly reported false results, so every verification below was done with a forced rebuild.
- Instrumented the real `AgentManagerPanel` (main row plus a worktree row with `files=14, +742/-169, ahead=2, behind=41` and a PR badge — the tallest row shape the panel renders) and drove it through repeated zooms, applying only what the platform does: raise the `*.font` defaults, raise the user scale, then `IJSwingUtilities.updateComponentTreeUI(panel)`. Agent-executed:

  ```
  ZOOM[100%] scale=1.0  label=13 rowPref=56 cell=56
  ZOOM[125%] scale=1.25 label=16 rowPref=70 cell=70
  ZOOM[100%] scale=1.0  label=13 rowPref=56 cell=56
  ZOOM[125%] scale=1.25 label=16 rowPref=70 cell=70
  ZOOM[100%] scale=1.0  label=13 rowPref=56 cell=56
  ```

- Confirmed `test renderer layout gaps are re derived after a zoom` fails without the renderer refresh and passes with it, each direction on a forced rebuild. Agent-executed.

### Reviewer test steps

1. Build and launch the plugin (`./gradlew runIde` from `packages/kilo-jetbrains/`).
2. Open the Kilo tool window and switch to the **Agents** tab so several worktrees are listed, ideally including some with diff metrics and PR badges.
3. Zoom in with `View | Appearance | Zoom IDE In` (or set a zoom level in `Settings | Appearance`).
4. Confirm row height, row padding, the "Local worktrees" section header band, and the `N files -x +y` metrics all grow in proportion to the text.
5. Zoom back out to 100% and confirm every one of those returns to its original size.

### Blocked checks and substitute verification

- **Not fully verified.** The reporter still sees row padding grow and not return after zooming back out, on a build that includes these changes. I could not reproduce that in-process: the faithful simulation above round-trips exactly, across two full zoom cycles, on the real panel.

  What I ruled out: the platform ordering is correct (`LafManagerImpl.updateUI` runs `patchLafFonts`, which sets the font defaults and `JBUIScale.setUserScaleFactor`, at line 823 — before `notifyLookAndFeelChanged` at 843 and the tree walk at 844), and `patchHiDPI` is idempotent for already-converted values.

  One detail argues for something accumulating rather than a single mis-scaled value: the reported rows are roughly 170px tall, while the instrumented panel measures 56px at 100% and 70px at 125%. Even 200% would only reach ~112px.

  So this PR is a real, test-covered fix for a real defect on this path, but it may not be the whole story. Landing it separately from the remaining investigation keeps the verified part reviewable, and the new `ActiveListScaleTest` gives the follow-up a place to add a failing case. Happy to hold this as a draft if a reviewer would rather wait for the full root cause.

- **A promising lead for that follow-up, surfaced by CI.** The first CI run failed the three "shrinks back" assertions on Linux with the height stuck at its zoomed value (`expected:<47> but was:<74>`) while passing locally on macOS — the reporter's symptom exactly. The cause turned out to be in the test rather than the product: the zoom helper installed a plain `Font` into the UI defaults, and `LookAndFeel.installColorsAndFont` only replaces a component font that is `null` or a `UIResource`, so components adopted the zoomed font once and then refused every later update. `LafManagerImpl.patchLafFonts` installs `FontUIResource` values; the helpers now do the same (second commit) and CI is green.

  That mechanism is worth carrying into the follow-up. Any component in the row tree holding a **non-`UIResource`, non-self-rescaling** font would be permanently pinned to the size it was assigned at — growing on one zoom and never shrinking. `RelativeFont.derive` is a concrete candidate: handed a `UIResource` it re-wraps its result in a plain `FontUIResource` (`RelativeFont.java:179-181`), losing `JBFont`'s self-rescaling, and `ActiveListRenderer.syncHeader` derives the section caption font from `sep.font` on every render — so once that font is a plain `FontUIResource` the caption is pinned. Whether `sep.font` ever becomes a `UIResource` is LaF-dependent, which would explain why this reproduces for the reporter and not for me. I did not change it here: I tried resetting that font earlier in this branch and it visibly altered the caption size (12px to 11px), so it needs a verified repro rather than another speculative edit.

- No screenshots of the visual result, for the reason given in that section.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

<!-- Agent-authored PR; reach the branch owner for follow-up. -->

