### PR TITLE
refactor(vscode): share terminal directory blocking

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/ScriptTerminalManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/ScriptTerminalManager.ts
@@ -2,6 +2,7 @@ import type { KiloClient } from "@kilocode/sdk/v2/client"
 import path from "node:path"
 import type { TerminalFont } from "./terminal-font"
 import type { RunHandle } from "./run/manager"
+import { block } from "./pty-cleanup"
 
 export type ScriptTerminalKind = "run" | "setup"
 type ScriptTerminalState = "running" | "stopping" | "exited" | "failed"
@@ -130,17 +131,7 @@ export class ScriptTerminalManager {
 
   async blockDirectory(directory: string) {
     const target = directoryKey(directory)
-    this.blocked.set(target, (this.blocked.get(target) ?? 0) + 1)
-    const creates = this.creates.get(target)
-    if (creates) await Promise.allSettled([...creates])
-    let released = false
-    return () => {
-      if (released) return
-      released = true
-      const count = this.blocked.get(target)
-      if (!count || count === 1) this.blocked.delete(target)
-      else this.blocked.set(target, count - 1)
-    }
+    return block(target, this.blocked, this.creates.get(target))
   }
 
   async closeDirectory(directory: string): Promise<void> {

--- a/packages/kilo-vscode/src/agent-manager/pty-cleanup.ts
+++ b/packages/kilo-vscode/src/agent-manager/pty-cleanup.ts
@@ -3,6 +3,19 @@ import type { ScriptTerminalManager } from "./ScriptTerminalManager"
 import type { SessionTerminalManager } from "./SessionTerminalManager"
 import type { TerminalRouter } from "./terminal-routing"
 
+export async function block(target: string, blocked: Map<string, number>, creates?: Set<Promise<unknown>>) {
+  blocked.set(target, (blocked.get(target) ?? 0) + 1)
+  if (creates) await Promise.allSettled([...creates])
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    const count = blocked.get(target)
+    if (!count || count === 1) blocked.delete(target)
+    else blocked.set(target, count - 1)
+  }
+}
+
 export async function removePtys(
   getClient: (directory: string) => Promise<KiloClient>,
   directory: string,

--- a/packages/kilo-vscode/src/agent-manager/terminal-manager.ts
+++ b/packages/kilo-vscode/src/agent-manager/terminal-manager.ts
@@ -15,6 +15,7 @@
 
 import type { KiloClient } from "@kilocode/sdk/v2/client"
 import path from "node:path"
+import { block } from "./pty-cleanup"
 
 const env = { KILO_UNICODE_LOGO: "0" }
 
@@ -95,17 +96,7 @@ export class TerminalManager {
 
   async blockDirectory(directory: string) {
     const target = key(directory)
-    this.blocked.set(target, (this.blocked.get(target) ?? 0) + 1)
-    const creates = this.creates.get(target)
-    if (creates) await Promise.allSettled([...creates])
-    let released = false
-    return () => {
-      if (released) return
-      released = true
-      const count = this.blocked.get(target)
-      if (!count || count === 1) this.blocked.delete(target)
-      else this.blocked.set(target, count - 1)
-    }
+    return block(target, this.blocked, this.creates.get(target))
   }
 
   async closeDirectory(directory: string): Promise<void> {

--- a/packages/kilo-vscode/tests/unit/pty-cleanup.test.ts
+++ b/packages/kilo-vscode/tests/unit/pty-cleanup.test.ts
@@ -3,12 +3,54 @@ import type { KiloClient } from "@kilocode/sdk/v2/client"
 import type { ProjectContext } from "../../src/agent-manager/project/context"
 import type { LifecycleHost } from "../../src/agent-manager/provider-lifecycle"
 import { discardWorktree } from "../../src/agent-manager/discard-worktree"
-import { acquirePtyCleanup, removePtys } from "../../src/agent-manager/pty-cleanup"
+import { acquirePtyCleanup, block, removePtys } from "../../src/agent-manager/pty-cleanup"
 import type { ScriptTerminalManager } from "../../src/agent-manager/ScriptTerminalManager"
 import type { SessionTerminalManager } from "../../src/agent-manager/SessionTerminalManager"
 import type { TerminalRouter } from "../../src/agent-manager/terminal-routing"
 
 describe("Agent Manager PTY cleanup", () => {
+  it("reference-counts directory blocks and releases each block only once", async () => {
+    const blocked = new Map<string, number>()
+    const first = await block("/worktree", blocked)
+    const second = await block("/worktree", blocked)
+    const other = await block("/other", blocked)
+    expect(blocked.get("/worktree")).toBe(2)
+
+    first()
+    first()
+    expect(blocked.get("/worktree")).toBe(1)
+    second()
+    expect(blocked.has("/worktree")).toBe(false)
+    expect(blocked.get("/other")).toBe(1)
+    other()
+    expect(blocked.size).toBe(0)
+  })
+
+  it("blocks immediately and waits for the pending snapshot, including rejected creates", async () => {
+    const blocked = new Map<string, number>()
+    const first = Promise.withResolvers<void>()
+    const second = Promise.withResolvers<void>()
+    const late = Promise.withResolvers<void>()
+    const creates = new Set([first.promise, second.promise])
+    let settled = false
+    const pending = block("/worktree", blocked, creates).then((release) => {
+      settled = true
+      return release
+    })
+    expect(blocked.get("/worktree")).toBe(1)
+    creates.clear()
+    creates.add(late.promise)
+
+    first.reject(new Error("create failed"))
+    await Promise.allSettled([first.promise])
+    expect(settled).toBe(false)
+    second.resolve()
+    const release = await pending
+    expect(blocked.get("/worktree")).toBe(1)
+    release()
+    expect(blocked.size).toBe(0)
+  })
+
   it("removes every listed PTY even when one removal fails", async () => {
     const removed: string[] = []
     const client = {

--- a/packages/kilo-vscode/tests/unit/pty-cleanup.test.ts
+++ b/packages/kilo-vscode/tests/unit/pty-cleanup.test.ts
@@ -3,54 +3,12 @@ import type { KiloClient } from "@kilocode/sdk/v2/client"
 import type { ProjectContext } from "../../src/agent-manager/project/context"
 import type { LifecycleHost } from "../../src/agent-manager/provider-lifecycle"
 import { discardWorktree } from "../../src/agent-manager/discard-worktree"
-import { acquirePtyCleanup, block, removePtys } from "../../src/agent-manager/pty-cleanup"
+import { acquirePtyCleanup, removePtys } from "../../src/agent-manager/pty-cleanup"
 import type { ScriptTerminalManager } from "../../src/agent-manager/ScriptTerminalManager"
 import type { SessionTerminalManager } from "../../src/agent-manager/SessionTerminalManager"
 import type { TerminalRouter } from "../../src/agent-manager/terminal-routing"
 
 describe("Agent Manager PTY cleanup", () => {
-  it("reference-counts directory blocks and releases each block only once", async () => {
-    const blocked = new Map<string, number>()
-    const first = await block("/worktree", blocked)
-    const second = await block("/worktree", blocked)
-    const other = await block("/other", blocked)
-    expect(blocked.get("/worktree")).toBe(2)
-
-    first()
-    first()
-    expect(blocked.get("/worktree")).toBe(1)
-    second()
-    expect(blocked.has("/worktree")).toBe(false)
-    expect(blocked.get("/other")).toBe(1)
-    other()
-    expect(blocked.size).toBe(0)
-  })
-
-  it("blocks immediately and waits for the pending snapshot, including rejected creates", async () => {
-    const blocked = new Map<string, number>()
-    const first = Promise.withResolvers<void>()
-    const second = Promise.withResolvers<void>()
-    const late = Promise.withResolvers<void>()
-    const creates = new Set([first.promise, second.promise])
-    let settled = false
-    const pending = block("/worktree", blocked, creates).then((release) => {
-      settled = true
-      return release
-    })
-    expect(blocked.get("/worktree")).toBe(1)
-    creates.clear()
-    creates.add(late.promise)
-
-    first.reject(new Error("create failed"))
-    await Promise.allSettled([first.promise])
-    expect(settled).toBe(false)
-    second.resolve()
-    const release = await pending
-    expect(blocked.get("/worktree")).toBe(1)
-    release()
-    expect(blocked.size).toBe(0)
-  })
-
   it("removes every listed PTY even when one removal fails", async () => {
     const removed: string[] = []
     const client = {

--- a/script/kilocode-duplication-allowlist.json
+++ b/script/kilocode-duplication-allowlist.json
@@ -193,18 +193,6 @@
     },
     {
       "files": [
-        "packages/kilo-vscode/src/agent-manager/ScriptTerminalManager.ts",
-        "packages/kilo-vscode/src/agent-manager/terminal-manager.ts"
-      ],
-      "fingerprint": "83aaa96c32fb3894",
-      "maxMatches": 1,
-      "maxTokens": 127,
-      "kind": "legacy",
-      "owner": "kilo-vscode",
-      "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
-    },
-    {
-      "files": [
         "packages/kilo-vscode/src/agent-manager/types.ts",
         "packages/kilo-vscode/webview-ui/agent-manager/pr/pr-types.ts"
       ],


### PR DESCRIPTION
## What Problem This Solves

The terminal and script-terminal managers duplicate the same reference-counted directory barrier used during worktree cleanup.

## Why This Change Was Made

Share only that barrier through the existing PTY cleanup module. Keep each manager’s maps, directory normalization, SDK calls, and error handling separate. Remove only duplication exception `83aaa96c32fb3894`.

## User Impact

No behavior change is intended. Blocking starts synchronously, waits for the current creation snapshot, and releases each lease at most once. The complete PR removes 17 net lines across four files, including 5 net production lines. No test code is added.

## Evidence

- Duplication report: 35 → 34 pairs, 684 → 669 lines, 4688 → 4561 tokens. Only the target fingerprint disappeared.
- 115 existing cleanup, terminal, routing, and architecture tests passed after removing the added tests.
- Typecheck, lint, knip, build:check, duplication and annotation guards, formatting, and diff checks passed.
- Visible isolated VS Code launch failed before UI verification: `electronApplication.evaluate: Resulting promise was garbage collected.` The isolated profile and harness were cleaned up.
- Manual follow-up: in a disposable repository, create a blank Agent Manager worktree, open its terminal, then delete that worktree. Confirm its terminal closes and an unrelated local terminal stays usable.

No changeset is needed for this internal behavior-preserving refactor.