### PR TITLE
refactor(ui): share project-relative path formatting

### DIFF
--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -170,7 +170,7 @@ export type PartComponent = Component<MessagePartProps>
 
 export const PART_MAPPING: Record<string, PartComponent | undefined> = {}
 
-function relativizeProjectPath(path: string, directory?: string) {
+export function relativizeProjectPath(path: string, directory?: string) {
   if (!path) return ""
   if (!directory) return path
   if (directory === "/") return path

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -20,6 +20,7 @@ import {
 } from "solid-js"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
+import { relativizeProjectPath } from "@kilocode/kilo-ui/message-part"
 import { createAutoScroll } from "@kilocode/kilo-ui/hooks"
 import { useSession } from "../../context/session"
 import { useServer } from "../../context/server"
@@ -114,21 +115,6 @@ export const MessageList: Component<MessageListProps> = (props) => {
   // back to kilo-ui's default hideDetails renderer, which never shows a
   // task's result text — indexing it there would produce a phantom match.
   const inAgentManager = !!useWorktreeMode()
-
-  // Mirrors message-part.tsx's own (unexported) relativizeProjectPath/
-  // getDirectory exactly, so the directory text indexed here matches what
-  // ToolMetaLine/ToolFileAccordion actually put on screen.
-  function relativizeProjectPath(path: string, directory?: string) {
-    if (!path) return ""
-    if (!directory) return path
-    if (directory === "/") return path
-    if (directory === "\\") return path
-    if (path === directory) return ""
-    const separator = directory.includes("\\") ? "\\" : "/"
-    const prefix = directory.endsWith(separator) ? directory : directory + separator
-    if (!path.startsWith(prefix)) return path
-    return path.slice(directory.length)
-  }
 
   function getDirectory(path: string | undefined) {
     return relativizeProjectPath(getRawDirectory(path), data.directory)

--- a/script/kilocode-duplication-allowlist.json
+++ b/script/kilocode-duplication-allowlist.json
@@ -160,18 +160,6 @@
     },
     {
       "files": [
-        "packages/kilo-ui/src/components/message-part.tsx",
-        "packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx"
-      ],
-      "fingerprint": "16e0edc3d99b9858",
-      "maxMatches": 1,
-      "maxTokens": 111,
-      "kind": "legacy",
-      "owner": "kilo-ui",
-      "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
-    },
-    {
-      "files": [
         "packages/kilo-vscode/src/agent-manager/orchestration-bridge.ts",
         "packages/kilo-vscode/src/services/notebook/bridge.ts"
       ],


### PR DESCRIPTION
## What Problem This Solves
Transcript search duplicates the path formatting used by rendered tool labels. Its mirror comment requires both implementations to stay identical.

## Why This Change Was Made
Export the existing relativizeProjectPath function and reuse it through the existing kilo-ui message-part entry point. The function body and both reactive directory wrappers remain unchanged. No new helper, framework, package export, or test harness is added.

## User Impact
No intended behavior change. Preserve root handling, separator boundaries, case sensitivity, and the existing leading-separator behavior. Search and displayed labels now use the same implementation.

## Evidence
- Fresh branch from origin/main after PR #13643 merged. Exactly three changed files: 2 additions, 28 deletions, net 26 fewer lines (14 fewer production lines).
- Duplication report: 32 to 31 pairs, 599 to 586 duplicated lines, 4,262 to 4,151 duplicated tokens. Remove only allowlist fingerprint 16e0edc3d99b9858.
- 70 existing transcript/cache/search/render tests passed, 137 assertions. Compile/build:check, host/webview typecheck, extension lint, knip, and duplication/annotation guards passed.
- Scoped root lint passed with existing warnings. The kilo-ui file has pre-existing formatting differences outside this edit; those were left untouched. No new tests or visual harness were added for this unchanged function reuse.