### PR TITLE
fix(vscode): align answered question font with tool output

### DIFF
--- a/.changeset/question-output-font.md
+++ b/.changeset/question-output-font.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Match answered question text to other tool output and respect the Kilo font size setting.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/labs-tool-call-lab/search-previews-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/labs-tool-call-lab/search-previews-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96a537574ebee768dab6914ffb449665d6930d2d577bf1dc42eb38d975e9be10
-size 749704
+oid sha256:e8d6200ce8ccc691979f7a9e3c26d39a6eca9a1cc3d1c37d82edf8daaa403d50
+size 746349

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeSessionEditorManagerTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeSessionEditorManagerTest.kt
@@ -11,6 +11,7 @@ import ai.kilocode.client.onboarding.FakeOnboardingController
 import ai.kilocode.client.session.SessionManager
 import ai.kilocode.client.session.SessionRef
 import ai.kilocode.client.session.SessionUi
+import ai.kilocode.client.session.SessionUiFactory
 import ai.kilocode.client.session.controller.SessionController
 import ai.kilocode.client.testing.FakeAppRpcApi
 import ai.kilocode.client.testing.FakeSessionRpcApi
@@ -173,6 +174,8 @@ class WorktreeSessionEditorManagerTest : BasePlatformTestCase() {
     }
 
     fun `test deleting shown session removes it and falls back to next session`() {
+        val gate = CompletableDeferred<Unit>()
+        rpc.deleteGate = gate
         val first = session("ses_1", updated = 3.0)
         val second = session("ses_2", updated = 2.0)
         rpc.listed += first
@@ -186,8 +189,11 @@ class WorktreeSessionEditorManagerTest : BasePlatformTestCase() {
         flush()
 
         assertEquals(listOf(DIR to "ses_1", DIR to "ses_2"), created)
+        assertEquals(setOf(first.id), edt { manager.deleting() })
+        gate.complete(Unit)
         waitUntil { manager.deleting().isEmpty() }
         assertEquals(listOf(first.id to DIR), rpc.deletes.toList())
+        assertTrue(notified.toString(), notified.isEmpty())
     }
 
     fun `test deleting middle shown session falls back to next visible session`() {
@@ -406,7 +412,7 @@ class WorktreeSessionEditorManagerTest : BasePlatformTestCase() {
                     workspace,
                     sessions,
                     app,
-                    coroutines.scope,
+                    SessionUiFactory(coroutines.scope).scope(),
                     ref = ref,
                     manager = owner,
                     workspaces = workspaces,
@@ -450,7 +456,8 @@ class WorktreeSessionEditorManagerTest : BasePlatformTestCase() {
     private fun flush() = coroutines.drain()
 
     private fun waitUntil(block: () -> Boolean) {
-        assertTrue(coroutines.pumpUntil { edt(block) })
+        val done = coroutines.pumpUntil { edt(block) }
+        assertTrue("created=$created, deletes=${rpc.deletes}, notified=$notified", done)
     }
 
     private fun useInactiveDisposeTimeout() {

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -528,10 +528,11 @@ html[data-theme="kilo-vscode"] [data-component="todos"] {
   gap: 8px;
   padding: 8px;
   font-family: var(--font-family-sans);
-  font-size: var(--kilo-font-size-13);
+  font-size: var(--kilo-font-size-12);
   line-height: var(--line-height-large);
 
   [data-slot="question-answer-item"] {
+    font-size: inherit;
     display: flex;
     flex-direction: column;
     gap: 2px;

--- a/packages/kilo-vscode/tests/unit/font-size-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/font-size-arch.test.ts
@@ -102,6 +102,15 @@ describe("webview font-size architecture", () => {
     ).toEqual([])
   })
 
+  it("scales answered questions with the tool output font", () => {
+    const css = fs.readFileSync(path.join(REPO, "packages/kilo-ui/src/components/message-part.css"), "utf-8")
+    const block = css.slice(css.indexOf('[data-component="question-answers"]'))
+    expect(block.slice(0, block.indexOf('[data-slot="question-answer-item"]'))).toContain(
+      "font-size: var(--kilo-font-size-12)",
+    )
+    expect(block.match(/\[data-slot="question-answer-item"\]\s*\{([^}]+)\}/)?.[1]).toContain("font-size: inherit")
+  })
+
   it("uses scalable line heights in polished tool previews", () => {
     const files = [
       path.join(REPO, "packages/kilo-ui/src/components/basic-tool.css"),


### PR DESCRIPTION
## What Problem This Solves
Answered question text was larger than nearby tool text and retained a fixed 13px size when the Kilo font size changed.

## Why This Change Was Made
Use the same scalable 12px token as tool output and explicitly inherit it on question items. This overrides the fixed upstream item style without changing upstream files or the interactive question dock.

## User Impact
Completed question and answer text fits the session typography and scales with the Kilo font size setting. Colors, wrapping, and collapse controls stay unchanged.

## Evidence
- Extension compile (including lint and host/webview typechecks), explicit typecheck, formatting, marker guard, and all 4 font architecture tests pass.
- Isolated VS Code self-test used deterministic transcript data, with no model calls. Verified long-question wrapping and collapse/expand. Both question and answer compute to 12px at the default setting and 14.7692px with font size 16, with no horizontal overflow.
- Screenshots show the same fixture and sidebar width before and after rebuilding and restarting the extension. Images were reviewed for privacy and are hosted outside this repository.

### Before
<img width="514" alt="Before: answered question text is larger than the adjacent tool labels" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260901-question-font-before-1229.png" />

### After
<img width="514" alt="After: answered question text matches tool typography" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260901-question-font-after-1229.png" />

### Manual Test
Open an answered question, collapse and expand it, then change the Kilo font size. Confirm that question and answer text scale together and long text wraps without clipping.

### CI test repair
The JetBrains worktree test fixture passed its shared coroutine scope to each session UI. Disposing the shown session cancelled that scope and raced the delete job. The fixture now uses production-style child scopes, and the deletion test gates the request to verify disposal does not cancel it. Production JetBrains code is unchanged. All 32 targeted tests and JetBrains typecheck pass locally; the full VS Code unit suite passes (4,584 passed, 1 skipped), as does Knip. JetBrains Detekt reports 1,902 existing issues.