### PR TITLE
fix(agent-manager): speed up long-session forks

### DIFF
--- a/.changeset/fast-session-forks.md
+++ b/.changeset/fast-session-forks.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Speed up forking long sessions while preserving conversation history and independent child sessions.

--- a/packages/core/src/event.ts
+++ b/packages/core/src/event.ts
@@ -7,6 +7,7 @@ import { and, asc, eq, gt, inArray } from "drizzle-orm"
 import { Database } from "./database/database"
 import { EventSequenceTable, EventTable } from "./event/sql"
 import * as EventStorage from "./kilocode/event-storage" // kilocode_change - released tool content shapes
+import * as EventBatch from "./kilocode/event-batch" // kilocode_change
 import { Location } from "./location"
 import { makeGlobalNode } from "./effect/app-node"
 import { isDeepStrictEqual } from "node:util"
@@ -131,6 +132,12 @@ export interface Interface {
     data: Data<D>,
     options?: PublishOptions,
   ) => Effect.Effect<Payload<D>>
+  // kilocode_change start
+  readonly publishAll: (
+    entries: readonly { readonly definition: Definition; readonly data: Data<Definition> }[],
+    options?: PublishOptions,
+  ) => Effect.Effect<void>
+  // kilocode_change end
   readonly subscribe: <D extends Definition>(definition: D) => Stream.Stream<Payload<D>>
   readonly all: () => Stream.Stream<Payload>
   readonly durable: (input: { readonly aggregateID: string; readonly after?: number }) => Stream.Stream<Payload>
