### PR TITLE
feat(vscode): prevent system sleep during tasks

### DIFF
--- a/.changeset/prevent-task-sleep.md
+++ b/.changeset/prevent-task-sleep.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Prevent automatic system sleep while agent tasks run, with localized settings, crash- and reconnect-safe native helpers, input-aware pausing, and a configurable active-time limit.

--- a/packages/kilo-ui/src/components/icon.tsx
+++ b/packages/kilo-ui/src/components/icon.tsx
@@ -74,6 +74,10 @@ const icons: Record<string, { path: string; viewBox: string }> = {
     viewBox: "0 0 20 20",
     path: `<rect x="2.5" y="3.5" width="15" height="10" rx="1" stroke="currentColor"/><path d="M6 16.5H14" stroke="currentColor" stroke-linecap="square"/><path d="M10 13.5V16.5" stroke="currentColor"/>`,
   },
+  battery: {
+    viewBox: "0 0 24 24",
+    path: `<rect x="3" y="7" width="17" height="10" rx="2" stroke="currentColor" stroke-width="2"/><path d="M21 10v4" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M6 10h7v4H6z" fill="currentColor"/>`,
+  },
 }
 
 type Name = keyof typeof icons

--- a/packages/kilo-vscode/README.md
+++ b/packages/kilo-vscode/README.md
@@ -42,6 +42,7 @@
 - **Code Generation:** Kilo can generate code using natural language.
 - **Inline Autocomplete:** Get intelligent code completions as you type, powered by AI.
 - **Task Automation:** Kilo can automate repetitive coding tasks to save time..
+- **System Sleep Prevention:** Kilo keeps the computer awake while agent tasks run without preventing display sleep or screen locking.
 - **Automated Refactoring:** Kilo can refactor and improve existing code efficiently.
 - **MCP Server Marketplace**: Kilo can easily find, and use MCP servers to extend the agent capabilities.
 - **Multi Mode**: Plan with Architect, Code with Coder, and Debug with Debugger, and make your own custom modes.
@@ -53,6 +54,10 @@
 3. Start coding with AI that adapts to your workflow. Watch our quick-start guide to see Kilo in action:
 
 <a href="https://youtu.be/pqGfYXgrhig"><img src="https://img.youtube.com/vi/pqGfYXgrhig/maxresdefault.jpg" alt="Watch the video" width="640" height="360"></a>
