### PR TITLE
refactor(vscode): share autocomplete FIM model selection

### DIFF
--- a/packages/kilo-vscode/src/services/autocomplete/AutocompleteServiceManager.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/AutocompleteServiceManager.ts
@@ -11,12 +11,8 @@ import { disposeLog } from "./next-edit/log"
 import { NextEditSuggestionManager } from "./next-edit/NextEditSuggestionManager"
 import { toAllowedMercuryRecentSnippets } from "./next-edit/recentSnippetsAdapter"
 import type { KiloConnectionService } from "../cli-backend"
-import { hasValidCredentials } from "./fim"
-import {
-  DEFAULT_AUTOCOMPLETE_MODEL,
-  getAutocompleteModel,
-  getAutocompleteModelById,
-} from "../../shared/autocomplete-models"
+import { hasValidCredentials, fimModel as notebookModel } from "./fim"
+import { DEFAULT_AUTOCOMPLETE_MODEL, getAutocompleteModel } from "../../shared/autocomplete-models"
 
 const CONFIG_SECTION = "kilo-code.new.autocomplete"
 
@@ -24,11 +20,7 @@ export function selector(kind: "classic" | "next-edit"): vscode.DocumentSelector
   return kind === "classic" ? [{ scheme: "file" }, { scheme: "vscode-notebook-cell" }] : [{ scheme: "file" }]
 }
 
-export function notebookModel(provider?: string, model?: string) {
-  const info = getAutocompleteModel(provider, model)
-  if (info.kind !== "edit") return info
-  return getAutocompleteModelById(info.fimModelID)
-}
+export { notebookModel }
 
 export interface AutocompleteServiceSettings {
   enableAutoTrigger?: boolean

--- a/packages/kilo-vscode/src/services/autocomplete/chat-autocomplete/ChatTextAreaAutocomplete.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/chat-autocomplete/ChatTextAreaAutocomplete.ts
@@ -6,8 +6,7 @@ import { postprocessAutocompleteSuggestion } from "../classic-auto-complete/usel
 import { VisibleCodeTracker } from "../context/VisibleCodeTracker"
 import { FileIgnoreController } from "../shims/FileIgnoreController"
 import type { KiloConnectionService } from "../../cli-backend"
-import { generateFim, hasValidCredentials } from "../fim"
-import { getAutocompleteModel, getAutocompleteModelById } from "../../../shared/autocomplete-models"
+import { generateFim, hasValidCredentials, fimModel as getChatAutocompleteModel } from "../fim"
 import { finalizeChatSuggestion, buildChatPrefix } from "./chat-autocomplete-utils"
 
 interface ChatCompletionRequestMessage {
@@ -20,11 +19,7 @@ interface ChatCompletionResponseSender {
   postMessage(message: { type: "chatCompletionResult"; text: string; requestId: string }): void
 }
 
-export function getChatAutocompleteModel(provider?: string, model?: string) {
-  const info = getAutocompleteModel(provider, model)
-  if (info.kind !== "edit") return info
-  return getAutocompleteModelById(info.fimModelID)
-}
+export { getChatAutocompleteModel }
 
 /**
  * Chat textarea autocomplete with cached per-request objects.

--- a/packages/kilo-vscode/src/services/autocomplete/fim.ts
+++ b/packages/kilo-vscode/src/services/autocomplete/fim.ts
@@ -1,8 +1,14 @@
 import { ResponseMetaData } from "./types"
 import type { KiloConnectionService } from "../cli-backend"
-import { getAutocompleteModelById } from "../../shared/autocomplete-models"
+import { getAutocompleteModel, getAutocompleteModelById } from "../../shared/autocomplete-models"
 
 const FIM_MAX_TOKENS = 256
+
+export function fimModel(provider?: string, model?: string) {
+  const info = getAutocompleteModel(provider, model)
+  if (info.kind !== "edit") return info
+  return getAutocompleteModelById(info.fimModelID)
+}
 
 /**
  * Generate a FIM (Fill-in-the-Middle) completion via the CLI backend.


### PR DESCRIPTION
## What Problem This Solves

Notebook and chat autocomplete duplicate the same model fallback selection for Next Edit models.

## Why This Change Was Made

Move the identical selector into the existing FIM module that both callers already import. Preserve the notebookModel and getChatAutocompleteModel exports through aliases. Model catalogs, settings, credentials, request routing, and streaming are unchanged.

## User Impact

No behavior change is intended. Next Edit models still use their configured FIM fallback; FIM selections still return the same model object. The PR removes 7 net production lines across three files, with no new files or test changes.

## Evidence

- 21 existing selector and chat autocomplete tests pass, including gateway/direct-provider Next Edit fallback and FIM passthrough.
- Host/webview typecheck, lint, knip, build:check, formatting, duplication guard, and diff checks pass.
- Duplication report unchanged at 27 pairs, 521 lines, 3646 tokens. This five-line duplicate is below the scanner threshold; no allowlist changes were made.
- The pure selector is covered by existing tests. No model requests or manual UI session were needed.

No changeset is needed for this internal behavior-preserving refactor.