### PR TITLE
refactor(vscode): reuse metadata leaf validators

### DIFF
--- a/packages/kilo-vscode/src/shared/browser-feedback.ts
+++ b/packages/kilo-vscode/src/shared/browser-feedback.ts
@@ -1,4 +1,11 @@
-import { fenced, partReview, type ReviewMessageData } from "./review-comments"
+import {
+  fenced,
+  partReview,
+  record,
+  text as string,
+  optionalLine as positive,
+  type ReviewMessageData,
+} from "./review-comments"
 
 export interface BrowserReference {
   id: string
@@ -39,16 +46,6 @@ const HTML_LIMIT = 20_000
 const STYLE_LIMIT = 256
 const SOURCE_LIMIT = 4_096
 
-function record(value: unknown): Record<string, unknown> | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
-  return value as Record<string, unknown>
-}
-
-function string(value: unknown, limit: number): string | undefined {
-  if (typeof value !== "string" || value.length > limit) return undefined
-  return value
-}
-
 function optionalString(value: unknown, limit: number): string | false | undefined {
   if (value === undefined) return undefined
   const result = string(value, limit)
@@ -79,12 +76,6 @@ function optionalUrl(value: unknown): string | false | undefined {
   if (typeof value !== "string" || value.length > URL_LIMIT) return false
   const result = url(value)
   return result === undefined ? false : result
-}
-
-function positive(value: unknown): number | false | undefined {
-  if (value === undefined) return undefined
-  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) return false
-  return value
 }
 
 function styles(value: unknown): BrowserReference["styles"] | false | undefined {

--- a/packages/kilo-vscode/src/shared/review-comments.ts
+++ b/packages/kilo-vscode/src/shared/review-comments.ts
@@ -94,12 +94,12 @@ export function formatReviewCommentsMarkdown(comments: ReviewCommentEntry[]): st
   return lines.join("\n").trimEnd()
 }
 
-function record(value: unknown): Record<string, unknown> | undefined {
+export function record(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
   return value as Record<string, unknown>
 }
 
-function text(value: unknown, limit: number): string | undefined {
+export function text(value: unknown, limit: number): string | undefined {
   if (typeof value !== "string" || value.length > limit) return undefined
   return value
 }
@@ -139,7 +139,7 @@ function optional(value: unknown, limit: number, valid?: (item: string) => boole
   return item
 }
 
-function optionalLine(value: unknown): number | false | undefined {
+export function optionalLine(value: unknown): number | false | undefined {
   if (value === undefined) return undefined
   if (typeof value !== "number" || !Number.isInteger(value) || value < 1) return false
   return value


### PR DESCRIPTION
## What Problem This Solves

Browser feedback and review-comment metadata repeat the same object, bounded-string, and optional-positive-integer validators.

## Why This Change Was Made

Export the existing review-comment validators and reuse them through browser feedback’s existing import. Keep local aliases and all callers unchanged. The validator bodies are identical; field limits, URL handling, path checks, and higher-level parsing stay separate.

## User Impact

No behavior change is intended. The PR removes 9 net production lines across two files. No new files, test code, dependencies, or generic validation framework are added.

## Evidence

- 82 existing browser-feedback, review-comment, and PR-comment tests passed, including metadata round trips and malformed/oversized fields.
- Host/webview typecheck, lint, knip, build:check, formatting, duplication guard, and diff checks passed.
- Duplication report unchanged: 25 pairs, 490 lines, 3391 tokens. These leaf duplicates are below the scanner threshold; the allowlist is untouched.
- The pending inline-review PR was inspected: it does not change these validator bodies.
- Pure validation reuse was checked through existing tests. No UI session or model requests were needed.

No changeset is needed for this internal behavior-preserving refactor.