### PR TITLE
refactor(vscode): share local activity indicator

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/ProjectSidebarBody.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ProjectSidebarBody.tsx
@@ -18,7 +18,7 @@ import type {
   WorktreeGitStats,
 } from "../src/types/messages"
 import type { LanguageContextValue } from "../src/context/language"
-import { ActivityIcon } from "../src/components/shared/ActivityIcon"
+import { LocalActivity } from "../src/components/shared/ActivityIcon"
 import { label, type Activity } from "../src/utils/session-activity"
 import { useVSCode } from "../src/context/vscode"
 import SectionHeader from "./SectionHeader"
@@ -298,18 +298,7 @@ export const ProjectSidebarBody: Component<Props> = (props) => {
         data-sidebar-id={`${props.project.id}:local`}
         onClick={() => props.onSelectLocal(props.project.id)}
       >
-        <span class="am-local-status" data-activity={localState()} aria-label={props.t(label(localState()))}>
-          <ActivityIcon
-            state={localState()}
-            idle={
-              <svg class="am-local-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <rect x="2.5" y="3.5" width="15" height="10" rx="1" stroke="currentColor" />
-                <path d="M6 16.5H14" stroke="currentColor" stroke-linecap="square" />
-                <path d="M10 13.5V16.5" stroke="currentColor" />
-              </svg>
-            }
-          />
-        </span>
+        <LocalActivity state={localState()} label={props.t(label(localState()))} />
         <div class="am-local-text">
           <span class="am-local-label">{props.t("agentManager.local")}</span>
           <Show when={props.local === undefined}>

--- a/packages/kilo-vscode/webview-ui/agent-manager/SidebarBody.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/SidebarBody.tsx
@@ -31,7 +31,7 @@ import { WorktreeItem } from "./WorktreeItem"
 import { WorktreeSectionActions } from "./WorktreeSectionActions"
 import { StatsSkeleton, WorktreeSkeleton } from "./Skeleton"
 import type { SidebarSearchMenuRef } from "./SidebarSearchMenu"
-import { ActivityIcon } from "../src/components/shared/ActivityIcon"
+import { LocalActivity } from "../src/components/shared/ActivityIcon"
 import { label, type Activity } from "../src/utils/session-activity"
 
 const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent)
@@ -106,18 +106,7 @@ export const SidebarBody: Component<SidebarBodyProps> = (props) => {
         data-sidebar-id="local"
         onClick={() => props.selectLocal()}
       >
-        <span class="am-local-status" data-activity={localState()} aria-label={props.t(label(localState()))}>
-          <ActivityIcon
-            state={localState()}
-            idle={
-              <svg class="am-local-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <rect x="2.5" y="3.5" width="15" height="10" rx="1" stroke="currentColor" />
-                <path d="M6 16.5H14" stroke="currentColor" stroke-linecap="square" />
-                <path d="M10 13.5V16.5" stroke="currentColor" />
-              </svg>
-            }
-          />
-        </span>
+        <LocalActivity state={localState()} label={props.t(label(localState()))} />
         <div class="am-local-text">
           <span class="am-local-label">{props.t("agentManager.local")}</span>
           <Show when={props.repoBranch()}>

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ActivityIcon.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ActivityIcon.tsx
@@ -20,3 +20,18 @@ export const ActivityIcon: Component<{
     </Match>
   </Switch>
 )
+
+export const LocalActivity: Component<{ state: Activity; label: string }> = (props) => (
+  <span class="am-local-status" data-activity={props.state} aria-label={props.label}>
+    <ActivityIcon
+      state={props.state}
+      idle={
+        <svg class="am-local-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="2.5" y="3.5" width="15" height="10" rx="1" stroke="currentColor" />
+          <path d="M6 16.5H14" stroke="currentColor" stroke-linecap="square" />
+          <path d="M10 13.5V16.5" stroke="currentColor" />
+        </svg>
+      }
+    />
+  </span>
+)

--- a/script/kilocode-duplication-allowlist.json
+++ b/script/kilocode-duplication-allowlist.json
@@ -238,18 +238,6 @@
     },
     {
       "files": [
-        "packages/kilo-vscode/webview-ui/agent-manager/ProjectSidebarBody.tsx",
-        "packages/kilo-vscode/webview-ui/agent-manager/SidebarBody.tsx"
-      ],
-      "fingerprint": "94761ffc9ac99167",
-      "maxMatches": 1,
-      "maxTokens": 155,
-      "kind": "legacy",
-      "owner": "kilo-vscode",
-      "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
-    },
-    {
-      "files": [
         "packages/kilo-vscode/webview-ui/src/context/session-variant-store.ts",
         "packages/opencode/src/kilocode/cli/cmd/run/variant.ts"
       ],


### PR DESCRIPTION
## What Problem This Solves
The single-project and multi-project Agent Manager sidebars duplicate the Local activity wrapper and idle computer SVG.

## Why This Change Was Made
Reuse a small LocalActivity component beside the existing ActivityIcon. Keep the same markup, CSS classes, activity state, accessible label, and idle SVG. Selection, project routing, labels, and branch details stay in each sidebar.

## User Impact
No intended visual or behavior change. No new files, dependencies, tests, or test harness are added.

## Evidence
- Fresh branch from origin/main after the previous PR merged. Three production files plus the target allowlist removal: 19 additions, 38 deletions. Net 19 fewer total lines, 7 fewer production lines.
- Duplication report: 30 to 29 pairs, 575 to 559 duplicated lines, 4,043 to 3,888 duplicated tokens. Remove only fingerprint 94761ffc9ac99167.
- 39 existing activity and project-navigation tests passed, 189 assertions. Compile/build:check, host/webview typecheck, lint, knip, formatting, source-link extraction, and duplication/annotation guards passed.
- Visible isolated VS Code on a disposable Git fixture: Local idle computer icon displayed correctly; data-activity was idle and aria-label was Current session. No prompt/model calls or real credentials. Cropped screenshot inspected and published; stop-vscode --cleanup true and stop completed. Busy states and multi-project mode were not manually exercised.

<img width="360" alt="Agent Manager Local entry with the unchanged idle computer icon" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260901-local-activity-dedupe-idle-1003.png" />