### PR TITLE
fix(gateway): compress large inference requests with Zstandard

### DIFF
--- a/.changeset/compress-gateway-requests.md
+++ b/.changeset/compress-gateway-requests.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/kilo-gateway": patch
+"@kilocode/cli": patch
+---
+
+Compress large Kilo Gateway requests without reducing image quality or removing conversation content.

--- a/packages/kilo-gateway/src/provider.ts
+++ b/packages/kilo-gateway/src/provider.ts
@@ -5,10 +5,14 @@ import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
 import type { KiloProvider, KiloProviderOptions } from "./types.js"
 import { getApiKey } from "./auth/token.js"
 import { buildKiloHeaders, getDefaultHeaders } from "./headers.js"
-import { ANONYMOUS_API_KEY } from "./api/constants.js"
+import { ANONYMOUS_API_KEY, DEFAULT_KILO_API_URL } from "./api/constants.js"
 import { resolveKiloOpenRouterBaseUrl } from "./api/url.js"
 import { transformRequestBody } from "./responses.js"
 import * as GatewayMetadata from "./gateway-metadata.js"
+import { promisify } from "node:util"
+import * as zlib from "node:zlib"
+
+const compress = typeof zlib.zstdCompress === "function" ? promisify(zlib.zstdCompress) : undefined
 
 export function buildRequestHeaders(defaultHeaders: Record<string, string>, requestHeaders?: HeadersInit): Headers {
   const headers = new Headers(defaultHeaders)
@@ -39,6 +43,7 @@ export function createKilo(options: KiloProviderOptions = {}): KiloProvider {
   const apiKey = getApiKey(options)
 
   const openRouterUrl = resolveKiloOpenRouterBaseUrl({ baseURL: options.baseURL, token: apiKey })
+  const compression = options.requestCompression ?? new URL(openRouterUrl).origin === DEFAULT_KILO_API_URL
 
   // Merge custom headers with defaults
   const customHeaders = {
@@ -61,10 +66,23 @@ export function createKilo(options: KiloProviderOptions = {}): KiloProvider {
       headers.set("Authorization", `Bearer ${apiKey}`)
     }
 
+    const payload = await (async () => {
+      if (!compression || !compress || typeof body !== "string" || headers.has("content-encoding")) return body
+      const size = Buffer.byteLength(body)
+      if (size < 64 * 1024) return body
+      init?.signal?.throwIfAborted()
+      const encoded = await compress(body, { params: { [zlib.constants.ZSTD_c_compressionLevel]: 3 } })
+      init?.signal?.throwIfAborted()
+      if (encoded.byteLength >= size) return body
+      headers.set("content-encoding", "zstd")
+      headers.delete("content-length")
+      return new Uint8Array(encoded)
+    })()
+
     return originalFetch(input, {
       ...init,
       headers,
-      body,
+      body: payload,
     })
   }
 

--- a/packages/kilo-gateway/src/types.ts
+++ b/packages/kilo-gateway/src/types.ts
@@ -109,6 +109,8 @@ export interface KiloProviderOptions {
    */
   dataCollection?: "allow" | "deny"
 
+  requestCompression?: boolean
+
   /**
    * Custom fetch function
    */

--- a/packages/kilo-gateway/test/provider.test.ts
+++ b/packages/kilo-gateway/test/provider.test.ts
@@ -1,5 +1,54 @@
 import { describe, expect, test } from "bun:test"
-import { buildRequestHeaders } from "../src/provider"
+import { zstdDecompressSync } from "node:zlib"
+import { buildRequestHeaders, createKilo } from "../src/provider"
+import type { KiloProvider, KiloProviderOptions, LanguageModelV3 } from "../src/types"
+
+const adapters = {
+  openrouter: (provider: KiloProvider) => provider.languageModel("test-model"),
+  openai: (provider: KiloProvider) => provider.openai("gpt-5"),
+  anthropic: (provider: KiloProvider) => provider.anthropic("claude-sonnet-4"),
+  compatible: (provider: KiloProvider) => provider.openaiCompatible("test-model"),
+}
+const image =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+type Call = Parameters<LanguageModelV3["doGenerate"]>[0]
+const prompt: Call["prompt"] = [
+  {
+    role: "user",
+    content: [
+      { type: "text", text: "image details 文字\n".repeat(8_000) },
+      { type: "file", data: new URL(image), mediaType: "image/png" },
+    ],
+  },
+]
+
+async function capture(
+  input: {
+    options?: KiloProviderOptions
+    kind?: keyof typeof adapters
+    method?: "doGenerate" | "doStream"
+    call?: Partial<Call>
+  } = {},
+) {
+  const requests: Array<{ url: string; init: RequestInit }> = []
+  const error = new Error("captured")
+  const provider = createKilo({
+    kilocodeToken: "test-token",
+    ...input.options,
+    fetch: async (url, init) => {
+      if (!init) throw new Error("Missing request options")
+      requests.push({ url: url instanceof Request ? url.url : String(url), init })
+      throw error
+    },
+  })
+  const model = adapters[input.kind ?? "openai"](provider)
+  if (typeof model === "string" || model.specificationVersion !== "v3") throw new Error("Expected V3 model")
+  await expect(model[input.method ?? "doGenerate"]({ prompt, ...input.call })).rejects.toBe(error)
+  expect(requests).toHaveLength(1)
+  const request = requests.at(0)
+  if (!request) throw new Error("Missing captured request")
+  return request
+}
 
 describe("Kilo provider request headers", () => {
   test("request headers override provider defaults", () => {
@@ -19,5 +68,105 @@ describe("Kilo provider request headers", () => {
     expect(headers.get("x-kilocode-feature")).toBe("agent-manager")
     expect(headers.get("x-default-only")).toBe("kept")
     expect(headers.get("x-request-only")).toBe("kept-too")
+  })
+})
+
+describe("Kilo request compression", () => {
+  for (const kind of ["openrouter", "openai", "anthropic", "compatible"] as const) {
+    for (const method of ["doGenerate", "doStream"] as const) {
+      test(`${kind} ${method} preserves the complete request`, async () => {
+        const controller = new AbortController()
+        const call = {
+          abortSignal: controller.signal,
+          headers: { "x-request": "kept", "content-length": "999999" },
+        }
+        const plain = await capture({ kind, method, call, options: { requestCompression: false } })
+        const encoded = await capture({ kind, method, call })
+        expect(encoded.url).toBe(plain.url)
+        if (typeof plain.init.body !== "string" || !(encoded.init.body instanceof Uint8Array))
+          throw new Error("Unexpected request body type")
+        expect(zstdDecompressSync(encoded.init.body).toString()).toBe(plain.init.body)
+        expect(encoded.init.body.byteLength).toBeLessThan(Buffer.byteLength(plain.init.body))
+        expect(plain.init.body).toContain(image.slice(image.indexOf(",") + 1))
+        const headers = new Headers(encoded.init.headers)
+        expect(headers.get("content-encoding")).toBe("zstd")
+        expect(headers.get("content-type")).toBe("application/json")
+        expect(headers.get("authorization")).toBe("Bearer test-token")
+        expect(headers.get("x-request")).toBe("kept")
+        expect(headers.has("content-length")).toBe(false)
+        expect(encoded.init.signal).toBe(controller.signal)
+      })
+    }
+  }
+
+  test("preserves encrypted reasoning after Responses sanitization", async () => {
+    const opaque = "opaque-state".repeat(10_000)
+    const call: Partial<Call> = {
+      prompt: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "reasoning",
+              text: "retained reasoning",
+              providerOptions: { openai: { itemId: "rs_test", reasoningEncryptedContent: opaque } },
+            },
+          ],
+        },
+        ...prompt,
+      ],
+      providerOptions: { openai: { store: false } },
+    }
+    const plain = await capture({ call, options: { requestCompression: false, dataCollection: "deny" } })
+    const encoded = await capture({ call, options: { dataCollection: "deny" } })
+    if (!(encoded.init.body instanceof Uint8Array)) throw new Error("Expected compressed request")
+    const decoded = zstdDecompressSync(encoded.init.body).toString()
+    expect(decoded).toBe(plain.init.body)
+    const body = JSON.parse(decoded)
+    expect(body.input.at(0).type).toBe("reasoning")
+    expect(body.input.at(0).encrypted_content === opaque).toBe(true)
+    expect(body.input.at(0).id).toBeUndefined()
+    expect(body.provider.data_collection).toBe("deny")
+  })
+
+  test("keeps small requests uncompressed", async () => {
+    const request = await capture({ call: { prompt: [{ role: "user", content: [{ type: "text", text: "small" }] }] } })
+    expect(typeof request.init.body).toBe("string")
+    expect(new Headers(request.init.headers).has("content-encoding")).toBe(false)
+  })
+
+  test("requires opt-in for custom gateways", async () => {
+    const options = { baseURL: "http://127.0.0.1:1" }
+    const plain = await capture({ options })
+    const encoded = await capture({ options: { ...options, requestCompression: true } })
+    expect(typeof plain.init.body).toBe("string")
+    expect(new Headers(plain.init.headers).has("content-encoding")).toBe(false)
+    if (!(encoded.init.body instanceof Uint8Array)) throw new Error("Expected compressed request")
+    expect(zstdDecompressSync(encoded.init.body).toString()).toBe(plain.init.body)
+  })
+
+  test("leaves an existing content encoding unchanged", async () => {
+    const request = await capture({ options: { headers: { "Content-Encoding": "identity" } } })
+    expect(typeof request.init.body).toBe("string")
+    expect(new Headers(request.init.headers).get("content-encoding")).toBe("identity")
+  })
+
+  test("does not send an aborted request", async () => {
+    const requests: RequestInit[] = []
+    const provider = createKilo({
+      kilocodeToken: "test-token",
+      fetch: async (_url, init) => {
+        if (init) requests.push(init)
+        throw new Error("Unexpected fetch")
+      },
+    })
+    const model = provider.openai("gpt-5")
+    if (typeof model === "string" || model.specificationVersion !== "v3") throw new Error("Expected V3 model")
+    const controller = new AbortController()
+    controller.abort()
+    await expect(model.doGenerate({ prompt, abortSignal: controller.signal })).rejects.toMatchObject({
+      name: "AbortError",
+    })
+    expect(requests).toHaveLength(0)
   })
 })


### PR DESCRIPTION
## What Problem This Solves

Large inference requests can exceed the Vercel Function body limit even when the model still has context capacity. Images, tool context, and encrypted reasoning all contribute to the serialized JSON size. Reducing image resolution or removing conversation content can lose information needed for the task.

## Why This Change Was Made

Compress the final normalized request JSON with native Zstandard level 3, without changing its decoded content. Requests below 64 KiB, requests with an existing content encoding, unsupported runtimes, and encodings that do not save bytes remain unchanged. Compression preserves request metadata and cancellation, and removes a stale Content-Length when the body changes.

Compression defaults on only for the resolved https://api.kilo.ai origin. The requestCompression provider option allows explicit opt-in for custom gateways or opt-out for the default gateway. This avoids assuming that arbitrary OpenAI-compatible servers accept Zstandard.

## User Impact

Large Kilo Gateway requests can use fewer wire bytes without another image-resizing or history-compaction policy. Requests that still exceed transport or provider limits can still fail; this is not unlimited context support.

**Server-first rollout:** keep this PR in draft until https://github.com/Kilo-Org/cloud/pull/5802 is deployed. The current production gateway does not decode Zstandard. Small and uncompressed requests retain their existing behavior.

## Evidence

The 33 focused gateway tests pass, including all four provider adapters in streaming and non-streaming modes, exact decoded request equality, encrypted reasoning and image preservation, headers, custom-origin opt-in, and cancellation. Gateway and CLI typechecks, scoped lint, and the CLI build smoke tests pass.

A local Node 24 HTTP test connected the actual SDK encoder to the companion gateway decoder. The identity request was 4,711,235 bytes; its Zstandard form was 1,123,346 bytes. Both produced the same decoded SHA-256 and unchanged image and reasoning fields. This fixture contains repeated images, so the ratio is not a general compression guarantee. No model provider was called.