### PR TITLE
fix(cli): avoid repeated Swarm board activity notices

### DIFF
--- a/.changeset/swarm-read-notices.md
+++ b/.changeset/swarm-read-notices.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Avoid repeated Swarm activity notices for messages already returned by a successful board read, without hiding unread or concurrent updates.

--- a/packages/opencode/src/kilocode/board/context.ts
+++ b/packages/opencode/src/kilocode/board/context.ts
@@ -47,7 +47,7 @@ export namespace BoardContext {
     const agents = yield* Agent.Service
     const database = yield* Database.Service
 
-    return <T extends Tool.ExecuteResult>(_tool: string, output: T, signal?: AbortSignal): Effect.Effect<T> =>
+    return <T extends Tool.ExecuteResult>(tool: string, output: T, signal?: AbortSignal): Effect.Effect<T> =>
       Effect.gen(function* () {
         if (signal?.aborted) return output
         const cfg = yield* config.get()
@@ -55,7 +55,14 @@ export namespace BoardContext {
         const session = yield* sessions.get(input.session.id)
         const agent = yield* agents.get(input.agent.name, cfg)
         if (!agent || !allowed({ session, agent, user: input.user })) return output
-        const activity = yield* BoardStore.activity({ sessionID: session.id, after: input.cache.cursor }).pipe(
+        const read =
+          tool === "board_read" && output.metadata.truncated === false && typeof output.metadata.cursor === "string"
+            ? {
+                cursor: output.metadata.cursor,
+                since: typeof output.metadata.since === "string" ? output.metadata.since : undefined,
+              }
+            : undefined
+        const activity = yield* BoardStore.activity({ sessionID: session.id, after: input.cache.cursor, read }).pipe(
           Effect.provideService(Database.Service, database),
         )
         if (signal?.aborted) return output

--- a/packages/opencode/src/kilocode/board/store.ts
+++ b/packages/opencode/src/kilocode/board/store.ts
@@ -245,11 +245,31 @@ export namespace BoardStore {
       .pipe(Effect.mapError((error) => mapError(error)))
   })
 
-  export const activity = Effect.fn("BoardStore.activity")(function* (input: { sessionID: SessionID; after: number }) {
+  export const activity = Effect.fn("BoardStore.activity")(function* (input: {
+    sessionID: SessionID
+    after: number
+    read?: { since?: string; cursor: string }
+  }) {
     if (!Number.isSafeInteger(input.after) || input.after < 0)
       return yield* fail("Board activity sequence must be a non-negative integer")
     const { db } = yield* Database.Service
     const current = yield* scope(input.sessionID)
+    const read = input.read
+      ? yield* db
+          .get<{ start: number | null; finish: number }>(
+            sql`
+            SELECT seq AS finish, ${
+              input.read.since
+                ? sql`(SELECT seq FROM kilo_board_message
+                    WHERE board_root_session_id = ${current.root} AND id = ${input.read.since})`
+                : sql`0`
+            } AS start
+            FROM kilo_board_message
+            WHERE board_root_session_id = ${current.root} AND id = ${input.read.cursor}
+          `,
+          )
+          .pipe(Effect.mapError((error) => mapError(error)))
+      : undefined
     const latest = yield* db
       .get<{ cursor: number; message: number | null }>(
         sql`
@@ -258,6 +278,7 @@ export namespace BoardStore {
           FROM kilo_board_message
           WHERE board_root_session_id = board.root_session_id
             AND seq > ${input.after} AND seq < board.next_seq
+            ${read?.start != null ? sql`AND (seq <= ${read.start} OR seq > ${read.finish})` : sql``}
             AND sender_session_id <> ${input.sessionID}
             AND (recipient = ${input.sessionID} OR recipient = ${ALL})
         ) AS message

--- a/packages/opencode/src/kilocode/tool/board.ts
+++ b/packages/opencode/src/kilocode/tool/board.ts
@@ -25,7 +25,7 @@ const Post = Schema.Struct({
   }),
 })
 
-type ReadMeta = { cursor?: string; hasMore: boolean; truncated: boolean }
+type ReadMeta = { since?: string; cursor?: string; hasMore: boolean; truncated: boolean }
 type PostMeta = { id: string; to: string; type: BoardStore.Kind; truncated: boolean }
 
 export const BoardReadTool = Tool.define<typeof Read, ReadMeta, Config.Service | Database.Service, "board_read">(
@@ -50,15 +50,16 @@ export const BoardReadTool = Tool.define<typeof Read, ReadMeta, Config.Service |
             )
           }
           yield* ctx.ask({ permission: "board_read", patterns: ["*"], always: ["*"], metadata: {} })
+          const since = params.since?.trim() || undefined
           const result = yield* BoardStore.read({
             sessionID: ctx.sessionID,
-            since: params.since?.trim() || undefined,
+            since,
             limit: params.limit ?? undefined,
           }).pipe(Effect.provideService(Database.Service, database))
           return {
             title: "Shared agent board",
             output: JSON.stringify(result),
-            metadata: { cursor: result.cursor, hasMore: result.hasMore, truncated: false },
+            metadata: { since, cursor: result.cursor, hasMore: result.hasMore, truncated: false },
           }
         }).pipe(Effect.orDie),
     }

--- a/packages/opencode/test/kilocode/board-context.test.ts
+++ b/packages/opencode/test/kilocode/board-context.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test"
-import { Effect } from "effect"
+import { Effect, Fiber } from "effect"
 import { sql } from "drizzle-orm"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
@@ -18,7 +18,7 @@ import { BoardContext } from "../../src/kilocode/board/context"
 import { BoardNotice } from "../../src/kilocode/board/notice"
 import { BoardStore } from "../../src/kilocode/board/store"
 import { disposeAllInstances, provideTmpdirInstance } from "../fixture/fixture"
-import { testEffect } from "../lib/effect"
+import { awaitWithTimeout, testEffect } from "../lib/effect"
 
 const it = testEffect(
   LayerNode.compile(
@@ -134,6 +134,67 @@ describe("shared board notifications", () => {
           expect(output.metadata).toEqual({ original: true })
           yield* post(child.id, "third")
           expect((yield* notify("read", output)).metadata).toMatchObject({ [BoardNotice.key]: 3 })
+        }),
+      options,
+    ),
+  )
+
+  it.live("keeps byte-limited pages and concurrent read notices separate", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const sessions = yield* Session.Service
+          const root = yield* sessions.create({ title: "Concurrent reader" })
+          const child = yield* sessions.create({ parentID: root.id, title: "Peer" })
+          const message = yield* seed(root.id, "Read peer findings")
+          const cache = BoardContext.cache()
+          const notify = yield* BoardContext.notifier({ cache, session: root, agent, user: message.info })
+          const read = (since?: string) =>
+            BoardStore.read({ sessionID: root.id, since, limit: 50 }).pipe(
+              Effect.map((page) => ({
+                title: "Board",
+                output: JSON.stringify(page),
+                metadata: { since, cursor: page.cursor, hasMore: page.hasMore, truncated: false },
+              })),
+            )
+          for (let index = 0; index < 12; index++) yield* post(child.id, `page-${index}`, "x".repeat(3000))
+          const page = yield* read()
+          expect(page.metadata.hasMore).toBe(true)
+          expect((yield* notify("board_read", page)).metadata).toHaveProperty(BoardNotice.key, 12)
+
+          yield* post(child.id, "overlap")
+          const ready = Promise.withResolvers<void>()
+          const release = Promise.withResolvers<void>()
+          const activity = BoardStore.activity
+          const probe = spyOn(BoardStore, "activity").mockImplementation((input) =>
+            Effect.gen(function* () {
+              const result = yield* activity(input)
+              if (input.read) return result
+              ready.resolve()
+              yield* Effect.promise(() => release.promise)
+              return result
+            }),
+          )
+          yield* Effect.addFinalizer(() =>
+            Effect.sync(() => {
+              release.resolve()
+              probe.mockRestore()
+            }),
+          )
+          const pending = yield* notify("read", output).pipe(Effect.forkChild)
+          yield* awaitWithTimeout(
+            Effect.promise(() => ready.promise),
+            "Activity check did not reach the barrier",
+          )
+          const rest = yield* read(page.metadata.cursor)
+          expect(rest.metadata.hasMore).toBe(false)
+          expect(yield* notify("board_read", rest)).toBe(rest)
+          expect(cache.cursor).toBe(13)
+          yield* post(child.id, "after-read")
+          release.resolve()
+          expect(yield* Fiber.join(pending)).toBe(output)
+          probe.mockRestore()
+          expect((yield* notify("read", output)).metadata).toHaveProperty(BoardNotice.key, 14)
         }),
       options,
     ),

--- a/packages/opencode/test/kilocode/board-tools.test.ts
+++ b/packages/opencode/test/kilocode/board-tools.test.ts
@@ -18,6 +18,8 @@ import { Tool } from "../../src/tool/tool"
 import { ToolRegistry } from "../../src/tool/registry"
 import { BoardReadTool, BoardPostTool } from "../../src/kilocode/tool/board"
 import { BoardStore } from "../../src/kilocode/board/store"
+import { BoardContext } from "../../src/kilocode/board/context"
+import { BoardNotice } from "../../src/kilocode/board/notice"
 import { KiloTask } from "../../src/kilocode/tool/task"
 import { KiloSessionPrompt } from "../../src/kilocode/session/prompt"
 import { disposeAllInstances, provideTmpdirInstance } from "../fixture/fixture"
@@ -173,6 +175,76 @@ describe("shared board tools", () => {
           expect(Exit.isFailure(cursor)).toBe(true)
           if (Exit.isFailure(cursor)) expect(Cause.pretty(cursor.cause)).toContain("Board cursor is not valid")
           expect((yield* BoardStore.read({ sessionID: root.session.id })).messages).toHaveLength(2)
+        }),
+      options,
+    ),
+  )
+
+  it.live("suppresses only activity included in a successful board read", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const sessions = yield* Session.Service
+          const agents = yield* Agent.Service
+          const root = yield* seed("Read progress")
+          const child = yield* sessions.create({ parentID: root.session.id, title: "Peer" })
+          const ctx = yield* context(root.session.id, root.message)
+          const agent = yield* agents.get(ctx.agent)
+          const user = ctx.messages.find((message) => message.info.role === "user")?.info
+          if (!agent || user?.role !== "user") throw new Error("Missing reader context")
+          const cache = BoardContext.cache()
+          const notify = yield* BoardContext.notifier({ cache, session: root.session, agent, user })
+          const read = yield* Tool.init(yield* BoardReadTool)
+          const output = { title: "Read file", output: "File contents", metadata: {} }
+          const post = (callID: string, body = callID) =>
+            BoardStore.post({ sessionID: child.id, messageID: root.message, callID, to: "main", type: "INFO", body })
+
+          const first = yield* post("first")
+          const page = yield* read.execute({}, ctx)
+          expect(yield* notify("board_read", page)).toBe(page)
+          expect(yield* notify("read", output)).toBe(output)
+          expect(cache.cursor).toBe(1)
+
+          yield* post("second")
+          const partial = yield* read.execute({ limit: 1 }, ctx)
+          expect(partial.metadata.cursor).toBe(first.id)
+          expect(partial.metadata.hasMore).toBe(true)
+          expect((yield* notify("board_read", partial)).metadata).toHaveProperty(BoardNotice.key, 2)
+          const rest = yield* read.execute({ since: partial.metadata.cursor }, ctx)
+          expect(yield* notify("board_read", rest)).toBe(rest)
+
+          const before = yield* read.execute({ since: rest.metadata.cursor }, ctx)
+          expect(JSON.parse(before.output).messages).toEqual([])
+          yield* post("concurrent")
+          expect((yield* notify("board_read", before)).metadata).toHaveProperty(BoardNotice.key, 3)
+
+          yield* post("failed")
+          expect(Exit.isFailure(yield* Effect.exit(read.execute({ since: "missing" }, ctx)))).toBe(true)
+          expect(cache.cursor).toBe(3)
+          const controller = new AbortController()
+          controller.abort()
+          const cancelled = yield* read.execute({}, ctx)
+          expect(yield* notify("board_read", cancelled, controller.signal)).toBe(cancelled)
+          expect(cache.cursor).toBe(3)
+          expect((yield* notify("read", output)).metadata).toHaveProperty(BoardNotice.key, 4)
+
+          const resumed = yield* BoardContext.notifier({
+            cache: BoardContext.cache(),
+            session: root.session,
+            agent,
+            user,
+          })
+          const latest = yield* read.execute({}, ctx)
+          expect(yield* resumed("board_read", latest)).toBe(latest)
+          expect(yield* resumed("read", output)).toBe(output)
+          const skipped = yield* BoardContext.notifier({
+            cache: BoardContext.cache(),
+            session: root.session,
+            agent,
+            user,
+          })
+          const suffix = yield* read.execute({ since: first.id }, ctx)
+          expect((yield* skipped("board_read", suffix)).metadata).toHaveProperty(BoardNotice.key, 1)
         }),
       options,
     ),


### PR DESCRIPTION
## What Problem This Solves

Successful board reads can be followed by activity notices for messages that were already returned. Advancing a notice cursor to every supplied history cursor would instead hide unread gaps, partial pages, or concurrent posts.

## Why This Change Was Made

Use the normalized start and returned cursor of a successful `board_read` to exclude only its consumed range from the next activity check. Keep history pagination separate from the existing per-turn notice cursor. Failed or cancelled checks do not advance notice progress.

This preserves the existing tools, configuration, storage, permission checks, and delivery model. It does not add durable acknowledgements, polling, automatic wake-up, or authority from peer messages.

## User Impact

Avoid repeated notices for messages already read while keeping earlier gaps, remaining pages, and later posts visible. This applies only when the shared-board experiment is enabled.

Fixes #13671.

## Evidence

Regression coverage includes successful and failed reads, cancelled checks, empty and limited pages, earlier gaps, byte-limited pages, concurrent posts, and interleaved read/tool notice checks. Focused code review found no unresolved correctness issue in this unit.

At exact head `54ec21c5f2945f6512f7ff624f6157095566387e`, 37 focused board/live tests, CLI typecheck, focused lint, and affected guards pass. CI had no failing or pending checks at 2026-09-02 14:45 UTC (expected skips/neutral entries only).

The isolated configured-model self-test passed at this same head with maximum reasoning. A freshly compiled CLI was verified by its source fingerprint, binary SHA-256, spawned executable/PID, and isolated database. Two real Task workers posted concrete findings before their remaining verification. A limit-1 read retained the notice for the remaining message; following its cursor consumed that message without another notice. A full read in a fresh continuation returned both messages, with no new notice on that read or the following ordinary read. Parent and child model configuration was verified from actual assistant records. Screenshots were read and remain local to protect private UI data. The isolated VS Code instance was cleaned up.

The only console entry was an existing Node `url.parse()` deprecation warning. One harness wait used an incorrect selector and timed out; the successful model task was verified and was not resent. This is bounded behavior evidence, not an exactly-once delivery or performance claim. The draft remains in the human-review handoff workflow; no review, Slack, or merge action is requested automatically.

Stack position 1 of 3. Actual PR base: `main`. Review bottom-up: this notice unit, https://github.com/Kilo-Org/kilocode/pull/13699 (base `swarm-read-notices`), then https://github.com/Kilo-Org/kilocode/pull/13701 (base `swarm-agent-state`). Each upper PR contains only its own scoped delta and has separate revision validation.
