### PR TITLE
fix(cli): prune old tool outputs in single-turn subagents

### DIFF
--- a/.changeset/fix-single-turn-subagent-pruning.md
+++ b/.changeset/fix-single-turn-subagent-pruning.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prune old tool outputs during long single-turn subagent runs while preserving recent working context and protected tools.

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -285,11 +285,17 @@ const layer = Layer.effect(
       let pruned = 0
       const toPrune: SessionV1.ToolPart[] = []
       let turns = 0
+      let steps = 0
+      let recent = true
 
       loop: for (let msgIndex = msgs.length - 1; msgIndex >= 0; msgIndex--) {
         const msg = msgs[msgIndex]
         if (msg.info.role === "user") turns++
-        if (turns < 2) continue
+        if (msg.info.role === "assistant") {
+          if (msg.info.summary) recent = false
+          if (msg.info.time.completed && msg.info.finish && msg.info.finish !== "error" && !msg.info.error) steps++
+        }
+        if (turns < 2 && (!recent || steps <= 2)) continue
         if (msg.info.role === "assistant" && msg.info.summary) break loop
         for (let partIndex = msg.parts.length - 1; partIndex >= 0; partIndex--) {
           const part = msg.parts[partIndex]

--- a/packages/opencode/test/kilocode/session-prompt-compaction-safety.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-compaction-safety.test.ts
@@ -319,6 +319,61 @@ const file = Effect.fn("prompt-safety.file")(function* (
 })
 
 describe("SessionPrompt compaction safety", () => {
+  it.live("prunes a single-turn subagent payload before the provider request", () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const root = yield* sessions.create({ title: "Parent" })
+        const chat = yield* sessions.create({ parentID: root.id, title: "Single-turn pruning" })
+        const request = yield* user(chat.id, "Complete the task")
+        const outputs = ["stale-output".repeat(120_000), "recent-one", "recent-two"]
+        expect(Buffer.byteLength(outputs.join(""))).toBeGreaterThan(1_250_000)
+        for (const output of outputs) {
+          const response = yield* assistant(chat.id, request.id, { finish: "tool-calls" })
+          yield* sessions.updateMessage({ ...response, time: { ...response.time, completed: Date.now() } })
+          yield* sessions.updatePart({
+            id: PartID.ascending(),
+            sessionID: chat.id,
+            messageID: response.id,
+            type: "tool",
+            callID: crypto.randomUUID(),
+            tool: "bash",
+            state: {
+              status: "completed",
+              input: { command: "pwd" },
+              output,
+              title: "result",
+              metadata: {},
+              time: { start: Date.now(), end: Date.now() },
+            },
+          })
+        }
+        yield* llm.text("final answer")
+
+        const result = yield* prompt.loop({ sessionID: chat.id })
+
+        expect(yield* llm.calls).toBe(1)
+        expect(result.parts.some((part) => part.type === "text" && part.text === "final answer")).toBe(true)
+        const body = JSON.stringify((yield* llm.inputs).at(-1)?.messages)
+        expect(Buffer.byteLength(body)).toBeLessThan(1_250_000)
+        expect(body).toContain("[Old tool result content cleared]")
+        expect(body).not.toContain("stale-output")
+        expect(body).toContain("recent-one")
+        expect(body).toContain("recent-two")
+        const messages = yield* sessions.messages({ sessionID: chat.id })
+        expect(messages.filter((message) => message.info.role === "user")).toHaveLength(1)
+        expect(
+          messages
+            .flatMap((message) => message.parts)
+            .filter((part) => part.type === "tool")
+            .map((part) => part.state.status === "completed" && !!part.state.time.compacted),
+        ).toEqual([true, false, false])
+      }),
+      { git: true, config: (url) => ({ ...providerCfg(url), compaction: { auto: false } }) },
+    ),
+  )
+
   it.live("compacts estimated outgoing context before the provider request", () =>
     provideTmpdirServer(
       Effect.fnUntraced(function* ({ llm }) {

--- a/packages/opencode/test/kilocode/session-pruning.test.ts
+++ b/packages/opencode/test/kilocode/session-pruning.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect } from "bun:test"
+import { Effect } from "effect"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Database } from "@opencode-ai/core/database/database"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { Session } from "@/session/session"
+import { SessionCompaction } from "@/session/compaction"
+import { MessageV2 } from "@/session/message-v2"
+import { MessageID, PartID, type SessionID } from "@/session/schema"
+import { ProviderTest } from "../fake/provider"
+import { seedProject, TestInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(
+  AppNodeBuilder.build(
+    LayerNode.group([SessionCompaction.node, Session.node, SessionProjector.node, Database.node, EventV2Bridge.node]),
+  ),
+)
+const model = ProviderTest.model()
+const config = { compaction: { prune: true } }
+
+const user = Effect.fnUntraced(function* (sessionID: SessionID) {
+  const sessions = yield* Session.Service
+  const message = yield* sessions.updateMessage({
+    id: MessageID.ascending(),
+    sessionID,
+    role: "user",
+    agent: "general",
+    model: { providerID: model.providerID, modelID: model.id },
+    time: { created: Date.now() },
+  })
+  yield* sessions.updatePart({
+    id: PartID.ascending(),
+    sessionID,
+    messageID: message.id,
+    type: "text",
+    text: "Complete the task",
+  })
+  return message
+})
+
+const setup = Effect.gen(function* () {
+  yield* seedProject
+  const sessions = yield* Session.Service
+  const root = yield* sessions.create({})
+  const child = yield* sessions.create({ parentID: root.id })
+  return yield* user(child.id)
+})
+
+const assistant = Effect.fnUntraced(function* (
+  parent: MessageV2.User,
+  opts: Partial<Pick<MessageV2.Assistant, "time" | "finish" | "summary" | "error">> = {},
+) {
+  const sessions = yield* Session.Service
+  const test = yield* TestInstance
+  const time = Date.now()
+  return yield* sessions.updateMessage({
+    id: MessageID.ascending(),
+    sessionID: parent.sessionID,
+    parentID: parent.id,
+    role: "assistant",
+    agent: "general",
+    mode: "general",
+    modelID: model.id,
+    providerID: model.providerID,
+    path: { cwd: test.directory, root: test.directory },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    time: { created: time, completed: time },
+    finish: "tool-calls",
+    ...opts,
+  })
+})
+
+const step = Effect.fnUntraced(function* (
+  parent: MessageV2.User,
+  output: string,
+  opts: { tool?: string; completed?: boolean; compacted?: number } = {},
+) {
+  const sessions = yield* Session.Service
+  const time = Date.now()
+  const message = yield* assistant(
+    parent,
+    opts.completed === false ? { time: { created: time }, finish: undefined } : {},
+  )
+  return yield* sessions.updatePart({
+    id: PartID.ascending(),
+    sessionID: parent.sessionID,
+    messageID: message.id,
+    type: "tool",
+    tool: opts.tool ?? "bash",
+    callID: crypto.randomUUID(),
+    state: {
+      status: "completed",
+      input: { command: "pwd" },
+      output,
+      title: "result",
+      metadata: {},
+      time: { start: time, end: time, compacted: opts.compacted },
+    },
+  })
+})
+
+const summary = Effect.fnUntraced(function* (parent: MessageV2.User) {
+  const sessions = yield* Session.Service
+  const message = yield* assistant(parent, { summary: true, finish: "stop" })
+  yield* sessions.updatePart({
+    id: PartID.ascending(),
+    sessionID: parent.sessionID,
+    messageID: message.id,
+    type: "text",
+    text: "Summary of completed work",
+  })
+})
+
+const tools = Effect.fnUntraced(function* (sessionID: SessionID) {
+  const sessions = yield* Session.Service
+  const messages = yield* sessions.messages({ sessionID })
+  return messages.flatMap((message) => message.parts).filter((part) => part.type === "tool")
+})
+
+const marked = (parts: MessageV2.ToolPart[]) =>
+  parts.map((part) => part.state.status === "completed" && !!part.state.time.compacted)
+
+const outputs = Array.from({ length: 6 }, (_, index) => String(index).repeat(80_000))
+
+describe("single-turn tool-output pruning", () => {
+  it.instance(
+    "prunes old subagent outputs while preserving two completed steps and the token budget",
+    Effect.gen(function* () {
+      const parent = yield* setup
+      const sessions = yield* Session.Service
+      const compact = yield* SessionCompaction.Service
+      const parts: MessageV2.ToolPart[] = []
+      for (const output of outputs) parts.push(yield* step(parent, output))
+
+      yield* compact.prune({ sessionID: parent.sessionID })
+
+      expect(marked(yield* tools(parent.sessionID))).toEqual([true, true, false, false, false, false])
+      const messages = yield* sessions.messages({ sessionID: parent.sessionID })
+      expect(messages.filter((message) => message.info.role === "user")).toHaveLength(1)
+      const converted = yield* MessageV2.toModelMessagesEffect(messages, model)
+      expect(converted.flatMap((message) => (message.role === "tool" ? message.content : []))).toEqual(
+        parts.map((part, index) => ({
+          type: "tool-result",
+          toolCallId: part.callID,
+          toolName: "bash",
+          output: { type: "text", value: index < 2 ? "[Old tool result content cleared]" : (outputs.at(index) ?? "") },
+        })),
+      )
+    }),
+    { config },
+  )
+
+  it.instance(
+    "does not count an in-flight assistant as a completed step",
+    Effect.gen(function* () {
+      const parent = yield* setup
+      const compact = yield* SessionCompaction.Service
+      yield* step(parent, "x".repeat(200_000))
+      yield* step(parent, "recent")
+      yield* assistant(parent, { time: { created: Date.now() } })
+
+      yield* compact.prune({ sessionID: parent.sessionID, reason: "payload-limit" })
+
+      expect(marked(yield* tools(parent.sessionID))).toEqual([false, false])
+    }),
+  )
+
+  for (const attempt of [
+    { name: "failed", info: { error: new MessageV2.AbortedError({ message: "aborted" }).toObject() } },
+    { name: "preflight", info: { finish: undefined } },
+    { name: "provider-error", info: { finish: "error" } },
+  ]) {
+    it.instance(
+      `does not count a ${attempt.name} assistant as a completed step`,
+      Effect.gen(function* () {
+        const parent = yield* setup
+        const compact = yield* SessionCompaction.Service
+        yield* step(parent, "x".repeat(200_000))
+        yield* step(parent, "recent")
+        yield* assistant(parent, attempt.info)
+
+        yield* compact.prune({ sessionID: parent.sessionID, reason: "payload-limit" })
+
+        expect(marked(yield* tools(parent.sessionID))).toEqual([false, false])
+      }),
+    )
+  }
+
+  it.instance(
+    "does not prune when eligible output only reaches the minimum",
+    Effect.gen(function* () {
+      const parent = yield* setup
+      const compact = yield* SessionCompaction.Service
+      for (const output of outputs.slice(1)) yield* step(parent, output)
+
+      yield* compact.prune({ sessionID: parent.sessionID })
+
+      expect(marked(yield* tools(parent.sessionID))).toEqual([false, false, false, false, false])
+    }),
+    { config },
+  )
+
+  it.instance(
+    "preserves protected skill output while pruning eligible tools",
+    Effect.gen(function* () {
+      const parent = yield* setup
+      const compact = yield* SessionCompaction.Service
+      const skill = yield* step(parent, "s".repeat(200_000), { tool: "skill" })
+      yield* step(parent, "x".repeat(200_000))
+      yield* step(parent, "recent one")
+      yield* step(parent, "recent two")
+
+      yield* compact.prune({ sessionID: parent.sessionID })
+
+      const parts = yield* tools(parent.sessionID)
+      expect(marked(parts)).toEqual([false, true, false, false])
+      expect(parts.at(0)).toEqual(skill)
+    }),
+    { config },
+  )
+
+  it.instance(
+    "keeps user-turn pruning for old messages without completion timestamps",
+    Effect.gen(function* () {
+      const parent = yield* setup
+      const compact = yield* SessionCompaction.Service
+      yield* step(parent, "x".repeat(200_000), { completed: false })
+      const second = yield* user(parent.sessionID)
+      yield* step(second, "y".repeat(200_000))
+      const third = yield* user(parent.sessionID)
+      yield* step(third, "z".repeat(200_000))
+
+      yield* compact.prune({ sessionID: parent.sessionID })
+
+      expect(marked(yield* tools(parent.sessionID))).toEqual([true, false, false])
+    }),
+    { config },
+  )
+
+  it.instance(
+    "does not activate step-based pruning before a recent summary",
+    Effect.gen(function* () {
+      const parent = yield* setup
+      const compact = yield* SessionCompaction.Service
+      yield* step(parent, "x".repeat(200_000))
+      const marker = yield* user(parent.sessionID)
+      yield* summary(marker)
+      yield* step(marker, "recent")
+
+      yield* compact.prune({ sessionID: parent.sessionID, reason: "post-compaction" })
+
+      expect(marked(yield* tools(parent.sessionID))).toEqual([false, false])
+    }),
+  )
+
+  it.instance(
+    "preserves user-turn cleanup across a recent compaction summary",
+    Effect.gen(function* () {
+      const parent = yield* setup
+      const compact = yield* SessionCompaction.Service
+      yield* step(parent, "x".repeat(200_000))
+      const marker = yield* user(parent.sessionID)
+      yield* summary(marker)
+      const continuation = yield* user(parent.sessionID)
+      yield* step(continuation, "recent one")
+      yield* step(continuation, "recent two")
+
+      yield* compact.prune({ sessionID: parent.sessionID, reason: "post-compaction" })
+
+      expect(marked(yield* tools(parent.sessionID))).toEqual([true, false, false])
+    }),
+  )
+
+  it.instance(
+    "stops at an already compacted tool output",
+    Effect.gen(function* () {
+      const parent = yield* setup
+      const compact = yield* SessionCompaction.Service
+      yield* step(parent, "old".repeat(80_000))
+      yield* step(parent, "cleared", { compacted: 1 })
+      for (const output of outputs) yield* step(parent, output)
+
+      yield* compact.prune({ sessionID: parent.sessionID })
+
+      const parts = yield* tools(parent.sessionID)
+      expect(marked(parts)).toEqual([false, true, true, true, false, false, false, false])
+      expect(parts.at(1)?.state).toMatchObject({ time: { compacted: 1 } })
+    }),
+    { config },
+  )
+
+  for (const reason of ["normal", "payload-limit"] as const) {
+    it.instance(
+      reason === "normal" ? "keeps normal pruning opt-in" : "honors explicitly disabled payload pruning",
+      Effect.gen(function* () {
+        const parent = yield* setup
+        const compact = yield* SessionCompaction.Service
+        for (const output of outputs) yield* step(parent, output)
+
+        yield* compact.prune({ sessionID: parent.sessionID, reason })
+
+        expect(marked(yield* tools(parent.sessionID))).toEqual([false, false, false, false, false, false])
+      }),
+      { config: { compaction: { prune: reason === "normal" ? undefined : false } } },
+    )
+  }
+})


### PR DESCRIPTION
## What Problem This Solves

Long-running Task and background subagents can execute many model/tool steps within one user turn. The two-user-turn pruning guard keeps all those outputs ineligible, including when the payload-limit safeguard runs.

Fixes #13710.

## Why This Change Was Made

Allow older completed tool outputs to become eligible after two finished, non-error assistant steps. Keep the existing user-turn path, token protection and minimum, protected tools, and configuration guards. Stop only the new step-based fallback at summaries so existing post-compaction cleanup still works. Failed, preflight, and in-flight attempts do not consume the step protection buffer.

The change stays inside the existing marked pruning block. It adds no model call or new pruning trigger.

## User Impact

Long single-turn runs can drop stale tool outputs at existing pruning boundaries without losing the recent working context or protected skill output. Normal pruning remains opt-in, and explicit `compaction.prune: false` still disables pruning. This is not a hard payload-size cap when recent or protected content is itself large.

## Evidence

- The single-user HTTP regression sent 1,452,763 bytes before the fix. It now verifies a request below the 1,250,000-byte threshold, persistent output clearing, retained recent outputs, and exactly one provider call.
- A local source-backend smoke test completed an actual Task subagent with 32 Bash calls in one user turn. The first prune cleared 21 old outputs; consecutive provider requests dropped from 1,220,089 to 260,909 bytes while the newest two tool outputs remained intact. Auto-compaction was disabled and normal pruning was not enabled.
- Focused regressions cover token thresholds, skill protection, failed and unfinished attempts, existing multi-turn behavior, summary boundaries, already-compacted output, and pruning opt-outs.

The smoke test used a local simulated provider, not a live model. No billing or latency improvement is claimed.