### PR TITLE
refactor(kilo-console): share model picker choices

### DIFF
--- a/packages/kilo-console/src/routes/config/state/agents.ts
+++ b/packages/kilo-console/src/routes/config/state/agents.ts
@@ -4,6 +4,7 @@ import type { AgentBuilderPreviewResponse, Model, Provider } from "@kilocode/sdk
 import { previewAgent, saveAgent, type AgentPayload, type Scope, type Snapshot } from "../../../client"
 import { useConfig } from "../../../context/config"
 import { clean, friendly, sorted, toMode, toolCapabilities, toolName } from "../../../shared/utils"
+import { choices } from "./models"
 import {
   defaults,
   defs,
@@ -199,23 +200,7 @@ export function useAgentBuilder(agent?: Accessor<string | undefined>) {
 
   const favorites = createMemo(() => snap()?.modelState.favorite ?? [])
   const fav = (item: Item) => favorites().some((ref) => same(item, ref))
-  const models = createMemo(() => {
-    const term = picker().trim().toLowerCase()
-    return all()
-      .filter((item) => {
-        if (!term) return true
-        return `${item.id} ${item.model.name} ${item.provider.name}`.toLowerCase().includes(term)
-      })
-      .sort((a, b) => {
-        const ranked = Number(fav(b)) - Number(fav(a))
-        if (ranked !== 0) return ranked
-        const named = a.model.name.localeCompare(b.model.name)
-        if (named !== 0) return named
-        const provider = a.provider.name.localeCompare(b.provider.name)
-        if (provider !== 0) return provider
-        return a.id.localeCompare(b.id)
-      })
-  })
+  const models = createMemo(() => choices(picker(), all(), fav))
   const item = (value: unknown) => {
     if (typeof value !== "string") return undefined
     return all().find((model) => model.id === value || `${model.model.providerID}/${model.model.id}` === value)

--- a/packages/kilo-console/src/routes/config/state/models.ts
+++ b/packages/kilo-console/src/routes/config/state/models.ts
@@ -52,6 +52,24 @@ function same(item: Item, ref: ModelRef) {
   return item.model.providerID === ref.providerID && item.model.id === ref.modelID
 }
 
+export function choices(search: string, items: Item[], fav: (item: Item) => boolean) {
+  const term = search.trim().toLowerCase()
+  return items
+    .filter((item) => {
+      if (!term) return true
+      return `${item.id} ${item.model.name} ${item.provider.name}`.toLowerCase().includes(term)
+    })
+    .sort((a, b) => {
+      const ranked = Number(fav(b)) - Number(fav(a))
+      if (ranked !== 0) return ranked
+      const named = a.model.name.localeCompare(b.model.name)
+      if (named !== 0) return named
+      const provider = a.provider.name.localeCompare(b.provider.name)
+      if (provider !== 0) return provider
+      return a.id.localeCompare(b.id)
+    })
+}
+
 export function useModelSettings() {
   const ctx = useConfig()
   const snap = () => ctx.data()
@@ -125,23 +143,7 @@ export function useModelSettings() {
       })
   })
 
-  const options = createMemo(() => {
-    const term = picker().trim().toLowerCase()
-    return all()
-      .filter((item) => {
-        if (!term) return true
-        return `${item.id} ${item.model.name} ${item.provider.name}`.toLowerCase().includes(term)
-      })
-      .sort((a, b) => {
-        const ranked = Number(fav(b)) - Number(fav(a))
-        if (ranked !== 0) return ranked
-        const named = a.model.name.localeCompare(b.model.name)
-        if (named !== 0) return named
-        const provider = a.provider.name.localeCompare(b.provider.name)
-        if (provider !== 0) return provider
-        return a.id.localeCompare(b.id)
-      })
-  })
+  const options = createMemo(() => choices(picker(), all(), fav))
 
   const label = createMemo(() => (field() === "model" ? "Default model" : "Small model"))
 

--- a/script/kilocode-duplication-allowlist.json
+++ b/script/kilocode-duplication-allowlist.json
@@ -76,18 +76,6 @@
     },
     {
       "files": [
-        "packages/kilo-console/src/routes/config/state/agents.ts",
-        "packages/kilo-console/src/routes/config/state/models.ts"
-      ],
-      "fingerprint": "f0f56e89b4d2ff59",
-      "maxMatches": 1,
-      "maxTokens": 171,
-      "kind": "legacy",
-      "owner": "kilo-console",
-      "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
-    },
-    {
-      "files": [
         "packages/kilo-indexing/src/indexing/embedders/openai-compatible.ts",
         "packages/kilo-indexing/src/indexing/embedders/openrouter.ts"
       ],


### PR DESCRIPTION
## What Problem This Solves
Agents and Models repeat the same model-picker search and ordering logic.

## Why This Change Was Made
Move only that pure filter/sort body into choices in the existing models state module. Both caller-owned createMemo computations remain in place. Keep provider preparation, favorite lookup, selection/save behavior, and the separate Models-page filtering unchanged.

## User Impact
No intended behavior change. Search still trims and ignores case; matches include ID, model name, and provider name. Ordering remains favorites first, then model name, provider name, and ID. Input arrays are not mutated.

## Evidence
- Three files: 21 additions and 46 deletions, net 25 fewer lines (13 production and 12 allowlist). No new files, dependencies, or tests.
- Existing console suite: 33 pass. Typecheck and production build pass. Focused lint has zero errors and two existing warnings; build retains its existing large-chunk warning. git diff check passes.
- Direct smoke checks exercise the actual helper for trimmed/case-insensitive search, ID/provider matches, all ordering levels, and input immutability. The in-memory fixture used an isolated HOME/XDG profile and a window.fetch shim that rejects network access; the profile was removed. No live model or UI requests were made.
- Fresh duplication report: 24 to 23 pairs, 465 to 448 duplicated lines, 3248 to 3077 duplicated tokens. Only fingerprint f0f56e89b4d2ff59 removed; ratchet passes.