### PR TITLE
refactor(cli): reuse config overlay reader after updates

### DIFF
--- a/packages/opencode/src/kilocode/server/httpapi/handlers/config-console.ts
+++ b/packages/opencode/src/kilocode/server/httpapi/handlers/config-console.ts
@@ -134,36 +134,7 @@ export const configConsoleHandlers = HttpApiBuilder.group(InstanceHttpApi, "conf
         }
         yield* markInstanceForDisposal(instance)
       }
-      const all = yield* auth.all().pipe(Effect.orElseSucceed(() => ({})))
-      const active = yield* account.active().pipe(
-        Effect.map(Option.getOrUndefined),
-        Effect.orElseSucceed(() => undefined),
-      )
-      const [base, global, sources] = yield* Effect.all(
-        [
-          config.get(),
-          config.getGlobal(),
-          Effect.promise(() =>
-            KilocodeConfigSources.list({
-              directory: instance.directory,
-              worktree: instance.worktree,
-              auth: all,
-              account: active,
-            }),
-          ),
-        ],
-        { concurrency: 3 },
-      )
-      const output = yield* Effect.promise(() =>
-        KilocodeConfigOverlay.resolve({
-          directory: instance.directory,
-          worktree: instance.worktree,
-          scope: body.scope,
-          effective: base,
-          global,
-          sources: sources.sources,
-        }),
-      )
+      const output = yield* overlay({ query: { scope: body.scope } })
       if (body.scope === "global" && result.changed && !hot) {
         yield* disposeAllInstancesAndEmitGlobalDisposed({ swallowErrors: true }).pipe(
           Effect.catchCause(() => Effect.void),

--- a/script/kilocode-duplication-allowlist.json
+++ b/script/kilocode-duplication-allowlist.json
@@ -261,18 +261,6 @@
       "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
     },
     {
-      "files": [
-        "packages/opencode/src/kilocode/server/httpapi/handlers/config-console.ts",
-        "packages/opencode/src/kilocode/server/httpapi/handlers/config-console.ts"
-      ],
-      "fingerprint": "ec31254ab83e4a2a",
-      "maxMatches": 1,
-      "maxTokens": 133,
-      "kind": "legacy",
-      "owner": "opencode",
-      "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
-    },
-    {
       "files": ["packages/opencode/src/kilocode/session/prompt.ts", "packages/opencode/src/kilocode/session/prompt.ts"],
       "fingerprint": "b985f7708c9b4632",
       "maxMatches": 1,


### PR DESCRIPTION
## What Problem This Solves
Config overlay updates repeat the same auth, account, config, and source reads used by the existing overlay reader.

## Why This Change Was Made
Call the existing overlay Effect after a successful update instead of maintaining a second resolution block. Keep write locking, conflicts, invalidation, events, and disposal ordering unchanged. The request InstanceRef remains the same; project disposal is registered for pre-response and global disposal still follows resolution.

## User Impact
No intended HTTP or config behavior change. Scope, fallback behavior, read concurrency, and response construction stay the same. Diagnostic tracing gains a nested ConfigConsoleHttpApi.overlay span under overlayUpdate.

## Evidence
- Two files: 1 added line, 42 removed, net 41 fewer lines (29 production plus 12 allowlist). No new helpers, public exports, dependencies, or tests.
- All 47 existing config-overlay, httpapi-instance-context, and httpapi-error-middleware tests pass. These exercise real HTTP reads and writes, response freshness, conflicts, and disposal behavior with temporary fixtures.
- CLI typecheck, focused lint (zero warnings/errors), annotations, and git diff check pass.
- Fresh report: 27 to 26 duplicate pairs, 521 to 502 duplicated lines, 3646 to 3513 duplicated tokens. Only fingerprint ec31254ab83e4a2a removed; duplication ratchet passes.
- No manual UI launch was needed for this internal reuse; the existing HTTP regression tests cover the affected paths.