### PR TITLE
fix(vscode): preserve packaged Playwright runtime

### DIFF
--- a/.changeset/fix-browser-runtime-packaging.md
+++ b/.changeset/fix-browser-runtime-packaging.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix an empty extension sidebar after installing a build with browser automation support.

--- a/packages/kilo-vscode/esbuild.js
+++ b/packages/kilo-vscode/esbuild.js
@@ -5,6 +5,7 @@ const crypto = require("crypto")
 const core = require("@babel/core")
 const solid = require("babel-preset-solid")
 const ts = require("@babel/preset-typescript")
+const playwright = require("./script/playwright-runtime")
 
 const production = process.argv.includes("--production")
 const watch = process.argv.includes("--watch")
@@ -264,7 +265,7 @@ function getExtensionConfig() {
     outfile: "dist/extension.js",
     external: ["vscode"],
     logLevel: "silent",
-    plugins: watch ? [esbuildProblemMatcherPlugin] : [],
+    plugins: [playwright, ...(watch ? [esbuildProblemMatcherPlugin] : [])],
   }
 }
 

--- a/packages/kilo-vscode/script/playwright-runtime.js
+++ b/packages/kilo-vscode/script/playwright-runtime.js
@@ -1,0 +1,35 @@
+const fs = require("node:fs")
+const path = require("node:path")
+const { createRequire } = require("node:module")
+
+function copy(name, from, dir) {
+  const file = createRequire(path.join(from, "package.json"))
+    .resolve.paths(name)
+    ?.map((dir) => path.join(dir, name, "package.json"))
+    .find((file) => fs.existsSync(file))
+  if (!file) throw new Error(`Could not locate runtime package ${name}`)
+
+  const root = fs.realpathSync(path.dirname(file))
+  const pkg = require(file)
+  const target = path.join(dir, name)
+  fs.rmSync(target, { recursive: true, force: true })
+  fs.cpSync(root, target, {
+    recursive: true,
+    dereference: true,
+    filter: (file) => path.basename(file) !== "node_modules",
+  })
+  for (const dep of Object.keys(pkg.dependencies ?? {})) copy(dep, root, path.join(target, "node_modules"))
+}
+
+module.exports = {
+  name: "playwright-runtime",
+  setup(build) {
+    build.onResolve({ filter: /^playwright-core(?:\/|$)/ }, (args) => ({ path: args.path, external: true }))
+    build.onEnd((result) => {
+      if (result.errors.length) return
+      const file = path.resolve(build.initialOptions.absWorkingDir ?? process.cwd(), build.initialOptions.outfile)
+      const dir = path.join(path.dirname(file), "node_modules")
+      for (const name of ["playwright-core", "chromium-bidi"]) copy(name, path.join(__dirname, ".."), dir)
+    })
+  },
+}

--- a/packages/kilo-vscode/tests/unit/esbuild-dependencies.test.ts
+++ b/packages/kilo-vscode/tests/unit/esbuild-dependencies.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect } from "bun:test"
 import fs from "node:fs"
 import path from "node:path"
 import { builtinModules } from "node:module"
+import os from "node:os"
+import { build } from "esbuild"
+import { listFiles, PackageManager } from "@vscode/vsce"
+import playwright from "../../script/playwright-runtime"
 
 const ROOT = path.resolve(import.meta.dir, "../..")
 const PKG_FILE = path.join(ROOT, "package.json")
@@ -59,4 +63,66 @@ describe("Build Script Dependency Declarations", () => {
 
     expect(undeclared).toEqual([])
   })
