### PR TITLE
fix(vscode): send review comments on second Cmd+Enter

### DIFF
--- a/.changeset/fix-review-comment-shortcut.md
+++ b/.changeset/fix-review-comment-shortcut.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Restore sending all Agent Manager diff comments with a second Cmd+Enter or Ctrl+Enter, including quick consecutive presses.

--- a/packages/kilo-vscode/tests/diff-scroll-preservation.spec.ts
+++ b/packages/kilo-vscode/tests/diff-scroll-preservation.spec.ts
@@ -131,6 +131,62 @@ test("preserves scroll while adding and editing a review comment", async ({ page
   await expect.poll(async () => scroller.evaluate((el) => el.scrollTop)).toBeCloseTo(saved, 0)
 })
 
+for (const modifier of ["Meta", "Control"] as const) {
+  test(`sends all review comments on the second ${modifier}+Enter before the next frame`, async ({ page }) => {
+    await openStory(page)
+    const target = await showTarget(page)
+    await alignTarget(page)
+
+    for (const text of ["First comment", "Second comment"]) {
+      await target.locator('[data-line="1"]').last().hover()
+      await target.locator("[data-utility-button]").last().click()
+      await target.locator(".am-annotation-textarea").fill(text)
+      if (text === "First comment") {
+        await target.getByRole("button", { name: "Comment", exact: true }).click()
+        await expect(target.getByText(text, { exact: true })).toBeVisible()
+      }
+    }
+
+    await page.keyboard.press("Shift+Enter")
+    await expect(target.locator(".am-annotation-textarea")).toHaveValue("Second comment\n")
+
+    const result = await page.evaluate((modifier) => {
+      const sent: Array<{ comments: Array<{ comment: string }>; autoSend: boolean }> = []
+      const listener = (event: MessageEvent) => {
+        if (event.data?.type === "appendReviewComments") sent.push(event.data)
+      }
+      window.addEventListener("message", listener)
+      const press = () =>
+        document.activeElement?.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "Enter",
+            metaKey: modifier === "Meta",
+            ctrlKey: modifier === "Control",
+            bubbles: true,
+            composed: true,
+            cancelable: true,
+          }),
+        )
+      press()
+      const first = sent.length
+      press()
+      const second = sent.length
+      press()
+      window.removeEventListener("message", listener)
+      return { first, second, sent }
+    }, modifier)
+
+    expect(result.first).toBe(0)
+    expect(result.second).toBe(1)
+    expect(result.sent).toHaveLength(1)
+    expect(result.sent.at(0)).toMatchObject({
+      comments: [{ comment: "First comment" }, { comment: "Second comment" }],
+      autoSend: true,
+    })
+    await expect(page.locator(".am-annotation")).toHaveCount(0)
+  })
+}
+
 test("resets virtual measurements and scroll when the review context changes", async ({ page }) => {
   const first = await openStory(page)
   const scroller = page.locator(".am-review-diff")

--- a/packages/kilo-vscode/webview-ui/diff-viewer/review-annotations.ts
+++ b/packages/kilo-vscode/webview-ui/diff-viewer/review-annotations.ts
@@ -337,6 +337,7 @@ export function buildReviewAnnotation(
       }
       if (event.key === "Enter" && !event.shiftKey) {
         event.preventDefault()
+        event.stopPropagation()
         submit()
       }
     })
@@ -414,6 +415,7 @@ export function buildReviewAnnotation(
       }
       if (event.key === "Enter" && !event.shiftKey) {
         event.preventDefault()
+        event.stopPropagation()
         save()
       }
     })

--- a/packages/kilo-vscode/webview-ui/diff-viewer/review-setup.ts
+++ b/packages/kilo-vscode/webview-ui/diff-viewer/review-setup.ts
@@ -42,9 +42,7 @@ export function createReviewSpeech(t: T): {
 }
 
 export function reviewFocus(root: () => HTMLElement | undefined): void {
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => root()?.focus())
-  })
+  root()?.focus({ preventScroll: true })
 }
 
 export function keepsNativeFocus(target: EventTarget | null): boolean {


### PR DESCRIPTION
## What Problem This Solves
A fast second Cmd+Enter in an Agent Manager diff comment could reach the old editor before focus moved to the review panel. It added a duplicate comment instead of sending the saved comments.

## Why This Change Was Made
Restore focus immediately with preventScroll rather than waiting for two animation frames. Consume the add/save key event so the first press cannot also trigger send-all. Keep the existing chat draft and send guards unchanged.

## User Impact
The first Cmd+Enter saves the current comment. The second sends all saved comments once, including rapid consecutive presses. Ctrl+Enter follows the same flow; Shift+Enter still inserts a newline.

## Evidence
- Both rapid-keyboard regression cases failed before the fix and pass after it. They assert no send on the first press, one complete batch on the second, and no duplicate batch on a third press.
- All 10 diff browser tests and 55 focused unit tests passed. Typecheck, lint, compile, formatting, knip, and the Kilo marker guard passed.
- Verified the inline review in isolated VS Code with two fixture comments: the first press restored panel focus immediately; the second submitted both comments and cleared the review annotations. The isolated test instance was stopped afterward.
- The browser regression uses synthetic consecutive key events in one frame to make the timing failure deterministic. It exercises the real review component and does not require a live model response.

After submitting the two fixture comments, the diff remains visible without pending annotations:

<img width="400" alt="Agent Manager diff after both review comments were submitted, with no pending comment annotations" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260902-review-comments-cleared-d3aa4186.png" />