@@ -624,6 +631,7 @@ export const layerWith = (options?: LayerOptions) =>
 
       return Service.of({
         publish,
+        publishAll: EventBatch.make({ db, projectors, durable: pubsub.durable, notify }), // kilocode_change
         subscribe,
         all: streamAll,
         durable,

--- a/packages/core/src/kilocode/event-batch.ts
+++ b/packages/core/src/kilocode/event-batch.ts
@@ -1,0 +1,132 @@
+import { Effect, Option, PubSub, Schema } from "effect"
+import { eq } from "drizzle-orm"
+import { Event, type Payload } from "@opencode-ai/schema/event"
+import type { Database } from "../database/database"
+import { InvalidDurableEventError, type Interface, type Subscriber } from "../event"
+import { EventSequenceTable, EventTable } from "../event/sql"
+import { Location } from "../location"
+import * as EventStorage from "./event-storage"
+
+const record = (input: unknown): input is Record<string, unknown> =>
+  typeof input === "object" && input !== null && !Array.isArray(input)
+
+export function make(input: {
+  readonly db: Database.Interface["db"]
+  readonly projectors: ReadonlyMap<string, readonly Subscriber[]>
+  readonly durable: ReadonlyMap<string, ReadonlySet<PubSub.PubSub<void>>>
+  readonly notify: (event: Payload, isolate: boolean) => Effect.Effect<void>
+}): Interface["publishAll"] {
+  return (entries, options) =>
+    Effect.gen(function* () {
+      if (entries.length === 0) return
+      const context = Option.getOrUndefined(yield* Effect.serviceOption(Location.Service))
+      const location =
+        options?.location ?? (context ? { directory: context.directory, workspaceID: context.workspaceID } : undefined)
+      const sequences = new Map<string, number>()
+      const pending = new Array<Payload>()
+      const rows = new Array<typeof EventTable.$inferInsert>()
+
+      yield* input.db
+        .transaction(
+          () =>
+            Effect.gen(function* () {
+              for (const entry of entries) {
+                const event: Payload = {
+                  id: options?.id ?? Event.ID.create(),
+                  ...(options?.metadata ? { metadata: options.metadata } : {}),
+                  type: entry.definition.type,
+                  ...(location ? { location } : {}),
+                  data: entry.data,
+                }
+                const durable = entry.definition.durable
+                if (!durable) {
+                  if (options?.commit)
+                    throw new InvalidDurableEventError({
+                      type: event.type,
+                      message: "Local commit hooks require a durable event",
+                    })
+                  pending.push(event)
+                  continue
+                }
+                const aggregate = record(event.data) ? event.data[durable.aggregate] : undefined
+                if (typeof aggregate !== "string")
+                  throw new InvalidDurableEventError({
+                    type: event.type,
+                    message: `Expected string aggregate field ${durable.aggregate}`,
+                  })
+                const latest =
+                  sequences.get(aggregate) ??
+                  (yield* input.db
+                    .select({ seq: EventSequenceTable.seq })
+                    .from(EventSequenceTable)
+                    .where(eq(EventSequenceTable.aggregate_id, aggregate))
+                    .get()
+                    .pipe(Effect.orDie))?.seq ??
+                  -1
+                const seq = latest + 1
+                const encoded = EventStorage.encode(
+                  entry.definition.type,
+                  Schema.encodeUnknownSync(entry.definition.data)(event.data),
+                )
+                if (!record(encoded))
+                  throw new InvalidDurableEventError({
+                    type: event.type,
+                    message: "Expected object durable event data",
+                  })
+                const committed: Payload = {
+                  ...event,
+                  durable: { aggregateID: aggregate, seq, version: durable.version },
+                }
+                for (const projector of input.projectors.get(event.type) ?? []) {
+                  yield* projector(committed)
+                }
+                if (options?.commit) yield* options.commit(seq)
+                sequences.set(aggregate, seq)
+                rows.push({
+                  id: event.id,
+                  aggregate_id: aggregate,
+                  seq,
+                  type: Event.versionedType(event.type, durable.version),
+                  data: encoded,
+                })
+                pending.push(committed)
+              }
+              for (const [aggregate, seq] of sequences) {
+                yield* input.db
+                  .insert(EventSequenceTable)
+                  .values({ aggregate_id: aggregate, seq })
+                  .onConflictDoUpdate({ target: EventSequenceTable.aggregate_id, set: { seq } })
+                  .run()
+                  .pipe(Effect.orDie)
+              }
+              for (let offset = 0; offset < rows.length; offset += 100) {
+                yield* input.db
+                  .insert(EventTable)
+                  .values(rows.slice(offset, offset + 100))
+                  .run()
+                  .pipe(Effect.orDie)
+              }
+            }),
+          { behavior: "immediate" },
+        )
+        .pipe(
+          Effect.orDie,
+          Effect.tap(() =>
+            Effect.forEach(
+              pending,
+              (event) =>
+                Effect.forEach(
+                  event.durable ? (input.durable.get(event.durable.aggregateID) ?? []) : [],
+                  (wake) => PubSub.publish(wake, undefined),
+                  { discard: true },
+                ),
+              { discard: true },
+            ),
+          ),
+          Effect.uninterruptible,
+        )
+      for (const event of pending) {
+        yield* input.notify(event, event.durable !== undefined)
+      }
+    })
+}

--- a/packages/core/test/kilocode/event-batch.test.ts
+++ b/packages/core/test/kilocode/event-batch.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "bun:test"
+import { Database as SQLite } from "bun:sqlite"
+import { Effect, Schema } from "effect"
+import path from "path"
+import { Database } from "@opencode-ai/core/database/database"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { EventV2 } from "@opencode-ai/core/event"
+import { EventSequenceTable, EventTable } from "@opencode-ai/core/event/sql"
+import { tmpdir } from "../fixture/tmpdir"
+import { testEffect } from "../lib/effect"
+
+const layer = (filename = ":memory:") =>
+  AppNodeBuilder.build(LayerNode.group([EventV2.node, Database.node]), [
+    [Database.node, Database.layerFromPath(filename)],
+  ])
+const it = testEffect(layer())
+const Durable = EventV2.define({
+  type: "test.batch.durable",
+  durable: { version: 1, aggregate: "id" },
+  schema: { id: Schema.String, value: Schema.Int },
+})
+const entries = Array.from({ length: 201 }, (_, value) => ({
+  definition: Durable,
+  data: { id: value % 2 === 0 ? "one" : "two", value },
+}))
+
+test("commits every chunk before notifying and preserves per-aggregate sequences", async () => {
+  await using tmp = await tmpdir()
+  const filename = path.join(tmp.path, "batch.db")
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const events = yield* EventV2.Service
+      const { db } = yield* Database.Service
+      for (const id of ["one", "two"]) yield* events.publish(Durable, { id, value: -1 })
+      const reader = yield* Effect.acquireRelease(
+        Effect.sync(() => new SQLite(filename, { readonly: true })),
+        (reader) => Effect.sync(() => reader.close()),
+      )
+      const observed = new Array<unknown>()
+      const stop = yield* events.listen(() =>
+        Effect.sync(() => observed.push(reader.query("SELECT COUNT(*) AS count FROM event").get())),
+      )
+      yield* events.publishAll(entries)
+      yield* stop
+      expect(observed).toEqual(Array.from({ length: 201 }, () => ({ count: 203 })))
+      const rows = yield* db.select().from(EventTable).orderBy(EventTable.seq).all()
+      for (const [id, count] of [
+        ["one", 102],
+        ["two", 101],
+      ] as const) {
+        expect(rows.filter((row) => row.aggregate_id === id).map((row) => row.seq)).toEqual(
+          Array.from({ length: count }, (_, seq) => seq),
+        )
+      }
+      const next = yield* events.publish(Durable, { id: "one", value: 201 })
+      expect(next.durable?.seq).toBe(102)
+    }).pipe(Effect.provide(layer(filename)), Effect.scoped),
+  )
+})
+
+it.effect("rolls back all chunks and projections without notifying on failure", () =>
+  Effect.gen(function* () {
+    const events = yield* EventV2.Service
+    const { db } = yield* Database.Service
+    const received = new Array<EventV2.Payload>()
+    yield* db.run("CREATE TABLE batch_probe (value integer NOT NULL)")
+    yield* events.project(Durable, (event) =>
+      Effect.gen(function* () {
+        yield* db.run("INSERT INTO batch_probe (value) VALUES (1)").pipe(Effect.orDie)
+        if (event.data.value === 100) yield* Effect.die("batch failed")
+      }),
+    )
+    yield* events.listen((event) => Effect.sync(() => received.push(event)))
+    const exit = yield* events.publishAll(entries).pipe(Effect.exit)
+    expect(String(exit)).toContain("batch failed")
+    expect(yield* db.all("SELECT value FROM batch_probe")).toEqual([])
+    expect(yield* db.select().from(EventTable).all()).toEqual([])
+    expect(yield* db.select().from(EventSequenceTable).all()).toEqual([])
+    expect(received).toEqual([])
+    const next = yield* events.publish(Durable, { id: "one", value: 0 })
+    expect(next.durable?.seq).toBe(0)
+  }),
+)

