### PR TITLE
fix(jetbrains): keep actions available while the IDE indexes

### DIFF
--- a/.changeset/jetbrains-actions-during-indexing.md
+++ b/.changeset/jetbrains-actions-during-indexing.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-jetbrains": patch
+---
+
+Keep Kilo's actions available while the IDE builds its indexes. Session history, worktree, and worktree session menu items no longer grey out during indexing, and their toolbar buttons no longer report that they are waiting for analysis.

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/CopyWorktreePrRefAction.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/CopyWorktreePrRefAction.kt
@@ -5,9 +5,10 @@ import ai.kilocode.client.agentManager.worktree.WorktreeDataKeys
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
 
 /** Copies a human-readable pull request reference (`<title> - <url>`) for the selected worktree. */
-class CopyWorktreePrRefAction : AnAction() {
+class CopyWorktreePrRefAction : AnAction(), DumbAware {
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
 
     override fun update(e: AnActionEvent) {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/DeleteSessionAction.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/DeleteSessionAction.kt
@@ -6,10 +6,11 @@ import ai.kilocode.client.session.SessionManager
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
 
-class DeleteSessionAction : AnAction() {
+class DeleteSessionAction : AnAction(), DumbAware {
     /** Overridable in tests to avoid showing a real modal dialog. */
     internal var confirm: (project: Project?, msg: String) -> Boolean = { project, msg ->
         Messages.showYesNoDialog(

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/DeleteWorktreeAction.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/DeleteWorktreeAction.kt
@@ -5,8 +5,9 @@ import ai.kilocode.client.agentManager.worktree.WorktreeDataKeys
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
 
-class DeleteWorktreeAction : AnAction() {
+class DeleteWorktreeAction : AnAction(), DumbAware {
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
 
     override fun update(e: AnActionEvent) {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/DeleteWorktreeSessionAction.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/DeleteWorktreeSessionAction.kt
@@ -4,8 +4,9 @@ import ai.kilocode.client.agentManager.worktree.WorktreeSessionDataKeys
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
 
-class DeleteWorktreeSessionAction : AnAction() {
+class DeleteWorktreeSessionAction : AnAction(), DumbAware {
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
 
     override fun update(e: AnActionEvent) {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/KiloSettingsAction.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/KiloSettingsAction.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.components.service
+import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import kotlinx.coroutines.Job
 
@@ -18,7 +19,7 @@ import kotlinx.coroutines.Job
  * as a popup. The group composition is declared in
  * `kilo.jetbrains.frontend.xml`.
  */
-class KiloSettingsAction : AnAction() {
+class KiloSettingsAction : AnAction(), DumbAware {
 
     companion object {
         const val GROUP_ID = "Kilo.SettingsGroup"

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/OpenSessionAction.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/OpenSessionAction.kt
@@ -5,8 +5,9 @@ import ai.kilocode.client.session.SessionManager
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
 
-class OpenSessionAction : AnAction() {
+class OpenSessionAction : AnAction(), DumbAware {
     override fun getActionUpdateThread() = ActionUpdateThread.EDT
 
     override fun update(e: AnActionEvent) {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/OpenWorktreeDiffAction.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/OpenWorktreeDiffAction.kt
@@ -5,8 +5,9 @@ import ai.kilocode.client.agentManager.worktree.WorktreeDataKeys
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
 
-class OpenWorktreeDiffAction : AnAction() {
+class OpenWorktreeDiffAction : AnAction(), DumbAware {
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
 
     override fun update(e: AnActionEvent) {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/OpenWorktreeLocalDiffAction.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/OpenWorktreeLocalDiffAction.kt
@@ -5,8 +5,9 @@ import ai.kilocode.client.agentManager.worktree.WorktreeDataKeys
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
 
-class OpenWorktreeLocalDiffAction : AnAction() {
+class OpenWorktreeLocalDiffAction : AnAction(), DumbAware {
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
 
     override fun update(e: AnActionEvent) {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/OpenWorktreePrAction.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/OpenWorktreePrAction.kt
@@ -5,8 +5,9 @@ import ai.kilocode.client.agentManager.worktree.WorktreeDataKeys
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
 
-class OpenWorktreePrAction : AnAction() {
+class OpenWorktreePrAction : AnAction(), DumbAware {
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
 
     override fun update(e: AnActionEvent) {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/RenameSessionAction.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/RenameSessionAction.kt
@@ -5,8 +5,9 @@ import ai.kilocode.client.session.SessionManager
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
 
-class RenameSessionAction : AnAction() {
+class RenameSessionAction : AnAction(), DumbAware {
     override fun getActionUpdateThread() = ActionUpdateThread.EDT
 
     override fun update(e: AnActionEvent) {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/RenameWorktreeAction.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/RenameWorktreeAction.kt
@@ -5,8 +5,9 @@ import ai.kilocode.client.agentManager.worktree.WorktreeDataKeys
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
 
-class RenameWorktreeAction : AnAction() {
+class RenameWorktreeAction : AnAction(), DumbAware {
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
 
     override fun update(e: AnActionEvent) {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/RenameWorktreeSessionAction.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/RenameWorktreeSessionAction.kt
@@ -4,8 +4,9 @@ import ai.kilocode.client.agentManager.worktree.WorktreeSessionDataKeys
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
 
-class RenameWorktreeSessionAction : AnAction() {
+class RenameWorktreeSessionAction : AnAction(), DumbAware {
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
 
     override fun update(e: AnActionEvent) {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/RunWorktreeSetupScriptAction.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/actions/RunWorktreeSetupScriptAction.kt
@@ -5,8 +5,9 @@ import ai.kilocode.client.agentManager.worktree.WorktreeDataKeys
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAware
 
-class RunWorktreeSetupScriptAction : AnAction() {
+class RunWorktreeSetupScriptAction : AnAction(), DumbAware {
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
 
     override fun update(e: AnActionEvent) {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/AgentManagerPanel.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/AgentManagerPanel.kt
@@ -68,7 +68,6 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionGroup
 import com.intellij.openapi.actionSystem.ActionUpdateThread
-import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.DataSink
@@ -80,6 +79,7 @@ import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.VirtualFile
@@ -682,7 +682,7 @@ class AgentManagerPanel(
         }
     }
 
-    private inner class RenameAction : AnAction(
+    private inner class RenameAction : DumbAwareAction(
         KiloBundle.message("worktree.rename.action"),
         null,
         AllIcons.Actions.Edit,

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeRunPopup.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeRunPopup.kt
@@ -71,9 +71,16 @@ internal object WorktreeRunPopup {
     }
 
     /**
-     * Dumb-aware so the popup does not render half its items greyed out while the host project
-     * indexes: [update] reads a captured flag, not an index. Whether the worktree project these
-     * run/build items target is ready is the backend's concern, not this menu's.
+     * Dumb-aware, matching how the platform treats its own run actions: `ExecutorAction`,
+     * `RunConfigurationsComboBoxAction`, and `BaseRunConfigurationAction` are all `DumbAware` so the
+     * run UI stays live during indexing, and the decision about whether a given configuration may
+     * actually start is made separately, against `ConfigurationType.isDumbAware`.
+     *
+     * We keep the first half and cannot express the second: these items carry `RunConfigDto`s fetched
+     * over RPC rather than local `RunnerAndConfigurationSettings`, so there is no `ConfigurationType`
+     * to consult, and the host project's dumb state describes the wrong project anyway — the run
+     * happens in the worktree. So readiness is the backend's call, surfaced through the existing
+     * `worktree.run.failed` notification rather than a dead menu item.
      */
     private fun action(
         text: String,

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeRunPopup.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeRunPopup.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.project.DumbAwareAction
 import javax.swing.Icon
 
 /**
@@ -69,13 +70,18 @@ internal object WorktreeRunPopup {
         return group
     }
 
+    /**
+     * Dumb-aware so the popup does not render half its items greyed out while the host project
+     * indexes: [update] reads a captured flag, not an index. Whether the worktree project these
+     * run/build items target is ready is the backend's concern, not this menu's.
+     */
     private fun action(
         text: String,
         icon: Icon?,
         description: String? = null,
         enabled: Boolean = true,
         handler: () -> Unit,
-    ): AnAction = object : AnAction(text, description, icon) {
+    ): AnAction = object : DumbAwareAction(text, description, icon) {
         override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.EDT
 
         override fun update(e: AnActionEvent) {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeSessionEditorPanel.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeSessionEditorPanel.kt
@@ -40,13 +40,13 @@ import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionPlaces
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.ActionGroup
-import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataSink
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.actionSystem.UiDataProvider
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
+import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.Disposer
@@ -593,7 +593,7 @@ class WorktreeSessionEditorPanel @RequiresEdt constructor(
         manager.onListChanged = null
     }
 
-    private inner class NewAction : AnAction(
+    private inner class NewAction : DumbAwareAction(
         KiloBundle.message("worktree.session.new.action"),
         null,
         AllIcons.General.Add,
@@ -605,7 +605,7 @@ class WorktreeSessionEditorPanel @RequiresEdt constructor(
         }
     }
 
-    private inner class DeleteAction : AnAction(
+    private inner class DeleteAction : DumbAwareAction(
         KiloBundle.message("worktree.session.delete.action"),
         null,
         AllIcons.Actions.GC,
@@ -622,7 +622,7 @@ class WorktreeSessionEditorPanel @RequiresEdt constructor(
         }
     }
 
-    private inner class RenameAction : AnAction(
+    private inner class RenameAction : DumbAwareAction(
         KiloBundle.message("worktree.session.rename.action"),
         null,
         AllIcons.Actions.Edit,

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/actions/DeclaredActionsDumbAwareTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/actions/DeclaredActionsDumbAwareTest.kt
@@ -1,0 +1,65 @@
+package ai.kilocode.client.actions
+
+import ai.kilocode.client.testing.PluginDescriptor
+import ai.kilocode.client.testing.attribute
+import ai.kilocode.client.testing.elements
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.project.DumbAware
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+/**
+ * Kilo owns no index-backed action: every one of them resolves its context from a `DataKey` and then
+ * calls the CLI, git, or Swing. So none of them may be gated on indexing.
+ *
+ * The platform decides that per action rather than per plugin, and it does not default the way you
+ * would hope: `AnAction.isDumbAware` falls back to `ActionClassMetaData.isDefaultUpdate`, so merely
+ * overriding `update(AnActionEvent)` classifies an action as index-dependent. Nearly all of ours
+ * override `update` to hide themselves when their data key is absent, which is exactly the shape that
+ * trips the fallback.
+ *
+ * Left unmarked, `ActionUtil.updateAction` force-disables the action in popup places, swaps its
+ * tooltip for "waits for analysis", and `ActionUtil.performAction` then refuses to run it at all —
+ * so a row menu goes dead, or worse, half-dead next to its already-marked siblings.
+ */
+class DeclaredActionsDumbAwareTest : BasePlatformTestCase() {
+
+    /**
+     * The ratchet. Implicit dumb-awareness is not enough to rely on: an action that happens to lack an
+     * `update` override passes [AnAction.isDumbAware] today and silently regresses the moment someone
+     * adds one. Requiring the explicit supertype makes that regression impossible.
+     *
+     * Groups are covered too. Every group we declare is classless and so becomes a `DefaultActionGroup`
+     * (implicitly dumb-aware), but the day one gains a `class` it needs the same marker.
+     */
+    fun `test every declared action and group is marked dumb aware`() {
+        val descriptor = PluginDescriptor.frontend()
+        val declared = (descriptor.elements("action") + descriptor.elements("group"))
+            .mapNotNull { element -> element.attribute("class")?.let { element.attribute("id") to it } }
+
+        assertTrue("expected the frontend descriptor to declare actions", declared.isNotEmpty())
+        val blocked = declared.filterNot { DumbAware::class.java.isAssignableFrom(Class.forName(it.second)) }
+
+        assertEquals("actions blocked during indexing", emptyList<Pair<String?, String>>(), blocked)
+    }
+
+    /**
+     * The behaviour behind the ratchet, asserted on real instances through the platform's own
+     * predicate rather than on the marker interface. [AnAction.isDumbAware] is what every call site
+     * that can strand us consults — `ActionUtil.updateAction` when it decides whether to force-disable
+     * a popup item, `ActionUtil.performAction` when it decides whether to run the action at all, and
+     * `ToolWindowSetInitializer` for `canWorkInDumbMode` — so agreement here is the property that
+     * matters at runtime.
+     *
+     * Instantiating each one also keeps the descriptor honest about classes and no-arg constructors.
+     */
+    fun `test the platform treats every declared action as dumb aware`() {
+        val classes = PluginDescriptor.frontend().elements("action").mapNotNull { it.attribute("class") }
+
+        assertTrue("expected the frontend descriptor to declare actions", classes.isNotEmpty())
+        val gated = classes.filterNot { name ->
+            (Class.forName(name).getDeclaredConstructor().newInstance() as AnAction).isDumbAware
+        }
+
+        assertEquals("actions the platform would gate on indexing", emptyList<String>(), gated)
+    }
+}

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/actions/SessionContextMenuActionsTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/actions/SessionContextMenuActionsTest.kt
@@ -10,6 +10,7 @@ import ai.kilocode.client.session.SessionUiTestBase
 import ai.kilocode.client.session.ui.prompt.PromptDataKeys
 import ai.kilocode.client.session.views.TextView
 import ai.kilocode.client.testing.FakeWorktreeRpcApi
+import ai.kilocode.client.testing.PluginDescriptor
 import ai.kilocode.rpc.dto.BranchStatusDto
 import ai.kilocode.rpc.dto.GhAvailability
 import ai.kilocode.rpc.dto.WorktreePrDto
@@ -23,13 +24,11 @@ import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.openapi.actionSystem.Toggleable
 import com.intellij.openapi.actionSystem.ex.ActionUtil
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.project.DumbAware
 import com.intellij.testFramework.replaceService
 import ai.kilocode.client.session.model.SessionState
 import org.w3c.dom.Document
 import org.w3c.dom.Element
 import java.awt.Component
-import javax.xml.parsers.DocumentBuilderFactory
 
 /**
  * Covers the two session action menus — the right-click context menu and the prompt bar's "more"
@@ -140,21 +139,8 @@ class SessionContextMenuActionsTest : SessionUiTestBase() {
         }
     }
 
-    fun `test every owned menu action works during indexing`() {
-        val ids = (menuChildren("Kilo.Session.ContextMenu") + menuChildren("Kilo.Session.PromptMenu"))
-            .filter { it.startsWith("Kilo.") }
-            .distinct()
-        val actions = descriptor().getElementsByTagName("action").let { nodes ->
-            (0 until nodes.length).map { nodes.item(it) as Element }
-        }.filter { it.getAttribute("id") in ids }
-
-        val blocked = actions.mapNotNull { action ->
-            val cls = Class.forName(action.getAttribute("class"))
-            action.getAttribute("id").takeUnless { DumbAware::class.java.isAssignableFrom(cls) }
-        }
-
-        assertEquals("menu actions blocked during indexing", emptyList<String>(), blocked)
-    }
+    // Dumb-awareness of these actions is covered for every declared action, not just the session
+    // menus, by DeclaredActionsDumbAwareTest.
 
     // ---- context resolution from the transcript ----
 
@@ -329,18 +315,7 @@ class SessionContextMenuActionsTest : SessionUiTestBase() {
         HeadlessDataManager.fallbackToProductionDataManager(testRootDisposable)
     }
 
-    /**
-     * The plugin's declared actions are not registered with `ActionManager` in the test fixture (which
-     * is why `BranchDock` null-guards its own lookups), so the menu's shape is asserted against the
-     * module descriptor instead of a live `ActionGroup`.
-     */
-    private fun descriptor(): Document {
-        val stream = javaClass.classLoader.getResourceAsStream("kilo.jetbrains.frontend.xml")
-            ?: error("kilo.jetbrains.frontend.xml missing from the test classpath")
-        return stream.use {
-            DocumentBuilderFactory.newDefaultInstance().newDocumentBuilder().parse(it)
-        }
-    }
+    private fun descriptor(): Document = PluginDescriptor.frontend()
 
     private fun menuChildren(groupId: String): List<String> {
         val groups = descriptor().getElementsByTagName("group")

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/testing/PluginDescriptor.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/testing/PluginDescriptor.kt
@@ -1,0 +1,31 @@
+package ai.kilocode.client.testing
+
+import org.w3c.dom.Document
+import org.w3c.dom.Element
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * The plugin's declared actions are not registered with `ActionManager` in the test fixture (which is
+ * why `BranchDock` null-guards its own lookups), so tests that need the declared shape read the module
+ * descriptor off the test classpath instead of asking for a live `ActionGroup`.
+ */
+internal object PluginDescriptor {
+    private const val FRONTEND = "kilo.jetbrains.frontend.xml"
+
+    fun frontend(): Document {
+        val stream = PluginDescriptor::class.java.classLoader.getResourceAsStream(FRONTEND)
+            ?: error("$FRONTEND missing from the test classpath")
+        return stream.use {
+            DocumentBuilderFactory.newDefaultInstance().newDocumentBuilder().parse(it)
+        }
+    }
+}
+
+/** Every `<tag>` element in the descriptor, in document order. */
+internal fun Document.elements(tag: String): List<Element> {
+    val nodes = getElementsByTagName(tag)
+    return (0 until nodes.length).map { nodes.item(it) as Element }
+}
+
+/** The value of [name], or null when the attribute is absent — `getAttribute` returns "" for both. */
+internal fun Element.attribute(name: String): String? = getAttribute(name).takeIf(String::isNotEmpty)


### PR DESCRIPTION
## Issue

No existing issue — found while auditing action registration. Searched open and closed issues for JetBrains indexing reports; the matches (#11550, #4763, #2918) are all about codebase/embedding indexing, not IntelliJ dumb mode.

## Context

While the IDE builds its indexes, most of Kilo's JetBrains actions were unavailable: the session history context menu, the Agent Manager worktree row menu, and the worktree session row menu greyed out, and the corresponding toolbar buttons reported that they were waiting for analysis instead of running.

None of those actions read an index. They resolve their context from a `DataKey` and then call the CLI, git, or Swing. So the unavailability was purely accidental.

The cause is that IntelliJ decides dumb-awareness per action, and the default is the opposite of what you'd expect. `AnAction.isDumbAware` falls back to `ActionClassMetaData.isDefaultUpdate`, so **merely overriding `update(AnActionEvent)` classifies an action as index-dependent**. Nearly every Kilo action overrides `update` to hide itself when its data key is absent, which is exactly that shape.

The consequences, in `ActionUtil`:

- `updateAction` clears `isEnabled` for `isFromContextMenu` events. All three menus above are opened through `createActionGroupPopup`, which defaults to `ActionPlaces.POPUP`, so they qualify.
- `updateAction` also replaces the tooltip with "waits for analysis", which is what the toolbar buttons showed.
- `performAction` refuses to run the action at all and shows the "not available while updating indices" balloon — this also covered the `use-shortcut-of="$Delete"` and `RenameElement` shortcuts.

The clearest sign this was unintended: `Kilo.Worktree.RowMenu` mixes these actions with `CopyBranchName`, `CopyBranchPath`, and `OpenSetupScript`, which were already marked. During indexing that single menu rendered half-enabled.

## Implementation

12 declared actions gained `DumbAware`, and 4 inline toolbar actions switched base class to `DumbAwareAction`. `KiloSettingsAction` is marked too — it was only *implicitly* dumb-aware because it happens not to override `update`, which is not a property worth depending on.

Two things worth a reviewer's attention:

**`WorktreeRunPopup` follows platform precedent.** Marking run items dumb-aware may look aggressive, but it is what the platform does with its own: `ExecutorAction`, `RunConfigurationsComboBoxAction`, and `BaseRunConfigurationAction` are all `DumbAware`, so the run UI stays live during indexing. The platform then makes a *second*, finer decision about whether a given configuration may actually start, against `ConfigurationType.isDumbAware` — see `BaseRunConfigurationAction.actionPerformed`, which shows a dumb-mode warning instead of running when the type is not dumb-aware. Since `ConfigurationType extends PossiblyDumbAware` (default `this instanceof DumbAware`), most types are not, so in practice the menu stays enabled and the individual run is what refuses.

We keep the first layer and cannot express the second: these items carry `RunConfigDto`s fetched over RPC rather than local `RunnerAndConfigurationSettings`, so there is no `ConfigurationType` to consult, and the host project's dumb state describes the wrong project anyway — the run happens in the worktree. Readiness is therefore the backend's call, surfaced through the existing `worktree.run.failed` notification rather than a dead menu item.

**The tool window needed no change**, contrary to how this started. `KiloToolWindowFactory` already implements `DumbAware`, and `ToolWindowSetInitializer` derives `canWorkInDumbMode` from it, so the stripe button and content creation already worked during indexing. Declared groups needed nothing either: all are classless, so they become `DefaultActionGroup`, which doesn't override `update` and is therefore implicitly dumb-aware.

Everything is under `packages/kilo-jetbrains/frontend/`, so no `kilocode_change` markers apply.

### Tests

`DeclaredActionsDumbAwareTest` covers this in two layers, because either alone is insufficient:

- **Behaviour** — instantiates every declared action and asserts the platform's own `AnAction.isDumbAware` agrees. That's the predicate `ActionUtil.updateAction`, `ActionUtil.performAction`, and `ToolWindowSetInitializer.canWorkInDumbMode` all consult, so it's the property that matters at runtime. On its own, though, it passes for an action that is only implicitly dumb-aware.
- **Ratchet** — every declared `<action>` and `<group>` naming a class must carry the explicit `DumbAware` supertype, so adding an `update` override later cannot silently flip the first assertion. Groups are included so a future classed group can't slip through.

`SessionContextMenuActionsTest.test every owned menu action works during indexing` is removed: the new test is a strict superset of it, so keeping both duplicated the assertion. Its descriptor-parsing helper moved to `testing/PluginDescriptor.kt`, now shared by both files.

## Screenshots / Video

N/A — no visual design change. The observable difference is whether menu items are enabled during indexing, which is asserted by the automated tests rather than captured as a still.

## How to Test

### Manual/local verification

Executed by the agent:

- `./gradlew typecheck test` from `packages/kilo-jetbrains/` — passes across all modules.
- Full frontend suite: 3706 tests, 0 failures, 0 errors.
- **Confirmed the new tests can actually fail.** I removed the `DumbAware` marker from `DeleteWorktreeAction` and re-ran: both assertions failed with actionable messages naming the id and class (`actions blocked during indexing expected:<[]> but was:<[(Kilo.Worktree.Delete, ...DeleteWorktreeAction)]>` and `actions the platform would gate on indexing ...`), then restored the marker and re-confirmed green.

One correction worth flagging, since it shaped the final test: my first behavioural test asserted that `updateAction` leaves no "waits for analysis" `TOOLTIP_TEXT` under a real `DumbService`. It passed even with the marker removed, so it was asserting nothing. Preconditions checked out (dumb mode active, `e.project` resolved), so that client property evidently behaves differently in the target platform than in the IntelliJ source I'd read. I replaced it with `isDumbAware`, which is version-stable and is what actually gates runtime behaviour.

### Reviewer test steps

1. `./gradlew runIde` from `packages/kilo-jetbrains/` and open any project.
2. Force indexing: **File | Invalidate Caches… | Invalidate and Restart**.
3. While the indexing progress bar is still running, open the Kilo tool window's **Agents** tab and right-click a worktree row.
4. Confirm the whole menu is enabled — before this change, Rename/Delete/Open PR/Copy PR Ref/Open Diff/Run Setup Script were greyed out while Copy Branch Name/Path stayed live.
5. Same check on the session history context menu (Open/Rename/Delete) and the worktree session row menu.
6. Click one of the previously-affected toolbar buttons during indexing and confirm it acts instead of showing "not available while updating indices".

### Blocked checks and substitute verification

- **Not verified in a running sandbox IDE by a human or the agent.** I did not launch `runIde` and drive a real indexing window; the reviewer steps above are untested as written. Substitute verification was the automated coverage described above (including the deliberate regression check) plus reading the decision path in the IntelliJ platform source: `AnAction.isDumbAware` → `ActionClassMetaData.isDefaultUpdate`, `ActionUtil.updateAction` (the `isFromContextMenu` disable and tooltip swap), `ActionUtil.performAction`, `PopupFactoryImpl` (the `ActionPlaces.POPUP` default), and `ToolWindowSetInitializer` (`canWorkInDumbMode`).

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes — patch changeset included
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

<!-- Discord handle, if you'd like. -->