+
+  it("loads the packaged browser broker outside the repository", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "kilo-browser-runtime-"))
+    const staging = path.join(dir, "staging")
+    const installed = path.join(dir, "installed")
+    try {
+      await build({
+        entryPoints: [path.join(ROOT, "src/services/browser-automation/browser-broker.ts")],
+        outfile: path.join(staging, "dist/extension.js"),
+        bundle: true,
+        format: "cjs",
+        platform: "node",
+        minify: true,
+        logLevel: "silent",
+        plugins: [playwright],
+      })
+      for (const file of ["package.json", ".vscodeignore"]) {
+        fs.copyFileSync(path.join(ROOT, file), path.join(staging, file))
+      }
+      const files = await listFiles({ cwd: staging, packageManager: PackageManager.None })
+      for (const file of [
+        "dist/node_modules/playwright-core/browsers.json",
+        "dist/node_modules/playwright-core/lib/generated/utilityScriptSource.js",
+        "dist/node_modules/chromium-bidi/node_modules/zod/package.json",
+      ]) {
+        expect(files).toContain(file)
+      }
+      for (const file of files) {
+        const target = path.join(installed, file)
+        fs.mkdirSync(path.dirname(target), { recursive: true })
+        fs.copyFileSync(path.join(staging, file), target)
+      }
+      const child = Bun.spawnSync(
+        [
+          "node",
+          "--no-global-search-paths",
+          "-e",
+          `
+          const assert = require("node:assert/strict")
+          const fs = require("node:fs")
+          const path = require("node:path")
+          const entry = process.argv[1]
+          const load = require("node:module").createRequire(entry)
+          assert.equal(typeof load(entry).BrowserBroker, "function")
+          assert.equal(load("playwright-core").chromium.name(), "chromium")
+          const manifest = fs.realpathSync(load.resolve("playwright-core/package.json"))
+          assert.ok(manifest.startsWith(fs.realpathSync(path.dirname(entry)) + path.sep))
+        `,
+          path.join(installed, "dist/extension.js"),
+        ],
+        {
+          cwd: installed,
+          env: { ...process.env, NODE_PATH: "", NODE_OPTIONS: "" },
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      )
+      expect(child.exitCode, child.stdout.toString() + child.stderr.toString()).toBe(0)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  }, 15_000)
 })


### PR DESCRIPTION
## What Problem This Solves

Fix the installed-extension activation regression introduced by #13501. A snapshot built from main fails before `activate()` with `Cannot find module '../../../package.json'`, leaving the Kilo sidebar empty while its toolbar remains visible.

Playwright resolves its package manifest relative to its own runtime files. Bundling those files into `dist/extension.js` changes that lookup to an ancestor outside the extension. Development can hide the error because the same path finds the monorepo's root manifest.

## Why This Change Was Made

Keep Playwright external to the extension bundle and copy its runtime package, Chromium BiDi, and their pinned runtime dependencies into `dist/node_modules`. Preserve package resources and dependency resolution without copying workspace dependency symlinks. The existing VSIX rules include this directory even when packaging with `--no-dependencies`.

The regression test builds the real browser broker, applies VSCE's file selection, copies only the selected files into an installation directory outside the repository, and loads it in a separate Node process with global module search disabled. It checks that Playwright resolves inside the installation and that required runtime assets ship.

## User Impact

Installed snapshots can activate and display the sidebar and Settings again. Browser automation retains a working Playwright runtime rather than relying on a substitute manifest or a path workaround.

Copying runs at build time. Playwright still loads eagerly at the existing startup point; the change from bundled code to separate package files has not been benchmarked, so this PR makes no startup-time guarantee.

## Evidence

- Extension unit suite: 4,560 passed, 1 skipped, 0 failed.
- Production package build, host/webview typechecks, lint, formatting, Knip, and the package marker guard passed.
- Installed the production VSIX into an isolated VS Code profile outside the repository, with separate Kilo data. The sidebar and Settings rendered successfully on macOS.
- Loaded Playwright from that installed VSIX, launched headless Chrome, and read test page content successfully.
- The final diff contains only the runtime packaging fix, its regression test, and a changeset. No screenshots or binaries are committed to this repository.

<img width="320" alt="Kilo sidebar renders its welcome screen and prompt input after installing the fixed VSIX" src="https://marius-kilocode.github.io/pr-assets/20260901-extension-startup-fixed-sidebar-0716.png" />
