### PR TITLE
refactor(cli): share common bash permission entries

### DIFF
--- a/packages/opencode/src/kilocode/agent/index.ts
+++ b/packages/opencode/src/kilocode/agent/index.ts
@@ -18,8 +18,7 @@ import PROMPT_ORCHESTRATOR from "../../agent/prompt/orchestrator.txt"
 import PROMPT_ASK from "../../agent/prompt/ask.txt"
 import PROMPT_EXPLORE from "../../agent/prompt/explore.txt"
 
-export const bash: Record<string, "allow" | "ask" | "deny"> = {
-  "*": "ask",
+const readable: Record<string, "allow"> = {
   "cat *": "allow",
   "head *": "allow",
   "tail *": "allow",
@@ -48,6 +47,11 @@ export const bash: Record<string, "allow" | "ask" | "deny"> = {
   "cut *": "allow",
   "tr *": "allow",
   "jq *": "allow",
+}
+
+export const bash: Record<string, "allow" | "ask" | "deny"> = {
+  "*": "ask",
+  ...readable,
   "touch *": "allow",
   "mkdir *": "allow",
   "cp *": "allow",
@@ -62,34 +66,7 @@ export const bash: Record<string, "allow" | "ask" | "deny"> = {
 
 export const readOnlyBash: Record<string, "allow" | "ask" | "deny"> = {
   "*": "deny",
-  "cat *": "allow",
-  "head *": "allow",
-  "tail *": "allow",
-  "less *": "allow",
-  "ls *": "allow",
-  "tree *": "allow",
-  "pwd *": "allow",
-  "echo *": "allow",
-  "wc *": "allow",
-  "which *": "allow",
-  "type *": "allow",
-  "file *": "allow",
-  "diff *": "allow",
-  "du *": "allow",
-  "df *": "allow",
-  "date *": "allow",
-  "uname *": "allow",
-  "whoami *": "allow",
-  "printenv *": "allow",
-  "man *": "allow",
-  "grep *": "allow",
-  "rg *": "allow",
-  "ag *": "allow",
-  "sort *": "allow",
-  "uniq *": "allow",
-  "cut *": "allow",
-  "tr *": "allow",
-  "jq *": "allow",
+  ...readable,
   "git *": "deny",
   "git log *": "allow",
   "git show *": "allow",

--- a/script/kilocode-duplication-allowlist.json
+++ b/script/kilocode-duplication-allowlist.json
@@ -297,15 +297,6 @@
       "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
     },
     {
-      "files": ["packages/opencode/src/kilocode/agent/index.ts", "packages/opencode/src/kilocode/agent/index.ts"],
-      "fingerprint": "9044b540f896a694",
-      "maxMatches": 1,
-      "maxTokens": 113,
-      "kind": "legacy",
-      "owner": "opencode",
-      "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
-    },
-    {
       "files": [
         "packages/opencode/src/kilocode/cli/cmd/tui/component/dialog-memory.tsx",
         "packages/opencode/src/kilocode/cli/cmd/tui/component/dialog-memory.tsx"


### PR DESCRIPTION
## What Problem This Solves
The default Bash permissions and read-only Bash permissions repeat the same 28 allow entries.

## Why This Change Was Made
Keep the identical entries in one private constant and spread them into both existing maps. Preserve property order: each wildcard stays first, and all mode-specific rules and deny overrides stay after the common entries. Both exports remain separate objects. No permission policy changes.

## User Impact
No intended behavior change. Default, Ask, Plan, and Explore command permissions remain the same.

## Evidence
- Two files only: 7 added lines, 39 removed, net reduction of 32 lines (23 production and 9 allowlist).
- No new files or tests. All 157 existing tests in ask-agent-permissions, agent-permission-overrides, and plan-mode-subagent-bypass pass.
- CLI typecheck, focused lint, annotation check, and git diff check pass.
- Fresh duplication report: 33 to 32 pairs, 614 to 586 duplicated lines, 4367 to 4254 duplicated tokens. Only fingerprint 9044b540f896a694 removed; ratchet passes.
- Existing tests exercise permission evaluation and actual agent construction. No model requests or manual UI session were needed for this literal-only extraction.