+
+### System sleep prevention
+
+System sleep prevention is disabled by default. Enable it with `kilo-code.new.preventSleepDuringTasks`. Each task releases its sleep lock after 30 minutes of active execution by default; time waiting for user input does not count. Change this limit with `kilo-code.new.preventSleepDuringTasksTimeoutMinutes`. Set it to `0` for no extension-imposed limit. Operating-system power rules still apply.
 
 ## Developer Setup
 

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -202,6 +202,11 @@
         "category": "Kilo Code"
       },
       {
+        "command": "kilo-code.new.allowSystemSleep",
+        "title": "Allow System Sleep",
+        "category": "Kilo Code"
+      },
+      {
         "command": "kilo-code.new.toggleMemory",
         "title": "Toggle Project Memory",
         "category": "Kilo Code"
@@ -1123,6 +1128,18 @@
           "type": "boolean",
           "default": true,
           "description": "Use system-installed Google Chrome. Disable only when a compatible Playwright Chromium browser is already installed."
+        },
+        "kilo-code.new.preventSleepDuringTasks": {
+          "type": "boolean",
+          "default": false,
+          "description": "Prevent automatic system sleep while Kilo Code tasks run. Screen locking and display sleep are not affected."
+        },
+        "kilo-code.new.preventSleepDuringTasksTimeoutMinutes": {
+          "type": "number",
+          "default": 30,
+          "minimum": 0,
+          "maximum": 1440,
+          "description": "Release system sleep prevention after this much active execution time per task. Time waiting for user input is excluded. Set to 0 for no extension-imposed limit; operating-system power rules still apply."
         },
         "kilo-code.new.attention.enabled": {
           "type": "boolean",

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -18,6 +18,7 @@ import { ensureBackendForAutocomplete } from "./services/autocomplete/ensure-bac
 import { AutocompleteServiceManager } from "./services/autocomplete/AutocompleteServiceManager"
 import { AttentionService } from "./services/attention"
 import { BrowserBroker } from "./services/browser-automation"
+import { SleepInhibitorService } from "./services/sleep-inhibitor"
 import { TelemetryEventName, TelemetryProxy } from "./services/telemetry"
 import { registerCommitMessageService } from "./services/commit-message"
 import { registerCodeActions, registerTerminalActions, KiloCodeActionProvider } from "./services/code-actions"
@@ -215,6 +216,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const attention = new AttentionService(connectionService, {
     approve: (event, directory) => autoApprove.approve(event, directory),
   })
+  const sleep = new SleepInhibitorService(connectionService)
 
   // Prewarm only after all global event consumers are ready.
   ensureBackendForAutocomplete(connectionService)
@@ -638,6 +640,7 @@ export async function activate(context: vscode.ExtensionContext) {
     dispose: () => {
       shuttingDown = true
       unsubscribeStateChange()
+      sleep.dispose()
       attention.dispose()
       browserBroker.dispose()
       provider.dispose()

--- a/packages/kilo-vscode/src/kilo-provider/early-message.ts
+++ b/packages/kilo-vscode/src/kilo-provider/early-message.ts
@@ -6,6 +6,7 @@ import type { SuggestionContext } from "./handlers/suggestion"
 import type { KiloClient } from "@kilocode/sdk/v2/client"
 import { buildChatSettingsMessage } from "./chat-settings"
 import { buildThroughputSettingMessage } from "./throughput-settings"
+import { buildSleepSettingsMessage } from "./sleep-settings"
 import { buildAutoApprovalReasonSettingMessage } from "./auto-approval-reason-settings"
 import { handleModelUsageMessage, type ModelUsageMessage } from "./model-usage"
 
@@ -67,6 +68,26 @@ function isResume(input: { sessionID?: unknown; messageID?: unknown; requestID?:
   )
 }
 
+function routeSettingsMessage(message: { type: string }, ctx: Ctx): boolean | undefined {
+  if (message.type === "requestChatSettings") {
+    ctx.post(buildChatSettingsMessage())
+    return true
+  }
+  if (message.type === "requestThroughputSetting") {
+    ctx.post(buildThroughputSettingMessage())
+    return true
+  }
+  if (message.type === "requestSleepSettings") {
+    ctx.post(buildSleepSettingsMessage())
+    return true
+  }
+  if (message.type === "requestAutoApprovalReasonSetting") {
+    ctx.post(buildAutoApprovalReasonSettingMessage())
+    return true
+  }
+  return undefined
+}
+
 export async function routeEarlyMessage(
   message: { type: string; id?: unknown; text?: unknown; state?: unknown },
   ctx: Ctx,
@@ -119,18 +140,7 @@ export async function routeEarlyMessage(
     ctx.openSessions(ids)
     return true
   }
-  if (message.type === "requestChatSettings") {
-    ctx.post(buildChatSettingsMessage())
-    return true
-  }
-  if (message.type === "requestThroughputSetting") {
-    ctx.post(buildThroughputSettingMessage())
-    return true
-  }
-  if (message.type === "requestAutoApprovalReasonSetting") {
-    ctx.post(buildAutoApprovalReasonSettingMessage())
-    return true
-  }
+  if (routeSettingsMessage(message, ctx)) return true
   if (message.type === "requestSpeechToTextModels") {
     await ctx.speechToTextModels()
     return true

--- a/packages/kilo-vscode/src/kilo-provider/sleep-settings.ts
+++ b/packages/kilo-vscode/src/kilo-provider/sleep-settings.ts
@@ -1,0 +1,10 @@
+import * as vscode from "vscode"
+
+export function buildSleepSettingsMessage() {
+  const config = vscode.workspace.getConfiguration("kilo-code.new")
+  return {
+    type: "sleepSettingsLoaded" as const,
+    enabled: config.get<boolean>("preventSleepDuringTasks", false),
+    timeout: config.get<number>("preventSleepDuringTasksTimeoutMinutes", 30),
+  }
+}

--- a/packages/kilo-vscode/src/services/i18n/ar.ts
+++ b/packages/kilo-vscode/src/services/i18n/ar.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": "المهمة «{{title}}» قيد التشغيل",
+  "kilocode:sleep.statusBar.tooltip":
+    "يُمنع سكون النظام أثناء تشغيل المهام. لا يتأثر قفل الشاشة أو سكون العرض. انقر للسماح بسكون النظام.",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/br.ts
+++ b/packages/kilo-vscode/src/services/i18n/br.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": 'A tarefa "{{title}}" está em execução',
+  "kilocode:sleep.statusBar.tooltip":
+    "A suspensão do sistema é impedida durante a execução de tarefas. O bloqueio e a suspensão da tela não são afetados. Clique para permitir a suspensão do sistema.",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/bs.ts
+++ b/packages/kilo-vscode/src/services/i18n/bs.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": 'Zadatak "{{title}}" je u toku',
+  "kilocode:sleep.statusBar.tooltip":
+    "Mirovanje sistema je spriječeno dok su zadaci u toku. Zaključavanje i mirovanje ekrana nisu pogođeni. Kliknite da dozvolite mirovanje sistema.",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/da.ts
+++ b/packages/kilo-vscode/src/services/i18n/da.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": 'Opgaven "{{title}}" kører',
+  "kilocode:sleep.statusBar.tooltip":
+    "Systemslumring forhindres, mens opgaver kører. Skærmlås og slumring af skærmen påvirkes ikke. Klik for at tillade systemslumring.",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/de.ts
+++ b/packages/kilo-vscode/src/services/i18n/de.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": 'Aufgabe "{{title}}" wird ausgeführt',
+  "kilocode:sleep.statusBar.tooltip":
+    "Während Aufgaben ausgeführt werden, wird der Systemruhezustand verhindert. Bildschirmsperre und Display-Ruhezustand bleiben unverändert. Klicken, um den Systemruhezustand zuzulassen.",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/en.ts
+++ b/packages/kilo-vscode/src/services/i18n/en.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": 'Task "{{title}}" is running',
+  "kilocode:sleep.statusBar.tooltip":
+    "System sleep is prevented while tasks run. Screen locking and display sleep remain unchanged. Click to allow system sleep.",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/es.ts
+++ b/packages/kilo-vscode/src/services/i18n/es.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": 'La tarea "{{title}}" se está ejecutando',
+  "kilocode:sleep.statusBar.tooltip":
+    "Se impide la suspensión del sistema mientras se ejecutan tareas. El bloqueo de pantalla y la suspensión de la pantalla no cambian. Haz clic para permitir la suspensión del sistema.",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/fa.ts
+++ b/packages/kilo-vscode/src/services/i18n/fa.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": "وظیفه «{{title}}» در حال اجرا است",
+  "kilocode:sleep.statusBar.tooltip":
+    "هنگام اجرای وظایف از خواب سیستم جلوگیری می‌شود. قفل صفحه و خواب نمایشگر تغییری نمی‌کنند. برای اجازه دادن به خواب سیستم کلیک کنید.",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/fr.ts
+++ b/packages/kilo-vscode/src/services/i18n/fr.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": 'La tâche "{{title}}" est en cours d’exécution',
+  "kilocode:sleep.statusBar.tooltip":
+    "La mise en veille du système est bloquée pendant l’exécution des tâches. Le verrouillage de l’écran et la mise en veille de l’affichage restent inchangés. Cliquez pour autoriser la mise en veille du système.",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/it.ts
+++ b/packages/kilo-vscode/src/services/i18n/it.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": 'L\'attività "{{title}}" è in esecuzione',
+  "kilocode:sleep.statusBar.tooltip":
+    "La sospensione del sistema viene impedita durante l'esecuzione delle attività. Il blocco e la sospensione dello schermo non cambiano. Fai clic per consentire la sospensione del sistema.",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/ja.ts
+++ b/packages/kilo-vscode/src/services/i18n/ja.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": "タスク「{{title}}」を実行中",
+  "kilocode:sleep.statusBar.tooltip":
+    "タスク実行中はシステムスリープを防止します。画面ロックとディスプレイのスリープには影響しません。クリックするとシステムスリープを許可します。",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/ko.ts
+++ b/packages/kilo-vscode/src/services/i18n/ko.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": '작업 "{{title}}" 실행 중',
+  "kilocode:sleep.statusBar.tooltip":
+    "작업 실행 중에는 시스템 절전 모드를 방지합니다. 화면 잠금과 디스플레이 절전에는 영향을 주지 않습니다. 시스템 절전을 허용하려면 클릭하세요.",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/nl.ts
+++ b/packages/kilo-vscode/src/services/i18n/nl.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": 'Taak "{{title}}" wordt uitgevoerd',
+  "kilocode:sleep.statusBar.tooltip":
+    "Systeemstand-by wordt voorkomen terwijl taken worden uitgevoerd. Schermvergrendeling en schermstand-by blijven ongewijzigd. Klik om systeemstand-by toe te staan.",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/no.ts
+++ b/packages/kilo-vscode/src/services/i18n/no.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": 'Oppgaven "{{title}}" kjører',
+  "kilocode:sleep.statusBar.tooltip":
+    "Systemhvile hindres mens oppgaver kjører. Skjermlåsing og skjermhvile påvirkes ikke. Klikk for å tillate systemhvile.",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/pl.ts
+++ b/packages/kilo-vscode/src/services/i18n/pl.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": "Zadanie „{{title}}” jest uruchomione",
+  "kilocode:sleep.statusBar.tooltip":
+    "Uśpienie systemu jest blokowane podczas wykonywania zadań. Blokada ekranu i uśpienie wyświetlacza pozostają bez zmian. Kliknij, aby zezwolić na uśpienie systemu.",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/ru.ts
+++ b/packages/kilo-vscode/src/services/i18n/ru.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": "Задача «{{title}}» выполняется",
+  "kilocode:sleep.statusBar.tooltip":
+    "Переход системы в спящий режим блокируется во время выполнения задач. Блокировка экрана и отключение дисплея не затрагиваются. Нажмите, чтобы разрешить спящий режим системы.",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/th.ts
+++ b/packages/kilo-vscode/src/services/i18n/th.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": 'งาน "{{title}}" กำลังทำงาน',
+  "kilocode:sleep.statusBar.tooltip":
+    "ระบบจะไม่พักเครื่องขณะงานกำลังทำงาน การล็อกและการพักหน้าจอไม่ได้รับผลกระทบ คลิกเพื่ออนุญาตให้ระบบพักเครื่อง",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/tr.ts
+++ b/packages/kilo-vscode/src/services/i18n/tr.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": '"{{title}}" görevi çalışıyor',
+  "kilocode:sleep.statusBar.tooltip":
+    "Görevler çalışırken sistem uykusu önlenir. Ekran kilidi ve ekran uykusu etkilenmez. Sistem uykusuna izin vermek için tıklayın.",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/uk.ts
+++ b/packages/kilo-vscode/src/services/i18n/uk.ts
@@ -4,4 +4,7 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": "Завдання «{{title}}» виконується",
+  "kilocode:sleep.statusBar.tooltip":
+    "Перехід системи в режим сну блокується під час виконання завдань. Блокування екрана та вимкнення дисплея не змінюються. Натисніть, щоб дозволити режим сну системи.",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/zh.ts
+++ b/packages/kilo-vscode/src/services/i18n/zh.ts
@@ -4,4 +4,6 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": "任务“{{title}}”正在运行",
+  "kilocode:sleep.statusBar.tooltip": "任务运行时会阻止系统休眠。屏幕锁定和显示器休眠不受影响。点击以允许系统休眠。",
 } as const

--- a/packages/kilo-vscode/src/services/i18n/zht.ts
+++ b/packages/kilo-vscode/src/services/i18n/zht.ts
@@ -4,4 +4,6 @@ export { autocompleteDict }
 
 export const dict = {
   ...autocompleteDict,
+  "kilocode:sleep.reason": "任務「{{title}}」正在執行",
+  "kilocode:sleep.statusBar.tooltip": "任務執行時會防止系統休眠。螢幕鎖定和顯示器休眠不受影響。點擊以允許系統休眠。",
 } as const

--- a/packages/kilo-vscode/src/services/sleep-inhibitor.ts
+++ b/packages/kilo-vscode/src/services/sleep-inhibitor.ts
@@ -8,6 +8,7 @@ import type {
   QuestionV2Request,
   SessionNetworkWait,
   SessionStatus,
+  SuggestionRequest,
 } from "@kilocode/sdk/v2/client"
 import type { KiloConnectionService } from "./cli-backend/connection-service"
 import type { SSEPayload } from "./cli-backend/sdk-sse-adapter"
@@ -124,30 +125,40 @@ function network(pending: Pending, waits?: SessionNetworkWait[]): void {
   }
 }
 
+function suggestions(pending: Pending, requests?: SuggestionRequest[]): void {
+  for (const request of requests ?? []) {
+    if (request.blocking !== false) add(pending, request.sessionID, `suggestion:${request.id}`)
+  }
+}
+
 async function requests(client: KiloClient, directory: string): Promise<Requests> {
-  const [legacyQuestions, legacyPermissions, networkWaits, modernQuestions, modernPermissions] =
+  const [legacyQuestions, legacyPermissions, networkWaits, modernQuestions, modernPermissions, suggestion] =
     await Promise.allSettled([
       client.question.list({ directory }),
       client.permission.list({ directory }),
       client.network.list({ directory }),
       client.v2.question.request.list({ location: { directory } }),
       client.v2.permission.request.list({ location: { directory } }),
+      client.suggestion.list({ directory }),
     ])
   const q = read(legacyQuestions)
   const p = read(legacyPermissions)
   const n = read(networkWaits)
   const q2 = read(modernQuestions)
   const p2 = read(modernPermissions)
+  const s = read(suggestion)
   const pending: Pending = new Map()
   const tools = new Map<string, QuestionTool>()
   const prefixes = new Set<string>()
-  const errors = [q.error, p.error, n.error, q2.error, p2.error].filter((error) => error !== undefined)
+  const errors = [q.error, p.error, n.error, q2.error, p2.error, s.error].filter((error) => error !== undefined)
   questions(pending, tools, q.data, q2.data?.data)
   permissions(pending, p.data, p2.data?.data)
   network(pending, n.data)
+  suggestions(pending, s.data)
   if (q.ok && q2.ok) prefixes.add("question:")
   if (p.ok && p2.ok) prefixes.add("permission:")
   if (n.ok) prefixes.add("network:")
+  if (s.ok) prefixes.add("suggestion:")
   return { pending, tools, prefixes, errors }
 }
 
@@ -893,30 +904,21 @@ export class SleepInhibitorService implements vscode.Disposable {
 
   private async restore(snapshot: Snapshot, dirs: string[]): Promise<void> {
     const client = this.connection.getClient()
-    const [results, waits, suggestions] = await Promise.all([
+    const [results, waits] = await Promise.all([
       Promise.allSettled(dirs.map((directory) => client.session.status({ directory }))),
       Promise.allSettled(dirs.map((directory) => requests(client, directory))),
-      Promise.allSettled([client.suggestion.list({ directory: dirs.at(0) })]),
     ])
     if (this.disposed || this.snapshot !== snapshot) return
 
     const restored = this.collect(results, dirs)
     const pending = this.collectWaits(waits, dirs)
-    const global: Pending = new Map()
-    const suggestion = suggestions.at(0)
-    const error = suggestion?.status === "rejected" ? suggestion.reason : suggestion?.value.error
-    if (error) this.log(`Could not restore pending suggestions: ${String(error)}`)
-    const data = suggestion?.status === "fulfilled" ? suggestion.value.data : undefined
-    for (const request of data ?? []) {
-      if (request.blocking !== false) add(global, request.sessionID, `suggestion:${request.id}`)
-    }
     const entries = [...restored.active]
     const infos = await Promise.allSettled(
       entries.map(([sessionID, item]) => client.session.get({ sessionID, directory: item.directory })),
     )
     if (this.disposed || this.snapshot !== snapshot) return
     this.names(snapshot, entries, infos)
-    this.reconcile(snapshot, restored, pending, global, suggestion?.status === "fulfilled" && !error, dirs.length)
+    this.reconcile(snapshot, restored, pending, dirs.length)
     if (this.snapshot === snapshot) this.snapshot = undefined
   }
 
@@ -980,16 +982,9 @@ export class SleepInhibitorService implements vscode.Disposable {
     }
   }
 
-  private reconcile(
-    snapshot: Snapshot,
-    restored: Restored,
-    pending: Map<string, Requests>,
-    global: Pending,
-    suggestions: boolean,
-    total: number,
-  ): void {
+  private reconcile(snapshot: Snapshot, restored: Restored, pending: Map<string, Requests>, total: number): void {
     for (const [sessionID, item] of restored.active) {
-      this.syncPending(snapshot, sessionID, item.directory, pending, global, suggestions)
+      this.syncPending(snapshot, sessionID, item.directory, pending)
       if (snapshot.changed.has(sessionID)) continue
       this.sessions.status(sessionID, item.status, this.titles.get(sessionID), item.directory)
     }
@@ -1003,25 +998,14 @@ export class SleepInhibitorService implements vscode.Disposable {
     }
   }
 
-  private syncPending(
-    snapshot: Snapshot,
-    sessionID: string,
-    directory: string,
-    pending: Map<string, Requests>,
-    global: Pending,
-    suggestions: boolean,
-  ): void {
+  private syncPending(snapshot: Snapshot, sessionID: string, directory: string, pending: Map<string, Requests>): void {
     if (snapshot.waits.has(sessionID)) return
     const local = pending.get(directory)
-    if (!local && !suggestions) return
-    const waits = new Set(local?.pending.get(sessionID) ?? [])
-    const prefixes = new Set(local?.prefixes ?? [])
-    if (suggestions) {
-      prefixes.add("suggestion:")
-      for (const requestID of global.get(sessionID) ?? []) waits.add(requestID)
-    }
+    if (!local) return
+    const waits = new Set(local.pending.get(sessionID) ?? [])
+    const prefixes = new Set(local.prefixes)
     if (prefixes.size > 0) this.sessions.syncWaits(sessionID, waits, prefixes)
-    if (local?.prefixes.has("question:")) this.syncQuestions(sessionID, local.tools)
+    if (local.prefixes.has("question:")) this.syncQuestions(sessionID, local.tools)
   }
 
   private dirty(sessionID: string): void {

--- a/packages/kilo-vscode/src/services/sleep-inhibitor.ts
+++ b/packages/kilo-vscode/src/services/sleep-inhibitor.ts
@@ -354,6 +354,15 @@ export class SleepInhibitor implements vscode.Disposable {
       if (token !== this.token) return
       next(`${item.cmd} exited unexpectedly (${signal ? `signal ${signal}` : `code ${code ?? "unknown"}`})`)
     })
+    child.once("close", (code, signal) => {
+      if (this.child !== child) return
+      if (this.closing) {
+        this.finish(child)
+        return
+      }
+      if (token !== this.token) return
+      next(`${item.cmd} closed unexpectedly (${signal ? `signal ${signal}` : `code ${code ?? "unknown"}`})`)
+    })
 
     if (item.ready) {
       const output = child.stdout

--- a/packages/kilo-vscode/src/services/sleep-inhibitor.ts
+++ b/packages/kilo-vscode/src/services/sleep-inhibitor.ts
@@ -1,0 +1,1069 @@
+import type { ChildProcess } from "child_process"
+import * as vscode from "vscode"
+import type {
+  KiloClient,
+  PermissionRequest,
+  PermissionV2Request,
+  QuestionRequest,
+  QuestionV2Request,
+  SessionNetworkWait,
+  SessionStatus,
+} from "@kilocode/sdk/v2/client"
+import type { KiloConnectionService } from "./cli-backend/connection-service"
+import type { SSEPayload } from "./cli-backend/sdk-sse-adapter"
+import { t } from "./i18n"
+import { spawn } from "../util/process"
+
+const DEFAULT_TIMEOUT = 30
+const READY = "KILO_SLEEP_INHIBITOR_READY"
+const CONNECTION_GRACE = 30_000
+
+export type InhibitionHandle = symbol
+
+type NativeProcess = Pick<ChildProcess, "kill" | "once" | "stdin" | "stdout">
+
+type Command = {
+  cmd: string
+  args: string[]
+  input?: boolean
+  ready?: string
+}
+
+type Options = {
+  platform?: NodeJS.Platform
+  pid?: number
+  launch?: (cmd: string, args: string[], output: boolean, input: boolean) => NativeProcess
+  retry?: (attempt: number) => number
+  startup?: number
+  grace?: number
+  log?: (message: string) => void
+  active?: (active: boolean) => void
+}
+
+type SessionOptions = {
+  timeout?: () => number
+  reason?: (title: string) => string
+  now?: () => number
+  log?: (message: string) => void
+}
+
+type Task = {
+  title: string
+  directory?: string
+  used: number
+  handle?: InhibitionHandle
+  started?: number
+  timer?: ReturnType<typeof setTimeout>
+}
+
+type Snapshot = {
+  changed: Set<string>
+  waits: Set<string>
+  titles: Set<string>
+  baseline: Map<string, string | undefined>
+}
+
+type Active = Map<string, { directory: string; status: SessionStatus }>
+type Pending = Map<string, Set<string>>
+type QuestionTool = { sessionID: string; messageID: string; callID: string }
+type Requests = {
+  pending: Pending
+  tools: Map<string, QuestionTool>
+  prefixes: Set<string>
+  errors: unknown[]
+}
+type Restored = { active: Active; ok: Set<string> }
+type Settled<T> = PromiseSettledResult<{ data?: T; error?: unknown }>
+type Read<T> = { data?: T; ok: boolean; error?: unknown }
+
+function add(pending: Pending, sessionID: string, requestID: string): void {
+  const waits = pending.get(sessionID) ?? new Set<string>()
+  waits.add(requestID)
+  pending.set(sessionID, waits)
+}
+
+function read<T>(result: Settled<T>): Read<T> {
+  if (result.status === "rejected") return { ok: false, error: result.reason }
+  if (result.value.error) return { ok: false, error: result.value.error }
+  return { data: result.value.data, ok: true }
+}
+
+function remember(
+  tools: Map<string, QuestionTool>,
+  request: { id: string; sessionID: string; tool?: { messageID: string; callID: string } },
+): void {
+  if (!request.tool) return
+  tools.set(request.id, { sessionID: request.sessionID, ...request.tool })
+}
+
+function questions(
+  pending: Pending,
+  tools: Map<string, QuestionTool>,
+  legacy?: QuestionRequest[],
+  modern?: QuestionV2Request[],
+) {
+  for (const request of legacy ?? []) {
+    if (request.blocking === false) continue
+    add(pending, request.sessionID, `question:${request.id}`)
+    remember(tools, request)
+  }
+  for (const request of modern ?? []) {
+    add(pending, request.sessionID, `question:${request.id}`)
+    remember(tools, request)
+  }
+}
+
+function permissions(pending: Pending, legacy?: PermissionRequest[], modern?: PermissionV2Request[]): void {
+  for (const request of legacy ?? []) add(pending, request.sessionID, `permission:${request.id}`)
+  for (const request of modern ?? []) add(pending, request.sessionID, `permission:${request.id}`)
+}
+
+function network(pending: Pending, waits?: SessionNetworkWait[]): void {
+  for (const request of waits ?? []) {
+    if (!request.restored) add(pending, request.sessionID, `network:${request.id}`)
+  }
+}
+
+async function requests(client: KiloClient, directory: string): Promise<Requests> {
+  const [legacyQuestions, legacyPermissions, networkWaits, modernQuestions, modernPermissions] =
+    await Promise.allSettled([
+      client.question.list({ directory }),
+      client.permission.list({ directory }),
+      client.network.list({ directory }),
+      client.v2.question.request.list({ location: { directory } }),
+      client.v2.permission.request.list({ location: { directory } }),
+    ])
+  const q = read(legacyQuestions)
+  const p = read(legacyPermissions)
+  const n = read(networkWaits)
+  const q2 = read(modernQuestions)
+  const p2 = read(modernPermissions)
+  const pending: Pending = new Map()
+  const tools = new Map<string, QuestionTool>()
+  const prefixes = new Set<string>()
+  const errors = [q.error, p.error, n.error, q2.error, p2.error].filter((error) => error !== undefined)
+  questions(pending, tools, q.data, q2.data?.data)
+  permissions(pending, p.data, p2.data?.data)
+  network(pending, n.data)
+  if (q.ok && q2.ok) prefixes.add("question:")
+  if (p.ok && p2.ok) prefixes.add("permission:")
+  if (n.ok) prefixes.add("network:")
+  return { pending, tools, prefixes, errors }
+}
+
+function commands(platform: NodeJS.Platform, reason: string, pid: number): Command[] {
+  const wait = ["/bin/sh", "-c", `printf '%s\\n' '${READY}'; IFS= read -r _ || true`]
+  if (platform === "linux") {
+    return [
+      {
+        cmd: "systemd-inhibit",
+        args: ["--what=sleep", "--who=Kilo", `--why=${reason}`, "--mode=block", ...wait],
+        input: true,
+        ready: READY,
+      },
+      {
+        cmd: "gnome-session-inhibit",
+        args: ["--app-id=ai.kilo.code", `--reason=${reason}`, "--inhibit=suspend", ...wait],
+        input: true,
+        ready: READY,
+      },
+    ]
+  }
+  if (platform === "darwin") {
+    return [{ cmd: "/usr/bin/caffeinate", args: ["-i", ...wait], input: true, ready: READY }]
+  }
+  if (platform === "win32") {
+    const script = [
+      "$ErrorActionPreference = 'Stop'",
+      'Add-Type -TypeDefinition \'using System; using System.Runtime.InteropServices; public static class KiloPower { [DllImport("kernel32.dll", SetLastError=true)] public static extern IntPtr OpenProcess(uint access, bool inherit, uint pid); [DllImport("kernel32.dll", SetLastError=true)] public static extern uint WaitForSingleObject(IntPtr handle, uint timeout); [DllImport("kernel32.dll")] public static extern uint SetThreadExecutionState(uint flags); [DllImport("kernel32.dll")] public static extern bool CloseHandle(IntPtr handle); }\'',
+      `$parent = [KiloPower]::OpenProcess(1048576, $false, [uint32]${pid})`,
+      "$error = [Runtime.InteropServices.Marshal]::GetLastWin32Error()",
+      'if ($parent -eq [IntPtr]::Zero) { throw "Cannot watch parent process ($error)" }',
+      "try {",
+      "  if ([KiloPower]::SetThreadExecutionState([uint32]2147483649) -eq 0) { throw 'SetThreadExecutionState failed' }",
+      "  try {",
+      `    [Console]::Out.WriteLine('${READY}')`,
+      "    [Console]::Out.Flush()",
+      "    $wait = [KiloPower]::WaitForSingleObject($parent, [uint32]::MaxValue)",
+      '    if ($wait -ne 0) { throw "Parent wait failed ($wait)" }',
+      "  } finally {",
+      "    [KiloPower]::SetThreadExecutionState([uint32]2147483648) | Out-Null",
+      "  }",
+      "} finally {",
+      "  [KiloPower]::CloseHandle($parent) | Out-Null",
+      "}",
+    ].join("\n")
+    return [
+      {
+        cmd: "powershell.exe",
+        args: ["-NoLogo", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-Command", script],
+        ready: READY,
+      },
+    ]
+  }
+  return []
+}
+
+export class SleepInhibitor implements vscode.Disposable {
+  private readonly refs = new Map<InhibitionHandle, string>()
+  private readonly platform: NodeJS.Platform
+  private readonly pid: number
+  private readonly launch: (cmd: string, args: string[], output: boolean, input: boolean) => NativeProcess
+  private readonly retry: (attempt: number) => number
+  private readonly startup: number
+  private readonly grace: number
+  private readonly log: (message: string) => void
+  private readonly active: (active: boolean) => void
+  private readonly exit = () => this.stop()
+  private child: NativeProcess | undefined
+  private timer: ReturnType<typeof setTimeout> | undefined
+  private probe: ReturnType<typeof setTimeout> | undefined
+  private killer: ReturnType<typeof setTimeout> | undefined
+  private token = 0
+  private ready = false
+  private closing = false
+  private shown = false
+  private disposed = false
+
+  constructor(opts: Options = {}) {
+    this.platform = opts.platform ?? process.platform
+    this.pid = opts.pid ?? process.pid
+    this.launch =
+      opts.launch ??
+      ((cmd, args, output, input) =>
+        spawn(cmd, args, {
+          stdio: [input ? "pipe" : "ignore", output ? "pipe" : "ignore", "ignore"],
+        }))
+    this.retry = opts.retry ?? ((attempt) => Math.min(1_000 * 2 ** attempt, 30_000))
+    this.startup = opts.startup ?? 10_000
+    this.grace = opts.grace ?? 1_000
+    this.log = opts.log ?? (() => undefined)
+    this.active = opts.active ?? (() => undefined)
+    process.on("exit", this.exit)
+  }
+
+  acquire(reason: string): InhibitionHandle {
+    const handle = Symbol(reason)
+    if (this.disposed) return handle
+    this.refs.set(handle, reason)
+    if (!this.child && !this.timer) this.start()
+    return handle
+  }
+
+  release(handle: InhibitionHandle): void {
+    if (!this.refs.delete(handle)) return
+    if (this.refs.size === 0) this.stop()
+  }
+
+  update(handle: InhibitionHandle, reason: string): void {
+    if (!this.refs.has(handle)) return
+    this.refs.set(handle, reason)
+  }
+
+  releaseAll(): void {
+    this.refs.clear()
+    this.stop()
+  }
+
+  isActive(): boolean {
+    return this.ready && this.child !== undefined
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    process.off("exit", this.exit)
+    this.releaseAll()
+    this.sync()
+  }
+
+  private start(attempt = 0): void {
+    const entry = this.refs.entries().next().value
+    if (!entry) return
+    const [, reason] = entry
+    const list = commands(this.platform, reason, this.pid)
+    if (list.length === 0) {
+      this.log(`System sleep inhibition is unsupported on ${this.platform}`)
+      return
+    }
+    this.run(list, 0, attempt)
+  }
+
+  private run(list: Command[], index: number, attempt: number): void {
+    if (this.disposed || this.refs.size === 0) return
+    const item = list[index]
+    if (!item) {
+      this.log("No system sleep inhibitor is available; tasks will continue normally")
+      this.schedule(attempt)
+      return
+    }
+
+    const child = (() => {
+      try {
+        return this.launch(item.cmd, item.args, item.ready !== undefined, item.input === true)
+      } catch (error) {
+        this.log(`${item.cmd} failed: ${error instanceof Error ? error.message : String(error)}`)
+        return undefined
+      }
+    })()
+    if (!child) {
+      this.run(list, index + 1, attempt)
+      return
+    }
+
+    this.child = child
+    this.ready = false
+    this.closing = false
+    const token = ++this.token
+    let failed = false
+
+    const next = (message: string) => {
+      if (token !== this.token || this.child !== child) return
+      this.clearProbe()
+      this.clearKiller()
+      this.child = undefined
+      this.ready = false
+      this.closing = false
+      this.sync()
+      this.log(message)
+      this.run(list, index + 1, attempt)
+    }
+
+    const activate = () => {
+      if (token !== this.token || this.child !== child || this.closing || this.ready || failed) return
+      this.clearProbe()
+      this.ready = true
+      this.sync()
+      this.log(`Started ${item.cmd}`)
+    }
+
+    child.once("error", (error) => {
+      if (this.closing && this.child === child) {
+        this.log(`${item.cmd} could not be stopped cleanly: ${error.message}`)
+        return
+      }
+      next(`${item.cmd} failed: ${error.message}`)
+    })
+    child.stdin?.once("error", (error) => this.log(`${item.cmd} input closed with an error: ${error.message}`))
+    child.once("exit", (code, signal) => {
+      if (this.child !== child) return
+      if (this.closing) {
+        this.finish(child)
+        return
+      }
+      if (token !== this.token) return
+      next(`${item.cmd} exited unexpectedly (${signal ? `signal ${signal}` : `code ${code ?? "unknown"}`})`)
+    })
+
+    if (item.ready) {
+      const output = child.stdout
+      if (!output) {
+        next(`${item.cmd} failed: startup confirmation channel is unavailable`)
+        return
+      }
+      let data = ""
+      output.on("data", (chunk) => {
+        data = `${data}${String(chunk)}`.slice(-4_096)
+        if (data.includes(item.ready ?? "")) activate()
+      })
+    } else {
+      child.once("spawn", activate)
+    }
+
+    this.probe = setTimeout(() => {
+      if (token !== this.token || this.child !== child || this.ready) return
+      failed = true
+      this.clearProbe()
+      this.log(`${item.cmd} did not confirm system sleep inhibition`)
+      this.terminate(child)
+    }, this.startup)
+    this.probe.unref?.()
+  }
+
+  private stop(): void {
+    this.token += 1
+    this.clearRetry()
+    this.clearProbe()
+    const child = this.child
+    if (!child) {
+      this.ready = false
+      this.sync()
+      return
+    }
+    this.closing = true
+    this.terminate(child)
+  }
+
+  private finish(child: NativeProcess): void {
+    if (this.child !== child) return
+    this.clearProbe()
+    this.clearKiller()
+    this.child = undefined
+    this.ready = false
+    this.closing = false
+    this.sync()
+    if (!this.disposed && this.refs.size > 0) this.start()
+  }
+
+  private schedule(attempt: number): void {
+    if (this.disposed || this.refs.size === 0 || this.timer) return
+    const wait = Math.max(0, this.retry(attempt))
+    const token = ++this.token
+    this.log(`Retrying system sleep inhibition in ${wait}ms`)
+    this.timer = setTimeout(() => {
+      if (token !== this.token) return
+      this.timer = undefined
+      this.start(attempt + 1)
+    }, wait)
+    this.timer.unref?.()
+  }
+
+  private clearRetry(): void {
+    if (!this.timer) return
+    clearTimeout(this.timer)
+    this.timer = undefined
+  }
+
+  private clearProbe(): void {
+    if (!this.probe) return
+    clearTimeout(this.probe)
+    this.probe = undefined
+  }
+
+  private terminate(child: NativeProcess): void {
+    const input = child.stdin
+    if (input && !input.destroyed && !input.writableEnded) {
+      input.end()
+      this.clearKiller()
+      this.killer = setTimeout(() => {
+        if (this.child !== child) return
+        const killed = child.kill()
+        if (!killed) this.log("System sleep inhibitor could not be terminated; waiting for process exit")
+      }, this.grace)
+      this.killer.unref?.()
+      return
+    }
+    const killed = child.kill()
+    if (!killed) this.log("System sleep inhibitor could not be terminated; waiting for process exit")
+  }
+
+  private clearKiller(): void {
+    if (!this.killer) return
+    clearTimeout(this.killer)
+    this.killer = undefined
+  }
+
+  private sync(): void {
+    const active = !this.disposed && this.isActive()
+    if (this.shown === active) return
+    this.shown = active
+    this.active(active)
+  }
+}
+
+export class SessionSleepInhibitor {
+  private readonly tasks = new Map<string, Task>()
+  private readonly waiting = new Map<string, Set<string>>()
+  private readonly timeout: () => number
+  private readonly reason: (title: string) => string
+  private readonly now: () => number
+  private readonly log: (message: string) => void
+  private enabled: boolean
+  private forced = false
+
+  constructor(
+    private readonly inhibitor: SleepInhibitor,
+    enabled: boolean,
+    opts: SessionOptions = {},
+  ) {
+    this.enabled = enabled
+    this.timeout = opts.timeout ?? (() => DEFAULT_TIMEOUT * 60_000)
+    this.reason = opts.reason ?? ((title) => `Task "${title}" is running`)
+    this.now = opts.now ?? Date.now
+    this.log = opts.log ?? (() => undefined)
+  }
+
+  status(sessionID: string, status: SessionStatus, title?: string, directory?: string): void {
+    if (status.type === "idle") {
+      this.remove(sessionID)
+      return
+    }
+    const task = this.tasks.get(sessionID) ?? { title: title ?? "Task", used: 0 }
+    task.directory = directory ?? task.directory
+    this.tasks.set(sessionID, task)
+    if (title !== undefined) this.title(sessionID, title)
+    if (status.type === "offline") {
+      this.pause(sessionID, `network:${status.requestID}`)
+      return
+    }
+    this.resumeAll(sessionID, "network:")
+    this.acquire(sessionID)
+  }
+
+  remove(sessionID: string): void {
+    this.deactivate(sessionID)
+    this.tasks.delete(sessionID)
+    this.waiting.delete(sessionID)
+    if (this.tasks.size === 0) this.forced = false
+  }
+
+  pause(sessionID: string, requestID: string): void {
+    const pending = this.waiting.get(sessionID) ?? new Set<string>()
+    pending.add(requestID)
+    this.waiting.set(sessionID, pending)
+    this.deactivate(sessionID)
+  }
+
+  resume(sessionID: string, requestID: string): void {
+    const pending = this.waiting.get(sessionID)
+    if (!pending) return
+    pending.delete(requestID)
+    if (pending.size > 0) return
+    this.waiting.delete(sessionID)
+    this.acquire(sessionID)
+  }
+
+  resumeAll(sessionID: string, prefix: string): void {
+    const pending = this.waiting.get(sessionID)
+    if (!pending) return
+    for (const requestID of pending) {
+      if (requestID.startsWith(prefix)) pending.delete(requestID)
+    }
+    if (pending.size > 0) return
+    this.waiting.delete(sessionID)
+    this.acquire(sessionID)
+  }
+
+  syncWaits(sessionID: string, waits: Set<string>, prefixes: Set<string>): void {
+    const pending = new Set(waits)
+    const known = [...prefixes]
+    for (const requestID of this.waiting.get(sessionID) ?? []) {
+      if (!known.some((prefix) => requestID.startsWith(prefix))) pending.add(requestID)
+    }
+    if (pending.size > 0) {
+      this.waiting.set(sessionID, pending)
+      this.deactivate(sessionID)
+      return
+    }
+    this.waiting.delete(sessionID)
+    this.acquire(sessionID)
+  }
+
+  configure(enabled: boolean, refresh = false): void {
+    if (this.enabled === enabled && !refresh) return
+    this.clear()
+    this.enabled = enabled
+    if (!enabled || this.forced) return
+    for (const sessionID of this.tasks.keys()) this.acquire(sessionID)
+  }
+
+  force(): void {
+    this.forced = this.tasks.size > 0
+    this.clear()
+  }
+
+  suspend(): void {
+    this.clear()
+  }
+
+  reset(): void {
+    this.clear()
+    this.tasks.clear()
+    this.waiting.clear()
+    this.forced = false
+  }
+
+  ids(): string[] {
+    return [...this.tasks.keys()]
+  }
+
+  directory(sessionID: string): string | undefined {
+    return this.tasks.get(sessionID)?.directory
+  }
+
+  title(sessionID: string, title: string): void {
+    const task = this.tasks.get(sessionID)
+    if (!task || task.title === title) return
+    task.title = title
+    if (task.handle) this.inhibitor.update(task.handle, this.reason(title.replaceAll('"', "'")))
+  }
+
+  private acquire(sessionID: string): void {
+    const task = this.tasks.get(sessionID)
+    if (!task || !this.enabled || this.forced || task.handle || this.waiting.has(sessionID)) return
+    const limit = this.limit()
+    const remaining = limit === 0 ? undefined : limit - task.used
+    if (remaining !== undefined && remaining <= 0) return
+
+    task.handle = this.inhibitor.acquire(this.reason(task.title.replaceAll('"', "'")))
+    task.started = this.now()
+    if (remaining === undefined) return
+    task.timer = setTimeout(() => {
+      if (this.tasks.get(sessionID) !== task || !task.handle) return
+      this.log(`Safety timeout reached for ${task.title}`)
+      this.deactivate(sessionID)
+    }, remaining)
+    task.timer.unref?.()
+  }
+
+  private clear(): void {
+    for (const sessionID of this.tasks.keys()) this.deactivate(sessionID)
+  }
+
+  private deactivate(sessionID: string): void {
+    const task = this.tasks.get(sessionID)
+    if (!task) return
+    if (task.timer) clearTimeout(task.timer)
+    task.timer = undefined
+    if (!task.handle) return
+    if (task.started !== undefined) task.used += Math.max(0, this.now() - task.started)
+    this.inhibitor.release(task.handle)
+    task.handle = undefined
+    task.started = undefined
+  }
+
+  private limit(): number {
+    const value = this.timeout()
+    if (!Number.isFinite(value)) return DEFAULT_TIMEOUT * 60_000
+    return Math.max(0, value)
+  }
+}
+
+export class SleepInhibitorService implements vscode.Disposable {
+  private readonly output = vscode.window.createOutputChannel("Kilo Sleep Prevention")
+  private readonly bar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 98)
+  private readonly inhibitor: SleepInhibitor
+  private readonly sessions: SessionSleepInhibitor
+  private readonly event: () => void
+  private readonly state: () => void
+  private readonly config: vscode.Disposable
+  private readonly command: vscode.Disposable
+  private readonly titles = new Map<string, string>()
+  private readonly questions = new Map<string, QuestionTool>()
+  private snapshot: Snapshot | undefined
+  private lost: ReturnType<typeof setTimeout> | undefined
+  private disposed = false
+
+  constructor(private readonly connection: KiloConnectionService) {
+    this.bar.command = "kilo-code.new.allowSystemSleep"
+    this.bar.text = "$(coffee) Kilo"
+    this.text()
+    this.inhibitor = new SleepInhibitor({
+      log: (message) => this.log(message),
+      active: (active) => (active ? this.bar.show() : this.bar.hide()),
+    })
+    this.sessions = new SessionSleepInhibitor(this.inhibitor, this.enabled(), {
+      timeout: () => this.timeout(),
+      reason: (title) => t("kilocode:sleep.reason", { title }),
+      log: (message) => this.log(message),
+    })
+    this.event = connection.onEvent((event, directory) => this.handle(event, directory))
+    this.state = connection.onStateChange((state) => {
+      if (state === "connected") {
+        this.clearLost()
+        this.seed()
+        return
+      }
+      if (state === "error" || state === "connecting") {
+        this.watch()
+        return
+      }
+      if (state === "disconnected") {
+        this.clearLost()
+        this.snapshot = undefined
+        this.sessions.suspend()
+      }
+    })
+    this.config = vscode.workspace.onDidChangeConfiguration((event) => {
+      const enabled = event.affectsConfiguration("kilo-code.new.preventSleepDuringTasks")
+      const timeout = event.affectsConfiguration("kilo-code.new.preventSleepDuringTasksTimeoutMinutes")
+      const language = event.affectsConfiguration("kilo-code.new.language")
+      if (language) this.text()
+      if (enabled || timeout || language) this.sessions.configure(this.enabled(), timeout || language)
+    })
+    this.command = vscode.commands.registerCommand("kilo-code.new.allowSystemSleep", () => {
+      this.sessions.force()
+      this.log("System sleep inhibition was released manually")
+    })
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    this.snapshot = undefined
+    this.event()
+    this.state()
+    this.clearLost()
+    this.config.dispose()
+    this.command.dispose()
+    this.questions.clear()
+    this.sessions.reset()
+    this.inhibitor.dispose()
+    this.bar.dispose()
+    this.output.dispose()
+  }
+
+  private handle(event: SSEPayload, directory?: string): void {
+    if (event.type === "session.created" || event.type === "session.updated") {
+      const sessionID = event.properties.sessionID
+      this.snapshot?.titles.add(sessionID)
+      this.titles.set(sessionID, event.properties.info.title)
+      this.sessions.title(sessionID, event.properties.info.title)
+      return
+    }
+    if (event.type === "sync" && (event.name === "session.created.1" || event.name === "session.updated.1")) {
+      const sessionID = event.data.sessionID
+      this.snapshot?.titles.add(sessionID)
+      this.titles.set(sessionID, event.data.info.title)
+      this.sessions.title(sessionID, event.data.info.title)
+      return
+    }
+    if (event.type === "session.status") {
+      this.dirty(event.properties.sessionID)
+      this.sessions.status(
+        event.properties.sessionID,
+        event.properties.status,
+        this.titles.get(event.properties.sessionID),
+        directory,
+      )
+      return
+    }
+    if (this.wait(event)) return
+    if (this.tool(event)) return
+    if (event.type === "session.deleted") {
+      this.dirty(event.properties.sessionID)
+      this.titles.delete(event.properties.sessionID)
+      this.clearQuestions(event.properties.sessionID)
+      this.sessions.remove(event.properties.sessionID)
+      return
+    }
+    if (event.type === "session.idle" || event.type === "session.turn.close") {
+      this.dirty(event.properties.sessionID)
+      this.clearQuestions(event.properties.sessionID)
+      this.sessions.remove(event.properties.sessionID)
+      return
+    }
+    if (event.type === "sync" && event.name === "session.deleted.1") {
+      this.dirty(event.data.sessionID)
+      this.titles.delete(event.data.sessionID)
+      this.clearQuestions(event.data.sessionID)
+      this.sessions.remove(event.data.sessionID)
+    }
+  }
+
+  private wait(event: SSEPayload): boolean {
+    return this.question(event) || this.permission(event) || this.network(event) || this.suggestion(event)
+  }
+
+  private question(event: SSEPayload): boolean {
+    if (event.type === "question.asked") {
+      this.waiting(event.properties.sessionID)
+      if (event.properties.blocking !== false) {
+        this.sessions.pause(event.properties.sessionID, `question:${event.properties.id}`)
+        remember(this.questions, event.properties)
+      }
+      return true
+    }
+    if (event.type === "question.replied" || event.type === "question.rejected") {
+      this.waiting(event.properties.sessionID)
+      this.questions.delete(event.properties.requestID)
+      this.sessions.resume(event.properties.sessionID, `question:${event.properties.requestID}`)
+      return true
+    }
+    if (event.type === "question.v2.asked") {
+      this.waiting(event.properties.sessionID)
+      this.sessions.pause(event.properties.sessionID, `question:${event.properties.id}`)
+      remember(this.questions, event.properties)
+      return true
+    }
+    if (event.type === "question.v2.replied" || event.type === "question.v2.rejected") {
+      this.waiting(event.properties.sessionID)
+      this.questions.delete(event.properties.requestID)
+      this.sessions.resume(event.properties.sessionID, `question:${event.properties.requestID}`)
+      return true
+    }
+    return false
+  }
+
+  private permission(event: SSEPayload): boolean {
+    if (event.type === "permission.asked") {
+      this.waiting(event.properties.sessionID)
+      this.sessions.pause(event.properties.sessionID, `permission:${event.properties.id}`)
+      return true
+    }
+    if (event.type === "permission.replied") {
+      this.waiting(event.properties.sessionID)
+      this.sessions.resume(event.properties.sessionID, `permission:${event.properties.requestID}`)
+      return true
+    }
+    if (event.type === "permission.v2.asked") {
+      this.waiting(event.properties.sessionID)
+      this.sessions.pause(event.properties.sessionID, `permission:${event.properties.id}`)
+      return true
+    }
+    if (event.type === "permission.v2.replied") {
+      this.waiting(event.properties.sessionID)
+      this.sessions.resume(event.properties.sessionID, `permission:${event.properties.requestID}`)
+      return true
+    }
+    return false
+  }
+
+  private network(event: SSEPayload): boolean {
+    if (event.type === "session.network.asked") {
+      this.waiting(event.properties.sessionID)
+      this.sessions.pause(event.properties.sessionID, `network:${event.properties.id}`)
+      return true
+    }
+    if (
+      event.type === "session.network.replied" ||
+      event.type === "session.network.rejected" ||
+      event.type === "session.network.restored"
+    ) {
+      this.waiting(event.properties.sessionID)
+      this.sessions.resume(event.properties.sessionID, `network:${event.properties.requestID}`)
+      return true
+    }
+    return false
+  }
+
+  private suggestion(event: SSEPayload): boolean {
+    if (event.type === "suggestion.shown") {
+      this.waiting(event.properties.sessionID)
+      if (event.properties.blocking !== false) {
+        this.sessions.pause(event.properties.sessionID, `suggestion:${event.properties.id}`)
+      }
+      return true
+    }
+    if (event.type === "suggestion.accepted" || event.type === "suggestion.dismissed") {
+      this.waiting(event.properties.sessionID)
+      this.sessions.resume(event.properties.sessionID, `suggestion:${event.properties.requestID}`)
+      return true
+    }
+    return false
+  }
+
+  private tool(event: SSEPayload): boolean {
+    const data = (() => {
+      if (event.type === "message.part.updated") return event.properties
+      if (event.type === "sync" && event.name === "message.part.updated.1") return event.data
+      return undefined
+    })()
+    if (!data || data.part.type !== "tool" || data.part.tool !== "question") return false
+    if (data.part.state.status === "pending" || data.part.state.status === "running") return false
+    let matched = false
+    for (const [requestID, tool] of this.questions) {
+      if (tool.sessionID !== data.sessionID) continue
+      if (tool.messageID !== data.part.messageID || tool.callID !== data.part.callID) continue
+      this.waiting(data.sessionID)
+      this.questions.delete(requestID)
+      this.sessions.resume(data.sessionID, `question:${requestID}`)
+      matched = true
+    }
+    return matched
+  }
+
+  private clearQuestions(sessionID: string): void {
+    for (const [requestID, tool] of this.questions) {
+      if (tool.sessionID === sessionID) this.questions.delete(requestID)
+    }
+  }
+
+  private seed(): void {
+    const dirs = this.connection.getKnownDirectories()
+    if (dirs.length === 0) return
+    const snapshot: Snapshot = {
+      changed: new Set(),
+      waits: new Set(),
+      titles: new Set(),
+      baseline: new Map(this.sessions.ids().map((sessionID) => [sessionID, this.sessions.directory(sessionID)])),
+    }
+    this.snapshot = snapshot
+    void this.restore(snapshot, dirs)
+  }
+
+  private async restore(snapshot: Snapshot, dirs: string[]): Promise<void> {
+    const client = this.connection.getClient()
+    const [results, waits, suggestions] = await Promise.all([
+      Promise.allSettled(dirs.map((directory) => client.session.status({ directory }))),
+      Promise.allSettled(dirs.map((directory) => requests(client, directory))),
+      Promise.allSettled([client.suggestion.list({ directory: dirs.at(0) })]),
+    ])
+    if (this.disposed || this.snapshot !== snapshot) return
+
+    const restored = this.collect(results, dirs)
+    const pending = this.collectWaits(waits, dirs)
+    const global: Pending = new Map()
+    const suggestion = suggestions.at(0)
+    const error = suggestion?.status === "rejected" ? suggestion.reason : suggestion?.value.error
+    if (error) this.log(`Could not restore pending suggestions: ${String(error)}`)
+    const data = suggestion?.status === "fulfilled" ? suggestion.value.data : undefined
+    for (const request of data ?? []) {
+      if (request.blocking !== false) add(global, request.sessionID, `suggestion:${request.id}`)
+    }
+    const entries = [...restored.active]
+    const infos = await Promise.allSettled(
+      entries.map(([sessionID, item]) => client.session.get({ sessionID, directory: item.directory })),
+    )
+    if (this.disposed || this.snapshot !== snapshot) return
+    this.names(snapshot, entries, infos)
+    this.reconcile(snapshot, restored, pending, global, suggestion?.status === "fulfilled" && !error, dirs.length)
+    if (this.snapshot === snapshot) this.snapshot = undefined
+  }
+
+  private collect(results: Settled<Record<string, SessionStatus>>[], dirs: string[]): Restored {
+    const active: Active = new Map()
+    const ok = new Set<string>()
+    for (const [index, result] of results.entries()) {
+      if (result.status === "rejected") {
+        this.log(`Could not restore running task status: ${String(result.reason)}`)
+        continue
+      }
+      if (result.value.error) {
+        this.log(`Could not restore running task status: ${String(result.value.error)}`)
+        continue
+      }
+      const directory = dirs.at(index)
+      if (!directory) continue
+      ok.add(directory)
+      for (const [sessionID, status] of Object.entries(result.value.data ?? {})) {
+        active.set(sessionID, { directory, status })
+      }
+    }
+    return { active, ok }
+  }
+
+  private collectWaits(results: PromiseSettledResult<Requests>[], dirs: string[]): Map<string, Requests> {
+    const pending = new Map<string, Requests>()
+    for (const [index, result] of results.entries()) {
+      const directory = dirs.at(index)
+      if (!directory) continue
+      if (result.status === "rejected") {
+        this.log(`Could not restore pending task input for ${directory}: ${String(result.reason)}`)
+        continue
+      }
+      for (const error of result.value.errors) {
+        this.log(`Could not completely restore pending task input for ${directory}: ${String(error)}`)
+      }
+      pending.set(directory, result.value)
+    }
+    return pending
+  }
+
+  private names(
+    snapshot: Snapshot,
+    entries: Array<[string, { directory: string; status: SessionStatus }]>,
+    infos: Settled<{ title: string }>[],
+  ): void {
+    for (const [index, result] of infos.entries()) {
+      const sessionID = entries.at(index)?.[0]
+      if (!sessionID || snapshot.titles.has(sessionID)) continue
+      if (result.status === "rejected") {
+        this.log(`Could not restore running task title: ${String(result.reason)}`)
+        continue
+      }
+      if (result.value.error || !result.value.data) {
+        if (result.value.error) this.log(`Could not restore running task title: ${String(result.value.error)}`)
+        continue
+      }
+      this.titles.set(sessionID, result.value.data.title)
+      this.sessions.title(sessionID, result.value.data.title)
+    }
+  }
+
+  private reconcile(
+    snapshot: Snapshot,
+    restored: Restored,
+    pending: Map<string, Requests>,
+    global: Pending,
+    suggestions: boolean,
+    total: number,
+  ): void {
+    for (const [sessionID, item] of restored.active) {
+      this.syncPending(snapshot, sessionID, item.directory, pending, global, suggestions)
+      if (snapshot.changed.has(sessionID)) continue
+      this.sessions.status(sessionID, item.status, this.titles.get(sessionID), item.directory)
+    }
+    for (const [sessionID, directory] of snapshot.baseline) {
+      if (restored.active.has(sessionID) || snapshot.changed.has(sessionID)) continue
+      const complete = directory ? restored.ok.has(directory) : restored.ok.size === total
+      if (!complete) continue
+      this.titles.delete(sessionID)
+      this.clearQuestions(sessionID)
+      this.sessions.remove(sessionID)
+    }
+  }
+
+  private syncPending(
+    snapshot: Snapshot,
+    sessionID: string,
+    directory: string,
+    pending: Map<string, Requests>,
+    global: Pending,
+    suggestions: boolean,
+  ): void {
+    if (snapshot.waits.has(sessionID)) return
+    const local = pending.get(directory)
+    if (!local && !suggestions) return
+    const waits = new Set(local?.pending.get(sessionID) ?? [])
+    const prefixes = new Set(local?.prefixes ?? [])
+    if (suggestions) {
+      prefixes.add("suggestion:")
+      for (const requestID of global.get(sessionID) ?? []) waits.add(requestID)
+    }
+    if (prefixes.size > 0) this.sessions.syncWaits(sessionID, waits, prefixes)
+    if (local?.prefixes.has("question:")) this.syncQuestions(sessionID, local.tools)
+  }
+
+  private dirty(sessionID: string): void {
+    this.snapshot?.changed.add(sessionID)
+  }
+
+  private waiting(sessionID: string): void {
+    this.snapshot?.waits.add(sessionID)
+  }
+
+  private syncQuestions(sessionID: string, tools: Map<string, QuestionTool>): void {
+    this.clearQuestions(sessionID)
+    for (const [requestID, tool] of tools) {
+      if (tool.sessionID === sessionID) this.questions.set(requestID, tool)
+    }
+  }
+
+  private watch(): void {
+    if (this.lost) return
+    this.lost = setTimeout(() => {
+      this.lost = undefined
+      this.snapshot = undefined
+      this.sessions.suspend()
+      this.log("Connection remained unavailable; system sleep inhibition was suspended")
+    }, CONNECTION_GRACE)
+    this.lost.unref?.()
+  }
+
+  private clearLost(): void {
+    if (!this.lost) return
+    clearTimeout(this.lost)
+    this.lost = undefined
+  }
+
+  private enabled(): boolean {
+    return vscode.workspace.getConfiguration("kilo-code.new").get("preventSleepDuringTasks", false)
+  }
+
+  private timeout(): number {
+    const value = vscode.workspace
+      .getConfiguration("kilo-code.new")
+      .get("preventSleepDuringTasksTimeoutMinutes", DEFAULT_TIMEOUT)
+    const minutes = Number.isFinite(value) ? Math.max(0, value) : DEFAULT_TIMEOUT
+    return minutes * 60_000
+  }
+
+  private text(): void {
+    this.bar.tooltip = t("kilocode:sleep.statusBar.tooltip")
+  }
+
+  private log(message: string): void {
+    this.output.appendLine(`[Kilo New] [${new Date().toISOString()}] ${message}`)
+  }
+}

--- a/packages/kilo-vscode/tests/unit/sleep-inhibitor.test.ts
+++ b/packages/kilo-vscode/tests/unit/sleep-inhibitor.test.ts
@@ -284,6 +284,23 @@ describe("SleepInhibitor", () => {
     expect(item(test.calls, 1).cmd).toBe("systemd-inhibit")
   })
 
+  it("starts a replacement after a closing helper fails to spawn", () => {
+    const test = setup()
+    const first = test.inhibitor.acquire("first")
+    const call = item(test.calls)
+
+    test.inhibitor.release(first)
+    call.child.emit("error", new Error("ENOENT"))
+    const second = test.inhibitor.acquire("second")
+    expect(test.calls).toHaveLength(1)
+
+    call.child.emit("close", null, null)
+
+    expect(test.calls).toHaveLength(2)
+    expect(item(test.calls, 1).cmd).toBe("systemd-inhibit")
+    test.inhibitor.release(second)
+  })
+
   it("falls back on Linux before scheduling a retry", () => {
     jest.useFakeTimers()
     const test = setup({ retry: () => 100 })

--- a/packages/kilo-vscode/tests/unit/sleep-inhibitor.test.ts
+++ b/packages/kilo-vscode/tests/unit/sleep-inhibitor.test.ts
@@ -111,7 +111,8 @@ function backend(
     questions?: object[]
     permissions?: object[]
     network?: object[]
-    suggestions?: object[]
+    suggestions?: object[] | Record<string, object[]>
+    queries?: string[]
     q2?: object[]
     p2?: object[]
     fail?: string[]
@@ -123,8 +124,12 @@ function backend(
     permission: { list: async () => ({ data: prompts.permissions ?? [] }) },
     network: { list: async () => ({ data: prompts.network ?? [] }) },
     suggestion: {
-      list: async () =>
-        prompts.fail?.includes("suggestion") ? { error: "suggestion failed" } : { data: prompts.suggestions ?? [] },
+      list: async (input: { directory?: string } = {}) => {
+        const directory = input.directory ?? ""
+        prompts.queries?.push(directory)
+        const data = Array.isArray(prompts.suggestions) ? prompts.suggestions : (prompts.suggestions?.[directory] ?? [])
+        return prompts.fail?.includes("suggestion") ? { error: "suggestion failed" } : { data }
+      },
     },
     v2: {
       question: {
@@ -656,6 +661,42 @@ describe("sleep prevention settings", () => {
 })
 
 describe("SleepInhibitorService reconnect", () => {
+  it("restores blocking suggestions from every known directory", async () => {
+    const queries: string[] = []
+    let state: ((state: "connected") => void) | undefined
+    const connection = {
+      onEvent: () => () => undefined,
+      onStateChange: (handler: (state: "connected") => void) => {
+        state = handler
+        return () => undefined
+      },
+      getKnownDirectories: () => ["/workspace", "/worktree"],
+      getClient: () =>
+        backend(
+          {
+            status: async ({ directory }: { directory: string }) => ({
+              data: directory === "/worktree" ? { one: { type: "busy" } } : {},
+            }),
+            get: async () => ({ data: { title: "Worktree task" } }),
+          },
+          {
+            suggestions: {
+              "/worktree": [{ id: "s1", sessionID: "one", text: "Choose", actions: [], blocking: true }],
+            },
+            queries,
+          },
+        ),
+    } as unknown as KiloConnectionService
+    const service = new SleepInhibitorService(connection)
+
+    state?.("connected")
+    await Bun.sleep(0)
+
+    expect(queries).toEqual(["/workspace", "/worktree"])
+    expect(blocked(service, "one")).toEqual(["suggestion:s1"])
+    service.dispose()
+  })
+
   it("restores pending input after a newer status event", async () => {
     const pending = Promise.withResolvers<{ data: { one: { type: "busy" } } }>()
     let event: ((event: SSEPayload, directory?: string) => void) | undefined

--- a/packages/kilo-vscode/tests/unit/sleep-inhibitor.test.ts
+++ b/packages/kilo-vscode/tests/unit/sleep-inhibitor.test.ts
@@ -1,0 +1,1017 @@
+import { afterEach, describe, expect, it, jest } from "bun:test"
+import { EventEmitter } from "node:events"
+import { PassThrough } from "node:stream"
+import type { KiloConnectionService } from "../../src/services/cli-backend/connection-service"
+import type { SSEPayload } from "../../src/services/cli-backend/sdk-sse-adapter"
+import { SessionSleepInhibitor, SleepInhibitor, SleepInhibitorService } from "../../src/services/sleep-inhibitor"
+
+class Process extends EventEmitter {
+  readonly stdin: PassThrough | null
+  readonly stdout = new PassThrough()
+  kills = 0
+  result = true
+
+  constructor(input: boolean) {
+    super()
+    this.stdin = input ? new PassThrough() : null
+  }
+
+  kill(): boolean {
+    this.kills += 1
+    return this.result
+  }
+}
+
+type Call = {
+  cmd: string
+  args: string[]
+  output: boolean
+  input: boolean
+  child: Process
+}
+
+type Setup = {
+  platform?: NodeJS.Platform
+  pid?: number
+  retry?: (attempt: number) => number
+  startup?: number
+}
+
+const inhibitors: SleepInhibitor[] = []
+
+afterEach(() => {
+  for (const inhibitor of inhibitors) inhibitor.dispose()
+  inhibitors.length = 0
+  jest.useRealTimers()
+})
+
+function setup(opts: Setup = {}) {
+  const calls: Call[] = []
+  const logs: string[] = []
+  const states: boolean[] = []
+  const inhibitor = new SleepInhibitor({
+    platform: opts.platform ?? "linux",
+    pid: opts.pid,
+    retry: opts.retry,
+    startup: opts.startup,
+    log: (message) => logs.push(message),
+    active: (active) => states.push(active),
+    launch: (cmd, args, output, input) => {
+      const child = new Process(input)
+      calls.push({ cmd, args, output, input, child })
+      return child
+    },
+  })
+  inhibitors.push(inhibitor)
+  const session = (enabled = true, timeout = 60_000) =>
+    new SessionSleepInhibitor(inhibitor, enabled, {
+      timeout: () => timeout,
+      now: () => Date.now(),
+      log: (message) => logs.push(message),
+    })
+  return { calls, logs, states, inhibitor, session }
+}
+
+function item(calls: Call[], index = 0): Call {
+  const call = calls.at(index)
+  if (!call) throw new Error(`Expected process call ${index}`)
+  return call
+}
+
+function spawn(call: Call): void {
+  call.child.emit("spawn")
+  if (call.output) call.child.stdout.write("KILO_SLEEP_INHIBITOR_READY\n")
+}
+
+function exit(call: Call): void {
+  call.child.emit("exit", 0, null)
+}
+
+function stopped(call: Call): boolean {
+  return call.child.kills > 0 || call.child.stdin?.writableEnded === true
+}
+
+function tracked(service: SleepInhibitorService): string[] {
+  return (service as unknown as { sessions: SessionSleepInhibitor }).sessions.ids()
+}
+
+function blocked(service: SleepInhibitorService, sessionID: string): string[] {
+  const sessions = (service as unknown as { sessions: { waiting: Map<string, Set<string>> } }).sessions
+  return [...(sessions.waiting.get(sessionID) ?? [])].sort()
+}
+
+function title(service: SleepInhibitorService, sessionID: string): string | undefined {
+  const sessions = (service as unknown as { sessions: { tasks: Map<string, { title: string }> } }).sessions
+  return sessions.tasks.get(sessionID)?.title
+}
+
+function backend(
+  session: object,
+  prompts: {
+    questions?: object[]
+    permissions?: object[]
+    network?: object[]
+    suggestions?: object[]
+    q2?: object[]
+    p2?: object[]
+    fail?: string[]
+  } = {},
+) {
+  return {
+    session,
+    question: { list: async () => ({ data: prompts.questions ?? [] }) },
+    permission: { list: async () => ({ data: prompts.permissions ?? [] }) },
+    network: { list: async () => ({ data: prompts.network ?? [] }) },
+    suggestion: {
+      list: async () =>
+        prompts.fail?.includes("suggestion") ? { error: "suggestion failed" } : { data: prompts.suggestions ?? [] },
+    },
+    v2: {
+      question: {
+        request: {
+          list: async () =>
+            prompts.fail?.includes("q2") ? { error: "q2 failed" } : { data: { data: prompts.q2 ?? [] } },
+        },
+      },
+      permission: { request: { list: async () => ({ data: { data: prompts.p2 ?? [] } }) } },
+    },
+  }
+}
+
+describe("SleepInhibitor", () => {
+  it("becomes active only after the native process confirms startup", () => {
+    const test = setup()
+    test.inhibitor.acquire("task")
+
+    expect(test.inhibitor.isActive()).toBe(false)
+    expect(test.states).toEqual([])
+
+    const call = item(test.calls)
+    call.child.emit("spawn")
+
+    expect(test.inhibitor.isActive()).toBe(false)
+    call.child.stdout.write("KILO_SLEEP_INHIBITOR_READY\n")
+
+    expect(test.inhibitor.isActive()).toBe(true)
+    expect(test.states).toEqual([true])
+  })
+
+  it("requires the Windows readiness marker instead of the spawn event", () => {
+    const test = setup({ platform: "win32" })
+    test.inhibitor.acquire("task")
+    const call = item(test.calls)
+
+    call.child.emit("spawn")
+    expect(test.inhibitor.isActive()).toBe(false)
+
+    call.child.stdout.write("prefix KILO_SLEEP_INHIBITOR_READY suffix\n")
+
+    expect(test.inhibitor.isActive()).toBe(true)
+    expect(test.states).toEqual([true])
+  })
+
+  it("uses a parent-pipe watchdog on macOS without blocking display sleep", () => {
+    const test = setup({ platform: "darwin", pid: 4242 })
+    test.inhibitor.acquire("task")
+
+    expect(item(test.calls)).toMatchObject({
+      cmd: "/usr/bin/caffeinate",
+      args: ["-i", "/bin/sh", "-c", expect.stringContaining("KILO_SLEEP_INHIBITOR_READY")],
+      output: true,
+      input: true,
+    })
+  })
+
+  it("uses a parent-pipe watchdog for both Linux inhibitors", () => {
+    const test = setup()
+    test.inhibitor.acquire("task")
+    const first = item(test.calls)
+
+    expect(first.input).toBe(true)
+    expect(first.args).toContain("/bin/sh")
+    expect(first.args).not.toContain("idle")
+
+    first.child.emit("error", new Error("missing"))
+    const second = item(test.calls, 1)
+    expect(second.input).toBe(true)
+    expect(second.args).toContain("/bin/sh")
+    expect(second.args).not.toContain("--inhibit-only")
+  })
+
+  it("uses a Windows parent handle and system-only execution state", () => {
+    const test = setup({ platform: "win32", pid: 4242 })
+    test.inhibitor.acquire("task")
+    const call = item(test.calls)
+    const script = call.args.join(" ")
+
+    expect(call.cmd).toBe("powershell.exe")
+    expect(call.output).toBe(true)
+    expect(call.input).toBe(false)
+    expect(call.args).toContain("Hidden")
+    expect(script).toContain("OpenProcess(1048576, $false, [uint32]4242)")
+    expect(script).toContain("WaitForSingleObject($parent")
+    expect(script).toContain("CloseHandle($parent)")
+    expect(script).toContain("2147483649")
+    expect(script).toContain("2147483648")
+    expect(script).not.toContain("ES_DISPLAY_REQUIRED")
+    expect(script).not.toContain("2147483650")
+  })
+
+  it("keeps one process until every task releases its handle", () => {
+    const test = setup()
+    const first = test.inhibitor.acquire("first")
+    const second = test.inhibitor.acquire("second")
+    const call = item(test.calls)
+    spawn(call)
+
+    expect(test.calls).toHaveLength(1)
+    test.inhibitor.release(first)
+    expect(stopped(call)).toBe(false)
+    expect(test.inhibitor.isActive()).toBe(true)
+
+    test.inhibitor.release(second)
+    expect(stopped(call)).toBe(true)
+  })
+
+  it("stays active until the stopped process confirms exit", () => {
+    const test = setup()
+    const handle = test.inhibitor.acquire("task")
+    const call = item(test.calls)
+    spawn(call)
+
+    test.inhibitor.release(handle)
+
+    expect(stopped(call)).toBe(true)
+    expect(test.inhibitor.isActive()).toBe(true)
+    expect(test.states).toEqual([true])
+
+    exit(call)
+
+    expect(test.inhibitor.isActive()).toBe(false)
+    expect(test.states).toEqual([true, false])
+  })
+
+  it("retains tracking and logs when process termination fails", () => {
+    const test = setup({ platform: "win32" })
+    const handle = test.inhibitor.acquire("task")
+    const call = item(test.calls)
+    call.child.result = false
+    spawn(call)
+
+    test.inhibitor.release(handle)
+
+    expect(stopped(call)).toBe(true)
+    expect(test.inhibitor.isActive()).toBe(true)
+    expect(test.logs.some((message) => message.includes("could not be terminated"))).toBe(true)
+
+    exit(call)
+    expect(test.inhibitor.isActive()).toBe(false)
+  })
+
+  it("starts a replacement after a closing process exits when work resumed", () => {
+    const test = setup()
+    const first = test.inhibitor.acquire("first")
+    const call = item(test.calls)
+    spawn(call)
+
+    test.inhibitor.release(first)
+    test.inhibitor.acquire("second")
+    expect(test.calls).toHaveLength(1)
+
+    exit(call)
+
+    expect(test.calls).toHaveLength(2)
+    expect(item(test.calls, 1).cmd).toBe("systemd-inhibit")
+  })
+
+  it("falls back on Linux before scheduling a retry", () => {
+    jest.useFakeTimers()
+    const test = setup({ retry: () => 100 })
+    test.inhibitor.acquire("task")
+
+    item(test.calls).child.emit("error", new Error("ENOENT"))
+    expect(item(test.calls, 1).cmd).toBe("gnome-session-inhibit")
+
+    item(test.calls, 1).child.emit("error", new Error("ENOENT"))
+    expect(test.calls).toHaveLength(2)
+    expect(test.logs.some((message) => message.includes("tasks will continue normally"))).toBe(true)
+
+    jest.advanceTimersByTime(99)
+    expect(test.calls).toHaveLength(2)
+    jest.advanceTimersByTime(1)
+    expect(item(test.calls, 2).cmd).toBe("systemd-inhibit")
+  })
+
+  it("uses increasing backoff and cancels a pending retry after release", () => {
+    jest.useFakeTimers()
+    const delays: number[] = []
+    const test = setup({
+      retry: (attempt) => {
+        const wait = (attempt + 1) * 100
+        delays.push(wait)
+        return wait
+      },
+    })
+    const handle = test.inhibitor.acquire("task")
+
+    item(test.calls).child.emit("error", new Error("missing"))
+    item(test.calls, 1).child.emit("error", new Error("missing"))
+    jest.advanceTimersByTime(100)
+    item(test.calls, 2).child.emit("error", new Error("missing"))
+    item(test.calls, 3).child.emit("error", new Error("missing"))
+
+    expect(delays).toEqual([100, 200])
+    test.inhibitor.release(handle)
+    jest.advanceTimersByTime(1_000)
+    expect(test.calls).toHaveLength(4)
+  })
+
+  it("keeps increasing backoff when helpers confirm startup and then exit", () => {
+    jest.useFakeTimers()
+    const delays: number[] = []
+    const test = setup({
+      retry: (attempt) => {
+        const wait = (attempt + 1) * 100
+        delays.push(wait)
+        return wait
+      },
+    })
+    test.inhibitor.acquire("task")
+
+    spawn(item(test.calls))
+    exit(item(test.calls))
+    spawn(item(test.calls, 1))
+    exit(item(test.calls, 1))
+    expect(delays).toEqual([100])
+
+    jest.advanceTimersByTime(100)
+    spawn(item(test.calls, 2))
+    exit(item(test.calls, 2))
+    spawn(item(test.calls, 3))
+    exit(item(test.calls, 3))
+
+    expect(delays).toEqual([100, 200])
+  })
+
+  it("cancels startup probing after a successful spawn", () => {
+    jest.useFakeTimers()
+    const test = setup({ startup: 50 })
+    test.inhibitor.acquire("task")
+    const call = item(test.calls)
+    spawn(call)
+
+    jest.advanceTimersByTime(100)
+
+    expect(call.child.kills).toBe(0)
+    expect(test.calls).toHaveLength(1)
+    expect(test.inhibitor.isActive()).toBe(true)
+  })
+
+  it("keeps an unconfirmed helper tracked until exit before falling back", () => {
+    jest.useFakeTimers()
+    const test = setup({ startup: 50 })
+    test.inhibitor.acquire("task")
+    const call = item(test.calls)
+
+    jest.advanceTimersByTime(50)
+
+    expect(stopped(call)).toBe(true)
+    expect(test.calls).toHaveLength(1)
+    expect(test.inhibitor.isActive()).toBe(false)
+
+    exit(call)
+    expect(item(test.calls, 1).cmd).toBe("gnome-session-inhibit")
+  })
+})
+
+describe("SessionSleepInhibitor", () => {
+  it("does not launch a process when disabled", () => {
+    const test = setup()
+    const sessions = test.session(false)
+
+    sessions.status("one", { type: "busy" })
+    expect(test.calls).toHaveLength(0)
+
+    sessions.configure(true)
+    expect(test.calls).toHaveLength(1)
+  })
+
+  it("tracks concurrent session completion, failure, and cancellation", () => {
+    const test = setup()
+    const sessions = test.session()
+
+    sessions.status("success", { type: "busy" })
+    sessions.status("failure", { type: "retry", attempt: 1, message: "retry", next: 1 })
+    sessions.status("cancelled", { type: "busy" })
+    sessions.status("success", { type: "idle" })
+    sessions.remove("failure")
+
+    expect(item(test.calls).child.kills).toBe(0)
+    sessions.status("cancelled", { type: "idle" })
+    expect(stopped(item(test.calls))).toBe(true)
+  })
+
+  it("uses the task title instead of its identifier in the inhibition reason", () => {
+    const test = setup()
+    const sessions = test.session()
+
+    sessions.status("ses_123", { type: "busy" }, "Refactor settings")
+
+    expect(item(test.calls).args).toContain('--why=Task "Refactor settings" is running')
+  })
+
+  it("updates a title without interrupting active inhibition", () => {
+    const test = setup()
+    const sessions = test.session()
+
+    sessions.status("one", { type: "busy" }, "Old title")
+    const first = item(test.calls)
+    spawn(first)
+    sessions.title("one", "New title")
+
+    expect(stopped(first)).toBe(false)
+    expect(test.calls).toHaveLength(1)
+  })
+
+  it("does not interrupt another task when the displayed task completes", () => {
+    const test = setup()
+    const sessions = test.session()
+
+    sessions.status("one", { type: "busy" }, "First task")
+    sessions.status("two", { type: "busy" }, "Second task")
+    const first = item(test.calls)
+    spawn(first)
+    sessions.remove("one")
+
+    expect(stopped(first)).toBe(false)
+    expect(test.calls).toHaveLength(1)
+    sessions.remove("two")
+    expect(stopped(first)).toBe(true)
+  })
+
+  it("suspends the active budget while waiting and resumes the remainder", () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(0))
+    const test = setup()
+    const sessions = test.session(true, 100)
+
+    sessions.status("one", { type: "busy" }, "Plan release")
+    const first = item(test.calls)
+    spawn(first)
+    jest.advanceTimersByTime(40)
+    sessions.pause("one", "question-1")
+    exit(first)
+
+    jest.advanceTimersByTime(1_000)
+    sessions.resume("one", "question-1")
+    const second = item(test.calls, 1)
+    spawn(second)
+
+    jest.advanceTimersByTime(59)
+    expect(stopped(second)).toBe(false)
+    jest.advanceTimersByTime(1)
+    expect(stopped(second)).toBe(true)
+    expect(test.logs.filter((message) => message.includes("Safety timeout"))).toHaveLength(1)
+  })
+
+  it("resumes only after the last answer without charging paused time twice", () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(0))
+    const test = setup()
+    const sessions = test.session(true, 100)
+
+    sessions.status("one", { type: "busy" })
+    const first = item(test.calls)
+    spawn(first)
+    jest.advanceTimersByTime(30)
+    sessions.pause("one", "question-1")
+    exit(first)
+
+    jest.advanceTimersByTime(500)
+    sessions.pause("one", "question-2")
+    jest.advanceTimersByTime(500)
+    sessions.resume("one", "question-1")
+    expect(test.calls).toHaveLength(1)
+
+    sessions.resume("one", "question-2")
+    const second = item(test.calls, 1)
+    spawn(second)
+    jest.advanceTimersByTime(69)
+    expect(stopped(second)).toBe(false)
+    jest.advanceTimersByTime(1)
+    expect(stopped(second)).toBe(true)
+  })
+
+  it("does not reset the active budget on repeated busy or retry status", () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(0))
+    const test = setup()
+    const sessions = test.session(true, 100)
+
+    sessions.status("one", { type: "busy" })
+    const call = item(test.calls)
+    spawn(call)
+    jest.advanceTimersByTime(60)
+    sessions.status("one", { type: "retry", attempt: 1, message: "retry", next: 1 })
+    jest.advanceTimersByTime(39)
+    expect(stopped(call)).toBe(false)
+    jest.advanceTimersByTime(1)
+    expect(stopped(call)).toBe(true)
+  })
+
+  it("preserves the active budget while a network request is offline", () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(0))
+    const test = setup()
+    const sessions = test.session(true, 100)
+
+    sessions.status("one", { type: "busy" })
+    const first = item(test.calls)
+    spawn(first)
+    jest.advanceTimersByTime(40)
+    sessions.status("one", { type: "offline", requestID: "net-1", message: "offline" })
+    exit(first)
+
+    jest.advanceTimersByTime(1_000)
+    sessions.status("one", { type: "busy" })
+    const second = item(test.calls, 1)
+    spawn(second)
+    jest.advanceTimersByTime(59)
+    expect(stopped(second)).toBe(false)
+    jest.advanceTimersByTime(1)
+    expect(stopped(second)).toBe(true)
+  })
+
+  it("preserves the active budget across a connection suspension", () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(0))
+    const test = setup()
+    const sessions = test.session(true, 100)
+
+    sessions.status("one", { type: "busy" })
+    const first = item(test.calls)
+    spawn(first)
+    jest.advanceTimersByTime(40)
+    sessions.suspend()
+    exit(first)
+
+    jest.advanceTimersByTime(1_000)
+    sessions.status("one", { type: "busy" })
+    const second = item(test.calls, 1)
+    spawn(second)
+    jest.advanceTimersByTime(60)
+
+    expect(stopped(second)).toBe(true)
+  })
+
+  it("keeps unlimited tasks inhibited across pause and resume", () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(0))
+    const test = setup()
+    const sessions = test.session(true, 0)
+
+    sessions.status("one", { type: "busy" })
+    const first = item(test.calls)
+    spawn(first)
+    jest.advanceTimersByTime(100_000)
+    expect(stopped(first)).toBe(false)
+
+    sessions.pause("one", "question")
+    exit(first)
+    jest.advanceTimersByTime(100_000)
+    sessions.resume("one", "question")
+    const second = item(test.calls, 1)
+    spawn(second)
+    jest.advanceTimersByTime(100_000)
+
+    expect(stopped(second)).toBe(false)
+    expect(test.logs.some((message) => message.includes("Safety timeout"))).toBe(false)
+  })
+
+  it("expires concurrent task budgets independently", () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(0))
+    const test = setup()
+    const sessions = test.session(true, 100)
+
+    sessions.status("first", { type: "busy" }, "First")
+    const call = item(test.calls)
+    spawn(call)
+    jest.advanceTimersByTime(40)
+    sessions.status("second", { type: "busy" }, "Second")
+
+    jest.advanceTimersByTime(60)
+    expect(stopped(call)).toBe(false)
+    expect(test.inhibitor.isActive()).toBe(true)
+
+    jest.advanceTimersByTime(40)
+    expect(stopped(call)).toBe(true)
+    expect(test.logs.filter((message) => message.includes("Safety timeout"))).toHaveLength(2)
+  })
+
+  it("honors manual release until all current sessions stop", () => {
+    const test = setup()
+    const sessions = test.session()
+
+    sessions.status("one", { type: "busy" })
+    sessions.force()
+    exit(item(test.calls))
+    sessions.status("two", { type: "busy" })
+    expect(test.calls).toHaveLength(1)
+
+    sessions.status("one", { type: "idle" })
+    sessions.status("two", { type: "idle" })
+    sessions.status("three", { type: "busy" })
+    expect(test.calls).toHaveLength(2)
+  })
+})
+
+describe("sleep prevention settings", () => {
+  it("keeps prevention disabled and uses a 30-minute safety timeout by default", async () => {
+    const manifest = (await Bun.file(new URL("../../package.json", import.meta.url)).json()) as {
+      contributes: { configuration: { properties: Record<string, { default?: unknown }> } }
+    }
+    const properties = manifest.contributes.configuration.properties
+
+    expect(properties["kilo-code.new.preventSleepDuringTasks"]?.default).toBe(false)
+    expect(properties["kilo-code.new.preventSleepDuringTasksTimeoutMinutes"]?.default).toBe(30)
+  })
+})
+
+describe("SleepInhibitorService reconnect", () => {
+  it("restores pending input after a newer status event", async () => {
+    const pending = Promise.withResolvers<{ data: { one: { type: "busy" } } }>()
+    let event: ((event: SSEPayload, directory?: string) => void) | undefined
+    let state: ((state: "connected") => void) | undefined
+    const connection = {
+      onEvent: (handler: (event: SSEPayload, directory?: string) => void) => {
+        event = handler
+        return () => undefined
+      },
+      onStateChange: (handler: (state: "connected") => void) => {
+        state = handler
+        return () => undefined
+      },
+      getKnownDirectories: () => ["/repo"],
+      getClient: () =>
+        backend(
+          {
+            status: () => pending.promise,
+            get: async () => ({ data: { title: "Current task" } }),
+          },
+          { questions: [{ id: "q1", sessionID: "one", questions: [], blocking: true }] },
+        ),
+    } as unknown as KiloConnectionService
+    const service = new SleepInhibitorService(connection)
+
+    state?.("connected")
+    event?.(
+      { id: "busy", type: "session.status", properties: { sessionID: "one", status: { type: "busy" } } } as SSEPayload,
+      "/repo",
+    )
+    pending.resolve({ data: { one: { type: "busy" } } })
+    await Bun.sleep(0)
+
+    expect(tracked(service)).toEqual(["one"])
+    expect(blocked(service, "one")).toEqual(["question:q1"])
+    service.dispose()
+  })
+
+  it("does not restore stale busy state after a newer idle event", async () => {
+    const pending = Promise.withResolvers<{ data: { one: { type: "busy" } } }>()
+    let event: ((event: SSEPayload, directory?: string) => void) | undefined
+    let state: ((state: "connecting" | "connected" | "disconnected" | "error") => void) | undefined
+    const connection = {
+      onEvent: (handler: (event: SSEPayload, directory?: string) => void) => {
+        event = handler
+        return () => undefined
+      },
+      onStateChange: (handler: (state: "connecting" | "connected" | "disconnected" | "error") => void) => {
+        state = handler
+        return () => undefined
+      },
+      getKnownDirectories: () => ["/repo"],
+      getClient: () =>
+        backend({
+          status: () => pending.promise,
+          get: async () => ({ data: { title: "Current task" } }),
+        }),
+    } as unknown as KiloConnectionService
+    const service = new SleepInhibitorService(connection)
+
+    state?.("connected")
+    event?.({
+      id: "idle",
+      type: "session.status",
+      properties: { sessionID: "one", status: { type: "idle" } },
+    } as SSEPayload)
+    pending.resolve({ data: { one: { type: "busy" } } })
+    await Bun.sleep(0)
+
+    expect(tracked(service)).toEqual([])
+    service.dispose()
+  })
+
+  it("removes tasks missed while the event stream was reconnecting", async () => {
+    let event: ((event: SSEPayload, directory?: string) => void) | undefined
+    let state: ((state: "connecting" | "connected" | "disconnected" | "error") => void) | undefined
+    const connection = {
+      onEvent: (handler: (event: SSEPayload, directory?: string) => void) => {
+        event = handler
+        return () => undefined
+      },
+      onStateChange: (handler: (state: "connecting" | "connected" | "disconnected" | "error") => void) => {
+        state = handler
+        return () => undefined
+      },
+      getKnownDirectories: () => ["/repo"],
+      getClient: () =>
+        backend({
+          status: async () => ({ data: {} }),
+          get: async () => ({ data: undefined }),
+        }),
+    } as unknown as KiloConnectionService
+    const service = new SleepInhibitorService(connection)
+
+    event?.({
+      id: "busy",
+      type: "session.status",
+      properties: { sessionID: "one", status: { type: "busy" } },
+    } as SSEPayload)
+    expect(tracked(service)).toEqual(["one"])
+
+    state?.("connected")
+    await Bun.sleep(0)
+
+    expect(tracked(service)).toEqual([])
+    service.dispose()
+  })
+
+  it("preserves waits through transient errors and reconciles missed replies", async () => {
+    let event: ((event: SSEPayload, directory?: string) => void) | undefined
+    let state: ((state: "connecting" | "connected" | "disconnected" | "error") => void) | undefined
+    let prompts: NonNullable<Parameters<typeof backend>[1]> = {
+      questions: [{ id: "q1", sessionID: "one", questions: [], blocking: true }],
+      p2: [{ id: "p2", sessionID: "one" }],
+      suggestions: [{ id: "s1", sessionID: "one", text: "Choose", actions: [], blocking: true }],
+    }
+    const connection = {
+      onEvent: (handler: (event: SSEPayload, directory?: string) => void) => {
+        event = handler
+        return () => undefined
+      },
+      onStateChange: (handler: typeof state) => {
+        state = handler
+        return () => undefined
+      },
+      getKnownDirectories: () => ["/repo"],
+      getClient: () =>
+        backend(
+          {
+            status: async () => ({ data: { one: { type: "busy" } } }),
+            get: async () => ({ data: { title: "Current task" } }),
+          },
+          prompts,
+        ),
+    } as unknown as KiloConnectionService
+    const service = new SleepInhibitorService(connection)
+
+    event?.(
+      { id: "busy", type: "session.status", properties: { sessionID: "one", status: { type: "busy" } } } as SSEPayload,
+      "/repo",
+    )
+    event?.({
+      id: "asked",
+      type: "question.asked",
+      properties: { id: "q1", sessionID: "one", questions: [], blocking: true },
+    } as SSEPayload)
+    state?.("error")
+    state?.("connecting")
+    expect(tracked(service)).toEqual(["one"])
+    expect(blocked(service, "one")).toEqual(["question:q1"])
+
+    state?.("connected")
+    await Bun.sleep(0)
+    expect(blocked(service, "one")).toEqual(["permission:p2", "question:q1", "suggestion:s1"])
+
+    prompts = {}
+    state?.("error")
+    state?.("connected")
+    await Bun.sleep(0)
+    expect(blocked(service, "one")).toEqual([])
+    service.dispose()
+  })
+
+  it("reconciles successful wait categories without clearing failed ones", async () => {
+    let event: ((event: SSEPayload, directory?: string) => void) | undefined
+    let state: ((state: "connected") => void) | undefined
+    const connection = {
+      onEvent: (handler: (event: SSEPayload, directory?: string) => void) => {
+        event = handler
+        return () => undefined
+      },
+      onStateChange: (handler: (state: "connected") => void) => {
+        state = handler
+        return () => undefined
+      },
+      getKnownDirectories: () => ["/repo"],
+      getClient: () =>
+        backend(
+          {
+            status: async () => ({ data: { one: { type: "busy" } } }),
+            get: async () => ({ data: { title: "Current task" } }),
+          },
+          {
+            questions: [{ id: "q1", sessionID: "one", questions: [], blocking: true }],
+            fail: ["q2", "suggestion"],
+          },
+        ),
+    } as unknown as KiloConnectionService
+    const service = new SleepInhibitorService(connection)
+
+    event?.(
+      { id: "busy", type: "session.status", properties: { sessionID: "one", status: { type: "busy" } } } as SSEPayload,
+      "/repo",
+    )
+    event?.({
+      id: "question",
+      type: "question.asked",
+      properties: { id: "q1", sessionID: "one", questions: [], blocking: true },
+    } as SSEPayload)
+    event?.({
+      id: "network",
+      type: "session.network.asked",
+      properties: { id: "n1", sessionID: "one", message: "offline" },
+    } as SSEPayload)
+    event?.({
+      id: "suggestion",
+      type: "suggestion.shown",
+      properties: { id: "s1", sessionID: "one", text: "Choose", actions: [], blocking: true },
+    } as SSEPayload)
+
+    state?.("connected")
+    await Bun.sleep(0)
+
+    expect(blocked(service, "one")).toEqual(["question:q1", "suggestion:s1"])
+    service.dispose()
+  })
+
+  it("resumes after a completed question tool even when no reply event arrives", () => {
+    let event: ((event: SSEPayload, directory?: string) => void) | undefined
+    const connection = {
+      onEvent: (handler: (event: SSEPayload, directory?: string) => void) => {
+        event = handler
+        return () => undefined
+      },
+      onStateChange: () => () => undefined,
+      getKnownDirectories: () => [],
+    } as unknown as KiloConnectionService
+    const service = new SleepInhibitorService(connection)
+
+    event?.(
+      { id: "busy", type: "session.status", properties: { sessionID: "one", status: { type: "busy" } } } as SSEPayload,
+      "/repo",
+    )
+    event?.({
+      id: "asked",
+      type: "question.asked",
+      properties: {
+        id: "q1",
+        sessionID: "one",
+        questions: [],
+        blocking: true,
+        tool: { messageID: "message", callID: "call" },
+      },
+    } as SSEPayload)
+    event?.({
+      id: "asked-2",
+      type: "question.asked",
+      properties: {
+        id: "q2",
+        sessionID: "one",
+        questions: [],
+        blocking: true,
+        tool: { messageID: "message-2", callID: "call-2" },
+      },
+    } as SSEPayload)
+    expect(blocked(service, "one")).toEqual(["question:q1", "question:q2"])
+
+    event?.({
+      id: "part",
+      type: "message.part.updated",
+      properties: {
+        sessionID: "one",
+        part: {
+          id: "part",
+          sessionID: "one",
+          messageID: "message",
+          type: "tool",
+          callID: "call",
+          tool: "question",
+          state: {
+            status: "completed",
+            input: {},
+            output: "",
+            title: "question",
+            metadata: {},
+            time: { start: 0, end: 1 },
+          },
+        },
+        time: 1,
+      },
+    } as SSEPayload)
+
+    expect(blocked(service, "one")).toEqual(["question:q2"])
+    event?.({
+      id: "reply-2",
+      type: "question.replied",
+      properties: { sessionID: "one", requestID: "q2", answers: [] },
+    } as SSEPayload)
+    expect(blocked(service, "one")).toEqual([])
+    service.dispose()
+  })
+
+  it("reconciles successful directories without dropping tasks from failed ones", async () => {
+    let event: ((event: SSEPayload, directory?: string) => void) | undefined
+    let state: ((state: "connected") => void) | undefined
+    const connection = {
+      onEvent: (handler: (event: SSEPayload, directory?: string) => void) => {
+        event = handler
+        return () => undefined
+      },
+      onStateChange: (handler: (state: "connected") => void) => {
+        state = handler
+        return () => undefined
+      },
+      getKnownDirectories: () => ["/a", "/b"],
+      getClient: () =>
+        backend({
+          status: async ({ directory }: { directory: string }) =>
+            directory === "/a" ? { data: {} } : { error: "backend unavailable" },
+          get: async () => ({ data: undefined }),
+        }),
+    } as unknown as KiloConnectionService
+    const service = new SleepInhibitorService(connection)
+
+    for (const [sessionID, directory] of [
+      ["a", "/a"],
+      ["b", "/b"],
+    ] as const) {
+      event?.(
+        { id: sessionID, type: "session.status", properties: { sessionID, status: { type: "busy" } } } as SSEPayload,
+        directory,
+      )
+    }
+
+    state?.("connected")
+    await Bun.sleep(0)
+
+    expect(tracked(service)).toEqual(["b"])
+    service.dispose()
+  })
+
+  it("restores offline status as a paused network wait", async () => {
+    let event: ((event: SSEPayload, directory?: string) => void) | undefined
+    let state: ((state: "connected") => void) | undefined
+    const connection = {
+      onEvent: (handler: (event: SSEPayload, directory?: string) => void) => {
+        event = handler
+        return () => undefined
+      },
+      onStateChange: (handler: (state: "connected") => void) => {
+        state = handler
+        return () => undefined
+      },
+      getKnownDirectories: () => ["/repo"],
+      getClient: () =>
+        backend(
+          {
+            status: async () => ({ data: { one: { type: "offline", requestID: "net", message: "offline" } } }),
+            get: async () => ({ data: { title: "Current task" } }),
+          },
+          {
+            network: [{ id: "net", sessionID: "one", message: "offline", restored: false, time: { created: 1 } }],
+          },
+        ),
+    } as unknown as KiloConnectionService
+    const service = new SleepInhibitorService(connection)
+
+    state?.("connected")
+    await Bun.sleep(0)
+    expect(blocked(service, "one")).toEqual(["network:net"])
+    expect(title(service, "one")).toBe("Current task")
+
+    event?.({
+      id: "restored",
+      type: "session.network.restored",
+      properties: { sessionID: "one", requestID: "net" },
+    } as SSEPayload)
+    event?.({
+      id: "busy",
+      type: "session.status",
+      properties: { sessionID: "one", status: { type: "busy" } },
+    } as SSEPayload)
+    expect(blocked(service, "one")).toEqual([])
+    service.dispose()
+  })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/Settings.tsx
@@ -16,6 +16,7 @@ import AutoApproveTab from "./AutoApproveTab"
 import BrowserTab from "./BrowserTab"
 import CheckpointsTab from "./CheckpointsTab"
 import DisplayTab from "./DisplayTab"
+import SleepTab from "./SleepTab"
 import AutocompleteTab from "./AutocompleteTab"
 import NotificationsTab from "./NotificationsTab"
 import ContextTab from "./ContextTab"
@@ -349,6 +350,10 @@ const Settings: Component<SettingsProps> = (props) => {
             <Icon name="eye" />
             <span class="label">{language.t("settings.display.title")}</span>
           </Tabs.Trigger>
+          <Tabs.Trigger value="sleep" aria-label={language.t("settings.sleep.title")}>
+            <Icon name="battery" />
+            <span class="label">{language.t("settings.sleep.title")}</span>
+          </Tabs.Trigger>
           <Tabs.Trigger value="autocomplete" aria-label={language.t("settings.autocomplete.title")}>
             <Icon name="code-lines" />
             <span class="label">{language.t("settings.autocomplete.title")}</span>
@@ -425,6 +430,10 @@ const Settings: Component<SettingsProps> = (props) => {
         <Tabs.Content value="display">
           <h3>{language.t("settings.display.title")}</h3>
           <DisplayTab />
+        </Tabs.Content>
+        <Tabs.Content value="sleep">
+          <h3>{language.t("settings.sleep.title")}</h3>
+          <SleepTab />
         </Tabs.Content>
         <Tabs.Content value="autocomplete">
           <h3>{language.t("settings.autocomplete.title")}</h3>

--- a/packages/kilo-vscode/webview-ui/src/components/settings/SleepTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/SleepTab.tsx
@@ -1,0 +1,66 @@
+import { Component, onMount } from "solid-js"
+import { Card } from "@kilocode/kilo-ui/card"
+import { Switch } from "@kilocode/kilo-ui/switch"
+import { TextField } from "@kilocode/kilo-ui/text-field"
+import { useVSCode } from "../../context/vscode"
+import { useLanguage } from "../../context/language"
+import { useConfig } from "../../context/config"
+import SettingsRow from "./SettingsRow"
+
+const SleepTab: Component = () => {
+  const vscode = useVSCode()
+  const language = useLanguage()
+  const { settings, updateSetting } = useConfig()
+  const enabled = () => settings().preventSleepDuringTasks === true
+  const timeout = () => Number(settings().preventSleepDuringTasksTimeoutMinutes ?? 30)
+
+  onMount(() => vscode.postMessage({ type: "requestSleepSettings" }))
+
+  const updateTimeout = (value: string) => {
+    const next = Math.max(0, Math.min(1440, Number(value) || 0))
+    updateSetting("preventSleepDuringTasksTimeoutMinutes", next)
+  }
+
+  return (
+    <Card>
+      <SettingsRow
+        title={language.t("settings.sleep.enable.title")}
+        description={language.t("settings.sleep.enable.description")}
+      >
+        <Switch
+          checked={enabled()}
+          onChange={(value) => {
+            updateSetting("preventSleepDuringTasks", value)
+          }}
+          hideLabel
+        >
+          {language.t("settings.sleep.enable.title")}
+        </Switch>
+      </SettingsRow>
+      <div data-slot="sleep-setting-child">
+        <SettingsRow
+          title={language.t("settings.sleep.timeout.title")}
+          description={language.t("settings.sleep.timeout.description")}
+          last
+        >
+          <div data-slot="sleep-timeout-input">
+            <TextField
+              type="number"
+              inputMode="numeric"
+              min="0"
+              max="1440"
+              step="1"
+              value={String(timeout())}
+              onChange={updateTimeout}
+              disabled={!enabled()}
+              hideLabel
+              label={language.t("settings.sleep.timeout.title")}
+            />
+          </div>
+        </SettingsRow>
+      </div>
+    </Card>
+  )
+}
+
+export default SleepTab

--- a/packages/kilo-vscode/webview-ui/src/context/config.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/config.tsx
@@ -78,6 +78,12 @@ function loadedSettings(message: ExtensionMessage): Record<string, unknown> | un
   }
   if (message.type === "throughputSettingLoaded") return { showTokenThroughput: message.visible }
   if (message.type === "autoApprovalReasonSettingLoaded") return { showAutoApprovalReason: message.visible }
+  if (message.type === "sleepSettingsLoaded") {
+    return {
+      preventSleepDuringTasks: message.enabled,
+      preventSleepDuringTasksTimeoutMinutes: message.timeout,
+    }
+  }
 }
 
 export const ConfigProvider: ParentComponent = (props) => {

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -662,6 +662,12 @@ export const dict = {
   "settings.webTools.webSearch.description": "اجعل البحث على الويب متاحًا لنماذج جميع المزوّدين.",
   "settings.checkpoints.title": "نقاط التحقق",
   "settings.display.title": "العرض",
+  "settings.sleep.title": "الطاقة",
+  "settings.sleep.enable.title": "منع سكون النظام أثناء المهام",
+  "settings.sleep.enable.description": "إبقاء الكمبيوتر في وضع التشغيل أثناء عمل Kilo Code. لا يتأثر قفل الشاشة.",
+  "settings.sleep.timeout.title": "الحد لكل مهمة (بالدقائق)",
+  "settings.sleep.timeout.description":
+    "يُحتسب وقت التنفيذ النشط فقط، ولا يُحتسب وقت انتظار ردك. استخدم 0 لعدم فرض حد من الإضافة. الافتراضي: 30 دقيقة.",
   "settings.autocomplete.title": "الإكمال التلقائي",
   "settings.autocomplete.model.title": "نموذج الإكمال التلقائي",
   "settings.autocomplete.model.description": "حدد النموذج المستخدم لإكمال الكود المضمن (inline completions)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -677,6 +677,13 @@ export const dict = {
   "settings.webTools.webSearch.description": "Disponibilize a pesquisa na web para modelos de todos os provedores.",
   "settings.checkpoints.title": "Pontos de Verificação",
   "settings.display.title": "Exibição",
+  "settings.sleep.title": "Energia",
+  "settings.sleep.enable.title": "Impedir suspensão do sistema durante tarefas",
+  "settings.sleep.enable.description":
+    "Mantenha o computador ativo enquanto Kilo Code trabalha. O bloqueio de tela não é afetado.",
+  "settings.sleep.timeout.title": "Limite por tarefa (minutos)",
+  "settings.sleep.timeout.description":
+    "Somente o tempo de execução ativo é contado; a espera pela sua resposta não é. Use 0 para não impor limite pela extensão. Padrão: 30 minutos.",
   "settings.autocomplete.title": "Autocompletar",
   "settings.autocomplete.model.title": "Modelo de autocompletar",
   "settings.autocomplete.model.description": "Selecione o modelo usado para preenchimento de código inline",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -717,6 +717,12 @@ export const dict = {
   "settings.webTools.webSearch.description": "Omogućite web pretragu modelima svih pružalaca.",
   "settings.checkpoints.title": "Kontrolne tačke",
   "settings.display.title": "Prikaz",
+  "settings.sleep.title": "Napajanje",
+  "settings.sleep.enable.title": "Spriječi mirovanje sistema tokom zadataka",
+  "settings.sleep.enable.description": "Držite računar budnim dok Kilo Code radi. Zaključavanje ekrana nije pogođeno.",
+  "settings.sleep.timeout.title": "Ograničenje po zadatku (minute)",
+  "settings.sleep.timeout.description":
+    "Računa se samo vrijeme aktivnog izvršavanja, bez čekanja na vaš odgovor. Koristite 0 bez ograničenja proširenja. Zadano: 30 minuta.",
   "settings.autocomplete.title": "Automatsko dovršavanje",
   "settings.autocomplete.model.title": "Model za automatsko dovršavanje",
   "settings.autocomplete.model.description": "Odaberite model koji se koristi za inline dovršavanje koda",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -715,6 +715,12 @@ export const dict = {
   "settings.webTools.webSearch.description": "Gør websøgning tilgængelig for modeller fra alle udbydere.",
   "settings.checkpoints.title": "Kontrolpunkter",
   "settings.display.title": "Visning",
+  "settings.sleep.title": "Strøm",
+  "settings.sleep.enable.title": "Forhindr systemslumring under opgaver",
+  "settings.sleep.enable.description": "Hold computeren vågen, mens Kilo Code arbejder. Skærmlås påvirkes ikke.",
+  "settings.sleep.timeout.title": "Grænse pr. opgave (minutter)",
+  "settings.sleep.timeout.description":
+    "Kun aktiv opgavetid tæller; ventetid på dit svar gør ikke. Brug 0 for ingen grænse fra udvidelsen. Standard: 30 minutter.",
   "settings.autocomplete.title": "Autofuldførelse",
   "settings.autocomplete.model.title": "Autocomplete-model",
   "settings.autocomplete.model.description": "Vælg den model, der bruges til inline kodefuldførelse",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -727,6 +727,13 @@ export const dict = {
   "settings.webTools.webSearch.description": "Machen Sie die Websuche für Modelle aller Anbieter verfügbar.",
   "settings.checkpoints.title": "Prüfpunkte",
   "settings.display.title": "Anzeige",
+  "settings.sleep.title": "Energie",
+  "settings.sleep.enable.title": "Systemruhezustand während Aufgaben verhindern",
+  "settings.sleep.enable.description":
+    "Hält den Computer wach, während Kilo Code arbeitet. Die Bildschirmsperre bleibt unverändert.",
+  "settings.sleep.timeout.title": "Limit pro Aufgabe (Minuten)",
+  "settings.sleep.timeout.description":
+    "Nur aktive Aufgabenzeit zählt; Wartezeit auf Ihre Antwort nicht. 0 bedeutet kein Limit durch die Erweiterung. Standard: 30 Minuten.",
   "settings.autocomplete.title": "Autovervollständigung",
   "settings.autocomplete.model.title": "Autocomplete-Modell",
   "settings.autocomplete.model.description": "Wählen Sie das Modell für Inline-Code-Vervollständigungen",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -626,6 +626,13 @@ export const dict = {
   "settings.webTools.webSearch.description": "Make web search available to models from all providers.",
   "settings.checkpoints.title": "Checkpoints",
   "settings.display.title": "Display",
+  "settings.sleep.title": "Power",
+  "settings.sleep.enable.title": "Prevent system sleep during tasks",
+  "settings.sleep.enable.description":
+    "Keep the computer awake while Kilo Code is working. Screen locking is not affected.",
+  "settings.sleep.timeout.title": "Limit per task (minutes)",
+  "settings.sleep.timeout.description":
+    "Only active task time counts; time waiting for your answer does not. Use 0 for no extension-imposed limit. Default: 30 minutes.",
   "settings.autocomplete.title": "Autocomplete",
   "settings.notifications.title": "Notifications",
   "settings.context.title": "Context",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -721,6 +721,13 @@ export const dict = {
   "settings.webTools.webSearch.description": "Permite que los modelos de todos los proveedores usen la búsqueda web.",
   "settings.checkpoints.title": "Puntos de control",
   "settings.display.title": "Pantalla",
+  "settings.sleep.title": "Energía",
+  "settings.sleep.enable.title": "Impedir la suspensión del sistema durante las tareas",
+  "settings.sleep.enable.description":
+    "Mantén el equipo activo mientras Kilo Code trabaja. El bloqueo de pantalla no se ve afectado.",
+  "settings.sleep.timeout.title": "Límite por tarea (minutos)",
+  "settings.sleep.timeout.description":
+    "Solo cuenta el tiempo de ejecución activo, no la espera de tu respuesta. Usa 0 para que la extensión no imponga ningún límite. Valor predeterminado: 30 minutos.",
   "settings.autocomplete.title": "Autocompletado",
   "settings.autocomplete.model.title": "Modelo de autocompletado",
   "settings.autocomplete.model.description": "Selecciona el modelo utilizado para el autocompletado de código en línea",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
@@ -629,6 +629,12 @@ export const dict = {
   "settings.webTools.webSearch.description": "جستجوی وب را برای مدل‌های همه ارائه‌دهندگان در دسترس قرار دهید.",
   "settings.checkpoints.title": "نقاط بازیابی",
   "settings.display.title": "نمایش",
+  "settings.sleep.title": "انرژی",
+  "settings.sleep.enable.title": "جلوگیری از خواب سیستم هنگام اجرای وظایف",
+  "settings.sleep.enable.description": "رایانه را هنگام کار Kilo Code بیدار نگه دارید. قفل صفحه تغییری نمی‌کند.",
+  "settings.sleep.timeout.title": "محدودیت هر وظیفه (دقیقه)",
+  "settings.sleep.timeout.description":
+    "فقط زمان اجرای فعال محاسبه می‌شود، نه زمان انتظار برای پاسخ شما. برای نبود محدودیت از سوی افزونه، ۰ را وارد کنید. پیش‌فرض: ۳۰ دقیقه.",
   "settings.autocomplete.title": "تکمیل خودکار",
   "settings.notifications.title": "اعلان‌ها",
   "settings.context.title": "زمینه",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -729,6 +729,13 @@ export const dict = {
     "Rendez la recherche web disponible pour les modèles de tous les fournisseurs.",
   "settings.checkpoints.title": "Points de contrôle",
   "settings.display.title": "Affichage",
+  "settings.sleep.title": "Alimentation",
+  "settings.sleep.enable.title": "Empêcher la mise en veille pendant les tâches",
+  "settings.sleep.enable.description":
+    "Garder l’ordinateur éveillé pendant le travail de Kilo Code. Le verrouillage de l’écran n’est pas affecté.",
+  "settings.sleep.timeout.title": "Limite par tâche (minutes)",
+  "settings.sleep.timeout.description":
+    "Seul le temps d’exécution actif est compté, pas l’attente de votre réponse. Utilisez 0 pour ne fixer aucune limite dans l’extension. Par défaut : 30 minutes.",
   "settings.autocomplete.title": "Autocomplétion",
   "settings.autocomplete.model.title": "Modèle d'autocomplétion",
   "settings.autocomplete.model.description": "Sélectionnez le modèle utilisé pour les complétions de code en ligne",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -554,6 +554,13 @@ export const dict = {
   "settings.webTools.webSearch.description": "Rendi disponibile la ricerca web ai modelli di tutti i provider.",
   "settings.checkpoints.title": "Checkpoint",
   "settings.display.title": "Visualizzazione",
+  "settings.sleep.title": "Alimentazione",
+  "settings.sleep.enable.title": "Impedisci la sospensione del sistema durante le attività",
+  "settings.sleep.enable.description":
+    "Mantieni il computer attivo mentre Kilo Code lavora. Il blocco dello schermo non cambia.",
+  "settings.sleep.timeout.title": "Limite per attività (minuti)",
+  "settings.sleep.timeout.description":
+    "Conta solo il tempo di esecuzione attivo, non l’attesa della tua risposta. Usa 0 per non imporre limiti dall’estensione. Predefinito: 30 minuti.",
   "settings.autocomplete.title": "Autocompletamento",
   "settings.notifications.title": "Notifiche",
   "settings.context.title": "Contesto",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -710,6 +710,13 @@ export const dict = {
   "settings.webTools.webSearch.description": "すべてのプロバイダーのモデルでウェブ検索を利用できるようにします。",
   "settings.checkpoints.title": "チェックポイント",
   "settings.display.title": "表示",
+  "settings.sleep.title": "電源",
+  "settings.sleep.enable.title": "タスク実行中のシステムスリープを防止",
+  "settings.sleep.enable.description":
+    "Kilo Code の作業中はコンピューターをスリープさせません。画面ロックには影響しません。",
+  "settings.sleep.timeout.title": "タスクごとの上限（分）",
+  "settings.sleep.timeout.description":
+    "実行中の時間だけを数え、回答待ちの時間は数えません。拡張機能による上限をなくすには 0 を指定します。既定値: 30 分。",
   "settings.autocomplete.title": "オートコンプリート",
   "settings.autocomplete.model.title": "オートコンプリートモデル",
   "settings.autocomplete.model.description": "インラインでのコード補完に使用するモデルを選択します",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -670,6 +670,13 @@ export const dict = {
   "settings.webTools.webSearch.description": "모든 제공업체의 모델에서 웹 검색을 사용할 수 있도록 합니다.",
   "settings.checkpoints.title": "체크포인트",
   "settings.display.title": "디스플레이",
+  "settings.sleep.title": "전원",
+  "settings.sleep.enable.title": "작업 중 시스템 절전 방지",
+  "settings.sleep.enable.description":
+    "Kilo Code가 작업하는 동안 컴퓨터를 절전 모드로 전환하지 않습니다. 화면 잠금에는 영향을 주지 않습니다.",
+  "settings.sleep.timeout.title": "작업당 제한(분)",
+  "settings.sleep.timeout.description":
+    "활성 실행 시간만 계산하며 답변 대기 시간은 제외합니다. 확장 프로그램 제한을 없애려면 0을 사용하세요. 기본값: 30분.",
   "settings.autocomplete.title": "자동 완성",
   "settings.autocomplete.model.title": "자동 완성 모델",
   "settings.autocomplete.model.description": "인라인 코드 완성에 사용되는 모델 선택",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -669,6 +669,13 @@ export const dict = {
   "settings.webTools.webSearch.description": "Maak zoeken op internet beschikbaar voor modellen van alle providers.",
   "settings.checkpoints.title": "Controlepunten",
   "settings.display.title": "Weergave",
+  "settings.sleep.title": "Energiebeheer",
+  "settings.sleep.enable.title": "Systeemstand-by voorkomen tijdens taken",
+  "settings.sleep.enable.description":
+    "Houd de computer actief terwijl Kilo Code werkt. Schermvergrendeling blijft ongewijzigd.",
+  "settings.sleep.timeout.title": "Limiet per taak (minuten)",
+  "settings.sleep.timeout.description":
+    "Alleen actieve uitvoeringstijd telt; wachten op uw antwoord niet. Gebruik 0 voor geen limiet vanuit de extensie. Standaard: 30 minuten.",
   "settings.autocomplete.title": "Automatisch Aanvullen",
   "settings.autocomplete.model.title": "Autocomplete-model",
   "settings.autocomplete.model.description": "Selecteer het model dat wordt gebruikt voor inline code-aanvullingen",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -677,6 +677,12 @@ export const dict = {
   "settings.webTools.webSearch.description": "Gjør nettsøk tilgjengelig for modeller fra alle leverandører.",
   "settings.checkpoints.title": "Kontrollpunkter",
   "settings.display.title": "Visning",
+  "settings.sleep.title": "Strøm",
+  "settings.sleep.enable.title": "Hindre systemhvile under oppgaver",
+  "settings.sleep.enable.description": "Hold datamaskinen våken mens Kilo Code arbeider. Skjermlåsing påvirkes ikke.",
+  "settings.sleep.timeout.title": "Grense per oppgave (minutter)",
+  "settings.sleep.timeout.description":
+    "Bare aktiv kjøretid teller; venting på svaret ditt gjør ikke det. Bruk 0 for ingen grense fra utvidelsen. Standard: 30 minutter.",
   "settings.autocomplete.title": "Autofullfør",
   "settings.autocomplete.model.title": "Autocomplete-modell",
   "settings.autocomplete.model.description": "Velg modellen som brukes for inline kodefullføring",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -673,6 +673,13 @@ export const dict = {
   "settings.webTools.webSearch.description": "Udostępnij wyszukiwanie w sieci modelom wszystkich dostawców.",
   "settings.checkpoints.title": "Punkty kontrolne",
   "settings.display.title": "Wyświetlanie",
+  "settings.sleep.title": "Zasilanie",
+  "settings.sleep.enable.title": "Zapobiegaj uśpieniu systemu podczas zadań",
+  "settings.sleep.enable.description":
+    "Komputer pozostaje aktywny podczas pracy Kilo Code. Blokada ekranu pozostaje bez zmian.",
+  "settings.sleep.timeout.title": "Limit na zadanie (minuty)",
+  "settings.sleep.timeout.description":
+    "Liczy się tylko czas aktywnego wykonywania, bez oczekiwania na odpowiedź. Użyj 0, aby rozszerzenie nie narzucało limitu. Domyślnie: 30 minut.",
   "settings.autocomplete.title": "Autouzupełnianie",
   "settings.autocomplete.model.title": "Model autouzupełniania",
   "settings.autocomplete.model.description": "Wybierz model używany do uzupełniania kodu w linii (inline)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -714,6 +714,13 @@ export const dict = {
   "settings.webTools.webSearch.description": "Сделайте веб-поиск доступным для моделей всех провайдеров.",
   "settings.checkpoints.title": "Контрольные точки",
   "settings.display.title": "Отображение",
+  "settings.sleep.title": "Питание",
+  "settings.sleep.enable.title": "Запретить переход системы в спящий режим во время задач",
+  "settings.sleep.enable.description":
+    "Не переводить компьютер в спящий режим во время работы Kilo Code. Блокировка экрана не затрагивается.",
+  "settings.sleep.timeout.title": "Лимит на задачу (минуты)",
+  "settings.sleep.timeout.description":
+    "Учитывается только время активного выполнения, без ожидания вашего ответа. Укажите 0, чтобы расширение не задавало лимит. По умолчанию: 30 минут.",
   "settings.autocomplete.title": "Автодополнение",
   "settings.autocomplete.model.title": "Модель автодополнения",
   "settings.autocomplete.model.description": "Выберите модель для встроенного (inline) автодополнения кода",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -707,6 +707,13 @@ export const dict = {
   "settings.webTools.webSearch.description": "ทำให้โมเดลจากผู้ให้บริการทั้งหมดใช้การค้นหาเว็บได้",
   "settings.checkpoints.title": "จุดตรวจสอบ",
   "settings.display.title": "การแสดงผล",
+  "settings.sleep.title": "พลังงาน",
+  "settings.sleep.enable.title": "ป้องกันระบบพักเครื่องระหว่างทำงาน",
+  "settings.sleep.enable.description":
+    "ให้คอมพิวเตอร์ทำงานต่อขณะที่ Kilo Code กำลังทำงาน การล็อกหน้าจอไม่ได้รับผลกระทบ",
+  "settings.sleep.timeout.title": "ขีดจำกัดต่อหนึ่งงาน (นาที)",
+  "settings.sleep.timeout.description":
+    "นับเฉพาะเวลาที่งานทำงานอยู่ ไม่นับเวลารอคำตอบจากคุณ ใช้ 0 หากไม่ต้องการให้ส่วนขยายกำหนดขีดจำกัด ค่าเริ่มต้น: 30 นาที",
   "settings.autocomplete.title": "เติมข้อความอัตโนมัติ",
   "settings.autocomplete.model.title": "โมเดล Autocomplete",
   "settings.autocomplete.model.description": "เลือกโมเดลที่ใช้สำหรับการเติมโค้ดแบบอินไลน์ (inline completions)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -667,6 +667,12 @@ export const dict = {
     "Web aramasını tüm sağlayıcıların modelleri için kullanılabilir hale getirin.",
   "settings.checkpoints.title": "Kontrol Noktaları",
   "settings.display.title": "Görünüm",
+  "settings.sleep.title": "Güç",
+  "settings.sleep.enable.title": "Görevler sırasında sistem uykusunu önle",
+  "settings.sleep.enable.description": "Kilo Code çalışırken bilgisayarı uyanık tutar. Ekran kilidi etkilenmez.",
+  "settings.sleep.timeout.title": "Görev başına sınır (dakika)",
+  "settings.sleep.timeout.description":
+    "Yalnızca etkin çalışma süresi sayılır; yanıtınızı bekleme süresi sayılmaz. Uzantının sınır koymaması için 0 kullanın. Varsayılan: 30 dakika.",
   "settings.autocomplete.title": "Otomatik Tamamlama",
   "settings.autocomplete.model.title": "Otomatik tamamlama modeli",
   "settings.autocomplete.model.description": "Satır içi (inline) kod tamamlamaları için kullanılacak modeli seçin",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -667,6 +667,13 @@ export const dict = {
   "settings.webTools.webSearch.description": "Зробіть вебпошук доступним для моделей усіх постачальників.",
   "settings.checkpoints.title": "Контрольні точки",
   "settings.display.title": "Відображення",
+  "settings.sleep.title": "Живлення",
+  "settings.sleep.enable.title": "Запобігати переходу системи в режим сну під час завдань",
+  "settings.sleep.enable.description":
+    "Не переводити комп’ютер у режим сну під час роботи Kilo Code. Блокування екрана не змінюється.",
+  "settings.sleep.timeout.title": "Ліміт на завдання (хвилини)",
+  "settings.sleep.timeout.description":
+    "Враховується лише час активного виконання, без очікування вашої відповіді. Укажіть 0, щоб розширення не встановлювало ліміт. Типове значення: 30 хвилин.",
   "settings.autocomplete.title": "Автодоповнення",
   "settings.autocomplete.model.title": "Модель автодоповнення",
   "settings.autocomplete.model.description": "Виберіть модель для вбудованого (inline) автодоповнення коду",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -691,6 +691,12 @@ export const dict = {
   "settings.webTools.webSearch.description": "让所有提供商的模型都可使用网页搜索。",
   "settings.checkpoints.title": "检查点",
   "settings.display.title": "显示",
+  "settings.sleep.title": "电源",
+  "settings.sleep.enable.title": "执行任务时阻止系统休眠",
+  "settings.sleep.enable.description": "Kilo Code 工作时让计算机保持唤醒。屏幕锁定不受影响。",
+  "settings.sleep.timeout.title": "每个任务的限制（分钟）",
+  "settings.sleep.timeout.description":
+    "仅计算任务的活跃运行时间，不计算等待你回答的时间。设为 0 表示扩展不施加限制。默认值：30 分钟。",
   "settings.autocomplete.title": "自动补全",
   "settings.autocomplete.model.title": "自动补全模型",
   "settings.autocomplete.model.description": "选择用于内联代码补全的模型",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -651,6 +651,12 @@ export const dict = {
   "settings.webTools.webSearch.description": "讓所有供應商的模型都可使用網頁搜尋。",
   "settings.checkpoints.title": "檢查點",
   "settings.display.title": "顯示",
+  "settings.sleep.title": "電源",
+  "settings.sleep.enable.title": "執行任務時防止系統休眠",
+  "settings.sleep.enable.description": "Kilo Code 工作時讓電腦保持喚醒。螢幕鎖定不受影響。",
+  "settings.sleep.timeout.title": "每個任務的限制（分鐘）",
+  "settings.sleep.timeout.description":
+    "只計算任務的實際執行時間，不計算等待你回答的時間。設為 0 表示擴充功能不施加限制。預設值：30 分鐘。",
   "settings.autocomplete.title": "自動完成",
   "settings.autocomplete.model.title": "自動補全模型",
   "settings.autocomplete.model.description": "選擇用於內聯程式碼補全的模型",

--- a/packages/kilo-vscode/webview-ui/src/styles/settings.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/settings.css
@@ -131,6 +131,16 @@
   max-width: none;
 }
 
+[data-slot="sleep-setting-child"] {
+  margin-left: 20px;
+  padding-left: 12px;
+  border-left: 2px solid var(--border-weak-base);
+}
+
+[data-slot="sleep-timeout-input"] {
+  width: 100px;
+}
+
 .settings-font-size-control {
   display: flex;
   align-items: center;

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -767,6 +767,12 @@ export interface ThroughputSettingLoadedMessage {
   visible: boolean
 }
 
+export interface SleepSettingsLoadedMessage {
+  type: "sleepSettingsLoaded"
+  enabled: boolean
+  timeout: number
+}
+
 export interface AutoApprovalReasonSettingLoadedMessage {
   type: "autoApprovalReasonSettingLoaded"
   visible: boolean
@@ -1489,6 +1495,7 @@ export interface AgentManagerBrowserDevtoolsMessage {
 }
 
 export type ExtensionMessage =
+  | SleepSettingsLoadedMessage
   | DocumentResultMessage
   | DocumentOpenMessage
   | AgentManagerFocusContextRequestedMessage

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -520,6 +520,10 @@ export interface RequestThroughputSettingMessage {
   type: "requestThroughputSetting"
 }
 
+export interface RequestSleepSettingsMessage {
+  type: "requestSleepSettings"
+}
+
 export interface RequestAutoApprovalReasonSettingMessage {
   type: "requestAutoApprovalReasonSetting"
 }
@@ -1520,6 +1524,7 @@ export interface DismissAgentMigrationBannerMessage {
 
 export type WebviewMessage =
   | { type: "sessionActivity"; state: Activity }
+  | RequestSleepSettingsMessage
   | DocumentRequestMessage
   | DocumentOpenFileMessage
   | DocumentCloseMessage


### PR DESCRIPTION
## Summary

Add opt-in, cross-platform system sleep prevention while VS Code agent tasks are actively running.

- Add the disabled-by-default `kilo-code.new.preventSleepDuringTasks` setting.
- Add a 30-minute active-execution limit per task; `0` removes only Kilo’s time limit.
- Add the localized **Power** settings panel, using a battery icon and a nested timeout field.
- Pause the active-time budget while a task awaits a question, permission, network recovery, or blocking suggestion.
- Do not prevent display sleep or screen locking.


## Why

Long-running agent tasks can be interrupted by automatic system sleep. Existing operating-system power settings are still respected, but users need an explicit way to keep the system awake while work is actually executing.

The feature is opt-in because changing power behaviour should never be a surprise. The timeout is based on active execution rather than wall-clock time so time spent waiting for the user is not charged.

## Behaviour

```mermaid
stateDiagram-v2
    [*] --> Running: task becomes busy/retry
    Running --> Paused: question / permission / network / blocking suggestion
    Paused --> Running: reply / recovery
    Running --> Finished: idle / completed / failed / cancelled / limit reached
    Paused --> Finished: task ends
    Finished --> [*]
```

```mermaid
flowchart LR
    A[Active task] --> B[Session sleep tracker]
    B --> C{Any task actively running?}
    C -- No --> D[Release native inhibitor]
    C -- Yes --> E[Shared native inhibitor]
    E --> F{Platform}
    F --> G[Windows: ES_SYSTEM_REQUIRED]
    F --> H[macOS: caffeinate -i]
    F --> I[Linux: systemd-inhibit]
    I --> J[Fallback: gnome-session-inhibit]
    G --> K[Ready signal]
    H --> K
    I --> K
    J --> K
    K --> L[Report inhibition active]
```

## Implementation notes

- Native helpers use readiness checks, parent-lifetime watchdogs, reference counting, and bounded retry/fallback behaviour.
- Windows requests system execution state only; it never requests display-required state.
- macOS uses `caffeinate -i`.
- Linux prefers `systemd-inhibit --what=sleep` and falls back to `gnome-session-inhibit --inhibit=suspend`.
- Reconnection restores task status, titles, pending input, network waits, and blocking suggestions without overwriting newer SSE events.
- Multiple tasks keep one shared native helper alive until the final active task releases it.

## Visual evidence

Kilo Settings:
<img width="1953" height="727" alt="Screenshot_20260902_113743" src="https://github.com/user-attachments/assets/19664f17-48ee-424c-b0ee-252afc6b2b0e" />

VSCode status bar:
<img width="531" height="84" alt="Screenshot_20260902_113611" src="https://github.com/user-attachments/assets/9c9f537e-7811-4feb-9740-0fa1e1b1eedf" />

System notification (KDE Plasma 6.7.4)
<img width="545" height="772" alt="image" src="https://github.com/user-attachments/assets/db9f4b62-57b2-46b8-abe4-b090876ba5cb" />




## Verification

Completed:

```text
cd packages/kilo-vscode

bun test tests/unit/sleep-inhibitor.test.ts \
  tests/unit/kilo-provider-indexing-refresh.test.ts
# 44 passing, 0 failing, 126 assertions

bun run typecheck
bun run lint
bun run format:check
bun run knip
bun run check-kilocode-change
```

The VSIX archive was also built and verified with `unzip -tq`.

`bun script/dev-snapshot.ts build` stalled locally while invoking `bun esbuild.js --production`. As substitute verification, `node esbuild.js --production` completed successfully and the same `@vscode/vsce` packaging path produced a valid VSIX archive.