### PR TITLE
refactor(vscode): share not-found error detection

### DIFF
--- a/packages/kilo-vscode/src/kilo-provider/handlers/not-found.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/not-found.ts
@@ -1,0 +1,12 @@
+export function isNotFoundError(error: unknown, tagged = false): boolean {
+  const record = (value: unknown) =>
+    value && typeof value === "object" ? (value as Record<string, unknown>) : undefined
+  const obj = record(error)
+  if (!obj) return false
+
+  const cause = record(obj.cause)
+  const body = record(cause?.body)
+  return [obj, record(obj.data), cause, body, record(body?.data)].some(
+    (value) => value?.name === "NotFoundError" || (tagged && value?._tag === "NotFound") || value?.status === 404,
+  )
+}

--- a/packages/kilo-vscode/src/kilo-provider/handlers/permission-handler.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/permission-handler.ts
@@ -6,6 +6,7 @@
  */
 
 import type { KiloClient, PermissionRequest } from "@kilocode/sdk/v2/client"
+import { isNotFoundError } from "./not-found"
 
 export type RecoverablePermission = PermissionRequest
 
@@ -33,19 +34,6 @@ export function recoverablePermissions(perms: RecoverablePermission[], tracked: 
     seen.add(perm.id)
     return tracked.has(perm.sessionID)
   })
-}
-
-function isNotFoundError(error: unknown): boolean {
-  const record = (value: unknown) =>
-    value && typeof value === "object" ? (value as Record<string, unknown>) : undefined
-  const obj = record(error)
-  if (!obj) return false
-
-  const cause = record(obj.cause)
-  const body = record(cause?.body)
-  return [obj, record(obj.data), cause, body, record(body?.data)].some(
-    (value) => value?.name === "NotFoundError" || value?.status === 404,
-  )
 }
 
 /**

--- a/packages/kilo-vscode/src/kilo-provider/handlers/question.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/question.ts
@@ -7,6 +7,7 @@
  */
 
 import type { KiloClient, QuestionRequest } from "@kilocode/sdk/v2/client"
+import { isNotFoundError } from "./not-found"
 
 export interface QuestionContext {
   readonly client: KiloClient | null
@@ -29,19 +30,6 @@ interface QuestionRecovery {
 }
 
 type QuestionRoute = { kind: "retry"; dir: string } | { kind: "stale" } | { kind: "failed" }
-
-function isNotFoundError(error: unknown): boolean {
-  const record = (value: unknown) =>
-    value && typeof value === "object" ? (value as Record<string, unknown>) : undefined
-  const obj = record(error)
-  if (!obj) return false
-
-  const cause = record(obj.cause)
-  const body = record(cause?.body)
-  return [obj, record(obj.data), cause, body, record(body?.data)].some(
-    (value) => value?.name === "NotFoundError" || value?._tag === "NotFound" || value?.status === 404,
-  )
-}
 
 async function recover(ctx: QuestionContext, requestID: string): Promise<QuestionRoute> {
   const result = await fetchAndSendPendingQuestions(ctx, requestID)
@@ -141,7 +129,7 @@ export async function handleQuestionReply(
     ctx.clearQuestionDirectory(requestID)
     return true
   } catch (error) {
-    const route = isNotFoundError(error) ? await recover(ctx, requestID) : undefined
+    const route = isNotFoundError(error, true) ? await recover(ctx, requestID) : undefined
     if (route?.kind === "stale") return false
     if (route?.kind === "retry" && route.dir !== dir) {
       try {
@@ -179,7 +167,7 @@ export async function handleQuestionReject(
     ctx.clearQuestionDirectory(requestID)
     return true
   } catch (error) {
-    const route = isNotFoundError(error) ? await recover(ctx, requestID) : undefined
+    const route = isNotFoundError(error, true) ? await recover(ctx, requestID) : undefined
     if (route?.kind === "stale") return false
     if (route?.kind === "retry" && route.dir !== dir) {
       try {

--- a/packages/kilo-vscode/tests/unit/permission-recovery.test.ts
+++ b/packages/kilo-vscode/tests/unit/permission-recovery.test.ts
@@ -205,7 +205,7 @@ describe("handlePermissionResponse", () => {
 
   it("does not treat other SDK-wrapped errors as stale", async () => {
     const error = new Error("Internal server error", {
-      cause: { status: 500, body: { name: "InternalServerError" } },
+      cause: { status: 500, body: { name: "InternalServerError", _tag: "NotFound" } },
     })
     const { fake, messages, permDirs } = ctx({ tracked: ["s1"], errors: { reply: error } })
     const spy = spyOn(console, "error").mockImplementation(() => {})

--- a/packages/kilo-vscode/tests/unit/question-handler.test.ts
+++ b/packages/kilo-vscode/tests/unit/question-handler.test.ts
@@ -267,7 +267,7 @@ describe("question handlers", () => {
 
   it("removes a fallback question when recovery confirms it is stale", async () => {
     const error = new Error("Question request not found", {
-      cause: { status: 404, body: { _tag: "NotFound" } },
+      cause: { body: { _tag: "NotFound" } },
     })
     const { fake, messages } = ctx({ errors: { reject: error } })
 
@@ -280,7 +280,7 @@ describe("question handlers", () => {
 
   it("keeps fallback questions retryable when recovery is incomplete", async () => {
     const error = new Error("Question request not found", {
-      cause: { status: 404, body: { _tag: "NotFound" } },
+      cause: { body: { _tag: "NotFound" } },
     })
     const dir = "/workspace/.kilo/worktrees/failing"
     const { fake, messages } = ctx({

--- a/script/kilocode-duplication-allowlist.json
+++ b/script/kilocode-duplication-allowlist.json
@@ -214,18 +214,6 @@
     },
     {
       "files": [
-        "packages/kilo-vscode/src/kilo-provider/handlers/permission-handler.ts",
-        "packages/kilo-vscode/src/kilo-provider/handlers/question.ts"
-      ],
-      "fingerprint": "edde84a63bcdb8a0",
-      "maxMatches": 1,
-      "maxTokens": 108,
-      "kind": "legacy",
-      "owner": "kilo-vscode",
-      "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
-    },
-    {
-      "files": [
         "packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css",
         "packages/kilo-vscode/webview-ui/src/styles/session-tabs.css"
       ],


### PR DESCRIPTION
## What Problem This Solves

Permission and question handlers duplicate the same SDK error-envelope lookup.

## Why This Change Was Made

Share the small detector, while keeping tagged NotFound handling opt-in for questions. Permissions continue to recognize only NotFoundError names or numeric 404 status. Recovery, retry, logging, and UI-message branches are unchanged. Remove only duplication exception `edde84a63bcdb8a0`.

## User Impact

No behavior change is intended. The PR removes 12 net production lines and 24 net lines overall, including the helper. Existing tests are reused: only three fixture lines change, with no added test cases or test LOC.

## Evidence

- Duplication report: 33 → 32 pairs, 614 → 603 lines, 4367 → 4259 tokens; the target fingerprint is absent.
- 34 permission and question handler tests pass. Updated fixtures verify tag-only question recovery and that permissions ignore that tag.
- Host and webview typecheck, lint, knip, build:check, formatting, duplication guard, marker guard, and diff checks pass.
- No UI changes. Missing-request and error-envelope behavior is exercised through existing handler tests; no real backend or model calls were made.

No changeset is needed for this internal behavior-preserving refactor.