### PR TITLE
feat(vscode): introduce Kilo Swarm branding

### DIFF
--- a/.changeset/shared-agent-board.md
+++ b/.changeset/shared-agent-board.md
@@ -4,7 +4,7 @@
 "kilo-code": minor
 ---
 
-Add opt-in shared agent boards with persistent session history and fixed activity notices in tool results. Read peer messages explicitly with `board_read`, without treating them as user requests or approval. Enable the board in Experimental settings to share discoveries between the main agent and its subagents.
+Introduce Kilo Swarm, an opt-in shared board scoped to a main session and its task descendants, with persistent session history and fixed activity notices in tool results. Enable Kilo Swarm in Experimental settings for parallel solution attempts or complementary work, not every task. Post messages with `board_post` and read peer messages explicitly with `board_read`, without treating them as user requests or approval. Posting a message does not guarantee delivery or reading, or start an agent. Keep `experimental.shared_agent_board`, tool names, stored identifiers, history, and permissions unchanged.
 
 Keep background task status available for models without a reasoning variant.
 

--- a/packages/kilo-docs/pages/getting-started/settings/index.md
+++ b/packages/kilo-docs/pages/getting-started/settings/index.md
@@ -186,6 +186,7 @@ Available experimental settings include:
 - **LSP integration** - expose language server diagnostics to the agent
 - **Paste summary** - summarize large clipboard pastes before including them
 - **Batch tool** - allow the agent to batch multiple tool calls in one step
+- **Kilo Swarm** - let a main session and its task subagents share a board (off by default)
 - **OpenTelemetry** - enable Kilo telemetry and optional OTLP export when configured
 
 Advanced options not exposed in the UI can be configured via the `experimental` key in `kilo.jsonc`:
@@ -212,3 +213,20 @@ Telemetry is enabled by default. Set `experimental.openTelemetry` to `false` in 
 
 {% /tab %}
 {% /tabs %}
