### PR TITLE
refactor(gateway): share device authorization HTTP requests

### DIFF
--- a/packages/kilo-gateway/src/auth/device-auth-tui.ts
+++ b/packages/kilo-gateway/src/auth/device-auth-tui.ts
@@ -1,62 +1,10 @@
 import { execFile } from "child_process"
-import type { DeviceAuthInitiateResponse, DeviceAuthPollResponse } from "../types.js"
+import type { DeviceAuthPollResponse } from "../types.js"
 import { poll } from "./polling.js"
+import { initiateDeviceAuth, pollDeviceAuth } from "./device.js"
 import { getKiloProfile, getKiloDefaultModel, defaultOrganizationId } from "../api/profile.js"
-import { KILO_API_BASE, POLL_INTERVAL_MS } from "../api/constants.js"
+import { POLL_INTERVAL_MS } from "../api/constants.js"
 import type { AuthOuathResult } from "@kilocode/plugin"
-
-/**
- * Initiate device authorization flow
- * @returns Device authorization details
- * @throws Error if initiation fails
- */
-async function initiateDeviceAuth(): Promise<DeviceAuthInitiateResponse> {
-  const response = await fetch(`${KILO_API_BASE}/api/device-auth/codes`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-  })
-
-  if (!response.ok) {
-    if (response.status === 429) {
-      throw new Error("Too many pending authorization requests. Please try again later.")
-    }
-    throw new Error(`Failed to initiate device authorization: ${response.status}`)
-  }
-
-  const data = await response.json()
-  return data as DeviceAuthInitiateResponse
-}
-
-/**
- * Poll for device authorization status
- * @param code The verification code
- * @returns Poll response with status and optional token
- * @throws Error if polling fails
- */
-async function pollDeviceAuth(code: string): Promise<DeviceAuthPollResponse> {
-  const response = await fetch(`${KILO_API_BASE}/api/device-auth/codes/${code}`)
-
-  if (response.status === 202) {
-    return { status: "pending" }
-  }
-
-  if (response.status === 403) {
-    return { status: "denied" }
-  }
-
-  if (response.status === 410) {
-    return { status: "expired" }
-  }
-
-  if (!response.ok) {
-    throw new Error(`Failed to poll device authorization: ${response.status}`)
-  }
-
-  const data = await response.json()
-  return data as DeviceAuthPollResponse
-}
 
 /**
  * TUI-compatible device authorization flow

--- a/packages/kilo-gateway/src/auth/device-auth.ts
+++ b/packages/kilo-gateway/src/auth/device-auth.ts
@@ -12,64 +12,9 @@ import open from "open"
 import { spinner } from "@clack/prompts"
 import type { DeviceAuthInitiateResponse, DeviceAuthPollResponse } from "../types.js"
 import { poll, formatTimeRemaining } from "./polling.js"
+import { initiateDeviceAuth, pollDeviceAuth } from "./device.js"
 import { getKiloProfile, getKiloDefaultModel, promptOrganizationSelection } from "../api/profile.js"
-import { KILO_API_BASE, POLL_INTERVAL_MS } from "../api/constants.js"
-
-/**
- * Initiate device authorization flow
- * @returns Device authorization details
- * @throws Error if initiation fails
- */
-async function initiateDeviceAuth(): Promise<DeviceAuthInitiateResponse> {
-  const response = await fetch(`${KILO_API_BASE}/api/device-auth/codes`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-  })
-
-  if (!response.ok) {
-    if (response.status === 429) {
-      throw new Error("Too many pending authorization requests. Please try again later.")
-    }
-    throw new Error(`Failed to initiate device authorization: ${response.status}`)
-  }
-
-  const data = await response.json()
-  return data as DeviceAuthInitiateResponse
-}
-
-/**
- * Poll for device authorization status
- * @param code The verification code
- * @returns Poll response with status and optional token
- * @throws Error if polling fails
- */
-async function pollDeviceAuth(code: string): Promise<DeviceAuthPollResponse> {
-  const response = await fetch(`${KILO_API_BASE}/api/device-auth/codes/${code}`)
-
-  if (response.status === 202) {
-    // Still pending
-    return { status: "pending" }
-  }
-
-  if (response.status === 403) {
-    // Denied by user
-    return { status: "denied" }
-  }
-
-  if (response.status === 410) {
-    // Code expired
-    return { status: "expired" }
-  }
-
-  if (!response.ok) {
-    throw new Error(`Failed to poll device authorization: ${response.status}`)
-  }
-
-  const data = await response.json()
-  return data as DeviceAuthPollResponse
-}
+import { POLL_INTERVAL_MS } from "../api/constants.js"
 
 export interface DeviceAuthResult {
   token: string

--- a/packages/kilo-gateway/src/auth/device.ts
+++ b/packages/kilo-gateway/src/auth/device.ts
@@ -1,0 +1,44 @@
+import type { DeviceAuthInitiateResponse, DeviceAuthPollResponse } from "../types.js"
+import { KILO_API_BASE } from "../api/constants.js"
+
+export async function initiateDeviceAuth(): Promise<DeviceAuthInitiateResponse> {
+  const response = await fetch(`${KILO_API_BASE}/api/device-auth/codes`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  })
+
+  if (!response.ok) {
+    if (response.status === 429) {
+      throw new Error("Too many pending authorization requests. Please try again later.")
+    }
+    throw new Error(`Failed to initiate device authorization: ${response.status}`)
+  }
+
+  const data = await response.json()
+  return data as DeviceAuthInitiateResponse
+}
+
+export async function pollDeviceAuth(code: string): Promise<DeviceAuthPollResponse> {
+  const response = await fetch(`${KILO_API_BASE}/api/device-auth/codes/${code}`)
+
+  if (response.status === 202) {
+    return { status: "pending" }
+  }
+
+  if (response.status === 403) {
+    return { status: "denied" }
+  }
+
+  if (response.status === 410) {
+    return { status: "expired" }
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to poll device authorization: ${response.status}`)
+  }
+
+  const data = await response.json()
+  return data as DeviceAuthPollResponse
+}

--- a/packages/kilo-gateway/test/auth/device.test.ts
+++ b/packages/kilo-gateway/test/auth/device.test.ts
@@ -1,76 +1,35 @@
-import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { afterEach, expect, mock, spyOn, test } from "bun:test"
 import { KILO_API_BASE } from "../../src/api/constants.js"
 import { initiateDeviceAuth, pollDeviceAuth } from "../../src/auth/device.js"
 
-afterEach(() => {
-  mock.restore()
+afterEach(() => mock.restore())
+
+test("device initiation preserves the POST, JSON, and rate-limit error", async () => {
+  const data = { code: "ABCD", verificationUrl: "https://example.com/device", expiresIn: 600, extra: true }
+  const request = spyOn(globalThis, "fetch").mockResolvedValue(Response.json(data))
+
+  await expect(initiateDeviceAuth()).resolves.toEqual(data)
+  expect(request.mock.calls).toStrictEqual([
+    [`${KILO_API_BASE}/api/device-auth/codes`, { method: "POST", headers: { "Content-Type": "application/json" } }],
+  ])
+  request.mockResolvedValue(new Response(null, { status: 429 }))
+  await expect(initiateDeviceAuth()).rejects.toThrow("Too many pending authorization requests. Please try again later.")
 })
 
-describe("initiateDeviceAuth", () => {
-  test("posts without a body and passes through JSON", async () => {
-    const data = { code: "ABCD", verificationUrl: "https://example.com/device", expiresIn: 600, extra: true }
-    const request = spyOn(globalThis, "fetch").mockResolvedValue(Response.json(data))
+test("device polling preserves the bare GET and JSON", async () => {
+  const data = { status: "approved", token: "token", userEmail: "user@example.com", extra: true }
+  const request = spyOn(globalThis, "fetch").mockResolvedValue(Response.json(data))
 
-    await expect(initiateDeviceAuth()).resolves.toEqual(data)
-    expect(request.mock.calls).toStrictEqual([
-      [`${KILO_API_BASE}/api/device-auth/codes`, { method: "POST", headers: { "Content-Type": "application/json" } }],
-    ])
-  })
-
-  test.each([
-    [429, "Too many pending authorization requests. Please try again later."],
-    [500, "Failed to initiate device authorization: 500"],
-  ])("rejects HTTP %i", async (status, message) => {
-    spyOn(globalThis, "fetch").mockResolvedValue(new Response("not json", { status }))
-
-    await expect(initiateDeviceAuth()).rejects.toThrow(message)
-  })
+  await expect(pollDeviceAuth("code/with space")).resolves.toEqual(data)
+  expect(request.mock.calls).toStrictEqual([[`${KILO_API_BASE}/api/device-auth/codes/code/with space`]])
 })
 
-describe("pollDeviceAuth", () => {
-  test("uses a bare GET with the code unchanged and passes through JSON", async () => {
-    const code = "code/with space"
-    const data = { status: "approved", token: "token", userEmail: "user@example.com", extra: true }
-    const request = spyOn(globalThis, "fetch").mockResolvedValue(Response.json(data))
+test.each([
+  [202, "pending"],
+  [403, "denied"],
+  [410, "expired"],
+])("device polling maps HTTP %i to %s without parsing JSON", async (status, state) => {
+  spyOn(globalThis, "fetch").mockResolvedValue(new Response("not json", { status }))
 
-    await expect(pollDeviceAuth(code)).resolves.toEqual(data)
-    expect(request.mock.calls).toStrictEqual([[`${KILO_API_BASE}/api/device-auth/codes/${code}`]])
-  })
-
-  test.each([
-    [202, "pending"],
-    [403, "denied"],
-    [410, "expired"],
-  ])("maps HTTP %i to %s without parsing JSON", async (status, state) => {
-    const response = new Response("not json", { status })
-    const json = spyOn(response, "json")
-    spyOn(globalThis, "fetch").mockResolvedValue(response)
-
-    await expect(pollDeviceAuth("code")).resolves.toEqual({ status: state })
-    expect(json).not.toHaveBeenCalled()
-  })
-
-  test("rejects other unsuccessful responses", async () => {
-    spyOn(globalThis, "fetch").mockResolvedValue(new Response("not json", { status: 500 }))
-
-    await expect(pollDeviceAuth("code")).rejects.toThrow("Failed to poll device authorization: 500")
-  })
-})
-
-describe.each([
-  ["initiateDeviceAuth", initiateDeviceAuth],
-  ["pollDeviceAuth", () => pollDeviceAuth("code")],
-] as const)("%s failures", (_name, run) => {
-  test("propagates network failures", async () => {
-    const error = new TypeError("Network unavailable")
-    spyOn(globalThis, "fetch").mockRejectedValue(error)
-
-    await expect(run()).rejects.toBe(error)
-  })
-
-  test("propagates invalid JSON failures", async () => {
-    spyOn(globalThis, "fetch").mockResolvedValue(new Response("not json"))
-
-    await expect(run()).rejects.toBeInstanceOf(SyntaxError)
-  })
+  await expect(pollDeviceAuth("code")).resolves.toEqual({ status: state })
 })

--- a/packages/kilo-gateway/test/auth/device.test.ts
+++ b/packages/kilo-gateway/test/auth/device.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import { KILO_API_BASE } from "../../src/api/constants.js"
+import { initiateDeviceAuth, pollDeviceAuth } from "../../src/auth/device.js"
+
+afterEach(() => {
+  mock.restore()
+})
+
+describe("initiateDeviceAuth", () => {
+  test("posts without a body and passes through JSON", async () => {
+    const data = { code: "ABCD", verificationUrl: "https://example.com/device", expiresIn: 600, extra: true }
+    const request = spyOn(globalThis, "fetch").mockResolvedValue(Response.json(data))
+
+    await expect(initiateDeviceAuth()).resolves.toEqual(data)
+    expect(request.mock.calls).toStrictEqual([
+      [`${KILO_API_BASE}/api/device-auth/codes`, { method: "POST", headers: { "Content-Type": "application/json" } }],
+    ])
+  })
+
+  test.each([
+    [429, "Too many pending authorization requests. Please try again later."],
+    [500, "Failed to initiate device authorization: 500"],
+  ])("rejects HTTP %i", async (status, message) => {
+    spyOn(globalThis, "fetch").mockResolvedValue(new Response("not json", { status }))
+
+    await expect(initiateDeviceAuth()).rejects.toThrow(message)
+  })
+})
+
+describe("pollDeviceAuth", () => {
+  test("uses a bare GET with the code unchanged and passes through JSON", async () => {
+    const code = "code/with space"
+    const data = { status: "approved", token: "token", userEmail: "user@example.com", extra: true }
+    const request = spyOn(globalThis, "fetch").mockResolvedValue(Response.json(data))
+
+    await expect(pollDeviceAuth(code)).resolves.toEqual(data)
+    expect(request.mock.calls).toStrictEqual([[`${KILO_API_BASE}/api/device-auth/codes/${code}`]])
+  })
+
+  test.each([
+    [202, "pending"],
+    [403, "denied"],
+    [410, "expired"],
+  ])("maps HTTP %i to %s without parsing JSON", async (status, state) => {
+    const response = new Response("not json", { status })
+    const json = spyOn(response, "json")
+    spyOn(globalThis, "fetch").mockResolvedValue(response)
+
+    await expect(pollDeviceAuth("code")).resolves.toEqual({ status: state })
+    expect(json).not.toHaveBeenCalled()
+  })
+
+  test("rejects other unsuccessful responses", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValue(new Response("not json", { status: 500 }))
+
+    await expect(pollDeviceAuth("code")).rejects.toThrow("Failed to poll device authorization: 500")
+  })
+})
+
+describe.each([
+  ["initiateDeviceAuth", initiateDeviceAuth],
+  ["pollDeviceAuth", () => pollDeviceAuth("code")],
+] as const)("%s failures", (_name, run) => {
+  test("propagates network failures", async () => {
+    const error = new TypeError("Network unavailable")
+    spyOn(globalThis, "fetch").mockRejectedValue(error)
+
+    await expect(run()).rejects.toBe(error)
+  })
+
+  test("propagates invalid JSON failures", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValue(new Response("not json"))
+
+    await expect(run()).rejects.toBeInstanceOf(SyntaxError)
+  })
+})

--- a/script/kilocode-duplication-allowlist.json
+++ b/script/kilocode-duplication-allowlist.json
@@ -111,15 +111,6 @@
       "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
     },
     {
-      "files": ["packages/kilo-gateway/src/auth/device-auth-tui.ts", "packages/kilo-gateway/src/auth/device-auth.ts"],
-      "fingerprint": "e6ac9a2221c1deb4",
-      "maxMatches": 1,
-      "maxTokens": 194,
-      "kind": "legacy",
-      "owner": "kilo-gateway",
-      "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
-    },
-    {
       "files": [
         "packages/kilo-indexing/src/indexing/embedders/openai-compatible.ts",
         "packages/kilo-indexing/src/indexing/embedders/openrouter.ts"


### PR DESCRIPTION
## What Problem This Solves
The legacy and TUI device-auth flows duplicate the same initiation POST and polling GET logic.

## Why This Change Was Made
Move only the identical HTTP functions into an internal auth helper. Keep both public entrypoints and their browser, progress, callback, credential, and organization-selection behavior unchanged. No new public exports, dependencies, retries, or validation.

## User Impact
No intended behavior change. Request shapes, initiation 429 text, polling 202/403/410 mappings, generic errors, JSON passthrough, and network/JSON failures are preserved.

## Evidence
- Production: 49 added / 112 removed, net 63 fewer lines across three source files. Focused tests add 35 lines; the verified allowlist entry removes 9. Entire PR: net 37 fewer lines.
- Fresh duplication report: 35 to 34 pairs, 684 to 629 duplicated lines, 4688 to 4494 duplicated tokens. Only fingerprint e6ac9a2221c1deb4 removed; ratchet passes.
- 10 focused helper/profile tests pass. Gateway and CLI consumer typechecks pass after installing worktree-local locked dependencies. Scoped lint has zero errors and three existing/moved production warnings; formatting and diff checks pass.
- Isolated loopback HTTP 429 smoke test exercised both real callers and confirmed the exact error without credentials, browser opening, or real authentication. The legacy spinner remained active after rejection until the test process timed out, an existing behavior left out of scope. The local server was stopped and temporary HOME/XDG profile removed. Full browser authentication was intentionally not exercised.