### PR TITLE
fix(vscode): open sent-message images in an editor tab

### DIFF
--- a/.changeset/user-message-image-preview-tab.md
+++ b/.changeset/user-message-image-preview-tab.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Open images attached to sent chat messages in an editor tab preview instead of a modal, matching the behavior of images attached in the prompt input.

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -757,6 +757,7 @@ export function UserMessageDisplay(props: {
   onDelete?: () => void
   onFork?: () => void
   onRevert?: () => void
+  onImageClick?: (url: string, filename?: string) => boolean
 }) {
   const data = useData()
   const dialog = useDialog()
@@ -818,6 +819,7 @@ export function UserMessageDisplay(props: {
   })
 
   const openImagePreview = (url: string, alt?: string) => {
+    if (props.onImageClick?.(url, alt)) return
     dialog.show(() => <ImagePreview src={url} alt={alt} />)
   }
 

--- a/packages/kilo-vscode/src/image-preview.ts
+++ b/packages/kilo-vscode/src/image-preview.ts
@@ -1,4 +1,5 @@
 import * as path from "path"
+import { imageMime } from "./shared/image-data-url"
 
 const IMAGE_PREVIEW_ID = "imagePreview.previewEditor"
 const PREVIEW_DIR = "image-preview"
@@ -11,14 +12,10 @@ type Preview = {
 }
 
 export function parseImage(dataUrl: string, filename: string): Preview | null {
-  const sep = dataUrl.indexOf(",")
-  if (sep === -1) return null
-
-  const head = dataUrl.slice(0, sep)
-  const mime = head.match(/^data:(image\/[A-Za-z0-9.+-]+);base64$/)?.[1]
+  const mime = imageMime(dataUrl)
   if (!mime) return null
 
-  const data = parseBase64(dataUrl.slice(sep + 1))
+  const data = parseBase64(dataUrl.slice(dataUrl.indexOf(",") + 1))
   if (!data) return null
 
   const ext = getExt(mime)

--- a/packages/kilo-vscode/src/shared/image-data-url.ts
+++ b/packages/kilo-vscode/src/shared/image-data-url.ts
@@ -1,0 +1,11 @@
+/**
+ * The exact shape of data URL the host can turn into a file on disk (see
+ * `parseImage` in ../image-preview.ts). Shared with the webview so a click
+ * is only routed to the host preview when the host can actually decode it —
+ * otherwise the webview keeps its own modal fallback.
+ */
+const PATTERN = /^data:(image\/[A-Za-z0-9.+-]+);base64,/
+
+export function imageMime(url: string): string | undefined {
+  return url.match(PATTERN)?.[1]
+}

--- a/packages/kilo-vscode/tests/unit/image-preview.test.ts
+++ b/packages/kilo-vscode/tests/unit/image-preview.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import { buildPreviewPath, getPreviewCommand, getPreviewDir, parseImage, trimEntries } from "../../src/image-preview"
+import { imageMime } from "../../src/shared/image-data-url"
 
 describe("parseImage", () => {
   it("parses png data urls and preserves a clean extension", () => {
@@ -25,6 +26,31 @@ describe("parseImage", () => {
 
   it("returns null when the header is not base64", () => {
     expect(parseImage("data:image/png,hello", "screen.png")).toBeNull()
+  })
+})
+
+// The webview decides whether to route a click to the host preview or keep
+// its own modal fallback by asking imageMime, so the two must agree on every
+// url: a url imageMime accepts but parseImage rejects would open nothing.
+describe("imageMime", () => {
+  it("accepts exactly the urls parseImage can decode", () => {
+    const urls = [
+      "data:image/png;base64,aGVsbG8=",
+      "data:image/svg+xml;base64,aGVsbG8=",
+      "data:image/png,hello",
+      "data:image/png;charset=utf-8;base64,aGVsbG8=",
+      "data:text/plain;base64,aGVsbG8=",
+      "https://example.com/screen.png",
+      "",
+    ]
+
+    for (const url of urls) {
+      expect([url, !!imageMime(url)]).toEqual([url, parseImage(url, "screen.png") !== null])
+    }
+  })
+
+  it("returns the image mime type", () => {
+    expect(imageMime("data:image/svg+xml;base64,aGVsbG8=")).toBe("image/svg+xml")
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/VscodeUserMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/VscodeUserMessage.tsx
@@ -1,6 +1,7 @@
 import { createMemo, Show, type Component } from "solid-js"
 import { UserMessageDisplay } from "@kilocode/kilo-ui/message-part"
 import { partFeedback } from "../../../../src/shared/browser-feedback"
+import { imageMime } from "../../../../src/shared/image-data-url"
 import type { Message, Part, TextPart } from "../../types/messages"
 import { BrowserReferences } from "./BrowserReferences"
 import { ReviewComments } from "./ReviewComments"
@@ -63,8 +64,11 @@ export const VscodeUserMessage: Component<VscodeUserMessageProps> = (props) => {
       onFork={props.onFork}
       onRevert={props.onRevert}
       onImageClick={(dataUrl, filename) => {
-        if (!dataUrl.startsWith("data:")) return false
-        vscode.postMessage({ type: "previewImage", dataUrl, filename: filename ?? "image" })
+        // Only claim the click when the host can decode the image; anything
+        // else (remote URLs, non-base64 data URLs) keeps the modal fallback
+        // rather than opening nothing at all.
+        if (!imageMime(dataUrl)) return false
+        vscode.postMessage({ type: "previewImage", dataUrl, filename: filename || "image" })
         return true
       }}
     />

--- a/packages/kilo-vscode/webview-ui/src/components/chat/VscodeUserMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/VscodeUserMessage.tsx
@@ -5,6 +5,7 @@ import type { Message, Part, TextPart } from "../../types/messages"
 import { BrowserReferences } from "./BrowserReferences"
 import { ReviewComments } from "./ReviewComments"
 import { useLanguage } from "../../context/language"
+import { useVSCode } from "../../context/vscode"
 
 interface VscodeUserMessageProps {
   message: Message
@@ -21,6 +22,7 @@ interface VscodeUserMessageProps {
 
 export const VscodeUserMessage: Component<VscodeUserMessageProps> = (props) => {
   const language = useLanguage()
+  const vscode = useVSCode()
   const text = createMemo(() => props.parts.find((part): part is TextPart => part.type === "text" && !part.synthetic))
   const feedback = createMemo(() => {
     const part = text()
@@ -60,6 +62,11 @@ export const VscodeUserMessage: Component<VscodeUserMessageProps> = (props) => {
       onDelete={props.onDelete}
       onFork={props.onFork}
       onRevert={props.onRevert}
+      onImageClick={(dataUrl, filename) => {
+        if (!dataUrl.startsWith("data:")) return false
+        vscode.postMessage({ type: "previewImage", dataUrl, filename: filename ?? "image" })
+        return true
+      }}
     />
   )
 }


### PR DESCRIPTION
## Issue

No linked issue — small behavior inconsistency found while using the sidebar chat.

## Context

Clicking an image attached in the prompt input opens it in a VS Code image preview editor tab, but clicking the same image after the message is sent opens it in a webview modal instead. The modal is small, cannot be zoomed or resized like the editor preview, and blocks the chat while it is open. This change makes both click targets behave the same way.

## Implementation

`UserMessageDisplay` in `@kilocode/kilo-ui` opened image attachments through `dialog.show(<ImagePreview />)` unconditionally. That component is shared with non-VS Code clients (TUI/session UI) where an editor tab does not exist, so the modal cannot simply be removed.

Instead the component now accepts an optional `onImageClick(url, filename)` handler. Returning `true` means the host handled the click; returning `false` (or not passing the prop at all) keeps the existing modal, so every other consumer is unchanged.

`VscodeUserMessage` passes that handler and posts the already-existing `previewImage` webview message — the same message the prompt input's attachment thumbnails send. The extension host path (`handleEditorAction` → `previewImage` in `src/kilo-provider/editor-actions.ts`) is reused as-is; no new message type, host handler, or extension command was added.

The handler only claims `data:` URLs, matching what the host-side `parseImage` can decode; anything else falls back to the modal rather than silently doing nothing.

## Screenshots / Video

| before | after |
|---|---|
| <img width="555" height="954" alt="image" src="https://github.com/user-attachments/assets/9532f184-0e28-45fa-8c1b-8d34ab8f987f" /> Clicking an image in a sent message opened the kilo-ui modal overlay | <img width="1493" height="963" alt="image" src="https://github.com/user-attachments/assets/7e53a5d4-4700-4eff-aa8a-a13430ded960" /> Clicking it opens the VS Code image preview editor tab |

## How to Test

### Manual/local verification

Performed by the agent:

- `bun run typecheck` in `packages/kilo-vscode/` — passed (both `check-types` and `check-types:webview`)
- `bun run lint` in `packages/kilo-vscode/` — passed
- `bun run format` in `packages/kilo-vscode/` — no reformatting of the touched files
- `bun test tests/unit/image-preview.test.ts` in `packages/kilo-vscode/` — 9 pass, covering the host-side `previewImage` path this change now reuses

### Reviewer test steps

1. Open the Kilo sidebar chat and attach an image to the prompt input (paste or drag-and-drop)
2. Click the attachment thumbnail below the input and confirm it opens in a VS Code image preview editor tab (unchanged baseline)
3. Send the message
4. Click the image thumbnail shown on the sent user message
5. Confirm it now opens in an image preview editor tab instead of a modal overlay

### Blocked checks and substitute verification

- The `pre-push` hook's full `bun turbo typecheck` could not complete locally: `@kilocode/kilo-jetbrains#typecheck` fails because Gradle cannot find a JDK 21 toolchain on this machine (only Java 24 is installed). All 29 JS/TS typecheck tasks in that same run passed, including `kilo-code`, and this change does not touch the JetBrains plugin. Substitute verification was the package-level `typecheck`, `lint`, and unit test run listed above.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

<!-- Discord handle not provided. -->
