### PR TITLE
fix(agent-manager): keep inspectors open on browser state updates

### DIFF
--- a/.changeset/keep-inspector-open-on-state-refresh.md
+++ b/.changeset/keep-inspector-open-on-state-refresh.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep Agent Manager inspector panels open during state updates when browser automation is disabled.

--- a/packages/kilo-vscode/tests/unit/project-state-handlers.test.ts
+++ b/packages/kilo-vscode/tests/unit/project-state-handlers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test"
+import path from "node:path"
 import { createProjectStateHandlers } from "../../webview-ui/agent-manager/project/state-handlers"
 import type { AgentManagerStateMessage } from "../../webview-ui/src/types/messages"
 
@@ -95,4 +96,122 @@ describe("createProjectStateHandlers", () => {
     expect(enabled).toBe(false)
     expect(closed).toBe(1)
   })
+
+  it.each(["shared signal", "panel controller"])(
+    "closes only Browser on disabled-browser refreshes with %s",
+    (mode) => {
+      const child = Bun.spawnSync(
+        [
+          process.execPath,
+          "--conditions=browser",
+          "-e",
+          `
+          import assert from "node:assert/strict"
+          import { createRoot, createSignal } from "solid-js"
+          import { createBrowserPanel } from "./agent-manager/BrowserPanel.tsx"
+          import { createSidePanel } from "./agent-manager/side-panel-state.ts"
+          import { SidePanel } from "./agent-manager/side-panel-layout.ts"
+          import { createProjectStateHandlers } from "./agent-manager/project/state-handlers.ts"
+
+          globalThis.KILO_BROWSER_AUTOMATION = false
+          createRoot((dispose) => {
+            const current = () => "session-a"
+            const shared = ${JSON.stringify(mode === "shared signal")}
+            const [panel, update] = createSignal(null)
+            const [history, setHistory] = createSignal(false)
+            const [review, setReview] = createSignal(false)
+            const controller = createSidePanel({
+              project: () => "project-a",
+              selection: () => "worktree-a",
+              current,
+              visible: (panel) => panel !== SidePanel.Browser || browser.tabs.browserAutomation(),
+            })
+            const panels = shared ? { panel, selected: panel, open: update } : controller
+            const browser = createBrowserPanel(
+              panels.panel,
+              shared ? update : (value) => {
+                const current = controller.selected()
+                const next = typeof value === "function" ? value(current) : value
+                if (next === current) return next
+                if (next) controller.open(next)
+                else controller.close(SidePanel.Browser)
+                return next
+              },
+              setHistory,
+              setReview,
+            )
+            const binding = browser.bind(current)
+            const handler = createProjectStateHandlers({
+              setMulti: () => {},
+              setProjects: () => {},
+              setStates: () => {},
+              prune: () => {},
+              ensure: () => ({ sections: () => [], applyState: () => {} }),
+              active: () => ({ sections: () => [], applyState: () => {} }),
+              routeCatalog: () => {},
+              routeState: () => {},
+              isActive: (project) => project === "project-a",
+              pending: () => false,
+              setPending: () => {},
+              rename: () => {},
+              font: () => {},
+              ...binding,
+            })
+            const state = (projectId, browserAutomation = false) => ({
+              type: "agentManager.state",
+              projectId,
+              worktrees: [],
+              sessions: [],
+              sections: [],
+              isGitRepo: true,
+              browserAutomation,
+            })
+
+            assert.equal(browser.tabs.browserAutomation(), false)
+            for (const mode of Object.values(SidePanel).filter((mode) => mode !== SidePanel.Browser)) {
+              panels.open(mode)
+              for (const project of ["project-a", "project-a", "project-b", undefined]) {
+                handler.state(state(project))
+                assert.equal(panels.panel(), mode, mode + " must stay visible")
+                assert.equal(panels.selected(), mode, mode + " must stay selected")
+                assert.equal(browser.tabs.browserAutomation(), false)
+              }
+              browser.tabs.onToggleBrowser()
+              binding.closeBrowser()
+              assert.equal(panels.panel(), mode)
+            }
+
+            for (const project of ["project-a", "project-b", undefined]) {
+              handler.state(state("project-a", true))
+              binding.openBrowser()
+              assert.equal(panels.panel(), SidePanel.Browser)
+              handler.state(state(project))
+              assert.equal(panels.panel(), null)
+              assert.equal(panels.selected(), null)
+              handler.state(state("project-a", true))
+              assert.equal(panels.panel(), null)
+            }
+
+            setHistory(true)
+            setReview(true)
+            browser.tabs.onToggleBrowser()
+            assert.equal(panels.panel(), SidePanel.Browser)
+            assert.equal(history(), false)
+            assert.equal(review(), false)
+            browser.tabs.onToggleBrowser()
+            assert.equal(panels.selected(), null)
+            binding.openBrowser()
+            binding.closeBrowser()
+            assert.equal(panels.selected(), null)
+            handler.state(state("project-b"))
+            assert.equal(panels.selected(), null)
+            dispose()
+          })
+        `,
+        ],
+        { cwd: path.resolve(import.meta.dir, "../../webview-ui"), stdout: "pipe", stderr: "pipe" },
+      )
+      expect(child.exitCode, child.stdout.toString() + child.stderr.toString()).toBe(0)
+    },
+  )
 })

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -372,7 +372,14 @@ const AgentManagerContent: Component = () => {
   const setReviewCommentsByContext = reviewState.setComments
   const browser = createBrowserPanel(
     sidePanel,
-    (panel) => (panel ? panels.open(panel) : panels.close(SidePanel.Browser)),
+    (value) => {
+      const current = panels.selected()
+      const next = typeof value === "function" ? value(current) : value
+      if (next === current) return next
+      if (next) panels.open(next)
+      else panels.close(SidePanel.Browser)
+      return next
+    },
     setHistory,
     setReviewActive,
   )

--- a/packages/kilo-vscode/webview-ui/agent-manager/BrowserPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/BrowserPanel.tsx
@@ -17,7 +17,7 @@ import { post } from "../src/utils/webview-message"
 
 export function createBrowserPanel(
   current: Accessor<SidePanel | null>,
-  panel: (value: SidePanel.Browser | null) => void,
+  panel: Setter<SidePanel | null>,
   history: Setter<boolean>,
   review: Setter<boolean>,
 ) {
@@ -25,7 +25,7 @@ export function createBrowserPanel(
     (globalThis as typeof globalThis & { KILO_BROWSER_AUTOMATION?: boolean }).KILO_BROWSER_AUTOMATION === true,
   )
   const visible = () => current() === SidePanel.Browser
-  const close = () => panel(null)
+  const close = () => panel((current) => (current === SidePanel.Browser ? null : current))
   const open = () => {
     history(false)
     review(false)


### PR DESCRIPTION
## What Problem This Solves

When browser automation is disabled, every Agent Manager state refresh calls the browser-close callback. The browser factory cleared the shared inspector unconditionally, so callers using the shared signal lost Diff, PR, Documents, Subagents, Terminal, or EditPreview even when Browser was not open.

## Why This Change Was Made

Guard the functional update in the browser factory itself instead of relying on each caller to protect other inspector modes. The newer panel controller already has a caller-side guard; its adapter now accepts functional updates against the selected mode and skips unchanged values. Using the selected mode also preserves closing Browser after disabling automation has hidden it. No state-handler routing, provider, or shared-board behavior changes.

## User Impact

Unrelated and repeated state refreshes with browser automation disabled leave non-Browser inspectors open. Disabling an active Browser, toggling it closed, and explicitly closing it still clear Browser. Include a patch changeset for the inspector fix.

## Evidence

- Reproduced the collapse through the real browser factory and state handler using the original shared-signal wiring. The regression failed before the guarded close and passed afterward.
- Cover all six non-Browser modes with Browser disabled from startup, repeated active-project refreshes, unrelated-project refreshes, and legacy payloads without a project ID. Run the same scenarios through the newer panel controller.
- Verify Browser closes on disable, stays closed after re-enabling, and preserves toggle and explicit-close behavior.
- 98 focused tests passed across project-state-handlers, side-panel-state, browser-controller, agent-manager-tab-bar, and agent-manager-arch.
- Extension typecheck, lint, production build, formatting, Knip, and change-marker checks passed.
- Tests exercise in-memory state without rendering a live webview. The separate affected worktree and running VS Code instance were not modified.