### PR TITLE
refactor(vscode): share dropped mention text insertion

### DIFF
--- a/packages/kilo-vscode/tests/unit/path-mentions.test.ts
+++ b/packages/kilo-vscode/tests/unit/path-mentions.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "bun:test"
-import { convertToMentionPath, extractDropPaths } from "../../webview-ui/src/utils/path-mentions"
+import { convertToMentionPath, extractDropPaths, insertPathMentions } from "../../webview-ui/src/utils/path-mentions"
+
+it("inserts dropped mentions without replacing following text", () => {
+  expect(insertPathMentions("ab", 1, ["x", "y z"])).toEqual({ text: "a@x @y z b", pos: 9 })
+  expect(insertPathMentions("a ", 1, ["x"])).toEqual({ text: "a@x  ", pos: 4 })
+  expect(insertPathMentions("", 0, [])).toEqual({ text: " ", pos: 1 })
+})
 
 describe("convertToMentionPath", () => {
   it("converts an absolute path under cwd to a relative path", () => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx
@@ -42,7 +42,7 @@ import { useImageAttachments, type ImageAttachment } from "../src/hooks/useImage
 import { useSpeechToText } from "../src/components/speech-to-text/useSpeechToText"
 import { useSpeechToTextModels } from "../src/context/speech-to-text-models"
 import { createSpeechShortcut } from "../src/components/speech-to-text/shortcut"
-import { convertToMentionPath } from "../src/utils/path-mentions"
+import { convertToMentionPath, insertPathMentions } from "../src/utils/path-mentions"
 import { insertSpacedText } from "../src/components/chat/prompt-input-utils"
 import { useSlashCommand } from "../src/hooks/useSlashCommand"
 import { WandSparkles } from "@kilocode/kilo-ui/lucide"
@@ -299,18 +299,12 @@ export const NewWorktreeDialog: Component<{
     const resolved = paths.map((p) => convertToMentionPath(p, cwd))
     const ref = textareaRef
     if (!ref) return
-    const val = ref.value
-    const cursor = ref.selectionStart ?? val.length
-    const before = val.substring(0, cursor)
-    const after = val.substring(cursor)
-    const inserted = resolved.map((p) => `@${p}`).join(" ")
-    const result = before + inserted + " " + after
-    ref.value = result
+    const result = insertPathMentions(ref.value, ref.selectionStart ?? ref.value.length, resolved)
+    ref.value = result.text
     cancel()
-    setPrompt(result)
-    persistPrompt(result)
-    const pos = cursor + inserted.length + 1
-    ref.setSelectionRange(pos, pos)
+    setPrompt(result.text)
+    persistPrompt(result.text)
+    ref.setSelectionRange(result.pos, result.pos)
     ref.focus()
     adjustHeight()
   })

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -39,7 +39,7 @@ import { useSpeechToText } from "../speech-to-text/useSpeechToText"
 import { useSpeechToTextModels } from "../../context/speech-to-text-models"
 import { createSpeechShortcut } from "../speech-to-text/shortcut"
 import { useImageAttachments, type ImageAttachment } from "../../hooks/useImageAttachments"
-import { convertToMentionPath } from "../../utils/path-mentions"
+import { convertToMentionPath, insertPathMentions } from "../../utils/path-mentions"
 import { SessionMentionPicker } from "./SessionMentionPicker"
 import { WorktreeMentionPicker } from "./WorktreeMentionPicker"
 import { usePromptHistory } from "../../hooks/usePromptHistory"
@@ -224,17 +224,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const resolved = paths.map((p) => convertToMentionPath(p, cwd))
     const ref = textareaRef
     if (!ref) return
-    const val = ref.value
-    const cursor = ref.selectionStart ?? val.length
-    const before = val.substring(0, cursor)
-    const after = val.substring(cursor)
-    const inserted = resolved.map((p) => `@${p}`).join(" ")
-    const result = before + inserted + " " + after
-    ref.value = result
-    setText(result)
+    const result = insertPathMentions(ref.value, ref.selectionStart ?? ref.value.length, resolved)
+    ref.value = result.text
+    setText(result.text)
     mention.addPaths(resolved, cwd)
-    const pos = cursor + inserted.length + 1
-    ref.setSelectionRange(pos, pos)
+    ref.setSelectionRange(result.pos, result.pos)
     ref.focus()
     adjustHeight()
   })

--- a/packages/kilo-vscode/webview-ui/src/utils/path-mentions.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/path-mentions.ts
@@ -47,6 +47,11 @@ export function convertToMentionPath(path: string, cwd: string): string {
   return cleaned
 }
 
+export function insertPathMentions(text: string, cursor: number, paths: string[]) {
+  const inserted = paths.map((path) => `@${path}`).join(" ") + " "
+  return { text: text.substring(0, cursor) + inserted + text.substring(cursor), pos: cursor + inserted.length }
+}
+
 /** Returns true when the line looks like a file URI or absolute path. */
 function isFilePath(line: string): boolean {
   if (line.startsWith("file://") || line.startsWith("vscode-remote://")) return true

--- a/script/kilocode-duplication-allowlist.json
+++ b/script/kilocode-duplication-allowlist.json
@@ -214,18 +214,6 @@
     },
     {
       "files": [
-        "packages/kilo-vscode/webview-ui/agent-manager/NewWorktreeDialog.tsx",
-        "packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx"
-      ],
-      "fingerprint": "0772e382c935aa93",
-      "maxMatches": 1,
-      "maxTokens": 122,
-      "kind": "legacy",
-      "owner": "kilo-vscode",
-      "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
-    },
-    {
-      "files": [
         "packages/kilo-vscode/webview-ui/src/context/session-variant-store.ts",
         "packages/opencode/src/kilocode/cli/cmd/run/variant.ts"
       ],


### PR DESCRIPTION
## What Problem This Solves
The chat prompt and New Worktree dialog duplicate the text and caret calculation for dropped file mentions.

## Why This Change Was Made
Share only the pure insertion calculation in the existing path-mentions utility. Keep path conversion, mention registration, prompt cancellation/persistence, focus, and textarea sizing local and in the same order. Preserve insertion at selectionStart without replacing selected text, the unconditional trailing space, and paths containing spaces.

## User Impact
No intended behavior change. No new files, dependencies, or test harness. Add one small regression test to the existing path-mentions suite.

## Evidence
- Fresh branch from origin/main after PR #13651 merged. Three production files, existing test file, and one allowlist removal: 23 additions, 36 deletions. Net 13 fewer total lines and 7 fewer production lines.
- Duplication report: 27 to 26 pairs, 521 to 509 duplicated lines, 3,646 to 3,524 duplicated tokens. Remove only fingerprint 0772e382c935aa93.
- 123 focused mention/terminal tests passed, 179 assertions. Compile/build:check, host/webview typecheck, lint, knip, formatting, and duplication/annotation guards passed.
- Visible isolated VS Code, disposable fixture and fresh HOME: dispatched an internal file-drop event for two paths into the real sidebar handler, with following text selected. Both mentions rendered, selected following text remained, caret collapsed to position 29, and focus stayed on the textarea. No prompt or model call was sent. The New Worktree dialog and an OS-originated drag were not manually exercised. Screenshot inspected; stop-vscode --cleanup true and stop completed.

<img width="500" alt="Two dropped file mentions inserted before preserved following text in an unsent prompt" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260901-file-drop-mentions-1037.png" />