### PR TITLE
refactor(vscode): reuse Git directory resolver

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -78,7 +78,7 @@ function stripRemotePrefix(ref: string): { branch: string; remote?: string } {
   return { branch: ref }
 }
 
-import { KILO_DIR, LEGACY_DIR, migrateAgentManagerData } from "./constants"
+import { KILO_DIR, LEGACY_DIR, migrateAgentManagerData, resolveGitDir } from "./constants"
 
 const SESSION_ID_FILE = "session-id"
 const METADATA_FILE = "metadata.json"
@@ -650,7 +650,7 @@ export class WorktreeManager {
   // ---------------------------------------------------------------------------
 
   async ensureGitExclude(): Promise<void> {
-    const gitDir = await this.resolveGitDir()
+    const gitDir = await resolveGitDir(this.root)
     const excludePath = path.join(gitDir, "info", "exclude")
     const items = [
       [".kilo/worktrees/", "Kilo Code agent worktrees"],
@@ -712,17 +712,6 @@ export class WorktreeManager {
       await fs.promises.mkdir(this.dir, { recursive: true })
     }
     await markNoIndex(this.dir, this.log)
-  }
-
-  private async resolveGitDir(): Promise<string> {
-    const gitPath = path.join(this.root, ".git")
-    const stat = await fs.promises.stat(gitPath)
-    if (stat.isDirectory()) return gitPath
-
-    const content = await fs.promises.readFile(gitPath, "utf-8")
-    const match = content.match(/^gitdir:\s*(.+)$/m)
-    if (!match) throw new Error("Invalid .git file format")
-    return path.resolve(path.dirname(gitPath), match[1].trim(), "..", "..")
   }
 
   private async worktreeInfo(wtPath: string): Promise<WorktreeInfo | undefined> {
@@ -919,7 +908,7 @@ export class WorktreeManager {
 
   async repoUsesLfs(): Promise<boolean> {
     // Check .git/lfs/ directory
-    const gitDir = await this.resolveGitDir()
+    const gitDir = await resolveGitDir(this.root)
     if (fs.existsSync(path.join(gitDir, "lfs"))) return true
 
     // Check .gitattributes

--- a/packages/kilo-vscode/src/agent-manager/constants.ts
+++ b/packages/kilo-vscode/src/agent-manager/constants.ts
@@ -118,20 +118,16 @@ async function isDirectory(filepath: string): Promise<boolean> {
  * When root/.git is a file (worktree), follows the gitdir pointer
  * up two levels to reach the shared git directory.
  */
-async function resolveGitDir(root: string): Promise<string | undefined> {
+export async function resolveGitDir(root: string): Promise<string> {
   const gitPath = path.join(root, ".git")
-  try {
-    const stat = await fs.promises.stat(gitPath)
-    if (stat.isDirectory()) return gitPath
+  const stat = await fs.promises.stat(gitPath)
+  if (stat.isDirectory()) return gitPath
 
-    const content = await fs.promises.readFile(gitPath, "utf-8")
-    const match = content.match(/^gitdir:\s*(.+)$/m)
-    if (!match?.[1]) return undefined
-    // gitdir points to e.g. /repo/.git/worktrees/foo — go up two levels to /repo/.git
-    return path.resolve(path.dirname(gitPath), match[1].trim(), "..", "..")
-  } catch {
-    return undefined
-  }
+  const content = await fs.promises.readFile(gitPath, "utf-8")
+  const match = content.match(/^gitdir:\s*(.+)$/m)
+  if (!match) throw new Error("Invalid .git file format")
+  // gitdir points to e.g. /repo/.git/worktrees/foo — go up two levels to /repo/.git
+  return path.resolve(path.dirname(gitPath), match[1].trim(), "..", "..")
 }
 
 /**
@@ -145,7 +141,7 @@ async function resolveGitDir(root: string): Promise<string | undefined> {
  * tell whether a VS Code git refresh is warranted.
  */
 async function fixGitWorktreeRefs(root: string, log: (msg: string) => void): Promise<number> {
-  const gitDir = await resolveGitDir(root)
+  const gitDir = await resolveGitDir(root).catch(() => undefined)
   if (!gitDir) {
     log("fixGitWorktreeRefs: could not resolve git directory")
     return 0


### PR DESCRIPTION
## What Problem This Solves

Worktree management and legacy migration duplicate the same filesystem-based Git common-directory lookup.

## Why This Change Was Made

Reuse the existing constants-module resolver and remove the private copy. Keep the manager’s thrown filesystem and invalid-format errors. Migration catches failures at its existing call site, preserving its undefined result and logging. The separate per-worktree metadata resolver is unchanged.

## User Impact

No behavior change is intended. The PR removes 15 net production lines across two files. No new files, test code, dependencies, or duplication exceptions are added.

## Evidence

- Existing worktree-manager and architecture tests: 176 passed, 1 skipped. Coverage includes migration, Git excludes, and LFS detection.
- Host/webview typecheck, lint, knip, build:check, formatting, duplication guard, and diff checks passed.
- Duplication report unchanged: 30 pairs, 575 lines, 4043 tokens. This smaller duplicate is below the scanner threshold; no allowlist changes were made.
- No UI behavior changed or manual VS Code instance started. Validation used existing disposable Git test fixtures.

No changeset is needed for this internal behavior-preserving refactor.