### PR TITLE
fix(vscode): keep finished background agents compact

### DIFF
--- a/.changeset/compact-finished-background-agents.md
+++ b/.changeset/compact-finished-background-agents.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep finished background agents in the compact header with status icons, and automatically collapse their list when all agents finish.

--- a/packages/kilo-vscode/tests/accessibility.spec.ts
+++ b/packages/kilo-vscode/tests/accessibility.spec.ts
@@ -73,7 +73,7 @@ test.describe("webview accessibility ratchet", () => {
     await expect(list).toBeHidden()
   })
 
-  test("Background agent spinners survive polling updates", async ({ page }) => {
+  test("Background agents preserve running spinners and collapse after completion", async ({ page }) => {
     await page.emulateMedia({ reducedMotion: "no-preference" })
     await page.clock.install()
     await page.clock.pauseAt(new Date())
@@ -95,7 +95,7 @@ test.describe("webview accessibility ratchet", () => {
                   {
                     id: "job-spinner",
                     type: "task",
-                    title: `Agent ${revision}`,
+                    title: `Background agent ${revision}`,
                     status: revision < 4 ? "running" : "completed",
                     started_at: 1,
                     metadata: { parentSessionId: message.sessionID, sessionId: "child-spinner", background: true },
@@ -109,24 +109,115 @@ test.describe("webview accessibility ratchet", () => {
       })
     })
     await open(page, "chat--task-header-background-agents-420")
-    await page.locator('[data-slot="task-header-agents-toggle"]').click()
-    const row = page.locator('[data-slot="task-header-agent"]')
-    await expect(row).toContainText("Agent 1")
+    const agents = page.locator('[data-component="task-header-agents"]')
+    const toggle = agents.locator('[data-slot="task-header-agents-toggle"]')
+    const list = agents.locator('[data-slot="task-header-todos-list"]')
+    const preview = agents.locator('[data-slot="task-header-agents-item"]')
+    await toggle.click()
+    const row = list.locator('[data-slot="task-header-agent"]')
+    await expect(row).toContainText("Background agent 1")
     const node = await row.elementHandle()
     const spinner = await row.locator('[data-component="spinner"]').elementHandle()
     expect(spinner).not.toBeNull()
 
     for (const revision of [2, 3]) {
       await page.clock.runFor(1000)
-      await expect(row).toContainText(`Agent ${revision}`)
+      await expect(row).toContainText(`Background agent ${revision}`)
+      await expect(row).toHaveAttribute("data-status", "running")
+      expect(await node!.evaluate((node) => node.isConnected)).toBe(true)
       expect(await spinner!.evaluate((node) => node.isConnected)).toBe(true)
     }
 
     await page.clock.runFor(1000)
+    await expect(toggle).toHaveAttribute("aria-expanded", "false")
+    await expect(list).toBeHidden()
+    await expect(preview).toHaveAttribute("data-status", "completed")
+    await expect(preview).toHaveAttribute("aria-hidden", "false")
+    await expect(preview).toHaveAccessibleName("Open background agent: Background agent 4 (Done)")
+    await expect(preview).toHaveAttribute("title", "Open background agent: Background agent 4 (Done)")
+    await expect(preview.locator('[data-component="icon"]')).toBeVisible()
+    await expect(preview.locator('[data-component="icon"] use')).toHaveAttribute("href", "#opencode-icon-circle-check")
+    await expect(agents.locator('[data-component="spinner"]')).toHaveCount(0)
+
+    await toggle.click()
+    await expect(list).toBeVisible()
     await expect(row).toHaveAttribute("data-status", "completed")
-    expect(await node!.evaluate((node) => node.isConnected)).toBe(true)
-    await expect(row.locator('[data-component="spinner"]')).toHaveCount(0)
-    await expect(row.getByRole("button", { name: "Dismiss: Agent 4" })).toBeVisible()
+    await expect(row.getByRole("button", { name: "Dismiss: Background agent 4", exact: true })).toBeVisible()
+    await page.clock.runFor(1000)
+    await expect(row).toContainText("Background agent 5")
+    await expect(toggle).toHaveAttribute("aria-expanded", "true")
+    await expect(list).toBeVisible()
+    await expect(agents.locator('[data-component="spinner"]')).toHaveCount(0)
+
+    await toggle.click()
+    await page.setViewportSize({ width: 200, height: 720 })
+    const summary = agents.locator('[data-slot="task-header-agents-summary"]')
+    await expect(summary).toHaveAttribute("aria-hidden", "false")
+    await expect(summary).toHaveText("1 background agent")
+    await expect(summary.locator('[data-component="icon"]')).toBeVisible()
+    await expect(summary.locator('[data-component="icon"] use')).toHaveAttribute("href", "#opencode-icon-circle-check")
+    await expect(preview).toHaveAttribute("aria-hidden", "true")
+  })
+
+  test("Background agent previews show all finished statuses and a compact summary", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 })
+    await page.addInitScript(() => {
+      Object.defineProperty(window, "acquireVsCodeApi", {
+        value: () => ({
+          getState: () => undefined,
+          setState: () => {},
+          postMessage: (message: { type: string; sessionID?: string; requestID?: string }) => {
+            if (message.type !== "requestBackgroundJobs") return
+            window.postMessage(
+              {
+                type: "backgroundJobsLoaded",
+                sessionID: message.sessionID,
+                requestID: message.requestID,
+                jobs: ["completed", "cancelled", "error"].map((status) => ({
+                  id: `job-${status}`,
+                  type: "task",
+                  title: `Background agent ${status}`,
+                  status,
+                  started_at: 1,
+                  metadata: { parentSessionId: message.sessionID, sessionId: `child-${status}`, background: true },
+                })),
+              },
+              "*",
+            )
+          },
+        }),
+      })
+    })
+    await open(page, "chat--task-header-background-agents-1280")
+    const agents = page.locator('[data-component="task-header-agents"]')
+    const items = agents.locator('[data-slot="task-header-agents-item"]')
+    await expect(items).toHaveCount(3)
+    const clear = agents.getByRole("button", { name: "Clear finished", exact: true })
+    await expect(clear).toHaveText("")
+    await expect(clear).toHaveAttribute("title", "Clear finished")
+    for (const [status, label, icon] of [
+      ["completed", "Done", "circle-check"],
+      ["cancelled", "Cancelled", "circle-ban-sign"],
+      ["error", "Error", "warning"],
+    ] as const) {
+      const item = agents.locator(`[data-slot="task-header-agents-item"][data-status="${status}"]`)
+      const name = `Open background agent: Background agent ${status} (${label})`
+      await expect(item).toHaveAttribute("aria-hidden", "false")
+      await expect(item).toHaveText(`Background agent ${status}`)
+      await expect(item).toHaveAccessibleName(name)
+      await expect(item).toHaveAttribute("title", name)
+      await expect(item.locator('[data-component="icon"]')).toBeVisible()
+      await expect(item.locator('[data-component="icon"] use')).toHaveAttribute("href", `#opencode-icon-${icon}`)
+    }
+    await expect(agents.locator('[data-component="spinner"]')).toHaveCount(0)
+
+    await page.setViewportSize({ width: 200, height: 720 })
+    const summary = agents.locator('[data-slot="task-header-agents-summary"]')
+    await expect(summary).toHaveAttribute("aria-hidden", "false")
+    await expect(summary).toHaveText("3 background agents")
+    await expect(summary.locator('[data-component="icon"]')).toBeVisible()
+    await expect(summary.locator('[data-component="icon"] use')).toHaveAttribute("href", "#opencode-icon-warning")
+    await expect(agents.locator('[data-slot="task-header-agents-item"][aria-hidden="false"]')).toHaveCount(0)
   })
 
   test("Agent Manager keeps virtualized transcript fragments laid out", async ({ page }) => {

--- a/packages/kilo-vscode/tests/accessibility.spec.ts
+++ b/packages/kilo-vscode/tests/accessibility.spec.ts
@@ -173,7 +173,12 @@ test.describe("webview accessibility ratchet", () => {
                 type: "backgroundJobsLoaded",
                 sessionID: message.sessionID,
                 requestID: message.requestID,
-                jobs: ["completed", "cancelled", "error"].map((status) => ({
+                jobs: [
+                  "completed",
+                  "cancelled",
+                  "error",
+                  ...(document.documentElement.dataset.running ? ["running"] : []),
+                ].map((status) => ({
                   id: `job-${status}`,
                   type: "task",
                   title: `Background agent ${status}`,
@@ -218,6 +223,16 @@ test.describe("webview accessibility ratchet", () => {
     await expect(summary.locator('[data-component="icon"]')).toBeVisible()
     await expect(summary.locator('[data-component="icon"] use')).toHaveAttribute("href", "#opencode-icon-warning")
     await expect(agents.locator('[data-slot="task-header-agents-item"][aria-hidden="false"]')).toHaveCount(0)
+
+    await page.evaluate(() => {
+      document.documentElement.dataset.running = "true"
+    })
+    await page.setViewportSize({ width: 600, height: 720 })
+    await expect(items).toHaveCount(4)
+    await expect(items.first()).toHaveAttribute("data-status", "running")
+    await expect(items.first()).toHaveAttribute("aria-hidden", "false")
+    await expect(items.first().locator('[data-component="spinner"]')).toBeVisible()
+    await expect(agents.locator('[data-slot="task-header-agents-overflow"]')).toHaveAttribute("aria-hidden", "false")
   })
 
   test("Agent Manager keeps virtualized transcript fragments laid out", async ({ page }) => {

--- a/packages/kilo-vscode/tests/accessibility.spec.ts
+++ b/packages/kilo-vscode/tests/accessibility.spec.ts
@@ -128,8 +128,11 @@ test.describe("webview accessibility ratchet", () => {
       expect(await spinner!.evaluate((node) => node.isConnected)).toBe(true)
     }
 
+    await row.locator('[data-slot="task-header-agent-main"]').focus()
     await page.clock.runFor(1000)
     await expect(toggle).toHaveAttribute("aria-expanded", "false")
+    await expect(toggle).toBeFocused()
+    await expect(toggle).toHaveAccessibleName("1 background agent (Done)")
     await expect(list).toBeHidden()
     await expect(preview).toHaveAttribute("data-status", "completed")
     await expect(preview).toHaveAttribute("aria-hidden", "false")
@@ -154,6 +157,7 @@ test.describe("webview accessibility ratchet", () => {
     const summary = agents.locator('[data-slot="task-header-agents-summary"]')
     await expect(summary).toHaveAttribute("aria-hidden", "false")
     await expect(summary).toHaveText("1 background agent")
+    await expect(summary).toHaveAccessibleName("1 background agent (Done)")
     await expect(summary.locator('[data-component="icon"]')).toBeVisible()
     await expect(summary.locator('[data-component="icon"] use')).toHaveAttribute("href", "#opencode-icon-circle-check")
     await expect(preview).toHaveAttribute("aria-hidden", "true")
@@ -220,6 +224,10 @@ test.describe("webview accessibility ratchet", () => {
     const summary = agents.locator('[data-slot="task-header-agents-summary"]')
     await expect(summary).toHaveAttribute("aria-hidden", "false")
     await expect(summary).toHaveText("3 background agents")
+    await expect(summary).toHaveAccessibleName("3 background agents (Error)")
+    await expect(agents.locator('[data-slot="task-header-agents-toggle"]')).toHaveAccessibleName(
+      "3 background agents (Error)",
+    )
     await expect(summary.locator('[data-component="icon"]')).toBeVisible()
     await expect(summary.locator('[data-component="icon"] use')).toHaveAttribute("href", "#opencode-icon-warning")
     await expect(agents.locator('[data-slot="task-header-agents-item"][aria-hidden="false"]')).toHaveCount(0)

--- a/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
@@ -39,6 +39,8 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
   const [loaded, setLoaded] = createSignal(false)
   const [mounted, setMounted] = createSignal(false)
   let pending: string | undefined
+  let list: HTMLDivElement | undefined
+  let toggle: HTMLButtonElement | undefined
   let revision = 0
 
   createEffect(
@@ -123,7 +125,9 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
     on(
       () => active().length > 0,
       (running, previous) => {
-        if (previous && !running) setOpen(false)
+        if (!previous || running) return
+        if (list?.contains(document.activeElement)) toggle?.focus({ preventScroll: true })
+        setOpen(false)
       },
     ),
   )
@@ -144,6 +148,9 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
   const count = createMemo(() => (open() ? 0 : Math.min(layout().count, visible().length)))
   const remaining = createMemo(() => visible().length - count())
   const caption = createMemo(() => (waiting() > 0 ? language.t("task.backgroundAgents.waiting") : summary()))
+  const accessible = createMemo(() =>
+    state() === "running" ? caption() : `${caption()} (${language.t(`task.backgroundAgents.status.${state()}`)})`,
+  )
   const more = (count: number) => language.t("task.backgroundAgents.more", { count: String(count) })
 
   createEffect(() => {
@@ -220,6 +227,7 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
             <Button
               data-slot="task-header-agents-summary"
               data-status={waiting() > 0 ? "waiting" : state()}
+              aria-label={accessible()}
               variant="ghost"
               size="small"
               aria-hidden={count() > 0}
@@ -281,8 +289,8 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
               aria-hidden={count() === 0 || remaining() === 0}
               tabIndex={count() > 0 && remaining() > 0 ? 0 : -1}
               aria-expanded={open()}
-              aria-label={`${more(remaining())}: ${caption()}`}
-              title={caption()}
+              aria-label={`${more(remaining())}: ${accessible()}`}
+              title={accessible()}
               onClick={() => setOpen((value) => !value)}
             >
               <span data-slot="task-header-agents-overflow-label">
@@ -293,11 +301,12 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
           </div>
           <Button
             data-slot="task-header-agents-toggle"
+            ref={toggle}
             variant="ghost"
             size="small"
             icon={waiting() > 0 ? "warning" : undefined}
-            aria-label={caption()}
-            title={caption()}
+            aria-label={accessible()}
+            title={accessible()}
             aria-expanded={open()}
             onClick={() => setOpen((value) => !value)}
           >
@@ -327,7 +336,7 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
           </Show>
         </div>
         <Show when={open()}>
-          <div data-slot="task-header-todos-list">
+          <div data-slot="task-header-todos-list" ref={list}>
             <Show when={visible().some((agent) => agent.permission || agent.question)}>
               <div data-slot="task-header-agent-attention">
                 <Icon name="warning" size="small" />

--- a/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
@@ -13,6 +13,7 @@
 import { Component, For, Show, createMemo, createSignal, onCleanup, onMount, createEffect, on } from "solid-js"
 import { Button } from "@kilocode/kilo-ui/button"
 import { Icon } from "@kilocode/kilo-ui/icon"
+import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
 import type { BackgroundJobInfo } from "../../types/messages"
 import { useLanguage } from "../../context/language"
@@ -42,6 +43,7 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
 
   createEffect(
     on(session.currentSessionID, () => {
+      setOpen(false)
       setLoaded(false)
       setJobs([])
       pending = undefined
@@ -103,8 +105,9 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
   const summary = createMemo(() => {
     const running = visible().filter((agent) => agent.status === "running").length
     const total = visible().length
-    if (total === 1 && running === 1) return language.t("task.backgroundAgents.running.one")
-    if (running === total) return language.t("task.backgroundAgents.running.many", { count: String(total) })
+    if (total === 1) return language.t("task.backgroundAgents.running.one")
+    if (running === 0 || running === total)
+      return language.t("task.backgroundAgents.running.many", { count: String(total) })
     return language.t("task.backgroundAgents.summary", { running: String(running), total: String(total) })
   })
 
@@ -116,14 +119,28 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
   const active = createMemo(() =>
     visible().filter((agent) => agent.status === "running" || agent.permission || agent.question),
   )
-  const keys = createMemo(() => active().map((agent) => agent.jobID))
+  createEffect(
+    on(
+      () => active().length > 0,
+      (running, previous) => {
+        if (previous && !running) setOpen(false)
+      },
+    ),
+  )
+  const state = createMemo(() => {
+    if (active().length > 0) return "running"
+    if (visible().some((agent) => agent.status === "error")) return "error"
+    if (visible().some((agent) => agent.status === "cancelled")) return "cancelled"
+    return "completed"
+  })
+  const keys = createMemo(() => visible().map((agent) => agent.jobID))
   const signature = createMemo(() => keys().join("\0"))
   const [box, setBox] = createSignal<HTMLDivElement>()
   const [preview, setPreview] = createSignal<HTMLDivElement>()
   const [overflow, setOverflow] = createSignal<HTMLButtonElement>()
   const [layout, setLayout] = createSignal({ count: 0, offset: 0 })
-  const count = createMemo(() => (open() ? 0 : Math.min(layout().count, active().length)))
-  const remaining = createMemo(() => active().length - count())
+  const count = createMemo(() => (open() ? 0 : Math.min(layout().count, visible().length)))
+  const remaining = createMemo(() => visible().length - count())
   const caption = createMemo(() => (waiting() > 0 ? language.t("task.backgroundAgents.waiting") : summary()))
   const more = (count: number) => language.t("task.backgroundAgents.more", { count: String(count) })
 
@@ -153,12 +170,15 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
 
   const status = (agent: BackgroundAgent) => language.t(`task.backgroundAgents.status.${agent.status}`)
 
-  const icon = (agent: BackgroundAgent) => {
-    if (agent.status === "completed") return "circle-check" as const
-    if (agent.status === "cancelled") return "circle-ban-sign" as const
-    if (agent.status === "error") return "warning" as const
+  const icon = (status: BackgroundAgent["status"]) => {
+    if (status === "completed") return "circle-check" as const
+    if (status === "cancelled") return "circle-ban-sign" as const
+    if (status === "error") return "warning" as const
     return undefined
   }
+
+  const tooltip = (agent: BackgroundAgent) =>
+    `${language.t("task.backgroundAgents.open")}: ${label(agent)} (${agent.permission || agent.question ? language.t("task.backgroundAgents.needsInput") : status(agent)})`
 
   const openAgent = (agent: BackgroundAgent) =>
     openSubagent({
@@ -197,6 +217,7 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
           <div data-slot="task-header-agents-content" ref={setBox}>
             <Button
               data-slot="task-header-agents-summary"
+              data-status={waiting() > 0 ? "waiting" : state()}
               variant="ghost"
               size="small"
               aria-hidden={count() > 0}
@@ -207,8 +228,8 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
               <Show
                 when={waiting() > 0}
                 fallback={
-                  <Show when={active().length > 0} fallback={<Icon name="task" size="small" />}>
-                    <Spinner />
+                  <Show when={icon(state())} fallback={<Spinner />}>
+                    {(name) => <Icon name={name()} size="small" />}
                   </Show>
                 }
               >
@@ -219,23 +240,27 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
             <div data-slot="task-header-agents-preview" ref={setPreview}>
               <For each={keys()}>
                 {(id, index) => (
-                  <Show when={active().find((agent) => agent.jobID === id)}>
+                  <Show when={visible().find((agent) => agent.jobID === id)}>
                     {(agent) => (
                       <Button
                         data-slot="task-header-agents-item"
+                        data-status={agent().permission || agent().question ? "waiting" : agent().status}
                         variant="ghost"
                         size="small"
                         aria-hidden={index() >= count()}
                         tabIndex={index() < count() ? 0 : -1}
-                        title={`${language.t("task.backgroundAgents.open")}: ${label(agent())}`}
-                        aria-label={`${language.t("task.backgroundAgents.open")}: ${label(agent())}${
-                          agent().permission || agent().question
-                            ? ` (${language.t("task.backgroundAgents.needsInput")})`
-                            : ""
-                        }`}
+                        title={tooltip(agent())}
+                        aria-label={tooltip(agent())}
                         onClick={() => openAgent(agent())}
                       >
-                        <Show when={agent().permission || agent().question} fallback={<Spinner />}>
+                        <Show
+                          when={agent().permission || agent().question}
+                          fallback={
+                            <Show when={icon(agent().status)} fallback={<Spinner />}>
+                              {(name) => <Icon name={name()} size="small" />}
+                            </Show>
+                          }
+                        >
                           <Icon name="warning" size="small" />
                         </Show>
                         <span dir="auto">{label(agent())}</span>
@@ -259,7 +284,7 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
               onClick={() => setOpen((value) => !value)}
             >
               <span data-slot="task-header-agents-overflow-label">
-                <span aria-hidden="true">{more(active().length)}</span>
+                <span aria-hidden="true">{more(visible().length)}</span>
                 <span>{more(remaining())}</span>
               </span>
             </Button>
@@ -289,17 +314,14 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
             </Button>
           </Show>
           <Show when={!props.readonly && visible().some((agent) => agent.status !== "running")}>
-            <Button
+            <IconButton
               icon="close-small"
               variant="ghost"
               size="small"
               aria-label={language.t("task.backgroundAgents.clearFinished")}
+              title={language.t("task.backgroundAgents.clearFinished")}
               onClick={hideFinished}
-            >
-              <span data-slot="task-header-agent-action-label">
-                {language.t("task.backgroundAgents.clearFinished")}
-              </span>
-            </Button>
+            />
           </Show>
         </div>
         <Show when={open()}>
@@ -315,7 +337,7 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
                 <Show when={visible().find((agent) => agent.jobID === id)}>
                   {(agent) => (
                     <div data-slot="task-header-agent" data-status={agent().status}>
-                      <Show when={icon(agent())} fallback={<Spinner />}>
+                      <Show when={icon(agent().status)} fallback={<Spinner />}>
                         {(name) => <Icon name={name()} size="small" data-slot="task-header-agent-status" />}
                       </Show>
                       <button

--- a/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/BackgroundAgents.tsx
@@ -133,7 +133,9 @@ export const BackgroundAgents: Component<{ readonly?: boolean }> = (props) => {
     if (visible().some((agent) => agent.status === "cancelled")) return "cancelled"
     return "completed"
   })
-  const keys = createMemo(() => visible().map((agent) => agent.jobID))
+  const keys = createMemo(() =>
+    [...active(), ...visible().filter((agent) => !active().includes(agent))].map((agent) => agent.jobID),
+  )
   const signature = createMemo(() => keys().join("\0"))
   const [box, setBox] = createSignal<HTMLDivElement>()
   const [preview, setPreview] = createSignal<HTMLDivElement>()

--- a/packages/kilo-vscode/webview-ui/src/styles/task-header.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/task-header.css
@@ -302,6 +302,21 @@
     color: var(--text-weak);
   }
 
+  [data-status="completed"] > [data-component="icon"] {
+    --icon-base: var(--icon-success-base);
+    color: var(--icon-success-base);
+  }
+
+  [data-status="error"] > [data-component="icon"] {
+    --icon-base: var(--icon-critical-base);
+    color: var(--icon-critical-base);
+  }
+
+  [data-status="waiting"] > [data-component="icon"] {
+    --icon-base: var(--icon-warning-base);
+    color: var(--icon-warning-base);
+  }
+
   [data-slot="task-header-agent-status-label"] {
     color: var(--text-weak);
     font-size: var(--kilo-font-size-11);


### PR DESCRIPTION
## What Problem This Solves

When background agents finished, their inline names disappeared and the header fell back to “0 of N background agents running.” An expanded list also stayed open after the last agent finished.

## Why This Change Was Made

Use the same compact header throughout the job lifecycle. Keep finished agent names available with static completion, cancellation, or error icons, and collapse the list once when the last active agent finishes. Manual reopening stays open across later polling updates. Keep the clear-finished action icon-only so it does not crowd out agent names.

## User Impact

- Finished agents remain directly accessible from the header without a loading spinner.
- Completion and error colors match the session-tab status indicators.
- Narrow headers retain the summary and overflow controls without claiming that zero agents are running.
- Active agents and agents awaiting input stay ahead of finished jobs in the inline preview.
- Auto-collapse preserves keyboard focus, and compact summaries expose the finished status to screen readers.

## Evidence

Validation after rebasing onto main and applying review fixes: the extension build (including typecheck and lint), 22 background-agent unit tests, three focused Chromium tests, Knip, and the Kilo marker guard all pass. Browser regressions also cover active-first overflow, keyboard focus after auto-collapse, and accessible terminal-state names.

Isolated VS Code self-tests used deterministic job-response fixtures, without model calls. Verified running-to-completed auto-collapse, manual reopening across polling, completed/error/cancelled icons, and clearing finished jobs. Screenshots below show the completed and mixed terminal states; both are cropped to the affected header.

**Completed agents**

<img width="1000" alt="Completed background agents retain their names with green check icons in one compact row" src="https://marius-kilocode.github.io/pr-assets/20260901-background-agents-completed-1147.png" />

**Completed, failed, and cancelled agents**

<img width="1000" alt="Background agent header shows distinct completion, error, and cancellation icons without spinners" src="https://marius-kilocode.github.io/pr-assets/20260901-background-agents-terminal-states-1147.png" />