--- a/packages/core/test/session-runner-tool-events.test.ts
+++ b/packages/core/test/session-runner-tool-events.test.ts
@@ -26,6 +26,7 @@ const capture = () => {
         })
         return event
       }),
+    publishAll: () => Effect.die("Unexpected publishAll"), // kilocode_change
     subscribe: () => Stream.empty,
     all: () => Stream.empty,
     durable: () => Stream.empty,

--- a/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
+++ b/packages/kilo-vscode/src/services/cli-backend/sdk-sse-adapter.ts
@@ -168,6 +168,7 @@ export class SdkSSEAdapter {
         console.log("[Kilo New] SSE: 🎬 Calling SDK global.event()...")
         const events = await this.client.global.event({
           signal: attempt.signal,
+          headers: { "x-kilo-sse-skip-fork-sync": "1" },
           // Disable SDK-internal retries — consumeLoop handles reconnection
           // with its own outer while-loop. Without this the SDK's infinite
           // retry loop with exponential backoff runs in parallel, causing

--- a/packages/kilo-vscode/tests/unit/sdk-sse-adapter.test.ts
+++ b/packages/kilo-vscode/tests/unit/sdk-sse-adapter.test.ts
@@ -4,6 +4,7 @@ import { KiloConnectionService } from "../../src/services/cli-backend/connection
 import { SdkSSEAdapter, type SSEPayload } from "../../src/services/cli-backend/sdk-sse-adapter"
 
 type Opts = {
+  headers?: Record<string, string>
   onSseError?: (error: unknown) => void
   signal?: AbortSignal
 }
@@ -59,6 +60,7 @@ describe("SdkSSEAdapter", () => {
   it("normalizes nested sync envelopes at the SSE boundary", async () => {
     const adapter = new SdkSSEAdapter(
       client(async function* (opts) {
+        expect(opts.headers).toEqual({ "x-kilo-sse-skip-fork-sync": "1" })
         yield sync()
         await aborted(opts.signal)
       }),

--- a/packages/opencode/src/event-v2-bridge.ts
+++ b/packages/opencode/src/event-v2-bridge.ts
@@ -5,6 +5,7 @@ import { InstanceRef, WorkspaceRef } from "@/effect/instance-ref"
 import { GlobalBus } from "@/bus/global"
 import { EventManifest } from "@/event-manifest" // kilocode_change
 import * as EventWire from "@/kilocode/event-wire" // kilocode_change
+import { batch } from "@/kilocode/event-v2-bridge" // kilocode_change
 import { EventV2 } from "@opencode-ai/core/event"
 import { Location } from "@opencode-ai/core/location"
 import { Project } from "@opencode-ai/core/project"
@@ -53,6 +54,7 @@ export const layer = Layer.effect(
           directory: event.location?.directory ?? ctx?.directory ?? "global", // kilocode_change - instance-less events are tagged "global" on the wire
           project: ctx?.project.id,
           workspace: workspaceID,
+          ...(event.metadata?.fork === true && { [EventWire.copied]: true }), // kilocode_change
           payload: {
             type: "sync",
             syncEvent: {
@@ -68,7 +70,7 @@ export const layer = Layer.effect(
     )
     yield* Effect.addFinalizer(() => unsubscribe)
 
-    return Service.of({ ...events, publish })
+    return Service.of({ ...events, publish, publishAll: batch(events) }) // kilocode_change
   }),
 )
 

--- a/packages/opencode/src/kilocode/event-v2-bridge.ts
+++ b/packages/opencode/src/kilocode/event-v2-bridge.ts
@@ -1,0 +1,24 @@
+import type { EventV2 } from "@opencode-ai/core/event"
+import { Location } from "@opencode-ai/core/location"
+import { Project } from "@opencode-ai/core/project"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Effect } from "effect"
+import { InstanceRef, WorkspaceRef } from "@/effect/instance-ref"
+
+export const batch =
+  (events: EventV2.Interface): EventV2.Interface["publishAll"] =>
+  (entries, options) =>
+    Effect.gen(function* () {
+      if (options?.location) return yield* events.publishAll(entries, options)
+      const ctx = yield* InstanceRef
+      if (!ctx) return yield* events.publishAll(entries, options)
+      const workspace = yield* WorkspaceRef
+      return yield* events.publishAll(entries, {
+        ...options,
+        location: new Location.Info({
+          directory: AbsolutePath.make(ctx.directory),
+          ...(workspace ? { workspaceID: workspace } : {}),
+          project: { id: Project.ID.make(ctx.project.id), directory: AbsolutePath.make(ctx.worktree) },
+        }),
+      })
+    })

--- a/packages/opencode/src/kilocode/event-wire.ts
+++ b/packages/opencode/src/kilocode/event-wire.ts
@@ -1,5 +1,7 @@
 import { DateTime, Schema } from "effect"
 
+export const copied = Symbol("copied")
+
 const codec = (schema: Schema.Top) => schema as Schema.Codec<unknown, unknown>
 
 function wire(value: unknown): unknown {

--- a/packages/opencode/src/kilocode/session/fork.ts
+++ b/packages/opencode/src/kilocode/session/fork.ts
@@ -1,4 +1,6 @@
 import { Effect, Schema } from "effect"
+import type { EventV2 } from "@opencode-ai/core/event"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
 import type { Session } from "@/session/session"
 import { MessageV2 } from "@/session/message-v2"
 import { MessageID, PartID, SessionID } from "@/session/schema"
@@ -7,6 +9,32 @@ import { KiloPartLifecycle } from "./part-lifecycle"
 
 const task = "task"
 type Ops = Pick<Session.Interface, "get" | "messages" | "create" | "updateMessage" | "updatePart">
+
+export function forkWriter(events: EventV2.Interface, ops: Pick<Ops, "get" | "messages" | "create">) {
+  const pending: Parameters<EventV2.Interface["publishAll"]>[0][number][] = []
+  const flush = Effect.suspend(() => {
+    if (!pending.length) return Effect.void
+    return events.publishAll(pending.splice(0), { metadata: { fork: true } })
+  })
+  return {
+    ...ops,
+    flush,
+    messages: (input: Parameters<Ops["messages"]>[0]) => flush.pipe(Effect.andThen(ops.messages(input))),
+    updateMessage: <T extends MessageV2.Info>(info: T): Effect.Effect<T> =>
+      Effect.sync(() => {
+        pending.push({ definition: SessionV1.Event.MessageUpdated, data: { sessionID: info.sessionID, info } })
+        return info
+      }),
+    updatePart: <T extends MessageV2.Part>(part: T): Effect.Effect<T> =>
+      Effect.sync(() => {
+        pending.push({
+          definition: SessionV1.Event.PartUpdated,
+          data: { sessionID: part.sessionID, part, time: Date.now() },
+        })
+        return part
+      }),
+  }
+}
 
 // Keep terminal task references so the fork can give them private child sessions.
 // In-flight jobs cannot be copied safely, so those remain historical errors.

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/global.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/global.ts
@@ -4,6 +4,7 @@ import { EffectBridge } from "@/effect/bridge"
 import { EventV2 } from "@opencode-ai/core/event"
 import { Installation } from "@/installation"
 import { disconnect } from "@/kilocode/server/sse" // kilocode_change
+import { copied } from "@/kilocode/event-wire" // kilocode_change
 import { disposeAllInstancesAndEmitGlobalDisposed } from "@/server/global-lifecycle"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { Effect, Queue, Schema } from "effect"
@@ -37,7 +38,12 @@ function eventResponse(request: HttpServerRequest.HttpServerRequest) {
     // kilocode_change end
     yield* Effect.logInfo("global event connected")
     const events = Stream.callback<GlobalBusEvent>((queue) => {
-      const handler = (event: GlobalBusEvent) => Queue.offerUnsafe(queue, event)
+      // kilocode_change start
+      const handler = (event: GlobalBusEvent) => {
+        if (request.headers["x-kilo-sse-skip-fork-sync"] === "1" && copied in event) return
+        Queue.offerUnsafe(queue, event)
+      }
+      // kilocode_change end
       return Effect.acquireRelease(
         Effect.sync(() => GlobalBus.on("event", handler)),
         () => Effect.sync(() => GlobalBus.off("event", handler)),

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -38,6 +38,7 @@ import { BackgroundProcess } from "@/kilocode/background-process"
 import * as SandboxInheritance from "@/kilocode/sandbox/inheritance"
 import { InteractiveTerminal } from "@/kilocode/interactive-terminal"
 import { KiloSession } from "@/kilocode/session"
+import { forkWriter } from "@/kilocode/session/fork"
 import { kiloSessionFork } from "@/kilocode/session/fork-command"
 import { KiloSessionEvent } from "@/kilocode/session/event"
 import { SessionExport } from "@/kilocode/session-export"
@@ -871,6 +872,7 @@ export const layer: Layer.Layer<
         platform: KiloSession.resolvePlatform(original.id), // kilocode_change - inherit platform telemetry attribution
       })
       const idMap = new Map<string, MessageID>()
+      const writer = forkWriter(events, { get, messages, create }) // kilocode_change
 
       for (const msg of msgs) {
         if (input.messageID && msg.info.id >= input.messageID) break
@@ -878,13 +880,15 @@ export const layer: Layer.Layer<
         idMap.set(msg.info.id, newID)
 
         const parentID = msg.info.role === "assistant" && msg.info.parentID ? idMap.get(msg.info.parentID) : undefined
-        const cloned = yield* updateMessage({
+        // kilocode_change start
+        const cloned = yield* writer.updateMessage({
           ...msg.info,
           sessionID: session.id,
           id: newID,
           ...(msg.info.role === "assistant" && { cost: 0 }), // kilocode_change - count only spend incurred after the fork
           ...(parentID && { parentID }),
         })
+        // kilocode_change end
 
         for (const part of msg.parts) {
           // kilocode_change - detach task calls + drop transient parts before copying the forked transcript
@@ -900,17 +904,19 @@ export const layer: Layer.Layer<
           if (p.type === "compaction" && p.tail_start_id) {
             p.tail_start_id = idMap.get(p.tail_start_id)
           }
-          yield* updatePart(p)
+          yield* writer.updatePart(p) // kilocode_change
         }
       }
+      yield* writer.flush // kilocode_change
       // kilocode_change - preserve imported/cumulative diffs when forking (self-contained Storage runtime keeps this shared file off the legacy Storage layer)
       yield* carryForkDiff(input.sessionID, session.id)
       // kilocode_change start - fork terminal task children under the new parent and remap their references
       yield* KiloSession.remapChildren({
         sessionID: session.id,
         remapped: new Map([[input.sessionID, session.id]]),
-        ops: { get, messages, create, updateMessage, updatePart },
+        ops: writer,
       })
+      yield* writer.flush
       // kilocode_change end
       return session
     })

--- a/packages/opencode/test/kilocode/server/httpapi-global-sse.test.ts
+++ b/packages/opencode/test/kilocode/server/httpapi-global-sse.test.ts
@@ -7,6 +7,7 @@ import { Auth } from "../../../src/auth"
 import { GlobalBus } from "../../../src/bus/global"
 import { Config } from "../../../src/config/config"
 import { Installation } from "../../../src/installation"
+import { copied } from "../../../src/kilocode/event-wire"
 import { ServerAuth } from "../../../src/server/auth"
 import { RootHttpApi } from "../../../src/server/routes/instance/httpapi/api"
 import { GlobalPaths } from "../../../src/server/routes/instance/httpapi/groups/global"
@@ -45,20 +46,39 @@ const it = testEffect(apiLayer)
 
 describe("global SSE lifecycle", () => {
   it.live(
-    "removes event listeners after clients disconnect",
+    "filters duplicate fork sync events without leaking listeners",
     () =>
       Effect.gen(function* () {
         const count = GlobalBus.listenerCount("event")
 
         for (const attempt of [1, 2, 3]) {
-          const response = yield* HttpClient.get(GlobalPaths.event)
+          const response = yield* HttpClient.get(GlobalPaths.event, {
+            headers: attempt === 2 ? { "x-kilo-sse-skip-fork-sync": "1" } : {},
+          })
           expect(response.status).toBe(200)
-          const fiber = yield* response.stream.pipe(Stream.runDrain, Effect.forkChild({ startImmediately: true }))
+          const chunks = new Array<string>()
+          const fiber = yield* response.stream.pipe(
+            Stream.decodeText,
+            Stream.runForEach((chunk) => Effect.sync(() => chunks.push(chunk))),
+            Effect.forkChild({ startImmediately: true }),
+          )
 
           yield* pollWithTimeout(
             Effect.sync(() => (GlobalBus.listenerCount("event") === count + 1 ? true : undefined)),
             `global event stream ${attempt} did not subscribe`,
           )
+          for (const id of ["evt_normal", "evt_copy", "evt_live"]) {
+            GlobalBus.emit("event", {
+              payload: { id, type: id === "evt_normal" ? "message.updated" : "sync" },
+              ...(id === "evt_copy" && { [copied]: true }),
+            })
+          }
+          yield* pollWithTimeout(
+            Effect.sync(() => (chunks.join("").includes("evt_live") ? true : undefined)),
+            "global event stream did not deliver live events",
+          )
+          expect(chunks.join("")).toContain("evt_normal")
+          expect(chunks.join("").includes("evt_copy")).toBe(attempt !== 2)
           yield* Fiber.interrupt(fiber)
           yield* pollWithTimeout(
             Effect.sync(() => (GlobalBus.listenerCount("event") === count ? true : undefined)),


### PR DESCRIPTION
## What Problem This Solves

Forking a long Agent Manager transcript waits for the backend to copy the entire history. A synthetic session with 2,000 messages and 6,000 parts took approximately 7.10 seconds before the fork's first transcript page arrived. Most of that time was outside the webview: copying used thousands of individual durable-event transactions, and every copied message/part was then sent twice over SSE.

## Why This Change Was Made

Batch copied history into one transaction per flush while retaining the existing projectors, durable event rows, per-session sequence ordering, and notifications after commit. This also applies to copied child sessions and reference remapping. Keep the implementation and publishing adapter in Kilo-owned files, with small integration hooks in shared code.

VS Code now opts out of only the duplicate `sync` envelopes for copied message/part events, before those envelopes enter the SSE queue. Normal message/part updates, live sync events, in-process cloud ingestion, and default SSE clients remain unchanged. Workspace replication still receives the complete durable stream.

## User Impact

The matched long-session scenario improved from approximately 7.10 seconds to 2.8617 seconds for first-page arrival, approximately 4.24 seconds less waiting (59.7% lower latency, 2.48x faster). The final fork was ready after two animation frames at 2.9081 seconds.

History, parent-message references, and independent child sessions remain intact. This is not a constant-time or instant fork: the full history is still read, copied, serialized, and persisted, so larger sessions can take longer.

## Evidence

### Recorded performance

- Same warmed source session, forked from the Agent Manager tab context menu with the diff panel closed.
- Isolated VS Code development host on macOS arm64, using the CLI built from this worktree. No LLM generation was used.
- Fixture: **2,000 messages, 6,000 parts**, with **590,000 bytes of message JSON + 37,229,566 bytes of part JSON = 37,819,566 bytes (37.82 MB)**.
- Chromium trace and CPU captures were taken with `vscode-self-test`. All retained captures report no trace data loss.

| Measurement from fork click | Original | Batched writes | Batched writes + duplicate filtering |
|---|---|---|---|
| Fork response received | approximately 6,940 ms | 3,064.2 ms | 2,696.8 ms |
| First transcript page received | approximately 7,100 ms | approximately 3,240 ms | 2,861.7 ms |
| Two animation frames after page receipt | Not captured | 3,298.2 ms | 2,908.1 ms |

The duplicate-transfer change alone reduced response latency by **367.4 ms (12.0%)** and the two-frame readiness measurement by **390.1 ms (11.8%)** relative to batching alone. The original capture recorded only **80.457 ms of webview JavaScript time**, which ruled out tab rendering as the main source of the multi-second wait.

Precision and scope: baseline and intermediate page-arrival values above are retained rounded measurements; final timings and the later semantic marks are reported to 0.1 ms. These are single matched captures, not medians or p95 estimates. Capture windows differ, so aggregate renderer CPU/DOM counters are not presented as before/after improvements. Captures were recorded against base `ff9d04b0ef` during implementation, before the behavior-preserving helper extraction/test reduction and fast-forward to current `main`.

### Correctness and validation

- Verified the real UI fork, loading earlier history, and expanded copied tool output in isolated VS Code.
- The original stayed at 2,000 messages / 6,000 parts. The fork had 2,001 messages / 6,001 parts, including the existing synthetic handoff reminder, with **zero invalid assistant-parent references**.
- Kept only two new batch-safety tests: cross-chunk sequence/commit-before-notify behavior and whole-batch rollback without notifications. Existing fork and SSE tests cover isolation and transport compatibility.
- Core and CLI focused suites: **130 passing tests** after test reduction. Earlier extension fork/SSE suites: **29 passing tests**. Package/workspace typechecks, extension build, lint (no errors), annotations, facade guard, and extension unused-export checks passed during implementation.

<img width="700" alt="Forked large synthetic session with copied tool output intact" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260901-agent-manager-fork-history-1209.png" />
