### PR TITLE
fix(vscode): show background agents collapse icon

### DIFF
--- a/.changeset/fix-background-agents-chevron.md
+++ b/.changeset/fix-background-agents-chevron.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix the invisible collapse icon in the background agents panel.

--- a/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
@@ -273,7 +273,7 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
             aria-expanded={open()}
             onClick={() => setOpen((value) => !value)}
           >
-            <Icon name={open() ? "chevron-up" : "chevron-down"} size="small" />
+            <Icon name="chevron-down" size="small" style={open() ? { transform: "rotate(180deg)" } : undefined} />
           </Button>
           <Show when={!props.readonly && visible().some((agent) => agent.status !== "running")}>
             <Button


### PR DESCRIPTION
## What Problem This Solves

The expanded background agents panel shows an empty collapse button because `chevron-up` does not exist in the icon registry. The button still works, but its purpose is not visible.

## Why This Change Was Made

Reuse the existing `chevron-down` icon and rotate it when the panel is expanded, matching the task header's existing toggle pattern. This keeps the fix local without adding a registry entry or changing panel behavior.

## User Impact

The background agents toggle has a visible arrow in both states: up when expanded, down when collapsed.

## Evidence

- Full extension compile, host/webview typecheck, lint, and 22 focused background-agent tests passed.
- Automated UI interaction in real isolated VS Code verified collapse, expansion, and collapse again with deterministic job fixtures. Screenshots were visually checked. No live model request was used.
- Read-only code review found no actionable issues.
- No directly matching issue was found.

### Before and after

Matching captures from real isolated VS Code, with the same fixture data and expanded panel.

<p><strong>Before</strong></p>
<img width="598" alt="Before: expanded background agents panel has no visible collapse chevron" src="https://marius-kilocode.github.io/pr-assets/20260901-background-agents-chevron-before-ahjltf.png" />

<p><strong>After</strong></p>
<img width="598" alt="After: expanded background agents panel shows the upward collapse chevron" src="https://marius-kilocode.github.io/pr-assets/20260901-background-agents-chevron-after-ahjltf.png" />

### Manual test

Open a session with background agents. Expand and collapse the panel with its arrow button. Confirm that the arrow remains visible and points up when expanded and down when collapsed.
