### PR TITLE
fix(docs): update VS Code telemetry link

### DIFF
--- a/packages/kilo-docs/pages/code-with-ai/features/message-feedback.md
+++ b/packages/kilo-docs/pages/code-with-ai/features/message-feedback.md
@@ -56,7 +56,7 @@ Feedback is part of telemetry, so turning telemetry off will cause the feedback 
 {% tabs %}
 {% tab label="VSCode" %}
 
-Open Settings (`Cmd+,` on Mac, `Ctrl+,` on Windows/Linux), search for **`telemetry.telemetryLevel`**, and set it to **Off**. The feedback buttons will no longer appear. Set it back to **All** to bring them back. (For more on what this setting controls, see [VS Code's telemetry docs](https://code.visualstudio.com/docs/getstarted/telemetry).)
+Open Settings (`Cmd+,` on Mac, `Ctrl+,` on Windows/Linux), search for **`telemetry.telemetryLevel`**, and set it to **Off**. The feedback buttons will no longer appear. Set it back to **All** to bring them back. (For more on what this setting controls, see [VS Code's telemetry docs](https://code.visualstudio.com/docs/configure/telemetry).)
 
 {% /tab %}
 


### PR DESCRIPTION
## What Problem This Solves
The message feedback documentation linked to the retired VS Code telemetry path, causing the documentation link checker to fail.

## Why This Change Was Made
VS Code now serves telemetry guidance at `/docs/configure/telemetry`.

## User Impact
The telemetry documentation link opens the current VS Code page.

## Evidence
- Confirmed the new URL resolves successfully.
- `git diff --check` passes.