### PR TITLE
refactor(kilo-console): share available provider selection

### DIFF
--- a/packages/kilo-console/src/routes/config/state/agents.ts
+++ b/packages/kilo-console/src/routes/config/state/agents.ts
@@ -4,7 +4,7 @@ import type { AgentBuilderPreviewResponse, Model, Provider } from "@kilocode/sdk
 import { previewAgent, saveAgent, type AgentPayload, type Scope, type Snapshot } from "../../../client"
 import { useConfig } from "../../../context/config"
 import { clean, friendly, sorted, toMode, toolCapabilities, toolName } from "../../../shared/utils"
-import { choices } from "./models"
+import { available, choices } from "./models"
 import {
   defaults,
   defs,
@@ -42,12 +42,6 @@ export const snippets = [
   "Inspect relevant files first, then summarize the root cause before editing.",
   "Run the smallest relevant validation checks and report any remaining failures.",
 ]
-
-function order(a: Provider, b: Provider) {
-  if (a.id === "kilo") return -1
-  if (b.id === "kilo") return 1
-  return a.name.localeCompare(b.name)
-}
 
 function same(item: Item, ref: Favorite) {
   if (item.provider.id === ref.providerID && item.model.id === ref.modelID) return true
@@ -178,15 +172,7 @@ export function useAgentBuilder(agent?: Accessor<string | undefined>) {
   const [search, setSearch] = createSignal("")
   const [chosen, setChosen] = createSignal<string[]>([])
 
-  const providers = createMemo(() => {
-    const data = snap()
-    if (!data) return []
-    const ids = new Set([...Object.keys(data.effective.provider ?? {}), ...data.providers.connected])
-    return data.providers.all
-      .filter((provider) => ids.has(provider.id))
-      .filter((provider) => Object.keys(provider.models).length > 0)
-      .sort(order)
-  })
+  const providers = createMemo(() => available(snap()))
 
   const all = createMemo(() => {
     return providers().flatMap((provider) =>

--- a/packages/kilo-console/src/routes/config/state/models.ts
+++ b/packages/kilo-console/src/routes/config/state/models.ts
@@ -1,6 +1,6 @@
 import { createMemo, createSignal } from "solid-js"
 import type { Model, Provider } from "@kilocode/sdk/v2/client"
-import { saveModelState, type ModelRef } from "../../../client"
+import { saveModelState, type ModelRef, type Snapshot } from "../../../client"
 import { useConfig } from "../../../context/config"
 import { hasGateway, visible } from "./privacy"
 
@@ -52,6 +52,15 @@ function same(item: Item, ref: ModelRef) {
   return item.model.providerID === ref.providerID && item.model.id === ref.modelID
 }
 
+export function available(data?: Snapshot) {
+  if (!data) return []
+  const ids = new Set([...Object.keys(data.effective.provider ?? {}), ...data.providers.connected])
+  return data.providers.all
+    .filter((provider) => ids.has(provider.id))
+    .filter((provider) => Object.keys(provider.models).length > 0)
+    .sort(order)
+}
+
 export function choices(search: string, items: Item[], fav: (item: Item) => boolean) {
   const term = search.trim().toLowerCase()
   return items
@@ -87,15 +96,7 @@ export function useModelSettings() {
   const [picker, setPicker] = createSignal("")
   const [choice, setChoice] = createSignal("")
 
-  const providers = createMemo(() => {
-    const data = snap()
-    if (!data) return []
-    const ids = new Set([...Object.keys(data.effective.provider ?? {}), ...data.providers.connected])
-    return data.providers.all
-      .filter((provider) => ids.has(provider.id))
-      .filter((provider) => Object.keys(provider.models).length > 0)
-      .sort(order)
-  })
+  const providers = createMemo(() => available(snap()))
 
   const all = createMemo(() => {
     return providers().flatMap((provider) =>

--- a/script/kilocode-duplication-allowlist.json
+++ b/script/kilocode-duplication-allowlist.json
@@ -64,18 +64,6 @@
     },
     {
       "files": [
-        "packages/kilo-console/src/routes/config/state/agents.ts",
-        "packages/kilo-console/src/routes/config/state/models.ts"
-      ],
-      "fingerprint": "1da5f78ab9ff1975",
-      "maxMatches": 1,
-      "maxTokens": 164,
-      "kind": "legacy",
-      "owner": "kilo-console",
-      "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
-    },
-    {
-      "files": [
         "packages/kilo-indexing/src/indexing/embedders/openai-compatible.ts",
         "packages/kilo-indexing/src/indexing/embedders/openrouter.ts"
       ],


### PR DESCRIPTION
## What Problem This Solves
Agents and Models repeat the same provider filtering and Kilo-first ordering.

## Why This Change Was Made
Move that pure selection into available in the existing models state module. Both caller-owned memos remain. Keep flattening, favorite matching, picker choices, and selection/save behavior unchanged. Reuse the identical comparator already in models instead of keeping a second copy.

## User Impact
No intended behavior change. The list still includes configured or connected providers, excludes providers with no models, puts Kilo first, and sorts the rest by provider name. Missing snapshot data still produces an empty list.

## Evidence
- Three files: 13 additions and 38 deletions, net 25 fewer lines (13 production and 12 allowlist). No new files, dependencies, or tests.
- Existing console suite: 33 pass. Typecheck and production build pass. Focused lint has zero errors and two existing warnings; build retains its existing large-chunk warning. git diff check passes.
- Direct smoke checks of the actual helper pass for missing data, configured/connected union, empty-model exclusion, Kilo-first/name ordering, and unchanged input. The in-memory fixture used an isolated HOME/XDG profile and blocked network access; the profile was removed. No live model or UI requests.
- Fresh report: 22 to 21 duplicate pairs, 426 to 404 duplicated lines, 2922 to 2758 duplicated tokens. Only fingerprint 1da5f78ab9ff1975 removed; duplication ratchet passes.