### PR TITLE
refactor(vscode): reuse script error formatting

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/ScriptTerminalManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/ScriptTerminalManager.ts
@@ -1,7 +1,7 @@
 import type { KiloClient } from "@kilocode/sdk/v2/client"
 import path from "node:path"
 import type { TerminalFont } from "./terminal-font"
-import type { RunHandle } from "./run/manager"
+import { message, type RunHandle } from "./run/manager"
 import { block } from "./pty-cleanup"
 
 export type ScriptTerminalKind = "run" | "setup"
@@ -68,11 +68,6 @@ interface TerminalMessage {
   terminalId?: unknown
   cols?: unknown
   rows?: unknown
-}
-
-function message(error: unknown): string {
-  if (error instanceof Error) return error.message
-  return String(error)
 }
 
 function missing(error: unknown): boolean {

--- a/packages/kilo-vscode/src/agent-manager/run/manager.ts
+++ b/packages/kilo-vscode/src/agent-manager/run/manager.ts
@@ -37,7 +37,7 @@ interface FinishOptions {
   error?: string
 }
 
-function message(error: unknown): string {
+export function message(error: unknown): string {
   if (error instanceof Error) return error.message
   return String(error)
 }


### PR DESCRIPTION
## What Problem This Solves

Run-script and script-terminal managers duplicate the same error-to-string conversion.

## Why This Change Was Made

Export the existing run-manager helper and reuse its identical body in the script-terminal manager. Keep all call sites, fallback text, log prefixes, missing-PTY detection, and lifecycle operations unchanged. The run-manager module has no imports or top-level side effects.

## User Impact

No behavior change is intended. Error objects still use their message; other values still use String conversion. The PR removes 5 net production lines across two files, with no new files or test code.

## Evidence

- 109 existing run-script, script-terminal, and architecture tests passed, including start/stop failures and failed terminal removal.
- Host/webview typecheck, lint, knip, build:check, formatting, duplication guard, and diff checks passed.
- Duplication report unchanged: 24 pairs, 465 lines, 3248 tokens. This four-line helper is below the scanner threshold; the allowlist is untouched.
- No UI behavior or services changed. Existing tests exercise the affected failure handling; no model calls or manual UI session were needed.

No changeset is needed for this internal behavior-preserving refactor.