### PR TITLE
refactor(vscode): share context menu styles

### DIFF
--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -79,6 +79,7 @@ const TSX_FILES = [
   path.join(ROOT, "webview-ui/src/components/chat/TabDnd.tsx"),
   path.join(ROOT, "webview-ui/diff-viewer/BaseBranchPicker.tsx"),
 ]
+const SHARED_CSS = path.join(ROOT, "webview-ui/src/styles/session-tabs.css")
 const TSX_FILE = TSX_FILES[0]!
 const KEYBIND_DEFAULTS_FILE = path.join(ROOT, "webview-ui/agent-manager/keybind-defaults.ts")
 const PROVIDER_FILE = path.join(ROOT, "src/agent-manager/AgentManagerProvider.ts")
@@ -145,7 +146,7 @@ describe("Agent Manager CSS Prefix", () => {
 
 describe("Agent Manager CSS/TSX Consistency", () => {
   it("all classes used in TSX should be defined in CSS", () => {
-    const css = readAllCss()
+    const css = readAllCss() + fs.readFileSync(SHARED_CSS, "utf-8")
     const tsx = readAllTsx()
 
     // Extract am- classes defined in CSS
@@ -162,7 +163,7 @@ describe("Agent Manager CSS/TSX Consistency", () => {
   })
 
   it("all am- classes defined in CSS should be used in TSX", () => {
-    const css = readAllCss()
+    const css = readAllCss() + fs.readFileSync(SHARED_CSS, "utf-8")
     const tsx = readAllTsx()
 
     // Extract am- classes defined in CSS

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -4814,35 +4814,6 @@ body.vscode-high-contrast-light {
   }
 }
 
-/* Context menu — restyle to match dropdown-menu visuals.
-   The kilo-ui ContextMenu component hardcodes its own data-component / data-slot
-   attributes after the prop spread, so we can't override them via props.
-   Instead we apply a class and re-declare the styles here. */
-
-.am-ctx-menu {
-  min-width: 210px;
-  border: 1px solid color-mix(in oklch, var(--border-base) 50%, transparent) !important;
-  box-shadow: var(--shadow-md) !important;
-
-  [data-slot="context-menu-item"],
-  [data-slot="context-menu-checkbox-item"],
-  [data-slot="context-menu-radio-item"],
-  [data-slot="context-menu-sub-trigger"] {
-    padding: 6px 10px;
-    font-size: var(--font-size-small);
-    transition: none;
-
-    &:hover,
-    &[data-highlighted] {
-      background: var(--surface-raised-base-hover);
-    }
-  }
-
-  [data-slot="context-menu-separator"] {
-    margin: 4px 0;
-  }
-}
-
 /* Shared sortable inspector tabs. */
 
 .am-tab-closable,

--- a/packages/kilo-vscode/webview-ui/src/styles/session-tabs.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/session-tabs.css
@@ -319,7 +319,8 @@
 }
 
 /* Match tab context menus to dropdown-menu visuals on every tab surface. */
-.session-tab-menu {
+.session-tab-menu,
+.am-ctx-menu {
   min-width: 210px;
   border: 1px solid color-mix(in oklch, var(--border-base) 50%, transparent) !important;
   box-shadow: var(--shadow-md) !important;

--- a/script/kilocode-duplication-allowlist.json
+++ b/script/kilocode-duplication-allowlist.json
@@ -193,18 +193,6 @@
         "packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css",
         "packages/kilo-vscode/webview-ui/src/styles/session-tabs.css"
       ],
-      "fingerprint": "73d7672dd2e6cd26",
-      "maxMatches": 1,
-      "maxTokens": 155,
-      "kind": "legacy",
-      "owner": "kilo-vscode",
-      "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
-    },
-    {
-      "files": [
-        "packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css",
-        "packages/kilo-vscode/webview-ui/src/styles/session-tabs.css"
-      ],
       "fingerprint": "9020d3c20123ef72",
       "maxMatches": 1,
       "maxTokens": 104,


### PR DESCRIPTION
## What Problem This Solves
Agent Manager context menus and session-tab context menus repeat the same CSS declarations.

## Why This Change Was Made
Group their existing single-class selectors in session-tabs.css and remove the Agent Manager copy. Both webviews already load this shared stylesheet. Keep declarations and selector specificity unchanged; no markup, behavior, dependencies, or test harness are added. Include this shared stylesheet in the existing CSS/TSX consistency checks without changing assertions or adding exceptions.

## User Impact
No intended visual change. Menu width, border, shadow, item padding, highlight styling, and separator spacing retain the same values.

## Evidence
- Fresh branch from origin/main after PR #13656 merged. Two CSS files, an existing architecture test, and one allowlist removal: 5 additions, 44 deletions, net 39 fewer total lines and 28 fewer CSS lines.
- Duplication report: 25 to 24 pairs, 490 to 468 duplicated lines, 3,391 to 3,236 duplicated tokens. Remove only fingerprint 73d7672dd2e6cd26.
- Initial CI exposed the architecture test indexing only Agent Manager styles. Updated its two consistency checks to include the shared stylesheet, while leaving Agent Manager prefix restrictions unchanged. No retry or test bypass.
- Full extension unit suite: 4,580 passed, one existing skip, zero failures. build:check including host/webview typecheck, lint and both bundles passed; knip, formatting and duplication/annotation guards passed. No tests added.
- Visible isolated VS Code with fresh HOME and disposable Git fixture: created a test section through the UI, opened its context menu, and inspected the cropped screenshot. Both selectors produced identical computed values for eight style properties across 27 live menu elements. Confirmed 210px minimum width and 6px/10px item padding. No prompt/model calls or real credentials. stop-vscode --cleanup true and stop completed. Separate sidebar-tab and high-contrast flows were not manually exercised.

<img width="360" alt="Agent Manager section context menu using shared menu styling" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260901-context-menu-dedupe-section-1118.png" />