### PR TITLE
fix(cli): use terminal-safe diagram guidance in Ask mode

### DIFF
--- a/.changeset/cli-ask-plain-text-diagrams.md
+++ b/.changeset/cli-ask-plain-text-diagrams.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Use plain-text diagrams in CLI Ask mode instead of recommending Mermaid, while preserving Mermaid guidance in VS Code and JetBrains.

--- a/packages/opencode/src/kilocode/agent/index.ts
+++ b/packages/opencode/src/kilocode/agent/index.ts
@@ -18,6 +18,8 @@ import PROMPT_ORCHESTRATOR from "../../agent/prompt/orchestrator.txt"
 import PROMPT_ASK from "../../agent/prompt/ask.txt"
 import PROMPT_EXPLORE from "../../agent/prompt/explore.txt"
 
+const mermaidClients = new Set(["vscode", "jetbrains"])
+
 const readable: Record<string, "allow"> = {
   "cat *": "allow",
   "head *": "allow",
@@ -610,7 +612,12 @@ export function patchAgents(
   agents.ask = {
     name: "ask",
     description: "Get answers and explanations without making changes to the codebase.",
-    prompt: PROMPT_ASK,
+    prompt: mermaidClients.has(Flag.KILO_CLIENT)
+      ? PROMPT_ASK
+      : PROMPT_ASK.replace(
+          "- Use Mermaid diagrams when they help clarify your response",
+          "- Use plain-text or ASCII diagrams when they help clarify your response. The CLI cannot render Mermaid diagrams. Only provide Mermaid source when the user explicitly requests it",
+        ),
     options: {},
     permission: Permission.merge(
       defaults,

--- a/packages/opencode/test/kilocode/system-prompt.test.ts
+++ b/packages/opencode/test/kilocode/system-prompt.test.ts
@@ -7,6 +7,8 @@ import { SessionID, MessageID, PartID } from "../../src/session/schema"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderTest } from "../fake/provider"
+import { patchAgents } from "../../src/kilocode/agent"
+import PROMPT_ASK from "../../src/agent/prompt/ask.txt"
 
 import PROMPT_ANTHROPIC from "../../src/session/prompt/anthropic.txt"
 import PROMPT_DEFAULT from "../../src/session/prompt/default.txt"
@@ -131,6 +133,38 @@ describe("SystemPrompt.provider", () => {
       const result = SystemPrompt.provider(model)
       expect(result).toEqual([PROMPT_CODEX])
     })
+  })
+})
+
+describe("Ask diagram guidance", () => {
+  test.each([
+    [undefined, false],
+    ["cli", false],
+    ["acp", false],
+    ["unknown", false],
+    ["vscode", true],
+    ["jetbrains", true],
+  ] as const)("matches rendering support for %s", (client, mermaid) => {
+    const previous = process.env.KILO_CLIENT
+    try {
+      if (client === undefined) delete process.env.KILO_CLIENT
+      if (client !== undefined) process.env.KILO_CLIENT = client
+      const agents: Parameters<typeof patchAgents>[0] = {}
+      patchAgents(agents, [], [], {}, { mcpRules: {}, defaultsPatch: [] }, "/repo", [])
+      const prompt = agents.ask.prompt
+      expect(prompt).toContain("You are in Ask mode")
+      expect(prompt).toContain("You must NOT modify files")
+      if (mermaid) {
+        expect(prompt).toBe(PROMPT_ASK)
+        return
+      }
+      expect(prompt).not.toContain("Use Mermaid diagrams")
+      expect(prompt).toContain("Use plain-text or ASCII diagrams")
+      expect(prompt).toContain("cannot render Mermaid")
+    } finally {
+      if (previous === undefined) delete process.env.KILO_CLIENT
+      if (previous !== undefined) process.env.KILO_CLIENT = previous
+    }
   })
 })
 


### PR DESCRIPTION
## What Problem This Solves

The built-in Ask prompt recommends Mermaid diagrams in every client, but the terminal displays Mermaid source instead of rendering a diagram.

## Why This Change Was Made

Use the existing client flag and a named set of Mermaid-capable clients to keep the change in Kilo-owned agent setup. VS Code and JetBrains retain the original prompt; CLI, unset, ACP, and unknown clients receive plain-text or ASCII guidance. No renderer or shared upstream prompt changes are needed.

## User Impact

CLI Ask mode no longer recommends unreadable Mermaid blocks for visual explanations. Explicit requests for Mermaid source remain allowed. Editor diagram support, read-only restrictions, and custom agent prompts are unchanged.

Detection remains server-process-wide: a terminal attached to an editor-owned backend still follows that backend client flag. Per-viewer capability negotiation is outside this fix.

## Evidence

- The regression matrix failed for all four non-rendering client cases before the fix and passes afterward; both editor cases retain the exact original prompt.
- All 28 focused prompt and chart-gating tests pass, as do CLI typecheck, targeted lint, diff whitespace checks, and the annotation guard. Lint reports three existing assertions in the test file; existing unrelated formatting warnings were left unchanged.
- An isolated source CLI `debug agent ask` smoke test confirms the final generated prompt contains ASCII guidance and no Mermaid recommendation, without making an LLM request.
- Manual check: in CLI Ask mode, request a flow diagram and expect plain text; explicitly request Mermaid source and confirm it remains allowed.