### PR TITLE
test(vscode): give session activity integration a 15s timeout

### DIFF
--- a/packages/kilo-vscode/tests/unit/session-provider-activity.test.ts
+++ b/packages/kilo-vscode/tests/unit/session-provider-activity.test.ts
@@ -49,5 +49,5 @@ describe("SessionProvider activity", () => {
     } finally {
       unlinkSync(file)
     }
-  })
+  }, 15_000)
 })


### PR DESCRIPTION
## What Problem This Solves

The SessionProvider activity integration test shares Bun's default 5-second budget between a cold esbuild bundle and a child-process fixture. After #13692 expanded the fixture by 541 added lines, [main CI attempt 1](https://github.com/Kilo-Org/kilocode/actions/runs/33654446973) timed out, killed the fixture and esbuild processes, then reported `exitCode: null` and downstream `The service is no longer running` errors. Attempt 3 passed unchanged, confirming an intermittent failure.

## Why This Change Was Made

Give only this test 15 seconds, matching the existing esbuild dependency integration test. Six concurrent runs on Bun 1.3.14 reproduced the exact 5000ms timeout and SIGTERM/null-exit symptom. With 15 seconds, all six completed their assertions and cleanup in about 5.7 seconds each. This is build/execution overhead, not a teardown hang. The bound leaves headroom without the 120-second wait proposed elsewhere.

This focused fix supersedes only the timeout adjustment in #13592 (commit `916b94f66c67f7c3cb974288e5cc887d66edea4c`), not its mention-search feature. The current-main fixture was used throughout; no assertions, sleeps, fixture behavior, or production code change.

## User Impact

No runtime behavior change. The extension unit suite can finish this integration test under load without killing the shared esbuild service.

## Evidence

- Temporary timing probes, removed from the diff: unloaded bundles 1.03-1.52s, child execution 1.11-1.48s, cleanup 3-4ms. Under six-process load, bundles took about 4s and every fixture completed with exit code 0 after the fix.
- Final code on Bun 1.3.14, macOS: focused test repeated 10 times, 10 passed; full extension suite, 4,640 passed, 1 skipped, 0 failed.
- Extension typecheck, ESLint, formatting, knip, and change-marker checks passed. Root lint finished with 0 errors and existing warnings. Architecture guard passed with 0 boundary violations.
- Existing architecture checks enforce selected domain/host boundaries, not this fixture's transitive UI graph or build-time budget. UI dependency cleanup is outside this test-only fix. No UI self-test is needed.
