### PR TITLE
fix(cli): normalize line breaks in question prompts

### DIFF
--- a/.changeset/fix-question-line-breaks.md
+++ b/.changeset/fix-question-line-breaks.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent question prompts from rendering as narrow stacks of text when a model inserts carriage returns.

--- a/packages/opencode/src/kilocode/question/index.ts
+++ b/packages/opencode/src/kilocode/question/index.ts
@@ -3,6 +3,7 @@ import { InstanceState } from "@/effect/instance-state"
 import * as Log from "@opencode-ai/core/util/log"
 import { SessionID } from "@/session/schema"
 import { KiloSessionPromptQueue } from "@/kilocode/session/prompt-queue"
+import type { Info } from "@/question"
 
 /**
  * Kilo-specific helpers for the shared `@/question` module.
@@ -13,6 +14,21 @@ import { KiloSessionPromptQueue } from "@/kilocode/session/prompt-queue"
  */
 export namespace KiloQuestion {
   const log = Log.create({ service: "question" })
+
+  export function normalize(info: Info): Info {
+    const line = (value: string) => value.replace(/\s+/g, (space) => (/[\r\n]/.test(space) ? " " : space)).trim()
+    const text = (value: string) => value.replace(/\r\n/g, "\n").replace(/\r/g, " ")
+    return {
+      ...info,
+      question: text(info.question),
+      header: line(info.header),
+      options: info.options.map((option) => ({
+        ...option,
+        label: line(option.label),
+        description: text(option.description),
+      })),
+    }
+  }
 
   /** Minimal entry shape both helpers need; matches `PendingEntry` in `@/question`. */
   type Entry = {

--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -101,7 +101,7 @@ export const layer = Layer.effect(
       const info: Request = {
         id,
         sessionID: input.sessionID,
-        questions: input.questions,
+        questions: input.questions.map(KiloQuestion.normalize), // kilocode_change
         blocking: input.blocking, // kilocode_change
         tool: input.tool,
       }

--- a/packages/opencode/test/kilocode/question-normalize.test.ts
+++ b/packages/opencode/test/kilocode/question-normalize.test.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "bun:test"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Effect, Fiber, Queue, Schema } from "effect"
+import { EventV2Bridge } from "../../src/event-v2-bridge"
+import { KiloQuestion } from "../../src/kilocode/question"
+import { Question } from "../../src/question"
+import { SessionID } from "../../src/session/schema"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(LayerNode.compile(LayerNode.group([Question.node, EventV2Bridge.node, CrossSpawnSpawner.node])))
+
+for (const [name, input, line, text] of [
+  ["bare CR", "Squash\rmerge", "Squash merge", "Squash merge"],
+  ["CRLF", "Squash\r\nmerge", "Squash merge", "Squash\nmerge"],
+  ["LF", "Squash\nmerge", "Squash merge", "Squash\nmerge"],
+  ["literal escape", "Squash\\rmerge", "Squash\\rmerge", "Squash\\rmerge"],
+  ["plain text", "Squash merge", "Squash merge", "Squash merge"],
+  ["spaces and tabs", " \tSquash  \tmerge\t ", "Squash  \tmerge", " \tSquash  \tmerge\t "],
+  ["whitespace around breaks", "Squash \t\r\n \tmerge", "Squash merge", "Squash \t\n \tmerge"],
+  ["unicode whitespace", "Squash\u00a0\u2028merge", "Squash\u00a0\u2028merge", "Squash\u00a0\u2028merge"],
+  ["only whitespace", " \t\r\n \t", "", " \t\n \t"],
+  ["empty text", "", "", ""],
+  ["mixed breaks", "Squash\rmerge\r\nnow\nplease", "Squash merge now please", "Squash merge\nnow\nplease"],
+] as const) {
+  test(`normalizes question ${name}`, () => {
+    const result = KiloQuestion.normalize({
+      header: input,
+      question: input,
+      options: [{ label: input, description: input }],
+    })
+    expect(result).toEqual({
+      header: line,
+      question: text,
+      options: [{ label: line, description: text }],
+    })
+    expect(KiloQuestion.normalize(result)).toEqual(result)
+  })
+}
+
+test("preserves long whitespace runs without breaks and collapses runs containing breaks", () => {
+  const space = " \t".repeat(20_000)
+  const label = `Squash${space}merge`
+  const result = KiloQuestion.normalize({
+    header: label,
+    question: "How should we merge?",
+    options: [
+      { label, description: "Preserve whitespace" },
+      { label: `Squash${space}\r\n${space}merge`, description: "Collapse line breaks" },
+    ],
+  })
+  expect(result.header).toBe(label)
+  expect(result.options.map((option) => option.label)).toEqual([label, "Squash merge"])
+})
+
+it.instance(
+  "publishes and stores normalized questions and accepts their displayed labels",
+  () =>
+    Effect.gen(function* () {
+      const question = yield* Question.Service
+      const bridge = yield* EventV2Bridge.Service
+      const asked = yield* Queue.unbounded<Question.Request>()
+      const off = yield* bridge.listen((event) => {
+        if (event.type === Question.Event.Asked.type)
+          Queue.offerUnsafe(asked, Schema.decodeUnknownSync(Question.Request)(event.data))
+        return Effect.void
+      })
+      yield* Effect.addFinalizer(() => off)
+
+      const input: Question.Info = {
+        header: " Merge\r\n method ",
+        question: "How\rshould we merge?\r\nKeep the history?",
+        questionKey: "merge.question",
+        headerKey: "merge.header",
+        multiple: true,
+        custom: false,
+        options: [
+          {
+            label: " Squash \r merge\n(Recommended) ",
+            description: "Combine\rcommits.\r\nKeep the message.\nThen merge.",
+            labelKey: "merge.squash",
+            descriptionKey: "merge.squash.description",
+            mode: "code",
+          },
+          { label: "Keep commits", description: "Preserve history" },
+        ],
+      }
+      const original = structuredClone(input)
+      const fiber = yield* question
+        .ask({ sessionID: SessionID.make("ses_test"), questions: [input], blocking: false })
+        .pipe(Effect.forkScoped)
+      const request = yield* Queue.take(asked).pipe(Effect.timeout("2 seconds"))
+
+      expect(request.questions).toEqual([
+        {
+          ...input,
+          header: "Merge method",
+          question: "How should we merge?\nKeep the history?",
+          options: [
+            {
+              label: "Squash merge (Recommended)",
+              description: "Combine commits.\nKeep the message.\nThen merge.",
+              labelKey: "merge.squash",
+              descriptionKey: "merge.squash.description",
+              mode: "code",
+            },
+            { label: "Keep commits", description: "Preserve history" },
+          ],
+        },
+      ])
+      expect(request.blocking).toBe(false)
+      expect(yield* question.list()).toEqual([request])
+      expect(input).toEqual(original)
+
+      const answers = [request.questions.flatMap((item) => item.options.map((option) => option.label))]
+      yield* question.reply({ requestID: request.id, answers })
+      expect(yield* Fiber.join(fiber)).toEqual([["Squash merge (Recommended)", "Keep commits"]])
+      expect(yield* question.list()).toEqual([])
+    }),
+  { git: true },
+)


### PR DESCRIPTION
## Summary
Model-generated carriage returns can make question prompts render as narrow stacks of text rather than readable options. This matches the still-open upstream report https://github.com/anomalyco/opencode/issues/36040.

Normalize question text once in `Question.ask`, before storing and broadcasting the request, so all live clients receive consistent text without renderer-specific fixes. Keep headers and option labels on one line; preserve LF/CRLF line breaks in question bodies and descriptions while replacing stray carriage returns with spaces. Literal backslash escapes remain unchanged.

Normalization preserves metadata and caller-owned inputs, and scans whitespace runs in linear time to avoid blocking the backend on long model-generated strings. The original persisted tool arguments are not rewritten.

## Before and after
Captured using the VS Code self-test instrumentation with the real CLI running in its integrated terminal at the same 142 × 41 terminal size. Both captures use the same deterministic question payload containing actual carriage returns; no LLM call is involved. The before capture bypasses the new normalizer in an isolated backend harness to reproduce the previous pass-through behavior; the after capture uses the production normalizer from this PR.

### Before
Carriage returns split the question and options into narrow stacks of text.

![Before: the CLI question and options occupy nearly the entire terminal height, with one word per line](https://raw.githubusercontent.com/Kilo-Org/kilocode/5cda21122572405b2a87d366715e4065f07fa243/question-before.png)

### After
The same question and options render as readable, compact lines.

![After: the same CLI question and options render as compact readable lines](https://raw.githubusercontent.com/Kilo-Org/kilocode/5cda21122572405b2a87d366715e4065f07fa243/question-after.png)