+
+### Kilo Swarm
+
+Kilo Swarm lets a main session and its task descendants, including nested subagents, exchange messages on a shared board. It is experimental and uses the existing Task tool, not a separate agent runtime. The board is not shared with unrelated sessions, even in the same repository or worktree.
+
+Enable **Kilo Swarm** in the VS Code **Experimental** settings, or set `experimental.shared_agent_board` to `true` in `kilo.jsonc`. It is off by default. This display name does not change the configuration key, tool names, stored board or session IDs, database migrations, history, or permissions.
+
+Use it when agents can benefit from discoveries during work:
+
+- **Search races:** agents try independent approaches to the same problem and share useful findings.
+- **Complementary teams:** agents work on different parts of a feature and share constraints or results.
+
+Straightforward tasks can stay solo. Enabling the board does not mean agents are always running or that every task needs a team.
+
+**Post message** (`board_post`) stores a message on the shared board. **Read messages** (`board_read`) retrieves messages from the board explicitly. Activity notices are best-effort: a stored message does not prove that a recipient was notified, read it, or acted on it. Posting does not start or resume an agent, and normal task completion still returns results to the parent.
+
+All participants can read the board history, including messages addressed to others. Recipient selection is not a privacy boundary. Peer messages do not grant user approval or change permissions; `HOLD` and `VETO` are advisory, not controls that pause or cancel work.

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -844,9 +844,9 @@ export const dict = {
   "settings.experimental.batch.description": "تمكين المعالجة الدفعية لاستدعاءات الأدوات",
   "settings.experimental.imageGeneration.title": "توليد الصور",
   "settings.experimental.imageGeneration.description": "تمكين توليد الصور بالذكاء الاصطناعي",
-  "settings.experimental.sharedAgentBoard.title": "لوحة الوكلاء المشتركة",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "السماح للوكيل الرئيسي ووكلائه الفرعيين بمشاركة الاكتشافات ضمن جلسة واحدة.",
+    "شارك لوحة بين جلسة رئيسية ووكلائها الفرعيين المكلّفين بالمهام، بما يشمل الوكلاء الفرعيين المتداخلين. استخدمها لمحاولات حل متوازية أو أعمال متكاملة، وليس لكل مهمة.",
   "settings.experimental.imageGenerationModel.title": "نموذج الصور",
   "settings.experimental.imageGenerationModel.description": "نموذج توليد الصور",
   "settings.experimental.imageGenerationModel.placeholder": "افتراضي (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -872,9 +872,9 @@ export const dict = {
   "settings.experimental.batch.description": "Ativar processamento em lote de chamadas de ferramentas",
   "settings.experimental.imageGeneration.title": "Geração de imagens",
   "settings.experimental.imageGeneration.description": "Ativar geração de imagens por IA",
-  "settings.experimental.sharedAgentBoard.title": "Quadro compartilhado de agentes",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "Permite que o agente principal e seus subagentes compartilhem descobertas dentro de uma mesma sessão.",
+    "Compartilhe um quadro entre uma sessão principal e seus subagentes de tarefas, incluindo subagentes aninhados. Use-o para tentativas de solução em paralelo ou trabalhos complementares, não para todas as tarefas.",
   "settings.experimental.imageGenerationModel.title": "Modelo de imagem",
   "settings.experimental.imageGenerationModel.description": "Modelo de geração de imagens",
   "settings.experimental.imageGenerationModel.placeholder": "Padrão (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -867,9 +867,9 @@ export const dict = {
   "settings.experimental.batch.description": "Omogući batch obradu poziva alata",
   "settings.experimental.imageGeneration.title": "Generisanje slika",
   "settings.experimental.imageGeneration.description": "Omogući AI generisanje slika",
-  "settings.experimental.sharedAgentBoard.title": "Zajednička ploča agenata",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "Omogućite glavnom agentu i njegovim podagentima da dijele otkrića unutar iste sesije.",
+    "Dijelite ploču između glavne sesije i njenih podagenata za zadatke, uključujući ugniježđene podagente. Koristite je za paralelne pokušaje rješavanja problema ili rad na zadacima koji se međusobno nadopunjuju, a ne za svaki zadatak.",
   "settings.experimental.imageGenerationModel.title": "Model slike",
   "settings.experimental.imageGenerationModel.description": "Model za generisanje slika",
   "settings.experimental.imageGenerationModel.placeholder": "Zadano (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -866,9 +866,9 @@ export const dict = {
   "settings.experimental.batch.description": "Aktiver batchbehandling af flere værktøjskald",
   "settings.experimental.imageGeneration.title": "Billedgenerering",
   "settings.experimental.imageGeneration.description": "Aktiver AI-billedgenerering",
-  "settings.experimental.sharedAgentBoard.title": "Delt agentboard",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "Lad hovedagenten og dens underagenter dele opdagelser i den samme session.",
+    "Del et board mellem en hovedsession og dens underagenter til opgaveløsning, herunder indlejrede underagenter. Brug det til parallelle løsningsforsøg eller arbejdsopgaver, der supplerer hinanden, ikke til alle opgaver.",
   "settings.experimental.imageGenerationModel.title": "Billedmodel",
   "settings.experimental.imageGenerationModel.description": "Billedgenereringsmodel",
   "settings.experimental.imageGenerationModel.placeholder": "Standard (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -884,9 +884,9 @@ export const dict = {
   "settings.experimental.batch.description": "Bündelung mehrerer Werkzeugaufrufe aktivieren",
   "settings.experimental.imageGeneration.title": "Bildgenerierung",
   "settings.experimental.imageGeneration.description": "KI-Bildgenerierung aktivieren",
-  "settings.experimental.sharedAgentBoard.title": "Gemeinsames Agent-Board",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "Ermöglicht dem Hauptagenten und seinen Unteragenten, Erkenntnisse innerhalb einer Sitzung zu teilen.",
+    "Teilen Sie ein Board zwischen einer Hauptsitzung und ihren mit Aufgaben betrauten Unteragenten, einschließlich verschachtelter Unteragenten. Nutzen Sie es für parallele Lösungsversuche oder sich ergänzende Arbeiten, nicht für jede Aufgabe.",
   "settings.experimental.imageGenerationModel.title": "Bildmodell",
   "settings.experimental.imageGenerationModel.description": "Bildgenerierungsmodell",
   "settings.experimental.imageGenerationModel.placeholder": "Standard (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -845,9 +845,9 @@ export const dict = {
   "settings.experimental.batch.description": "Enable batching of multiple tool calls",
   "settings.experimental.imageGeneration.title": "Image Generation",
   "settings.experimental.imageGeneration.description": "Enable AI image generation",
-  "settings.experimental.sharedAgentBoard.title": "Shared agent board",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "Let the main agent and its subagents share discoveries within one session.",
+    "Share a board between a main session and its task subagents, including nested subagents. Use it for parallel solution attempts or complementary work, not every task.",
   "settings.experimental.imageGenerationModel.title": "Image Model",
   "settings.experimental.imageGenerationModel.description": "Image Generation Model",
   "settings.experimental.imageGenerationModel.placeholder": "Default (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -874,9 +874,9 @@ export const dict = {
   "settings.experimental.batch.description": "Habilitar procesamiento por lotes de llamadas a herramientas",
   "settings.experimental.imageGeneration.title": "Generación de imágenes",
   "settings.experimental.imageGeneration.description": "Habilitar generación de imágenes con IA",
-  "settings.experimental.sharedAgentBoard.title": "Tablero de agentes compartido",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "Permite que el agente principal y sus subagentes compartan descubrimientos dentro de una misma sesión.",
+    "Comparte un tablero entre una sesión principal y sus subagentes de tareas, incluidos los subagentes anidados. Úsalo para intentos de solución en paralelo o trabajos complementarios, no para todas las tareas.",
   "settings.experimental.imageGenerationModel.title": "Modelo de imagen",
   "settings.experimental.imageGenerationModel.description": "Modelo de generación de imágenes",
   "settings.experimental.imageGenerationModel.placeholder": "Predeterminado (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
@@ -850,9 +850,9 @@ export const dict = {
   "settings.experimental.batch.description": "فعال‌سازی دسته‌بندی چندین فراخوانی ابزار",
   "settings.experimental.imageGeneration.title": "تولید تصویر",
   "settings.experimental.imageGeneration.description": "فعال‌سازی تولید تصویر با هوش مصنوعی",
-  "settings.experimental.sharedAgentBoard.title": "برد مشترک عامل‌ها",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "به عامل اصلی و عامل‌های فرعی آن اجازه می‌دهد یافته‌ها را در یک جلسه به اشتراک بگذارند.",
+    "یک برد را بین یک جلسهٔ اصلی و عامل‌های فرعی مسئول وظایف آن، از جمله عامل‌های فرعی تودرتو، به اشتراک بگذارید. از آن برای تلاش‌های موازی جهت یافتن راه‌حل یا کارهای مکمل استفاده کنید، نه برای هر وظیفه.",
   "settings.experimental.imageGenerationModel.title": "مدل تصویر",
   "settings.experimental.imageGenerationModel.description": "مدل تولید تصویر",
   "settings.experimental.imageGenerationModel.placeholder": "پیش‌فرض (مسیریاب خودکار)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -886,9 +886,9 @@ export const dict = {
   "settings.experimental.batch.description": "Activer le traitement par lot d'appels d'outils",
   "settings.experimental.imageGeneration.title": "Génération d'images",
   "settings.experimental.imageGeneration.description": "Activer la génération d'images par IA",
-  "settings.experimental.sharedAgentBoard.title": "Tableau d'agents partagé",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "Permet à l'agent principal et à ses sous-agents de partager leurs découvertes au sein d'une même session.",
+    "Partagez un tableau entre une session principale et ses sous-agents chargés de tâches, y compris les sous-agents imbriqués. Utilisez-le pour des tentatives de résolution en parallèle ou des travaux complémentaires, pas pour toutes les tâches.",
   "settings.experimental.imageGenerationModel.title": "Modèle d'image",
   "settings.experimental.imageGenerationModel.description": "Modèle de génération d'images",
   "settings.experimental.imageGenerationModel.placeholder": "Par défaut (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -741,9 +741,9 @@ export const dict = {
     "Abilita l'indicizzazione semantica del codebase e il tool semantic_search. Richiede configurazione indicizzazione.",
   "settings.experimental.imageGeneration.title": "Generazione di immagini",
   "settings.experimental.imageGeneration.description": "Abilita la generazione di immagini con AI",
-  "settings.experimental.sharedAgentBoard.title": "Board condivisa degli agenti",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "Consente all'agente principale e ai suoi sotto-agenti di condividere le scoperte all'interno della stessa sessione.",
+    "Condividi una board tra una sessione principale e i suoi sotto-agenti incaricati dei task, inclusi quelli annidati. Usala per tentativi di soluzione in parallelo o attività complementari, non per ogni task.",
   "settings.experimental.imageGenerationModel.title": "Modello di immagine",
   "settings.experimental.imageGenerationModel.description": "Modello di generazione di immagini",
   "settings.experimental.imageGenerationModel.placeholder": "Predefinito (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -860,9 +860,9 @@ export const dict = {
   "settings.experimental.batch.description": "複数のツール呼び出しのバッチ処理を有効にする",
   "settings.experimental.imageGeneration.title": "画像生成",
   "settings.experimental.imageGeneration.description": "AI画像生成を有効にする",
-  "settings.experimental.sharedAgentBoard.title": "共有エージェントボード",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "メインエージェントとサブエージェントが同じセッション内で発見を共有できるようにします。",
+    "メインセッションと、そのタスクを担当するサブエージェント（ネストされたサブエージェントを含む）の間でボードを共有します。すべてのタスクで使うのではなく、並行して解決策を試す場合や、互いに補完し合う作業に使用してください。",
   "settings.experimental.imageGenerationModel.title": "画像モデル",
   "settings.experimental.imageGenerationModel.description": "画像生成モデル",
   "settings.experimental.imageGenerationModel.placeholder": "デフォルト (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -857,9 +857,9 @@ export const dict = {
   "settings.experimental.batch.description": "여러 도구 호출의 배치 처리 활성화",
   "settings.experimental.imageGeneration.title": "이미지 생성",
   "settings.experimental.imageGeneration.description": "AI 이미지 생성 활성화",
-  "settings.experimental.sharedAgentBoard.title": "공유 에이전트 보드",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "한 세션 안에서 주 에이전트와 하위 에이전트가 발견한 내용을 공유하도록 합니다.",
+    "메인 세션과 해당 세션의 작업을 맡은 하위 에이전트(중첩된 하위 에이전트 포함)가 보드를 공유합니다. 모든 작업에 사용하지 말고, 해결책을 병렬로 시도하거나 서로 보완하는 작업을 수행할 때 사용하세요.",
   "settings.experimental.imageGenerationModel.title": "이미지 모델",
   "settings.experimental.imageGenerationModel.description": "이미지 생성 모델",
   "settings.experimental.imageGenerationModel.placeholder": "기본값 (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -864,9 +864,9 @@ export const dict = {
   "settings.experimental.batch.description": "Schakel batching van meerdere tool calls in",
   "settings.experimental.imageGeneration.title": "Afbeeldingsgeneratie",
   "settings.experimental.imageGeneration.description": "AI-afbeeldingsgeneratie inschakelen",
-  "settings.experimental.sharedAgentBoard.title": "Gedeeld agentenbord",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "Laat de hoofdagent en subagenten ontdekkingen delen binnen één sessie.",
+    "Deel een bord tussen een hoofdsessie en de subagenten die haar taken uitvoeren, inclusief geneste subagenten. Gebruik het voor parallelle oplossingspogingen of werkzaamheden die elkaar aanvullen, niet voor elke taak.",
   "settings.experimental.imageGenerationModel.title": "Afbeeldingsmodel",
   "settings.experimental.imageGenerationModel.description": "Afbeeldingsgeneratiemodel",
   "settings.experimental.imageGenerationModel.placeholder": "Standaard (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -827,9 +827,9 @@ export const dict = {
   "settings.experimental.batch.description": "Aktiver batchbehandling av verktøykall",
   "settings.experimental.imageGeneration.title": "Bildegenerering",
   "settings.experimental.imageGeneration.description": "Aktiver AI-bildegenerering",
-  "settings.experimental.sharedAgentBoard.title": "Delt agenttavle",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "La hovedagenten og underagentene dele oppdagelser i samme økt.",
+    "Del en tavle mellom en hovedøkt og underagentene som utfører oppgavene dens, inkludert nestede underagenter. Bruk den til parallelle løsningsforsøk eller arbeidsoppgaver som utfyller hverandre, ikke til alle oppgaver.",
   "settings.experimental.imageGenerationModel.title": "Bildemodell",
   "settings.experimental.imageGenerationModel.description": "Bildegenereringsmodell",
   "settings.experimental.imageGenerationModel.placeholder": "Standard (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -823,9 +823,9 @@ export const dict = {
   "settings.experimental.batch.description": "Włącz przetwarzanie wsadowe wywołań narzędzi",
   "settings.experimental.imageGeneration.title": "Generowanie obrazów",
   "settings.experimental.imageGeneration.description": "Włącz generowanie obrazów przez AI",
-  "settings.experimental.sharedAgentBoard.title": "Wspólna tablica agentów",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "Pozwól agentowi głównemu i jego podagentom dzielić się odkryciami w ramach jednej sesji.",
+    "Współdziel tablicę między główną sesją a jej podagentami wykonującymi zadania, w tym zagnieżdżonymi podagentami. Używaj jej do równoległych prób rozwiązania problemu lub wzajemnie uzupełniających się prac, a nie do każdego zadania.",
   "settings.experimental.imageGenerationModel.title": "Model obrazu",
   "settings.experimental.imageGenerationModel.description": "Model generowania obrazów",
   "settings.experimental.imageGenerationModel.placeholder": "Domyślny (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -863,9 +863,9 @@ export const dict = {
   "settings.experimental.batch.description": "Включить пакетную обработку вызовов инструментов",
   "settings.experimental.imageGeneration.title": "Генерация изображений",
   "settings.experimental.imageGeneration.description": "Включить генерацию изображений с помощью ИИ",
-  "settings.experimental.sharedAgentBoard.title": "Общая доска агентов",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "Позволяет главному агенту и его подагентам делиться находками в рамках одного сеанса.",
+    "Предоставьте общую доску основному сеансу и его подагентам, выполняющим задачи, включая вложенных подагентов. Используйте её для параллельных попыток найти решение или взаимодополняющей работы, а не для каждой задачи.",
   "settings.experimental.imageGenerationModel.title": "Модель изображений",
   "settings.experimental.imageGenerationModel.description": "Модель генерации изображений",
   "settings.experimental.imageGenerationModel.placeholder": "По умолчанию (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -852,9 +852,9 @@ export const dict = {
   "settings.experimental.batch.description": "เปิดใช้งานการประมวลผลแบทช์ของการเรียกเครื่องมือ",
   "settings.experimental.imageGeneration.title": "การสร้างภาพ",
   "settings.experimental.imageGeneration.description": "เปิดใช้งานการสร้างภาพด้วย AI",
-  "settings.experimental.sharedAgentBoard.title": "กระดานเอเจนต์ที่ใช้ร่วมกัน",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "ให้เอเจนต์หลักและเอเจนต์ย่อยแชร์สิ่งที่ค้นพบภายในเซสชันเดียวกัน",
+    "แชร์กระดานระหว่างเซสชันหลักกับเอเจนต์ย่อยที่รับมอบหมายงานจากเซสชันนั้น รวมถึงเอเจนต์ย่อยที่ซ้อนกัน ใช้สำหรับการลองแก้ปัญหาแบบขนานหรืองานที่เสริมกัน ไม่ใช่สำหรับทุกงาน",
   "settings.experimental.imageGenerationModel.title": "โมเดลภาพ",
   "settings.experimental.imageGenerationModel.description": "โมเดลการสร้างภาพ",
   "settings.experimental.imageGenerationModel.placeholder": "ค่าเริ่มต้น (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -856,9 +856,9 @@ export const dict = {
   "settings.experimental.batch.description": "Birden fazla araç çağrısının toplu işlenmesini etkinleştir",
   "settings.experimental.imageGeneration.title": "Görüntü oluşturma",
   "settings.experimental.imageGeneration.description": "AI görüntü oluşturmayı etkinleştir",
-  "settings.experimental.sharedAgentBoard.title": "Paylaşılan ajan panosu",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "Ana ajanın ve alt ajanlarının keşifleri aynı oturum içinde paylaşmasını sağlar.",
+    "Bir ana oturum ile görevlerini yürüten alt ajanları arasında, iç içe geçmiş alt ajanlar da dahil olmak üzere bir pano paylaşın. Her görev için değil, paralel çözüm denemeleri veya birbirini tamamlayan çalışmalar için kullanın.",
   "settings.experimental.imageGenerationModel.title": "Görüntü modeli",
   "settings.experimental.imageGenerationModel.description": "Görüntü oluşturma modeli",
   "settings.experimental.imageGenerationModel.placeholder": "Varsayılan (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -857,9 +857,9 @@ export const dict = {
   "settings.experimental.batch.description": "Увімкнути пакетну обробку кількох викликів інструментів",
   "settings.experimental.imageGeneration.title": "Генерація зображень",
   "settings.experimental.imageGeneration.description": "Увімкнути генерацію зображень за допомогою ШІ",
-  "settings.experimental.sharedAgentBoard.title": "Спільна дошка агентів",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
   "settings.experimental.sharedAgentBoard.description":
-    "Дозволяє головному агенту та його підлеглим агентам ділитися відкриттями в межах одного сеансу.",
+    "Надайте спільну дошку головному сеансу та його субагентам, які виконують завдання, включно з вкладеними субагентами. Використовуйте її для паралельних спроб знайти розв'язання або взаємодоповнювальної роботи, а не для кожного завдання.",
   "settings.experimental.imageGenerationModel.title": "Модель зображень",
   "settings.experimental.imageGenerationModel.description": "Модель генерації зображень",
   "settings.experimental.imageGenerationModel.placeholder": "За замовчуванням (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -832,8 +832,9 @@ export const dict = {
   "settings.experimental.batch.description": "启用多个工具调用的批处理",
   "settings.experimental.imageGeneration.title": "图像生成",
   "settings.experimental.imageGeneration.description": "启用 AI 图像生成",
-  "settings.experimental.sharedAgentBoard.title": "共享智能体看板",
-  "settings.experimental.sharedAgentBoard.description": "让主智能体及其子智能体在同一会话中共享发现。",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
+  "settings.experimental.sharedAgentBoard.description":
+    "让主会话与负责其任务的子智能体共享看板，包括嵌套的子智能体。用于并行尝试解决方案或开展相互补充的工作，而不是用于每一项任务。",
   "settings.experimental.imageGenerationModel.title": "图像模型",
   "settings.experimental.imageGenerationModel.description": "图像生成模型",
   "settings.experimental.imageGenerationModel.placeholder": "默认 (Auto Router)",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -792,8 +792,9 @@ export const dict = {
   "settings.experimental.batch.description": "啟用多個工具呼叫的批次處理",
   "settings.experimental.imageGeneration.title": "圖像生成",
   "settings.experimental.imageGeneration.description": "啟用 AI 圖像生成",
-  "settings.experimental.sharedAgentBoard.title": "共享代理看板",
-  "settings.experimental.sharedAgentBoard.description": "讓主要代理與其子代理在同一個工作階段分享發現。",
+  "settings.experimental.sharedAgentBoard.title": "Kilo Swarm",
+  "settings.experimental.sharedAgentBoard.description":
+    "讓主要工作階段與負責其任務的子代理共用看板，包括巢狀子代理。用於並行嘗試解決方案或進行相互補充的工作，而不是用於每一項任務。",
   "settings.experimental.imageGenerationModel.title": "圖像模型",
   "settings.experimental.imageGenerationModel.description": "圖像生成模型",
   "settings.experimental.imageGenerationModel.placeholder": "預設 (Auto Router)",


### PR DESCRIPTION
## What Problem This Solves

The experimental shared-agent-board feature still appears as “Shared agent board” in settings, while its usability milestone names it Kilo Swarm. The existing help also describes a single session without explaining nested task agents or when cooperation helps.

Closes #13669. Part of #13673, built on the merged prototype #13629.

## Why This Change Was Made

Use Kilo Swarm as the feature name while keeping the domain language precise: a board is the shared space, a message is an entry, and the actions are Post message and Read messages. Update the existing Experimental setting and all 21 locale dictionaries, the existing settings documentation, and the prototype's pending release note. No new documentation page or translation key is added.

The diff deliberately avoids message-card rendering, session navigation, backend guidance, identity, and activity-notice logic. Card display aliases remain with the separate cards change; this PR does not add placeholder strings or depend on an unfinished branch. `BoardStore` and its `Message` type already express the intended domain distinction, so no internal rename is needed.

## User Impact

- Experimental settings show **Kilo Swarm**, with help covering a main session and its task descendants, including nested subagents.
- Documentation explains independent solution attempts and complementary teams without suggesting that every task needs a team.
- Messages remain advisory. Posting neither starts an agent nor guarantees notification, reading, or action; addressed messages are not private.
- `experimental.shared_agent_board`, `board_read`, `board_post`, permissions, opt-in behavior, stored IDs, history, and migrations stay unchanged.

## Evidence

- Verified that prototype merge `7dff92b6452ee1e86de098114bb28f8debad7d48` is in the base. This is one standalone commit on current main, not a stacked PR.
- **51 focused tests passed**: translation key coverage, unused keys, configuration scope, and configuration utilities.
- Extension typecheck, lint, compile, unused-export check, translation formatting, and merge-marker check passed. Typecheck, lint, the focused tests, and unused-export check were rerun after updating the branch to current main.
- Docs typecheck and lint passed, with 264 existing lint warnings. Markdown table and diff whitespace checks passed. No source URLs changed, so source-link extraction was not needed.
- Isolated VS Code checks verified English and Norwegian settings text, readable wrapping, the Kilo Swarm accessible label, and toggle/discard behavior. Screenshots were inspected and the isolated instances were cleaned up. Other locales were checked automatically, not visually. No model calls or runtime benchmarks were performed.
- The prototype's Cloud configuration-schema release prerequisite remains outside this copy-only PR and was not reverified here.

### Manual test

Open Experimental settings and inspect Kilo Swarm in English and another UI language. Toggle it and discard the change; the previous value must return. Read the Kilo Swarm section on the existing settings page and confirm that board, message, Post message, and Read messages have distinct meanings.

<img width="700" alt="Kilo Swarm setting and help text in English" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260902-kilo-swarm-branding-en-1837.png" />

<img width="700" alt="Kilo Swarm setting and help text in Norwegian" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260902-kilo-swarm-branding-no-1837.png" />
