### PR TITLE
refactor(kilo-console): remove duplicate remote MCP normalization

### DIFF
--- a/packages/kilo-console/src/routes/config/state/mcp.ts
+++ b/packages/kilo-console/src/routes/config/state/mcp.ts
@@ -258,16 +258,6 @@ function normalized(input: Dict): Config {
     if (typeof input.timeout === "number") cfg.timeout = input.timeout
     return cfg
   }
-  if (input.type === "remote" && typeof input.url === "string") {
-    const cfg: McpRemoteConfig = { type: "remote", url: input.url }
-    const headers = strings(input.headers)
-    const auth = input.oauth === false || record(input.oauth) === input.oauth ? input.oauth : undefined
-    if (headers) cfg.headers = headers
-    if (auth === false || (auth && typeof auth === "object")) cfg.oauth = auth as McpRemoteConfig["oauth"]
-    if (input.enabled === false) cfg.enabled = false
-    if (typeof input.timeout === "number") cfg.timeout = input.timeout
-    return cfg
-  }
   if (typeof input.url === "string") {
     const cfg: McpRemoteConfig = { type: "remote", url: input.url }
     const headers = strings(input.headers)

--- a/script/kilocode-duplication-allowlist.json
+++ b/script/kilocode-duplication-allowlist.json
@@ -100,18 +100,6 @@
     },
     {
       "files": [
-        "packages/kilo-console/src/routes/config/state/mcp.ts",
-        "packages/kilo-console/src/routes/config/state/mcp.ts"
-      ],
-      "fingerprint": "64494aa992cccc8d",
-      "maxMatches": 1,
-      "maxTokens": 129,
-      "kind": "legacy",
-      "owner": "kilo-console",
-      "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
-    },
-    {
-      "files": [
         "packages/kilo-indexing/src/indexing/embedders/openai-compatible.ts",
         "packages/kilo-indexing/src/indexing/embedders/openrouter.ts"
       ],


### PR DESCRIPTION
## What Problem This Solves
MCP marketplace normalization has two adjacent branches with identical remote-config handling. The first checks type=remote plus a string URL; the second accepts any string URL.

## Why This Change Was Made
Delete the narrower duplicate branch. Its inputs now reach the identical broader branch. Local command-array handling remains first, so its precedence is unchanged. Headers, OAuth, enabled state, timeout, and fallback behavior remain unchanged.

## User Impact
No intended behavior change. Explicit remote and URL-only marketplace entries use the same existing normalization path.

## Evidence
- Two files, 22 lines removed and zero added: 10 production lines plus the 12-line verified allowlist entry. No new helpers, exports, dependencies, or tests.
- Fresh duplication report: 30 to 29 pairs, 575 to 565 duplicated lines, 4043 to 3914 duplicated tokens. Only fingerprint 64494aa992cccc8d removed; ratchet passes.
- Console suite: 33 tests pass. Console typecheck and production build pass. Focused lint has zero errors and 13 existing warnings; build retains the existing large-chunk warning. git diff check passes.
- The removed body is identical to its immediate successor, whose predicate includes every removed case. No live MCP server or manual UI flow was needed for this internal branch deletion.