### PR TITLE
docs: add OpenZoo provider page

### DIFF
--- a/packages/kilo-docs/lib/nav/ai-providers.ts
+++ b/packages/kilo-docs/lib/nav/ai-providers.ts
@@ -38,6 +38,7 @@ export const AiProvidersNav: NavSection[] = [
         children: "Vercel AI Gateway",
       },
       { href: "/ai-providers/edenai", children: "Eden AI" },
+      { href: "/ai-providers/openzoo", children: "OpenZoo" },
     ],
   },
   {

--- a/packages/kilo-docs/pages/ai-providers/index.md
+++ b/packages/kilo-docs/pages/ai-providers/index.md
@@ -50,6 +50,7 @@ Route requests through unified APIs with additional features:
 - **[DaoXE](/docs/ai-providers/daoxe)** - Connect multiple model families through one API
 - **[Cloudflare AI Gateway](/docs/ai-providers/cloudflare)** - Route providers through your Cloudflare account
 - **[Eden AI](/docs/ai-providers/edenai)** - EU-based gateway with one key across vendors
+- **[OpenZoo](/docs/ai-providers/openzoo)** - Signup-free gateway paid per call, hosted or local via npx
 
 ## Choosing a Provider
 

--- a/packages/kilo-docs/pages/ai-providers/index.md
+++ b/packages/kilo-docs/pages/ai-providers/index.md
@@ -50,7 +50,7 @@ Route requests through unified APIs with additional features:
 - **[DaoXE](/docs/ai-providers/daoxe)** - Connect multiple model families through one API
 - **[Cloudflare AI Gateway](/docs/ai-providers/cloudflare)** - Route providers through your Cloudflare account
 - **[Eden AI](/docs/ai-providers/edenai)** - EU-based gateway with one key across vendors
-- **[OpenZoo](/docs/ai-providers/openzoo)** - Signup-free gateway paid per call, hosted or local via npx
+- **[OpenZoo](/docs/ai-providers/openzoo)** - Pay-per-call gateway via a local `npx openzoo` proxy, no account
 
 ## Choosing a Provider
 

--- a/packages/kilo-docs/pages/ai-providers/openzoo.md
+++ b/packages/kilo-docs/pages/ai-providers/openzoo.md
@@ -1,49 +1,50 @@
 ---
 title: "Using OpenZoo with Kilo Code"
-description: "Configure OpenZoo in Kilo Code — an OpenAI-compatible provider with no signup that pays per call, hosted or local via npx."
+description: "Configure OpenZoo in Kilo Code — an OpenAI-compatible provider that pays per call over x402 from a local npx proxy, no account."
 sidebar_label: OpenZoo
 ---
 
 # Using OpenZoo With Kilo Code
 
-[OpenZoo](https://openzoo.fun) is an OpenAI-compatible gateway that needs no
-account: any API key value is accepted and usage is paid per request — by card,
-or automatically via the x402 protocol. It runs hosted at
-`https://api.openzoo.fun/v1` or fully locally with `npx openzoo` at
-`http://localhost:8402/v1`.
+[OpenZoo](https://openzoo.fun) is an OpenAI-compatible gateway with no
+account. You run a small local proxy (`npx openzoo`) that pays for each
+request over the x402 protocol from a local burner wallet; Kilo Code talks to
+the proxy at `http://localhost:8402/v1` like any other OpenAI-compatible
+endpoint.
 
 ## Before you begin
 
-1. No signup is needed. Use any API key value, for example `sk-openzoo`.
-2. Pick a model id from the live catalogue at
-   [api.openzoo.fun/v1/models](https://api.openzoo.fun/v1/models) (free to
-   fetch). Ids are namespaced, like `z-ai/glm-5.3-flash`.
+1. Start the proxy: `npx openzoo`. It listens on `http://localhost:8402/v1`.
+2. Fund its wallet: `npx openzoo address` prints the address — send USDC on
+   Solana or Base. `npx openzoo balance` shows what is left.
+3. Pick a model id from the live catalogue at
+   `http://localhost:8402/v1/models` (free to fetch). Ids are namespaced,
+   like `z-ai/glm-5.3-flash`.
 
 ## Configure Kilo Code
 
 1. Open **Settings** in the Kilo Code extension.
 2. Go to the **Providers** tab, choose **Add a custom provider**, and pick the
    **OpenAI Compatible** type.
-3. Set the Base URL to `https://api.openzoo.fun/v1` (or
-   `http://localhost:8402/v1` for local).
-4. Enter any API key value, e.g. `sk-openzoo`.
+3. Set the Base URL to `http://localhost:8402/v1`.
+4. Enter any non-empty API key value, e.g. `sk-openzoo` — the proxy ignores it.
 5. Enter a model id from `/v1/models`.
 
 ## CLI
 
 For the Kilo CLI, add a custom OpenAI-compatible provider to
-`~/.config/kilo/kilo.json` pointing at the same base URL
-(`https://api.openzoo.fun/v1` or the local gateway) with any API key value,
-then select one of its models in the CLI's model picker.
+`~/.config/kilo/kilo.json` pointing at `http://localhost:8402/v1` with any
+non-empty API key value, then select one of its models in the CLI's model
+picker.
 
 ## Tips and Notes
 
-- **Local mode:** `npx openzoo` serves the same API at
-  `http://localhost:8402/v1` and pays per call from a local burner wallet — no
-  cloud dependency.
 - **Streaming:** SSE streaming is supported.
-- **Billing:** per call; there is no dashboard or account to manage. An HTTP
-  402 response carries its own directions (card link and wallet commands).
+- **Billing:** per call from the proxy's wallet; there is no dashboard or
+  account to manage. An HTTP 402 from the proxy means the wallet is unfunded.
+- **Hosted endpoint:** `https://api.openzoo.fun/v1` answers HTTP 402 unless
+  the caller pays x402 or presents an OpenZoo subscription key
+  (`ozk_live_…`). Kilo Code cannot pay x402 itself, so use the local proxy.
 
 {% callout type="note" %}
 This documentation was contributed by OpenZoo, the provider it describes.

--- a/packages/kilo-docs/pages/ai-providers/openzoo.md
+++ b/packages/kilo-docs/pages/ai-providers/openzoo.md
@@ -18,8 +18,9 @@ endpoint.
 2. Fund its wallet: `npx openzoo address` prints the address — send USDC on
    Solana or Base. `npx openzoo balance` shows what is left.
 3. Pick a model id from the live catalogue at
-   `http://localhost:8402/v1/models` (free to fetch). Ids are namespaced,
-   like `z-ai/glm-5.3-flash`.
+   `http://localhost:8402/v1/models` (free to fetch). Ids are bare model
+   names, like `claude-sonnet-5` or `gpt-4o-mini`; `auto` lets the proxy pick a
+   model per request.
 
 ## Configure Kilo Code
 
@@ -45,8 +46,8 @@ in `~/.config/kilo/kilo.json` or `./kilo.json`:
     "openzoo": {
       "npm": "@ai-sdk/openai-compatible",
       "models": {
-        "z-ai/glm-5.3-flash": {
-          "name": "GLM 5.3 Flash",
+        "auto": {
+          "name": "OpenZoo Auto",
         },
       },
       "options": {
@@ -55,7 +56,7 @@ in `~/.config/kilo/kilo.json` or `./kilo.json`:
       },
     },
   },
-  "model": "openzoo/z-ai/glm-5.3-flash",
+  "model": "openzoo/auto",
 }
 ```
 

--- a/packages/kilo-docs/pages/ai-providers/openzoo.md
+++ b/packages/kilo-docs/pages/ai-providers/openzoo.md
@@ -1,0 +1,42 @@
+---
+title: "Using OpenZoo with Kilo Code"
+description: "Configure OpenZoo in Kilo Code — an OpenAI-compatible provider with no signup that pays per call, hosted or local via npx."
+sidebar_label: OpenZoo
+---
+
+# Using OpenZoo With Kilo Code
+
+[OpenZoo](https://openzoo.fun) is an OpenAI-compatible gateway that needs no
+account: any API key value is accepted and usage is paid per request — by card,
+or automatically via the x402 protocol. It runs hosted at
+`https://api.openzoo.fun/v1` or fully locally with `npx openzoo` at
+`http://localhost:8402/v1`.
+
+## Before you begin
+
+1. No signup is needed. Use any API key value, for example `sk-openzoo`.
+2. Pick a model id from the live catalogue at
+   [api.openzoo.fun/v1/models](https://api.openzoo.fun/v1/models) (free to
+   fetch). Ids are namespaced, like `z-ai/glm-5.3-flash`.
+
+## Configure Kilo Code
+
+1. Open **Settings** in the Kilo Code extension.
+2. Go to the **Providers** tab and select **OpenAI Compatible**.
+3. Set the Base URL to `https://api.openzoo.fun/v1` (or
+   `http://localhost:8402/v1` for local).
+4. Enter any API key value, e.g. `sk-openzoo`.
+5. Enter a model id from `/v1/models`.
+
+## Tips and Notes
+
+- **Local mode:** `npx openzoo` serves the same API at
+  `http://localhost:8402/v1` and pays per call from a local burner wallet — no
+  cloud dependency.
+- **Streaming:** SSE streaming is supported.
+- **Billing:** per call; there is no dashboard or account to manage. An HTTP
+  402 response carries its own directions (card link and wallet commands).
+
+{% callout type="note" %}
+This documentation was contributed by OpenZoo, the provider it describes.
+{% /callout %}

--- a/packages/kilo-docs/pages/ai-providers/openzoo.md
+++ b/packages/kilo-docs/pages/ai-providers/openzoo.md
@@ -22,11 +22,18 @@ or automatically via the x402 protocol. It runs hosted at
 ## Configure Kilo Code
 
 1. Open **Settings** in the Kilo Code extension.
-2. Go to the **Providers** tab and select **OpenAI Compatible**.
+2. Go to the **Providers** tab, choose **Add a custom provider**, and pick the
+   **OpenAI Compatible** type.
 3. Set the Base URL to `https://api.openzoo.fun/v1` (or
    `http://localhost:8402/v1` for local).
 4. Enter any API key value, e.g. `sk-openzoo`.
 5. Enter a model id from `/v1/models`.
+
+## CLI
+
+For the Kilo CLI, add a custom provider to `~/.config/kilo/kilo.json` pointing
+at the same base URL (`https://api.openzoo.fun/v1` or the local gateway), with
+any API key value, then select it with `kilo auth login --provider`.
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/openzoo.md
+++ b/packages/kilo-docs/pages/ai-providers/openzoo.md
@@ -31,9 +31,10 @@ or automatically via the x402 protocol. It runs hosted at
 
 ## CLI
 
-For the Kilo CLI, add a custom provider to `~/.config/kilo/kilo.json` pointing
-at the same base URL (`https://api.openzoo.fun/v1` or the local gateway), with
-any API key value, then select it with `kilo auth login --provider`.
+For the Kilo CLI, add a custom OpenAI-compatible provider to
+`~/.config/kilo/kilo.json` pointing at the same base URL
+(`https://api.openzoo.fun/v1` or the local gateway) with any API key value,
+then select one of its models in the CLI's model picker.
 
 ## Tips and Notes
 

--- a/packages/kilo-docs/pages/ai-providers/openzoo.md
+++ b/packages/kilo-docs/pages/ai-providers/openzoo.md
@@ -23,6 +23,9 @@ endpoint.
 
 ## Configure Kilo Code
 
+{% tabs %}
+{% tab label="VSCode" %}
+
 1. Open **Settings** in the Kilo Code extension.
 2. Go to the **Providers** tab, choose **Add a custom provider**, and pick the
    **OpenAI Compatible** type.
@@ -30,12 +33,38 @@ endpoint.
 4. Enter any non-empty API key value, e.g. `sk-openzoo` — the proxy ignores it.
 5. Enter a model id from `/v1/models`.
 
-## CLI
+{% /tab %}
+{% tab label="CLI" %}
 
-For the Kilo CLI, add a custom OpenAI-compatible provider to
-`~/.config/kilo/kilo.json` pointing at `http://localhost:8402/v1` with any
-non-empty API key value, then select one of its models in the CLI's model
-picker.
+OpenZoo is a custom OpenAI-compatible gateway, not a built-in provider. Add it
+in `~/.config/kilo/kilo.json` or `./kilo.json`:
+
+```jsonc
+{
+  "provider": {
+    "openzoo": {
+      "npm": "@ai-sdk/openai-compatible",
+      "models": {
+        "z-ai/glm-5.3-flash": {
+          "name": "GLM 5.3 Flash",
+        },
+      },
+      "options": {
+        "apiKey": "sk-openzoo",
+        "baseURL": "http://localhost:8402/v1",
+      },
+    },
+  },
+  "model": "openzoo/z-ai/glm-5.3-flash",
+}
+```
+
+Replace the model id with any id from `http://localhost:8402/v1/models`. The
+proxy ignores the API key, so any non-empty value works. Then select the
+model in the CLI model picker, or keep the `model` field as the default.
+
+{% /tab %}
+{% /tabs %}
 
 ## Tips and Notes
 


### PR DESCRIPTION
Updated 2026-09-02: corrected — the hosted `https://api.openzoo.fun/v1` endpoint answers HTTP 402 to a plain OpenAI client (it only serves calls that pay x402 or carry an OpenZoo subscription key, `ozk_live_…`). The page now sets up the local `npx openzoo` proxy (`http://localhost:8402/v1`), which pays x402 per call from a local burner wallet and ignores the API key.

Adds a provider page for [OpenZoo](https://openzoo.fun) — the same 3-file shape as the merged Eden AI page (#13169): new page in `packages/kilo-docs/pages/ai-providers/`, nav link in `lib/nav/ai-providers.ts` (AI Gateways section), one line in the index.

OpenZoo works in Kilo Code today via the OpenAI Compatible provider type; the page documents the local `npx openzoo` proxy as the base URL (`http://localhost:8402/v1`; the proxy ignores the API key, so any non-empty value works; billing is per call from the proxy's wallet), notes that the hosted endpoint needs x402 or a subscription key, and says where the live model list is. Includes the vendor-contribution callout per the Eden AI precedent — I operate OpenZoo.

Verification: `npx openzoo` then `curl http://localhost:8402/v1/models` is free and lists model ids + pricing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
