### PR TITLE
fix(jetbrains): open the worktree row popup only for pull requests

### DIFF
--- a/.changeset/jetbrains-worktree-popup-pr-only.md
+++ b/.changeset/jetbrains-worktree-popup-pr-only.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-jetbrains": patch
+---
+
+Only open the Agent Manager worktree hover popup for worktrees that have a pull request, instead of restating the change counts already shown on the row.

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/AgentManagerPanel.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/AgentManagerPanel.kt
@@ -568,22 +568,18 @@ class AgentManagerPanel(
     }
 
     /**
-     * The hover detail for one row, or null when the row has nothing to detail. A pull request is not the
-     * bar: a worktree that has no pull request yet is exactly the one whose changes are still uncommitted,
-     * and this popup is the only place that breaks those out. What it will not do is follow the pointer
-     * down a list of untouched worktrees as an empty balloon.
+     * The hover detail for one row, or null when the row has no pull request. This popup is the pull
+     * request view — state, title, verdicts — so a worktree that has none is left alone: its counts are
+     * already painted on the row, and opening for it means the pointer trails a balloon with nothing but
+     * a base-branch behind-count down a list of local worktrees.
      */
     @RequiresEdt
     private fun request(row: WorktreeRow): SidePopupRequest? {
         if (project == null || row.progress != null) return null
+        val pull = row.pr ?: return null
         val key = normalizeWorktreePath(row.dto.path)
-        val pull = row.pr
         val base = stats[key]
         val local = dirty[key]
-        val any = pull != null ||
-            (local != null && local.files > 0) ||
-            (base != null && (base.files > 0 || base.ahead > 0 || base.behind > 0))
-        if (!any) return null
         return SidePopupRequest(
             build = {
                 val disposable = Disposer.newDisposable("Worktree row popup")

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeRowPopupBody.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeRowPopupBody.kt
@@ -7,8 +7,6 @@ import ai.kilocode.client.ui.UiStyle
 import ai.kilocode.client.ui.checksLabel
 import ai.kilocode.client.ui.layout.Stack
 import ai.kilocode.client.ui.reviewLabel
-import ai.kilocode.rpc.dto.GhChecksDto
-import ai.kilocode.rpc.dto.GhReview
 import ai.kilocode.rpc.dto.WorktreeDirtyDto
 import ai.kilocode.rpc.dto.WorktreePrDto
 import ai.kilocode.rpc.dto.WorktreeStatsDto
@@ -21,6 +19,9 @@ import javax.swing.Icon
  * Everything known about one worktree's pull request, for the row hover popup, one thing per line: state,
  * verdict glyphs and title, then the full changes summary under a rule, then a line each for the review
  * and CI verdicts whose row glyphs have no room to say more than their color.
+ *
+ * Only a row that has a pull request gets one, which is why [update] takes a non-null one: without that
+ * chrome the popup is a restatement of the counts already on the row.
  *
  * Reuses [PrHeaderView] in [ChangesPanel.Mode.FULL] rather than laying out PR title, number, state badge
  * and diff counts again — that widget already renders the committed and uncommitted counts side by side
@@ -46,7 +47,7 @@ internal class WorktreeRowPopupBody @RequiresEdt constructor(
     }
 
     @RequiresEdt
-    fun update(stats: WorktreeStatsDto?, pull: WorktreePrDto?, name: String, dirty: WorktreeDirtyDto?) {
+    fun update(stats: WorktreeStatsDto?, pull: WorktreePrDto, name: String, dirty: WorktreeDirtyDto?) {
         header.update(
             files = stats?.files ?: 0,
             additions = stats?.additions ?: 0,
@@ -60,8 +61,8 @@ internal class WorktreeRowPopupBody @RequiresEdt constructor(
             localDeletions = dirty?.deletions ?: 0,
             base = stats?.base.orEmpty(),
         )
-        line(review, PrIcons.review(pull?.review ?: GhReview.NONE), reviewLabel(pull?.review ?: GhReview.NONE))
-        line(checks, PrIcons.checks(pull?.checks ?: GhChecksDto()), checksLabel(pull?.checks ?: GhChecksDto()))
+        line(review, PrIcons.review(pull.review), reviewLabel(pull.review))
+        line(checks, PrIcons.checks(pull.checks), checksLabel(pull.checks))
     }
 
     /** Hidden when there is no glyph, so a PR with no CI does not leave an empty row behind. */

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeRowPopupBodyTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeRowPopupBodyTest.kt
@@ -166,13 +166,13 @@ class WorktreeRowPopupBodyTest : BasePlatformTestCase() {
         }
     }
 
-    fun `test a worktree with no pull request still breaks its changes out`() {
+    fun `test the uncommitted changes are broken out beside the committed ones`() {
         val body = body()
 
         edt {
             body.update(
-                stats = WorktreeStatsDto(path, ahead = 1, behind = 2),
-                pull = null,
+                stats = WorktreeStatsDto(path, additions = 9, deletions = 4, files = 3, ahead = 1, behind = 2),
+                pull = pr(GhReview.NONE, GhChecksDto()),
                 name = "feature-x",
                 dirty = WorktreeDirtyDto(path, additions = 6, deletions = 2, files = 4),
             )
@@ -180,13 +180,13 @@ class WorktreeRowPopupBodyTest : BasePlatformTestCase() {
         }
 
         edt {
-            // No pull request chrome to show, but the counters are the reason the popup opened.
-            assertTrue(components(body).filterIsInstance<JBLabel>().none { it.icon is FilledBadgeIcon })
-            assertFalse(components(body).filterIsInstance<SimpleColoredComponent>().single().isVisible)
+            // The PR chrome leads, and every count the row cannot fit follows it.
+            assertNotNull(components(body).filterIsInstance<JBLabel>().find { it.icon is FilledBadgeIcon })
+            assertTrue(components(body).filterIsInstance<SimpleColoredComponent>().single().isVisible)
             val changes = UIUtil.findComponentOfType(body, ChangesPanel::class.java)!!
             assertTrue(changes.isVisible)
             assertEquals(
-                listOf("4 files", "-2", "+6", "1", "2"),
+                listOf("4 files", "-2", "+6", "1", "2", "3 files", "-4", "+9"),
                 components(changes).filterIsInstance<JBLabel>().filter { it.isVisible }.map { it.text },
             )
         }


### PR DESCRIPTION
## Issue

<!-- No tracking issue; reported directly against the current Agent Manager hover popup behaviour. -->

Fixes #

## Context

Hovering any worktree row in the JetBrains Agent Manager opened the detail balloon. For a row with no
pull request there is no PR chrome to show — the title line is hidden, the state pill is gone, the
review and CI lines are hidden — so the popup degraded to a bare restatement of the `N files +A -D`
summary already painted on the row, plus an ahead/behind count against the base branch that is noise
for a local scratch worktree. Passing the pointer down a list of local worktrees trailed one of those
for every row.

The popup is the pull request view, so a pull request is now the bar for opening it.

## Implementation

`AgentManagerPanel.request()` previously opened on any signal — a PR, uncommitted files, or committed
files/ahead/behind — and its KDoc argued explicitly that a PR was *not* the bar. That decision is
reversed: the gate is now `val pull = row.pr ?: return null`, and the comment states the new rule.

`WorktreeRowPopupBody.update` takes a non-null `WorktreePrDto` rather than falling back to
`GhReview.NONE` / `GhChecksDto()`, so the compiler is what rules out a popup without a PR instead of a
runtime branch that could drift back. `stats` and `dirty` stay nullable — a PR whose stats have not
polled yet still opens.

Nothing else moves: the row's `#number` pill, review/CI glyphs and changes summary are untouched, as
is the dwell. A PR-less row still starts the dwell and simply resolves to no request when it elapses.

One consequence worth a reviewer's attention: `prs` is empty whenever `gh` is missing,
unauthenticated, or rate-limited, so in those states no row gets a popup even when it does have a PR
upstream. That follows from making PR presence the gate.

## Screenshots / Video

## Before

<img width="907" height="752" alt="Screen Shot 2026-09-01 at 9 48 44 AM" src="https://github.com/user-attachments/assets/7915f494-9b46-48c9-bc18-6b14e5146d98" />

## After 

<img width="1186" height="886" alt="GIF Recording 2026-09-01 at 9 51 32 AM" src="https://github.com/user-attachments/assets/8ad8f8ae-0c73-4668-a86b-77b56541bc89" />


## How to Test

### Manual/local verification

- `./gradlew typecheck` from `packages/kilo-jetbrains/` — passes, and proves no other caller passes a null `pull` to the popup body (agent-executed)
- `./gradlew test` from `packages/kilo-jetbrains/` — full frontend + backend suite passes (agent-executed)
- `./gradlew :frontend:test --tests '*WorktreeRowPopupBodyTest*'` — 9 cases pass, including the replaced one (agent-executed)

### Reviewer test steps

1. Run the plugin against a repo with several worktrees, at least one with an open PR and one without
2. Hover a worktree row that shows a `#number` pill — the detail popup still opens beside it with title, state, verdicts and both change counts
3. Hover a worktree row with no `#number` pill but with local changes — no popup appears, and the row's own `N files +A -D` summary and its changes-cell tooltip still work
4. Drag the pointer down the list across PR-less rows — no balloon flashes for them

### Blocked checks and substitute verification

- Panel-level assertion of the gate is not reachable in this test harness: `AgentManagerPanel.place` needs a root pane and a laid-out list, and under `BasePlatformTestCase` the panel is never in a window, so `place` returns null and no balloon opens for any row — which is why the original feature commit (`aebd040a80`) shipped with no panel test either. Substitute verification is the compile-time non-null contract plus `WorktreeRowPopupBodyTest`, where the case asserting the old PR-less behaviour was replaced with a PR row carrying `ahead`/`behind` and uncommitted counts so the changes-breakout coverage it provided survives.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

<!-- -->
