### PR TITLE
feat(agent-manager): show CLI activity in terminal tabs and worktrees

### DIFF
--- a/.changeset/terminal-cli-activity.md
+++ b/.changeset/terminal-cli-activity.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": minor
+"@kilocode/cli": minor
+---
+
+Show CLI activity in Agent Manager terminal tabs and worktree indicators, including working, waiting for input, retrying, errors, and completed tasks.

--- a/packages/kilo-vscode/src/agent-manager/terminal-manager.ts
+++ b/packages/kilo-vscode/src/agent-manager/terminal-manager.ts
@@ -16,7 +16,7 @@
 import type { KiloClient } from "@kilocode/sdk/v2/client"
 import path from "node:path"
 
-const env = { KILO_UNICODE_LOGO: "0" }
+const env = { KILO_UNICODE_LOGO: "0", KILO_TERMINAL_ACTIVITY: "1" }
 
 function key(directory: string) {
   const value = path.resolve(directory)

--- a/packages/kilo-vscode/tests/unit/agent-manager-terminal-activity.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-terminal-activity.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "bun:test"
+import { registerActivity } from "../../webview-ui/agent-manager/terminal/activity"
+import { createTerminalState } from "../../webview-ui/agent-manager/terminal/state"
+import type { Activity } from "../../webview-ui/src/utils/session-activity"
+
+function receiver() {
+  const states: Activity[] = []
+  let handle!: (data: string) => boolean | Promise<boolean>
+  let disposed = false
+  const receiver = registerActivity(
+    {
+      registerOscHandler: (id, callback) => {
+        expect(id).toBe(777)
+        handle = callback
+        return {
+          dispose: () => {
+            disposed = true
+          },
+        }
+      },
+    },
+    (state) => states.push(state),
+  )
+  return { ...receiver, states, handle: (data: string) => handle(data), disposed: () => disposed }
+}
+
+const packet = (state: string, time = Date.now()) => `kilo;activity;1;${state};${time}`
+
+describe("terminal activity", () => {
+  it("accepts every state and clears on disconnect and disposal", () => {
+    const input = receiver()
+    for (const state of ["idle", "busy", "retry", "waiting", "error", "done"] as const) {
+      expect(input.handle(packet(state))).toBe(true)
+      expect(input.states.at(-1)).toBe(state)
+    }
+    input.clear()
+    expect(input.states.at(-1)).toBe("idle")
+    input.handle(packet("busy"))
+    input.dispose()
+    expect(input.states.at(-1)).toBe("idle")
+    expect(input.disposed()).toBe(true)
+  })
+
+  it("ignores malformed, stale, future and unrelated output", () => {
+    const input = receiver()
+    expect(input.handle("notify;hello")).toBe(false)
+    for (const value of [
+      packet("unknown"),
+      packet("busy", Date.now() - 16_000),
+      packet("busy", Date.now() + 6_000),
+      "kilo;activity;2;busy;1",
+      "kilo;activity;1;busy;NaN",
+      `${packet("busy")};extra`,
+    ]) {
+      expect(input.handle(value)).toBe(true)
+    }
+    expect(input.states).toEqual([])
+    input.dispose()
+  })
+
+  it("expires a signal that is not refreshed", async () => {
+    const input = receiver()
+    input.handle(packet("busy", Date.now() - 14_950))
+    expect(input.states).toEqual(["busy"])
+    await Bun.sleep(80)
+    expect(input.states).toEqual(["busy", "idle"])
+    input.dispose()
+  })
+
+  it("aggregates tab and side activity without remounting or crossing projects", () => {
+    const state = createTerminalState(() => "one:wt")
+    const add = (id: string, context: string, placement: "tab" | "side") =>
+      state.add(context, {
+        id,
+        title: id,
+        placement,
+        wsUrl: "",
+        font: { fontFamily: "monospace", fontSize: 12 },
+      })
+    add("first", "one:wt", "tab")
+    add("second", "one:wt", "side")
+    add("other", "two:wt", "tab")
+    const record = state.all().at(0)
+    state.setActivity("first", "busy")
+    state.setActivity("second", "waiting")
+    state.setActivity("other", "error")
+    expect(state.activityFor("one:wt")).toBe("waiting")
+    expect(state.activityFor("two:wt")).toBe("error")
+    state.setActivity("second", "idle")
+    expect(state.activityFor("one:wt")).toBe("busy")
+    expect(state.all().at(0)).toBe(record)
+    state.remove("first")
+    expect(state.activityFor("one:wt")).toBe("idle")
+    expect(state.activity("first")).toBe("idle")
+    state.setActivity("first", "busy")
+    expect(state.activity("first")).toBe("idle")
+  })
+})

--- a/packages/kilo-vscode/tests/unit/agent-manager-terminal-activity.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-terminal-activity.test.ts
@@ -1,13 +1,13 @@
-import { describe, expect, it } from "bun:test"
+import { expect, it } from "bun:test"
 import { registerActivity } from "../../webview-ui/agent-manager/terminal/activity"
 import { createTerminalState } from "../../webview-ui/agent-manager/terminal/state"
 import type { Activity } from "../../webview-ui/src/utils/session-activity"
 
-function receiver() {
+it("accepts all states, ignores invalid signals, and clears on expiry and disposal", async () => {
   const states: Activity[] = []
   let handle!: (data: string) => boolean | Promise<boolean>
   let disposed = false
-  const receiver = registerActivity(
+  const input = registerActivity(
     {
       registerOscHandler: (id, callback) => {
         expect(id).toBe(777)
@@ -21,29 +21,9 @@ function receiver() {
     },
     (state) => states.push(state),
   )
-  return { ...receiver, states, handle: (data: string) => handle(data), disposed: () => disposed }
-}
-
-const packet = (state: string, time = Date.now()) => `kilo;activity;1;${state};${time}`
-
-describe("terminal activity", () => {
-  it("accepts every state and clears on disconnect and disposal", () => {
-    const input = receiver()
-    for (const state of ["idle", "busy", "retry", "waiting", "error", "done"] as const) {
-      expect(input.handle(packet(state))).toBe(true)
-      expect(input.states.at(-1)).toBe(state)
-    }
-    input.clear()
-    expect(input.states.at(-1)).toBe("idle")
-    input.handle(packet("busy"))
-    input.dispose()
-    expect(input.states.at(-1)).toBe("idle")
-    expect(input.disposed()).toBe(true)
-  })
-
-  it("ignores malformed, stale, future and unrelated output", () => {
-    const input = receiver()
-    expect(input.handle("notify;hello")).toBe(false)
+  const packet = (state: string, time = Date.now()) => `kilo;activity;1;${state};${time}`
+  try {
+    expect(handle("notify;hello")).toBe(false)
     for (const value of [
       packet("unknown"),
       packet("busy", Date.now() - 16_000),
@@ -52,47 +32,46 @@ describe("terminal activity", () => {
       "kilo;activity;1;busy;NaN",
       `${packet("busy")};extra`,
     ]) {
-      expect(input.handle(value)).toBe(true)
+      expect(handle(value)).toBe(true)
     }
-    expect(input.states).toEqual([])
-    input.dispose()
-  })
-
-  it("expires a signal that is not refreshed", async () => {
-    const input = receiver()
-    input.handle(packet("busy", Date.now() - 14_950))
-    expect(input.states).toEqual(["busy"])
+    expect(states).toEqual([])
+    for (const state of ["idle", "busy", "retry", "waiting", "error", "done"]) {
+      expect(handle(packet(state))).toBe(true)
+      expect(states.at(-1)).toBe(state)
+    }
+    input.clear()
+    expect(states.at(-1)).toBe("idle")
+    handle(packet("busy", Date.now() - 14_950))
+    expect(states.at(-1)).toBe("busy")
     await Bun.sleep(80)
-    expect(input.states).toEqual(["busy", "idle"])
+    expect(states.at(-1)).toBe("idle")
+    handle(packet("busy"))
+  } finally {
     input.dispose()
-  })
+  }
+  expect(states.at(-1)).toBe("idle")
+  expect(disposed).toBe(true)
+})
 
-  it("aggregates tab and side activity without remounting or crossing projects", () => {
-    const state = createTerminalState(() => "one:wt")
-    const add = (id: string, context: string, placement: "tab" | "side") =>
-      state.add(context, {
-        id,
-        title: id,
-        placement,
-        wsUrl: "",
-        font: { fontFamily: "monospace", fontSize: 12 },
-      })
-    add("first", "one:wt", "tab")
-    add("second", "one:wt", "side")
-    add("other", "two:wt", "tab")
-    const record = state.all().at(0)
-    state.setActivity("first", "busy")
-    state.setActivity("second", "waiting")
-    state.setActivity("other", "error")
-    expect(state.activityFor("one:wt")).toBe("waiting")
-    expect(state.activityFor("two:wt")).toBe("error")
-    state.setActivity("second", "idle")
-    expect(state.activityFor("one:wt")).toBe("busy")
-    expect(state.all().at(0)).toBe(record)
-    state.remove("first")
-    expect(state.activityFor("one:wt")).toBe("idle")
-    expect(state.activity("first")).toBe("idle")
-    state.setActivity("first", "busy")
-    expect(state.activity("first")).toBe("idle")
-  })
+it("aggregates main and side terminals without remounting or crossing projects", () => {
+  const state = createTerminalState(() => "one:wt")
+  const add = (id: string, context: string, placement: "tab" | "side") =>
+    state.add(context, { id, title: id, placement, wsUrl: "", font: { fontFamily: "monospace", fontSize: 12 } })
+  add("first", "one:wt", "tab")
+  add("second", "one:wt", "side")
+  add("other", "two:wt", "tab")
+  const record = state.all().at(0)
+  state.setActivity("first", "busy")
+  state.setActivity("second", "waiting")
+  state.setActivity("other", "error")
+  expect(state.activityFor("one:wt")).toBe("waiting")
+  expect(state.activityFor("two:wt")).toBe("error")
+  state.setActivity("second", "idle")
+  expect(state.activityFor("one:wt")).toBe("busy")
+  expect(state.all().at(0)).toBe(record)
+  state.remove("first")
+  expect(state.activityFor("one:wt")).toBe("idle")
+  expect(state.activity("first")).toBe("idle")
+  state.setActivity("first", "busy")
+  expect(state.activity("first")).toBe("idle")
 })

--- a/packages/kilo-vscode/tests/unit/agent-manager-terminal-routing.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-terminal-routing.test.ts
@@ -50,10 +50,10 @@ describe("Agent Manager terminal routing", () => {
       worktreeId: "wt-1",
       projectId: "prj-1",
     })
-    expect(envs[0]).toEqual({ KILO_UNICODE_LOGO: "0" })
+    expect(envs[0]).toEqual({ KILO_UNICODE_LOGO: "0", KILO_TERMINAL_ACTIVITY: "1" })
     router.handle({ type: "agentManager.terminal.restart", terminalId: "side-1" })
     await wait()
-    expect(envs[1]).toEqual({ KILO_UNICODE_LOGO: "0" })
+    expect(envs[1]).toEqual({ KILO_UNICODE_LOGO: "0", KILO_TERMINAL_ACTIVITY: "1" })
 
     router.handle({
       type: "agentManager.terminal.create",

--- a/packages/kilo-vscode/tests/unit/project-session-busy.test.ts
+++ b/packages/kilo-vscode/tests/unit/project-session-busy.test.ts
@@ -61,6 +61,28 @@ describe("createSessionActivity", () => {
 })
 
 describe("createWorktreeActivity", () => {
+  it("merges terminal states without changing deletion guards", () => {
+    const states: Record<string, Activity> = {
+      "current:wt-current": "waiting",
+      "current:local": "busy",
+      "background:wt-current": "error",
+    }
+    const state = createWorktreeActivity({
+      ...options({ "current-wt": "busy" }),
+      inUseFor: () => false,
+      terminal: (id, project = "current") => states[`${project}:${id ?? "local"}`] ?? "idle",
+      worktrees: () => [],
+      subscribe: () => () => undefined,
+    })
+    expect(state.local()).toBe("busy")
+    expect(state.agent("wt-current")).toBe("waiting")
+    expect(state.project("background", "wt-current")).toBe("error")
+    expect(state.project("background", null)).toBe("idle")
+    expect(state.blocked("wt-current")).toBe(false)
+    states["current:wt-current"] = "idle"
+    expect(state.agent("wt-current")).toBe("busy")
+  })
+
   it("keeps directory activity separate from parent status and other projects", () => {
     const listeners = new Set<(message: ExtensionMessage) => void>()
     const state = createWorktreeActivity({

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -905,6 +905,7 @@ const AgentManagerContent: Component = () => {
     active: activeProjectId,
     activityFor: session.activityFor,
     inUseFor: session.inUseFor,
+    terminal: (id, project) => terms.activityFor(`${project ?? currentProjectId() ?? "single"}:${id ?? LOCAL}`),
     worktrees: (id) => (id ? registry.ensure(id) : registry.active()).worktrees(),
     subscribe: vscode.onMessage,
   })

--- a/packages/kilo-vscode/webview-ui/agent-manager/project/session-busy.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/project/session-busy.ts
@@ -43,6 +43,7 @@ export function createSessionActivity(opts: {
 
 export function createWorktreeActivity(
   opts: Parameters<typeof createSessionActivity>[0] & {
+    terminal?: (id: string | null, project?: string) => Activity
     inUseFor: (id: string) => boolean
     worktrees: (project?: string) => { id: string; path: string }[]
     subscribe: (callback: (message: ExtensionMessage) => void) => () => void
@@ -59,9 +60,14 @@ export function createWorktreeActivity(
     active().has(opts.worktrees(project).find((worktree) => worktree.id === id)?.path ?? "") ? "busy" : "idle"
   return {
     ...activity,
-    agent: (id: string) => strongest([activity.agent(id), working(id)]),
+    local: () => strongest([activity.local(), opts.terminal?.(null) ?? "idle"]),
+    agent: (id: string) => strongest([activity.agent(id), working(id), opts.terminal?.(id) ?? "idle"]),
     project: (project: string, id: string | null) =>
-      strongest([activity.project(project, id), id === null ? "idle" : working(id, project)]),
+      strongest([
+        activity.project(project, id),
+        id === null ? "idle" : working(id, project),
+        opts.terminal?.(id, project) ?? "idle",
+      ]),
     blocked: (id: string, project?: string) => {
       if (working(id, project) === "busy") return true
       const items = project && project !== opts.active() ? (opts.projects()[project] ?? []) : opts.managed()

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/SideTerminalPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/SideTerminalPanel.tsx
@@ -87,6 +87,7 @@ export const SideTerminalPanel: Component<Props> = (props) => {
               label={props.state.title(term.id) ?? term.title}
               tooltip={props.state.title(term.id) ?? term.title}
               status={props.state.scriptStatus(term.id)}
+              state={props.state.activity(term.id)}
               showKeybind={false}
               keybind={active() === term.id ? "" : props.nextKeybind}
               closeKeybind={props.closeKeybind}

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/SortableTerminalTab.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/SortableTerminalTab.tsx
@@ -13,6 +13,8 @@ import { useLanguage } from "../../src/context/language"
 import { SortableClosableTab, type ClosableTabProps } from "../ClosableTab"
 import { terminalChrome, terminalClosable, terminalStoppable } from "./chrome"
 import type { ScriptTerminalStatus } from "./state"
+import { ActivityIcon } from "../../src/components/shared/ActivityIcon"
+import { label } from "../../src/utils/session-activity"
 
 interface Props extends Omit<ClosableTabProps, "icon" | "onClose" | "trailing"> {
   label: string
@@ -71,29 +73,40 @@ export const SortableTerminalTab: Component<
     id: string
     onCloseOthers: () => void
   }
-> = (props) => (
-  <SortableClosableTab
-    id={props.id}
-    label={props.label}
-    tooltip={terminalChrome(props.tooltip, props.status).tooltip}
-    icon={() => icon(props.status)}
-    iconStatus={() => iconStatus(props.status)}
-    class="am-tab-terminal"
-    focused={props.focused}
-    active={props.active}
-    closeable={terminalClosable(props.status)}
-    keybind={props.keybind}
-    closeKeybind={props.closeKeybind}
-    role={props.role}
-    selected={props.selected}
-    tabIndex={props.tabIndex}
-    onKeyDown={props.onKeyDown}
-    onSelect={props.onSelect}
-    onMiddleClick={props.onMiddleClick}
-    onClose={props.onClose}
-    onCloseOthers={props.onCloseOthers}
-    trailing={
-      <StopButton active={terminalStoppable(props.status)} tabIndex={props.active ? 0 : -1} onStop={props.onStop} />
-    }
-  />
-)
+> = (props) => {
+  const { t } = useLanguage()
+  const state = () => (props.status ? undefined : props.state)
+  const title = () => {
+    const current = state()
+    return current && current !== "idle" ? t(label(current)) : undefined
+  }
+  return (
+    <SortableClosableTab
+      id={props.id}
+      label={props.label}
+      tooltip={title() ? `${props.tooltip} (${title()})` : terminalChrome(props.tooltip, props.status).tooltip}
+      icon={() => icon(props.status)}
+      iconNode={state() && state() !== "idle" ? <ActivityIcon state={state()!} spinner="am-tab-spinner" /> : undefined}
+      iconStatus={() => iconStatus(props.status)}
+      state={state()}
+      stateLabel={title()}
+      class="am-tab-terminal"
+      focused={props.focused}
+      active={props.active}
+      closeable={terminalClosable(props.status)}
+      keybind={props.keybind}
+      closeKeybind={props.closeKeybind}
+      role={props.role}
+      selected={props.selected}
+      tabIndex={props.tabIndex}
+      onKeyDown={props.onKeyDown}
+      onSelect={props.onSelect}
+      onMiddleClick={props.onMiddleClick}
+      onClose={props.onClose}
+      onCloseOthers={props.onCloseOthers}
+      trailing={
+        <StopButton active={terminalStoppable(props.status)} tabIndex={props.active ? 0 : -1} onStop={props.onStop} />
+      }
+    />
+  )
+}

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/TerminalTab.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/TerminalTab.tsx
@@ -23,6 +23,8 @@ import { formatReviewCommentsMarkdown } from "../../src/utils/review-comment-mar
 import type { ScriptTerminalStatus, TerminalFont } from "./state"
 import { createInputBuffer, createReplayGate, createWriteBatcher } from "./replay"
 import { registerTerminalOutput, unregisterTerminalOutput } from "./output"
+import { registerActivity } from "./activity"
+import type { Activity } from "../../src/utils/session-activity"
 
 interface Props {
   terminalId: string
@@ -58,6 +60,7 @@ interface Props {
    *  command, oh-my-zsh to user@host:cwd, vim to the file name. The
    *  state layer mirrors it into the tab label. */
   onTitleChange?: (title: string) => void
+  onActivityChange?: (state: Activity) => void
   /** Provider-owned script status (Run/Setup), used to annotate the
    *  output when a script ends in failure. */
   status?: () => ScriptTerminalStatus | undefined
@@ -224,6 +227,9 @@ export const TerminalTab: Component<Props> = (props) => {
     let fallbackTimer: ReturnType<typeof setTimeout> | undefined
     let streamed = false
     let socketEnded = false
+    const activity = registerActivity(term.parser, (state) => {
+      props.onActivityChange?.(closed || socketEnded ? "idle" : state)
+    })
     let frame: number | undefined
     let deferred: number | undefined
     const batcher = createWriteBatcher((data, callback) => term.write(data, callback))
@@ -367,6 +373,7 @@ export const TerminalTab: Component<Props> = (props) => {
           fallbackTimer = undefined
         }
         socketEnded = true
+        activity.clear()
         noteFailure()
         if (props.restartable) {
           disconnected = true
@@ -611,6 +618,7 @@ export const TerminalTab: Component<Props> = (props) => {
 
     onCleanup(() => {
       closed = true
+      activity.dispose()
       batcher.cancel()
       replay.cancel()
       unregisterTerminalOutput(props.terminalId)

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/activity.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/activity.ts
@@ -1,0 +1,30 @@
+import type { IParser } from "@xterm/xterm"
+import { isActivity, type Activity } from "../../src/utils/session-activity"
+
+export function registerActivity(parser: Pick<IParser, "registerOscHandler">, report: (state: Activity) => void) {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const clear = () => {
+    clearTimeout(timer)
+    timer = undefined
+    report("idle")
+  }
+  const handler = parser.registerOscHandler(777, (data) => {
+    if (!data.startsWith("kilo;activity;")) return false
+    const [, , version, state, stamp, extra] = data.split(";")
+    const time = Number(stamp)
+    const age = Date.now() - time
+    if (version !== "1" || extra !== undefined || !isActivity(state) || !Number.isSafeInteger(time)) return true
+    if (age < -5_000 || age >= 15_000) return true
+    clearTimeout(timer)
+    report(state)
+    timer = setTimeout(clear, Math.min(15_000, 15_000 - age))
+    return true
+  })
+  return {
+    clear,
+    dispose: () => {
+      handler.dispose()
+      clear()
+    },
+  }
+}

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/render.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/render.tsx
@@ -19,6 +19,14 @@ function focusSerial(state: TerminalStateControls, id: string): number {
   return request?.id === id ? request.serial : 0
 }
 
+function focus(state: TerminalStateControls, id: string, report?: (focused: boolean) => void) {
+  return (focused: boolean) => {
+    if (focused) state.setFocusedId(id)
+    else if (state.focusedId() === id) state.setFocusedId(undefined)
+    report?.(focused)
+  }
+}
+
 export interface TerminalTabRenderDeps {
   id: string
   terms: TerminalStateControls
@@ -120,11 +128,7 @@ export function renderTerminalLayer(props: {
                   active={visible()}
                   focusSerial={focusSerial(props.state, term.id)}
                   font={term.font}
-                  onFocusChange={(focused) => {
-                    if (focused) props.state.setFocusedId(term.id)
-                    else if (props.state.focusedId() === term.id) props.state.setFocusedId(undefined)
-                    props.onFocusChange?.(focused)
-                  }}
+                  onFocusChange={focus(props.state, term.id, props.onFocusChange)}
                   onFocusPrompt={props.onFocusPrompt}
                   onTitleChange={(title) => props.state.setTitle(term.id, title)}
                   onActivityChange={(state) => props.state.setActivity(term.id, state)}
@@ -175,11 +179,7 @@ export function renderSideTerminalLayer(props: {
                 font={term.font}
                 status={() => props.state.scriptStatus(term.id)}
                 restartable={term.kind === undefined}
-                onFocusChange={(focused) => {
-                  if (focused) props.state.setFocusedId(term.id)
-                  else if (props.state.focusedId() === term.id) props.state.setFocusedId(undefined)
-                  props.onFocusChange?.(focused)
-                }}
+                onFocusChange={focus(props.state, term.id, props.onFocusChange)}
                 onFocusPrompt={props.onFocusPrompt}
                 onTitleChange={(title) => props.state.setTitle(term.id, title)}
                 onActivityChange={(state) => props.state.setActivity(term.id, state)}

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/render.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/render.tsx
@@ -49,6 +49,7 @@ export function renderTerminalTab(deps: TerminalTabRenderDeps): JSX.Element {
       label={deps.terms.title(deps.id) ?? term.title}
       tooltip={deps.terms.title(deps.id) ?? term.title}
       status={deps.terms.scriptStatus(deps.id)}
+      state={deps.terms.activity(deps.id)}
       keybind={isActive() ? "" : deps.keybind()}
       closeKeybind={deps.closeKeybind()}
       focused={deps.terms.focusedId() === deps.id}
@@ -126,6 +127,7 @@ export function renderTerminalLayer(props: {
                   }}
                   onFocusPrompt={props.onFocusPrompt}
                   onTitleChange={(title) => props.state.setTitle(term.id, title)}
+                  onActivityChange={(state) => props.state.setActivity(term.id, state)}
                 />
               </div>
             )
@@ -180,6 +182,7 @@ export function renderSideTerminalLayer(props: {
                 }}
                 onFocusPrompt={props.onFocusPrompt}
                 onTitleChange={(title) => props.state.setTitle(term.id, title)}
+                onActivityChange={(state) => props.state.setActivity(term.id, state)}
               />
             </div>
           )

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/state.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/state.ts
@@ -15,6 +15,7 @@
 import { createSignal } from "solid-js"
 import type { Accessor } from "solid-js"
 import { LOCAL } from "../navigate"
+import { strongest, type Activity } from "../../src/utils/session-activity"
 import type {
   ExtensionMessage,
   ScriptTerminalKind,
@@ -67,6 +68,9 @@ interface SideRequest {
 }
 
 export interface TerminalStateControls {
+  activity(terminalId: string): Activity
+  setActivity(terminalId: string, state: Activity): void
+  activityFor(context: string): Activity
   /** Add a terminal record to one context. */
   add(worktreeId: string | null, term: TerminalTabState): void
   /** Fill an optimistic terminal record without replacing its xterm-owning object. */
@@ -186,6 +190,20 @@ export function createTerminalState(selection: Accessor<string | null>): Termina
   // <For> reference inequality (see the module comment above).
   const [titles, setTitles] = createSignal<Record<string, string>>({})
   const [scripts, setScripts] = createSignal<Record<string, ScriptTerminalStatus>>({})
+  const [activities, setActivities] = createSignal<Record<string, Activity>>({})
+  const activity = (id: string): Activity => activities()[id] ?? "idle"
+  const setActivity = (id: string, state: Activity) => {
+    if (!contextFor(id) || isScript(id)) return
+    setActivities((prev) => {
+      if ((prev[id] ?? "idle") === state) return prev
+      const next = { ...prev }
+      if (state === "idle") delete next[id]
+      else next[id] = state
+      return next
+    })
+  }
+  const activityFor = (context: string) =>
+    strongest((terminalsByContext()[context] ?? []).map((term) => activity(term.id)))
   // Active side terminal per context.
   const [actives, setActives] = createSignal<Record<string, string>>({})
   let focusSerial = 0
@@ -317,6 +335,7 @@ export function createTerminalState(selection: Accessor<string | null>): Termina
     const key = contextFor(terminalId)
     if (!key) return undefined
     const removed = terminalsByContext()[key]?.find((t) => t.id === terminalId)
+    setActivity(terminalId, "idle")
     setTerminalsByContext((prev) => {
       const list = (prev[key] ?? []).filter((t) => t.id !== terminalId)
       const next = { ...prev }
@@ -563,6 +582,9 @@ export function createTerminalState(selection: Accessor<string | null>): Termina
   }
 
   return {
+    activity,
+    setActivity,
+    activityFor,
     add,
     attach,
     remove,

--- a/packages/opencode/src/kilocode/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/app.tsx
@@ -7,7 +7,8 @@
 
 import { createEffect, createMemo, on, onCleanup } from "solid-js"
 import { useKeyboard, useRenderer } from "@opentui/solid"
-import { TextAttributes } from "@opentui/core"
+import { resolveRenderLib, TextAttributes } from "@opentui/core"
+import { KiloTerminalActivity } from "./terminal-activity"
 import * as Clipboard from "@tui/clipboard"
 import { useBindings } from "@tui/keymap"
 import { useSDK } from "@tui/context/sdk"
@@ -83,6 +84,17 @@ export function useSessionEffects(deps: {
   const session = createMemo(() => (deps.route.data.type === "session" ? deps.route.data.sessionID : undefined))
   let active = true
   const meta = { prev: "" }
+
+  KiloTerminalActivity.use({
+    enabled: process.env.KILO_TERMINAL_ACTIVITY,
+    session,
+    data: deps.sync.data,
+    subscribe: (handler) =>
+      deps.sdk.event.on("event", (event) => {
+        if (event.payload.type !== "sync") handler(event.payload)
+      }),
+    write: (data) => resolveRenderLib().writeOut(renderer.rendererPtr, data),
+  })
 
   function send() {
     const id = session()

--- a/packages/opencode/src/kilocode/cli/cmd/tui/terminal-activity.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/terminal-activity.ts
@@ -1,0 +1,85 @@
+import type { Event, EventSessionTurnClose } from "@kilocode/sdk/v2"
+import { createEffect, createMemo, onCleanup } from "solid-js"
+import { createStore } from "solid-js/store"
+import { KiloTerminalTitle } from "./terminal-title"
+
+type Outcome = EventSessionTurnClose["properties"]["reason"]
+
+type Message = {
+  id: string
+  role: string
+  error?: { name: string }
+  finish?: string
+}
+
+export namespace KiloTerminalActivity {
+  export type State = "idle" | "busy" | "retry" | "waiting" | "error" | "done"
+
+  export type Data = Omit<KiloTerminalTitle.Data, "message"> & {
+    message: Record<string, readonly Message[] | undefined>
+  }
+
+  export function classify(input: { id?: string; data: Data; outcomes?: Record<string, Outcome | undefined> }): State {
+    if (!input.id) return "idle"
+    const root = KiloTerminalTitle.root(input.data.session, input.id)
+    const ids = [...new Set([root, ...KiloTerminalTitle.family(input.data.session, root)])]
+    if (ids.some((id) => KiloTerminalTitle.attention(input.data, id))) return "waiting"
+    if (ids.some((id) => input.data.session_status[id]?.type === "retry")) return "retry"
+    if (ids.some((id) => input.data.session_status[id]?.type === "busy")) return "busy"
+
+    const outcome = input.outcomes?.[root]
+    if (outcome === "error") return "error"
+    if (outcome === "interrupted" || outcome === "superseded") return "idle"
+    const message = input.data.message[root]?.at(-1)
+    if (message?.role === "assistant") {
+      if (message.error?.name === "MessageAbortedError") return "idle"
+      if (message.error || message.finish === "error" || message.finish === "content-filter") return "error"
+      if (message.finish && message.finish !== "stop") return "idle"
+    }
+    return outcome === "completed" ? "done" : "idle"
+  }
+
+  export function format(state: State, timestamp = Date.now()) {
+    return `\x1b]777;kilo;activity;1;${state};${timestamp}\x07`
+  }
+
+  export function use(input: {
+    enabled?: string
+    session: () => string | undefined
+    data: Data
+    subscribe: (handler: (event: Event) => void) => () => void
+    write: (data: string) => void
+  }) {
+    if (input.enabled !== "1") return
+    const [outcomes, setOutcomes] = createStore<Record<string, Outcome | undefined>>({})
+    const off = input.subscribe((event) => {
+      if (
+        event.type === "session.turn.open" ||
+        (event.type === "session.status" &&
+          (event.properties.status.type === "busy" || event.properties.status.type === "retry"))
+      ) {
+        setOutcomes(event.properties.sessionID, undefined)
+      }
+      if (event.type === "session.turn.close") {
+        setOutcomes(event.properties.sessionID, (prev) =>
+          prev === "error" && event.properties.reason === "completed" ? prev : event.properties.reason,
+        )
+      }
+      if (event.type === "session.error" && event.properties.sessionID) {
+        setOutcomes(
+          event.properties.sessionID,
+          event.properties.error?.name === "MessageAbortedError" ? "interrupted" : "error",
+        )
+      }
+    })
+    const state = createMemo(() => classify({ id: input.session(), data: input.data, outcomes }))
+    const send = () => input.write(format(state()))
+    createEffect(send)
+    const timer = setInterval(send, 5_000)
+    onCleanup(() => {
+      off()
+      clearInterval(timer)
+      input.write(format("idle"))
+    })
+  }
+}

--- a/packages/opencode/src/kilocode/cli/cmd/tui/terminal-title.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/terminal-title.ts
@@ -99,11 +99,11 @@ export namespace KiloTerminalTitle {
     return title.slice(0, 37) + "..."
   }
 
-  function root(list: readonly Session[], id: string) {
+  export function root(list: readonly Session[], id: string) {
     return list.find((item) => item.id === id)?.parentID ?? id
   }
 
-  function family(list: readonly Session[], id: string) {
+  export function family(list: readonly Session[], id: string) {
     return list.filter((item) => item.id === id || item.parentID === id).map((item) => item.id)
   }
 
@@ -118,7 +118,7 @@ export namespace KiloTerminalTitle {
     return status?.type === "busy" || status?.type === "retry"
   }
 
-  function attention(data: Data, id: string) {
+  export function attention(data: Data, id: string) {
     if (data.session_status[id]?.type === "offline") return true
     if ((data.permission[id]?.length ?? 0) > 0) return true
     if ((data.question[id]?.length ?? 0) > 0) return true

--- a/packages/opencode/test/kilocode/terminal-activity.test.ts
+++ b/packages/opencode/test/kilocode/terminal-activity.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, test } from "bun:test"
+import { expect, test } from "bun:test"
 import type { Event } from "@kilocode/sdk/v2"
 import { createRoot, createSignal } from "solid-js"
 import { createStore } from "solid-js/store"
-import { KiloTerminalActivity } from "../../src/kilocode/cli/cmd/tui/terminal-activity"
+import { KiloTerminalActivity as Activity } from "../../src/kilocode/cli/cmd/tui/terminal-activity"
 
-function data(input: Partial<KiloTerminalActivity.Data> = {}): KiloTerminalActivity.Data {
+function data(input: Partial<Activity.Data> = {}): Activity.Data {
   return {
     session: [
       { id: "parent", title: "Session" },
@@ -21,233 +21,97 @@ function data(input: Partial<KiloTerminalActivity.Data> = {}): KiloTerminalActiv
   }
 }
 
-function events() {
-  const listeners = new Set<(event: Event) => void>()
-  return {
-    listeners,
-    subscribe: (handler: (event: Event) => void) => {
-      listeners.add(handler)
-      return () => {
-        listeners.delete(handler)
-      }
-    },
-    emit(event: Event) {
-      for (const handler of listeners) handler(event)
-    },
+const classify = (input: Partial<Activity.Data>, outcome?: "completed" | "error" | "interrupted" | "superseded") =>
+  Activity.classify({ id: "parent", data: data(input), outcomes: { parent: outcome } })
+
+test("classifies active children, attention and completed outcomes", () => {
+  expect(Activity.classify({ data: data({ session_status: { parent: { type: "busy" } } }) })).toBe("idle")
+  for (const type of ["idle", "busy", "retry"] as const) {
+    expect(classify({ session: [], session_status: { parent: { type } } })).toBe(type)
+    expect(classify({ session_status: { child: { type } } })).toBe(type)
   }
-}
-
-function state(value: string) {
-  return value.split(";").at(4)
-}
-
-describe("terminal activity", () => {
-  test("home is idle even when sessions are active", () => {
-    expect(KiloTerminalActivity.classify({ data: data({ session_status: { parent: { type: "busy" } } }) })).toBe("idle")
-  })
-
-  test("uses real status before session metadata arrives", () => {
-    for (const type of ["idle", "busy", "retry"] as const) {
-      expect(
-        KiloTerminalActivity.classify({
-          id: "parent",
-          data: data({ session: [], session_status: { parent: { type } } }),
-        }),
-      ).toBe(type)
-    }
-  })
-
-  test("child attention overrides running and completed outcomes", () => {
-    for (const key of ["permission", "question", "suggestion", "network"] as const) {
-      expect(
-        KiloTerminalActivity.classify({
-          id: "parent",
-          data: data({ [key]: { child: [{}] }, session_status: { parent: { type: "busy" } } }),
-          outcomes: { parent: "completed" },
-        }),
-      ).toBe("waiting")
-    }
-    expect(
-      KiloTerminalActivity.classify({ id: "parent", data: data({ session_status: { child: { type: "offline" } } }) }),
-    ).toBe("waiting")
-    expect(
-      KiloTerminalActivity.classify({
-        id: "parent",
-        data: data({
-          message: { child: [{ id: "plan", role: "assistant" }] },
-          part: { plan: [{ type: "tool", tool: "plan_exit", state: { status: "completed" } }] },
-        }),
-      }),
-    ).toBe("waiting")
-  })
-
-  test("includes child activity when viewing parent or child", () => {
-    for (const id of ["parent", "child"]) {
-      for (const type of ["busy", "retry"] as const) {
-        expect(
-          KiloTerminalActivity.classify({
-            id,
-            data: data({ session_status: { child: { type } } }),
-            outcomes: { parent: "completed" },
-          }),
-        ).toBe(type)
-      }
-    }
-  })
-
-  test("only completed outcomes are done", () => {
-    for (const [outcome, expected] of [
-      [undefined, "idle"],
-      ["completed", "done"],
-      ["error", "error"],
-      ["interrupted", "idle"],
-      ["superseded", "idle"],
-    ] as const) {
-      expect(KiloTerminalActivity.classify({ id: "parent", data: data(), outcomes: { parent: outcome } })).toBe(
-        expected,
-      )
-    }
-  })
-
-  test("failed or incomplete assistant messages are never success", () => {
-    for (const [finish, expected] of [
-      ["error", "error"],
-      ["content-filter", "error"],
-      ["length", "idle"],
-      ["unknown", "idle"],
-      ["other", "idle"],
-      ["tool-calls", "idle"],
-    ] as const) {
-      expect(
-        KiloTerminalActivity.classify({
-          id: "parent",
-          data: data({ message: { parent: [{ id: "reply", role: "assistant", finish }] } }),
-          outcomes: { parent: "completed" },
-        }),
-      ).toBe(expected)
-    }
-    for (const [name, expected] of [
-      ["APIError", "error"],
-      ["MessageAbortedError", "idle"],
-    ] as const) {
-      expect(
-        KiloTerminalActivity.classify({
-          id: "parent",
-          data: data({ message: { parent: [{ id: "reply", role: "assistant", finish: "stop", error: { name } }] } }),
-          outcomes: { parent: "completed" },
-        }),
-      ).toBe(expected)
-    }
-  })
-
-  test("formats all six states as OSC 777 with BEL and a millisecond timestamp", () => {
-    const timestamp = Date.now()
-    for (const value of ["idle", "busy", "retry", "waiting", "error", "done"] as const) {
-      expect(KiloTerminalActivity.format(value, timestamp)).toBe(`\x1b]777;kilo;activity;1;${value};${timestamp}\x07`)
-    }
-    const before = Date.now()
-    const signal = KiloTerminalActivity.format("busy")
-    expect(signal).toMatch(/^\x1b\]777;kilo;activity;1;busy;\d+\x07$/)
-    expect(Number(signal.split(";").at(-1)?.slice(0, -1))).toBeGreaterThanOrEqual(before)
-    expect(Number(signal.split(";").at(-1)?.slice(0, -1))).toBeLessThanOrEqual(Date.now())
-  })
-
-  test("does not subscribe or write without the exact opt-in", () => {
-    for (const enabled of [undefined, "", "0", "true"]) {
-      const source = events()
-      const output: string[] = []
-      const dispose = createRoot((dispose) => {
-        KiloTerminalActivity.use({
-          enabled,
-          session: () => "parent",
-          data: data(),
-          subscribe: source.subscribe,
-          write: (value) => output.push(value),
-        })
-        return dispose
-      })
-      dispose()
-      expect(source.listeners.size).toBe(0)
-      expect(output).toEqual([])
-    }
-  })
-
-  test("sends initial state, reactive transitions, and idle cleanup independently of titles", () => {
-    const source = events()
-    const output: string[] = []
-    const [session, select] = createSignal<string | undefined>("parent")
-    const [store, set] = createStore(data({ session_status: { parent: { type: "busy" } } }))
-    const dispose = createRoot((dispose) => {
-      KiloTerminalActivity.use({
-        enabled: "1",
-        session,
-        data: store,
-        subscribe: source.subscribe,
-        write: (value) => output.push(value),
-      })
-      return dispose
-    })
-    try {
-      expect(output.map(state)).toEqual(["busy"])
-      set("session", 0, "title", "Renamed")
-      expect(output).toHaveLength(1)
-      set("question", "child", [{}])
-      set("question", "child", [])
-      set("session_status", "parent", { type: "retry" })
-      set("session_status", "parent", { type: "idle" })
-      source.emit({ id: "failed", type: "session.error", properties: { sessionID: "parent" } })
-      source.emit({
-        id: "closed",
-        type: "session.turn.close",
-        properties: { sessionID: "parent", reason: "completed" },
-      })
-      expect(output.at(-1)).toContain(";error;")
-      source.emit({ id: "opened", type: "session.turn.open", properties: { sessionID: "parent" } })
-      source.emit({
-        id: "completed",
-        type: "session.turn.close",
-        properties: { sessionID: "parent", reason: "completed" },
-      })
-      select(undefined)
-      expect(output.map(state)).toEqual(["busy", "waiting", "busy", "retry", "idle", "error", "idle", "done", "idle"])
-    } finally {
-      dispose()
-    }
-    expect(source.listeners.size).toBe(0)
-    expect(state(output.at(-1)!)).toBe("idle")
-    const count = output.length
-    select("parent")
-    set("session_status", "parent", { type: "busy" })
-    expect(output).toHaveLength(count)
-  })
-
-  test("refreshes the current state every five seconds and stops on cleanup", async () => {
-    const source = events()
-    const output: string[] = []
-    const heartbeat = Promise.withResolvers<void>()
-    const dispose = createRoot((dispose) => {
-      KiloTerminalActivity.use({
-        enabled: "1",
-        session: () => "parent",
-        data: data({ session_status: { parent: { type: "retry" } } }),
-        subscribe: source.subscribe,
-        write: (value) => {
-          output.push(value)
-          if (output.length === 2) heartbeat.resolve()
-        },
-      })
-      return dispose
-    })
-    try {
-      await heartbeat.promise
-      expect(output.map(state)).toEqual(["retry", "retry"])
-      const stamps = output.map((value) => Number(value.split(";").at(-1)?.slice(0, -1)))
-      expect(stamps.at(1)! - stamps.at(0)!).toBeGreaterThanOrEqual(4_900)
-    } finally {
-      dispose()
-    }
-    expect(output.map(state)).toEqual(["retry", "retry", "idle"])
-    await Bun.sleep(5_100)
-    expect(output).toHaveLength(3)
-  }, 15_000)
+  for (const key of ["permission", "question", "suggestion", "network"] as const) {
+    expect(classify({ [key]: { child: [{}] }, session_status: { parent: { type: "busy" } } }, "completed")).toBe(
+      "waiting",
+    )
+  }
+  expect(classify({ session_status: { child: { type: "offline" } } })).toBe("waiting")
+  for (const [outcome, expected] of [
+    [undefined, "idle"],
+    ["completed", "done"],
+    ["error", "error"],
+    ["interrupted", "idle"],
+    ["superseded", "idle"],
+  ] as const) {
+    expect(classify({}, outcome)).toBe(expected)
+  }
+  for (const finish of ["error", "content-filter", "length", "unknown", "other", "tool-calls"]) {
+    expect(classify({ message: { parent: [{ id: "reply", role: "assistant", finish }] } }, "completed")).toBe(
+      ["error", "content-filter"].includes(finish) ? "error" : "idle",
+    )
+  }
+  for (const name of ["APIError", "MessageAbortedError"]) {
+    expect(classify({ message: { parent: [{ id: "reply", role: "assistant", error: { name } }] } }, "completed")).toBe(
+      name === "APIError" ? "error" : "idle",
+    )
+  }
 })
+
+test("opt-in emitter sends transitions, heartbeat and cleanup independently of titles", async () => {
+  const [session, select] = createSignal<string | undefined>("parent")
+  const [store, set] = createStore(data())
+  const output: string[] = []
+  let emit!: (event: Event) => void
+  let subscribed = false
+  const heartbeat = Promise.withResolvers<void>()
+  const dispose = createRoot((dispose) => {
+    const opts = {
+      session,
+      data: store,
+      subscribe: (handler: (event: Event) => void) => {
+        emit = handler
+        subscribed = true
+        return () => {
+          subscribed = false
+        }
+      },
+      write: (value: string) => {
+        const state = value.split(";").at(4)!
+        if (state === "done" && output.at(-1) === "done") heartbeat.resolve()
+        output.push(state)
+        expect(value).toMatch(/^\x1b\]777;kilo;activity;1;\w+;\d+\x07$/)
+      },
+    }
+    for (const enabled of [undefined, "", "0", "true"]) Activity.use({ ...opts, enabled })
+    expect(subscribed).toBe(false)
+    expect(output).toEqual([])
+    Activity.use({ ...opts, enabled: "1" })
+    return dispose
+  })
+  try {
+    set("session", 0, "title", "Renamed")
+    expect(output).toEqual(["idle"])
+    set("session_status", "parent", { type: "busy" })
+    set("question", "child", [{}])
+    set("question", "child", [])
+    set("session_status", "parent", { type: "retry" })
+    set("session_status", "parent", { type: "idle" })
+    emit({ id: "failed", type: "session.error", properties: { sessionID: "parent" } })
+    emit({ id: "closed", type: "session.turn.close", properties: { sessionID: "parent", reason: "completed" } })
+    expect(output.at(-1)).toBe("error")
+    emit({ id: "opened", type: "session.turn.open", properties: { sessionID: "parent" } })
+    emit({ id: "completed", type: "session.turn.close", properties: { sessionID: "parent", reason: "completed" } })
+    expect(output).toEqual(["idle", "busy", "waiting", "busy", "retry", "idle", "error", "idle", "done"])
+    await heartbeat.promise
+    select(undefined)
+    expect(output.slice(-3)).toEqual(["done", "done", "idle"])
+  } finally {
+    dispose()
+  }
+  expect(subscribed).toBe(false)
+  const count = output.length
+  select("parent")
+  set("session_status", "parent", { type: "busy" })
+  await Bun.sleep(5_100)
+  expect(output).toHaveLength(count)
+}, 15_000)

--- a/packages/opencode/test/kilocode/terminal-activity.test.ts
+++ b/packages/opencode/test/kilocode/terminal-activity.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, test } from "bun:test"
+import type { Event } from "@kilocode/sdk/v2"
+import { createRoot, createSignal } from "solid-js"
+import { createStore } from "solid-js/store"
+import { KiloTerminalActivity } from "../../src/kilocode/cli/cmd/tui/terminal-activity"
+
+function data(input: Partial<KiloTerminalActivity.Data> = {}): KiloTerminalActivity.Data {
+  return {
+    session: [
+      { id: "parent", title: "Session" },
+      { id: "child", title: "Child", parentID: "parent" },
+    ],
+    session_status: {},
+    permission: {},
+    question: {},
+    suggestion: {},
+    network: {},
+    message: {},
+    part: {},
+    ...input,
+  }
+}
+
+function events() {
+  const listeners = new Set<(event: Event) => void>()
+  return {
+    listeners,
+    subscribe: (handler: (event: Event) => void) => {
+      listeners.add(handler)
+      return () => {
+        listeners.delete(handler)
+      }
+    },
+    emit(event: Event) {
+      for (const handler of listeners) handler(event)
+    },
+  }
+}
+
+function state(value: string) {
+  return value.split(";").at(4)
+}
+
+describe("terminal activity", () => {
+  test("home is idle even when sessions are active", () => {
+    expect(KiloTerminalActivity.classify({ data: data({ session_status: { parent: { type: "busy" } } }) })).toBe("idle")
+  })
+
+  test("uses real status before session metadata arrives", () => {
+    for (const type of ["idle", "busy", "retry"] as const) {
+      expect(
+        KiloTerminalActivity.classify({
+          id: "parent",
+          data: data({ session: [], session_status: { parent: { type } } }),
+        }),
+      ).toBe(type)
+    }
+  })
+
+  test("child attention overrides running and completed outcomes", () => {
+    for (const key of ["permission", "question", "suggestion", "network"] as const) {
+      expect(
+        KiloTerminalActivity.classify({
+          id: "parent",
+          data: data({ [key]: { child: [{}] }, session_status: { parent: { type: "busy" } } }),
+          outcomes: { parent: "completed" },
+        }),
+      ).toBe("waiting")
+    }
+    expect(
+      KiloTerminalActivity.classify({ id: "parent", data: data({ session_status: { child: { type: "offline" } } }) }),
+    ).toBe("waiting")
+    expect(
+      KiloTerminalActivity.classify({
+        id: "parent",
+        data: data({
+          message: { child: [{ id: "plan", role: "assistant" }] },
+          part: { plan: [{ type: "tool", tool: "plan_exit", state: { status: "completed" } }] },
+        }),
+      }),
+    ).toBe("waiting")
+  })
+
+  test("includes child activity when viewing parent or child", () => {
+    for (const id of ["parent", "child"]) {
+      for (const type of ["busy", "retry"] as const) {
+        expect(
+          KiloTerminalActivity.classify({
+            id,
+            data: data({ session_status: { child: { type } } }),
+            outcomes: { parent: "completed" },
+          }),
+        ).toBe(type)
+      }
+    }
+  })
+
+  test("only completed outcomes are done", () => {
+    for (const [outcome, expected] of [
+      [undefined, "idle"],
+      ["completed", "done"],
+      ["error", "error"],
+      ["interrupted", "idle"],
+      ["superseded", "idle"],
+    ] as const) {
+      expect(KiloTerminalActivity.classify({ id: "parent", data: data(), outcomes: { parent: outcome } })).toBe(
+        expected,
+      )
+    }
+  })
+
+  test("failed or incomplete assistant messages are never success", () => {
+    for (const [finish, expected] of [
+      ["error", "error"],
+      ["content-filter", "error"],
+      ["length", "idle"],
+      ["unknown", "idle"],
+      ["other", "idle"],
+      ["tool-calls", "idle"],
+    ] as const) {
+      expect(
+        KiloTerminalActivity.classify({
+          id: "parent",
+          data: data({ message: { parent: [{ id: "reply", role: "assistant", finish }] } }),
+          outcomes: { parent: "completed" },
+        }),
+      ).toBe(expected)
+    }
+    for (const [name, expected] of [
+      ["APIError", "error"],
+      ["MessageAbortedError", "idle"],
+    ] as const) {
+      expect(
+        KiloTerminalActivity.classify({
+          id: "parent",
+          data: data({ message: { parent: [{ id: "reply", role: "assistant", finish: "stop", error: { name } }] } }),
+          outcomes: { parent: "completed" },
+        }),
+      ).toBe(expected)
+    }
+  })
+
+  test("formats all six states as OSC 777 with BEL and a millisecond timestamp", () => {
+    const timestamp = Date.now()
+    for (const value of ["idle", "busy", "retry", "waiting", "error", "done"] as const) {
+      expect(KiloTerminalActivity.format(value, timestamp)).toBe(`\x1b]777;kilo;activity;1;${value};${timestamp}\x07`)
+    }
+    const before = Date.now()
+    const signal = KiloTerminalActivity.format("busy")
+    expect(signal).toMatch(/^\x1b\]777;kilo;activity;1;busy;\d+\x07$/)
+    expect(Number(signal.split(";").at(-1)?.slice(0, -1))).toBeGreaterThanOrEqual(before)
+    expect(Number(signal.split(";").at(-1)?.slice(0, -1))).toBeLessThanOrEqual(Date.now())
+  })
+
+  test("does not subscribe or write without the exact opt-in", () => {
+    for (const enabled of [undefined, "", "0", "true"]) {
+      const source = events()
+      const output: string[] = []
+      const dispose = createRoot((dispose) => {
+        KiloTerminalActivity.use({
+          enabled,
+          session: () => "parent",
+          data: data(),
+          subscribe: source.subscribe,
+          write: (value) => output.push(value),
+        })
+        return dispose
+      })
+      dispose()
+      expect(source.listeners.size).toBe(0)
+      expect(output).toEqual([])
+    }
+  })
+
+  test("sends initial state, reactive transitions, and idle cleanup independently of titles", () => {
+    const source = events()
+    const output: string[] = []
+    const [session, select] = createSignal<string | undefined>("parent")
+    const [store, set] = createStore(data({ session_status: { parent: { type: "busy" } } }))
+    const dispose = createRoot((dispose) => {
+      KiloTerminalActivity.use({
+        enabled: "1",
+        session,
+        data: store,
+        subscribe: source.subscribe,
+        write: (value) => output.push(value),
+      })
+      return dispose
+    })
+    try {
+      expect(output.map(state)).toEqual(["busy"])
+      set("session", 0, "title", "Renamed")
+      expect(output).toHaveLength(1)
+      set("question", "child", [{}])
+      set("question", "child", [])
+      set("session_status", "parent", { type: "retry" })
+      set("session_status", "parent", { type: "idle" })
+      source.emit({ id: "failed", type: "session.error", properties: { sessionID: "parent" } })
+      source.emit({
+        id: "closed",
+        type: "session.turn.close",
+        properties: { sessionID: "parent", reason: "completed" },
+      })
+      expect(output.at(-1)).toContain(";error;")
+      source.emit({ id: "opened", type: "session.turn.open", properties: { sessionID: "parent" } })
+      source.emit({
+        id: "completed",
+        type: "session.turn.close",
+        properties: { sessionID: "parent", reason: "completed" },
+      })
+      select(undefined)
+      expect(output.map(state)).toEqual(["busy", "waiting", "busy", "retry", "idle", "error", "idle", "done", "idle"])
+    } finally {
+      dispose()
+    }
+    expect(source.listeners.size).toBe(0)
+    expect(state(output.at(-1)!)).toBe("idle")
+    const count = output.length
+    select("parent")
+    set("session_status", "parent", { type: "busy" })
+    expect(output).toHaveLength(count)
+  })
+
+  test("refreshes the current state every five seconds and stops on cleanup", async () => {
+    const source = events()
+    const output: string[] = []
+    const heartbeat = Promise.withResolvers<void>()
+    const dispose = createRoot((dispose) => {
+      KiloTerminalActivity.use({
+        enabled: "1",
+        session: () => "parent",
+        data: data({ session_status: { parent: { type: "retry" } } }),
+        subscribe: source.subscribe,
+        write: (value) => {
+          output.push(value)
+          if (output.length === 2) heartbeat.resolve()
+        },
+      })
+      return dispose
+    })
+    try {
+      await heartbeat.promise
+      expect(output.map(state)).toEqual(["retry", "retry"])
+      const stamps = output.map((value) => Number(value.split(";").at(-1)?.slice(0, -1)))
+      expect(stamps.at(1)! - stamps.at(0)!).toBeGreaterThanOrEqual(4_900)
+    } finally {
+      dispose()
+    }
+    expect(output.map(state)).toEqual(["retry", "retry", "idle"])
+    await Bun.sleep(5_100)
+    expect(output).toHaveLength(3)
+  }, 15_000)
+})


### PR DESCRIPTION
## What Problem This Solves

Agent Manager can show Run-script progress, but an interactive Kilo CLI inside an embedded terminal can be working or waiting for input while its terminal tab and worktree still look idle.

## Why This Change Was Made

Use a small, opt-in OSC status message over the existing PTY stream rather than parse screen text or depend on terminal titles. Agent Manager enables the signal for its terminals. The CLI reports idle, busy, retry, waiting, error, and done from session state and turn outcomes.

Signals refresh every five seconds and expire after fifteen seconds. Old replay output cannot leave a permanent spinner. Disconnect, disposal, and normal CLI exit clear the activity. Worktree indicators combine terminal activity with existing session and Run activity, so an idle tab cannot clear another terminal's busy state. Run/Setup status and deletion guards remain separate.

## User Impact

- See CLI activity in main terminal tabs, side terminals, and worktree indicators, including when the terminal is hidden.
- See pending questions/permissions and errors without opening each terminal.
- Keep terminal title preferences unchanged.

Both the extension and the interactive CLI must include this change, and existing terminal processes must be restarted to receive the opt-in environment. A system-installed `kilo` on PATH is not updated by rebuilding the extension. `kilo run` and `--mini` are unchanged. Historical sessions without an observed completed turn remain idle rather than claiming success.

## Evidence

- Extension build, lint, typecheck, Knip, annotation and marker guards passed.
- 128 focused extension tests and 17 focused CLI tests passed after consolidating the test scaffolding. Lint, typechecks, and the duplication guard passed. The smaller diff keeps six-state transitions, opt-in, heartbeat/disposal, signal validation/expiry, and multiple-terminal/project isolation coverage; runtime code is unchanged by this reduction.
- Isolated VS Code with the rebuilt CLI and a deterministic local provider: all six states appeared in terminal and worktree indicators with terminal-title updates disabled. Verified retry/error recovery, question submission, hidden-tab heartbeat, side-terminal aggregation, stale-signal expiry, and normal CLI exit. The test instance was cleaned up.
- The UI test explicitly launched the rebuilt CLI inside the terminal; it did not use the older CLI on the system PATH.

Supplied screenshot, cropped to show the matching needs-input indicators without publishing model details:

<img width="780" alt="Matching needs-input indicators in the Agent Manager header and CLI terminal tab" src="https://marius-kilocode.github.io/pr-assets/20260901-terminal-activity-question-headers-0925.png" />

Isolated self-test with a pending CLI question:

<img width="700" alt="CLI question with needs-input indicators on the terminal tab and worktree" src="https://marius-kilocode.github.io/pr-assets/20260901-terminal-activity-waiting-selftest-0925.png" />
