### PR TITLE
refactor(vscode): reuse Markdown fence formatting

### DIFF
--- a/packages/kilo-vscode/src/shared/browser-feedback.ts
+++ b/packages/kilo-vscode/src/shared/browser-feedback.ts
@@ -1,4 +1,4 @@
-import { partReview, type ReviewMessageData } from "./review-comments"
+import { fenced, partReview, type ReviewMessageData } from "./review-comments"
 
 export interface BrowserReference {
   id: string
@@ -188,13 +188,6 @@ function normalize(references: readonly BrowserReference[]): BrowserReference[] 
 
 function escapeInline(value: string): string {
   return value.replace(/[\r\n]+/g, " ").replace(/([\\`*_[\]{}()#+\-!|<>])/g, "\\$1")
-}
-
-function fenced(value: string): string[] {
-  const matches = value.match(/`+/g) ?? []
-  const longest = matches.reduce((max, item) => Math.max(max, item.length), 0)
-  const fence = "`".repeat(Math.max(3, longest + 1))
-  return [fence, value, fence]
 }
 
 function page(item: BrowserReference): string | undefined {

--- a/packages/kilo-vscode/src/shared/review-comments.ts
+++ b/packages/kilo-vscode/src/shared/review-comments.ts
@@ -53,7 +53,7 @@ function escapeInline(value: string): string {
 }
 
 /** Wrap a snippet in a fence long enough to survive backticks inside it. */
-function fenced(value: string): string[] {
+export function fenced(value: string): string[] {
   const matches = value.match(/`+/g) ?? []
   const longest = matches.reduce((max, item) => Math.max(max, item.length), 0)
   const fence = "`".repeat(Math.max(3, longest + 1))


### PR DESCRIPTION
## What Problem This Solves

Browser feedback and review comments duplicate the same Markdown fence construction.

## Why This Change Was Made

Export the existing review-comment helper and reuse it through browser feedback’s existing import. The six-line helper body is identical in both modules and remains unchanged, including backtick-run handling. Nearby escaping and validation logic stays separate.

## User Impact

No behavior change is intended. The PR removes 7 net production lines across two files, with no new files, dependencies, or test code.

## Evidence

- 82 existing review-comment, PR-comment, and browser-feedback tests passed.
- Host/webview typecheck, lint, knip, build:check, formatting, duplication guard, and diff checks passed.
- Duplication report unchanged at 27 pairs, 521 lines, 3646 tokens. This smaller clone is below the scanner threshold; the allowlist is untouched.
- Exact overlap was inspected: the pending inline-review PR changes other sections of review-comments.ts, not this fence helper.
- Pure formatter reuse is covered through existing tests; no UI session or model requests were needed.

No changeset is needed for this internal behavior-preserving refactor.