### PR TITLE
refactor(kilo-console): share CLI settings toggle

### DIFF
--- a/packages/kilo-console/src/routes/config/CliNotificationsRoute.tsx
+++ b/packages/kilo-console/src/routes/config/CliNotificationsRoute.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@kilocode/kilo-web-ui/button"
 import { Card } from "@kilocode/kilo-web-ui/card"
 import { CustomSelect, type SelectOption } from "../../components/CustomSelect"
-import { ConfigPage, ConfigTag as Tag } from "./ConfigPage"
+import { ConfigPage, ConfigToggle as Toggle } from "./ConfigPage"
 import { type TitleIcon, useTuiNotificationSettings } from "./state/ui"
 
 const icons = [
@@ -9,31 +9,6 @@ const icons = [
   { value: "unicode", label: "Unicode" },
   { value: "emojis", label: "Emojis" },
 ] satisfies SelectOption<TitleIcon>[]
-
-function Toggle(props: {
-  label: string
-  description: string
-  checked: boolean
-  disabled?: boolean
-  onChange: () => void
-}) {
-  return (
-    <button
-      class="ui-toggle"
-      classList={{ selected: props.checked }}
-      type="button"
-      aria-pressed={props.checked}
-      disabled={props.disabled}
-      onClick={props.onChange}
-    >
-      <span>
-        <strong>{props.label}</strong>
-        <small>{props.description}</small>
-      </span>
-      <Tag tone={props.checked ? "success" : "neutral"}>{props.checked ? "On" : "Off"}</Tag>
-    </button>
-  )
-}
 
 export function CliNotificationsRoute() {
   const state = useTuiNotificationSettings()

--- a/packages/kilo-console/src/routes/config/CliUiRoute.tsx
+++ b/packages/kilo-console/src/routes/config/CliUiRoute.tsx
@@ -3,7 +3,7 @@ import { Button } from "@kilocode/kilo-web-ui/button"
 import { Card } from "@kilocode/kilo-web-ui/card"
 import { CustomSelect, type SelectOption } from "../../components/CustomSelect"
 import { SearchField } from "../../components/SearchField"
-import { ConfigPage, ConfigTag as Tag } from "./ConfigPage"
+import { ConfigPage, ConfigToggle as Toggle } from "./ConfigPage"
 import { type Theme, themeTitle, useTuiUiSettings } from "./state/ui"
 
 const diffs = [
@@ -28,31 +28,6 @@ function ThemePreview(props: { item: Theme }) {
       </div>
       <ThemeSwatches swatches={props.item.swatches} />
     </div>
-  )
-}
-
-function Toggle(props: {
-  label: string
-  description: string
-  checked: boolean
-  disabled?: boolean
-  onChange: () => void
-}) {
-  return (
-    <button
-      class="ui-toggle"
-      classList={{ selected: props.checked }}
-      type="button"
-      aria-pressed={props.checked}
-      disabled={props.disabled}
-      onClick={props.onChange}
-    >
-      <span>
-        <strong>{props.label}</strong>
-        <small>{props.description}</small>
-      </span>
-      <Tag tone={props.checked ? "success" : "neutral"}>{props.checked ? "On" : "Off"}</Tag>
-    </button>
   )
 }
 

--- a/packages/kilo-console/src/routes/config/ConfigPage.tsx
+++ b/packages/kilo-console/src/routes/config/ConfigPage.tsx
@@ -40,6 +40,31 @@ export function ConfigToolbar(props: {
   )
 }
 
+export function ConfigToggle(props: {
+  label: string
+  description: string
+  checked: boolean
+  disabled?: boolean
+  onChange: () => void
+}) {
+  return (
+    <button
+      class="ui-toggle"
+      classList={{ selected: props.checked }}
+      type="button"
+      aria-pressed={props.checked}
+      disabled={props.disabled}
+      onClick={props.onChange}
+    >
+      <span>
+        <strong>{props.label}</strong>
+        <small>{props.description}</small>
+      </span>
+      <ConfigTag tone={props.checked ? "success" : "neutral"}>{props.checked ? "On" : "Off"}</ConfigTag>
+    </button>
+  )
+}
+
 export function SourceBadge(props: { source?: string; inherited?: boolean; overridden?: boolean }) {
   return <UiSourceBadge {...props} />
 }

--- a/script/kilocode-duplication-allowlist.json
+++ b/script/kilocode-duplication-allowlist.json
@@ -64,18 +64,6 @@
     },
     {
       "files": [
-        "packages/kilo-console/src/routes/config/CliNotificationsRoute.tsx",
-        "packages/kilo-console/src/routes/config/CliUiRoute.tsx"
-      ],
-      "fingerprint": "3d8c2a788d682c4e",
-      "maxMatches": 1,
-      "maxTokens": 143,
-      "kind": "legacy",
-      "owner": "kilo-console",
-      "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
-    },
-    {
-      "files": [
         "packages/kilo-console/src/routes/config/state/agents.ts",
         "packages/kilo-console/src/routes/config/state/models.ts"
       ],


### PR DESCRIPTION
## What Problem This Solves
CLI UI and CLI Notifications each define the same stateless toggle button.

## Why This Change Was Made
Move the identical JSX into ConfigToggle in the existing ConfigPage module. Both routes import it under their existing Toggle name, so all five call sites, props, reactive reads, state, and save logic remain unchanged. Keep the different Indexing toggle out of scope.

## User Impact
No intended visual or behavior change. Button type, disabled state, aria-pressed, selected class, click handling, label, description, and On/Off badge are preserved.

## Evidence
- Three production files plus one allowlist entry: 27 additions and 64 deletions, net 37 fewer lines (25 production and 12 allowlist).
- No new files, dependencies, or tests. Console suite: 33 tests pass; typecheck and production build pass. Lint has zero warnings/errors; formatting and diff checks pass. Build retains its existing large-chunk warning.
- Fresh duplication report: 25 to 24 pairs, 490 to 465 duplicated lines, 3391 to 3248 duplicated tokens. Only fingerprint 3d8c2a788d682c4e removed; ratchet passes.
- JSX and call-site comparison verifies a mechanical move. No interactive UI smoke was run. Manual check: toggle settings on both pages with mouse and keyboard; turning attention alerts off must disable desktop notifications and sound.