### PR TITLE
fix(agent-manager): preserve terminal-only tabs when switching contexts

### DIFF
--- a/.changeset/terminal-only-tab-restore.md
+++ b/.changeset/terminal-only-tab-restore.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep terminal-only tabs active when switching between Agent Manager worktrees and Local, without adding a new session when returning from another project.

--- a/packages/kilo-vscode/tests/unit/agent-manager-selection-actions.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-selection-actions.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "bun:test"
+import { createRoot, createSignal } from "solid-js"
+import { needsLocalDraft } from "../../webview-ui/agent-manager/project/local-tabs"
+import { createTerminalState } from "../../webview-ui/agent-manager/terminal/state"
 import {
   rememberSelectionTab,
   selectLocalAction,
@@ -14,7 +17,7 @@ function deps() {
     setSelection: () => {},
     post: () => {},
     tabMemory: () => ({}),
-    terms: { hasRemembered: () => false, setActiveId: () => {} },
+    terms: { forSelection: () => [], hasRemembered: () => false, setActiveId: () => {} },
     nsKey: (id) => id,
     activateTerminal: () => {},
     setActivePendingId: () => {},
@@ -71,6 +74,102 @@ describe("selectLocalAction", () => {
     selectLocalAction(result.value, [], ["ses-b"])
 
     expect(result.calls).toContain("local:ses-b")
+  })
+})
+
+for (const target of ["local", "wt-b"]) {
+  describe(`${target} terminal restoration`, () => {
+    it.each([undefined, "terminal:closed", "terminal:second"])("restores a terminal with memory %s", (remembered) => {
+      createRoot((dispose) => {
+        const result = deps()
+        const [selection, select] = createSignal("prj-a:other")
+        const terms = createTerminalState(selection)
+        for (const id of ["terminal:first", "terminal:second"]) {
+          terms.add(`prj-a:${target}`, {
+            id,
+            title: "Terminal",
+            wsUrl: "",
+            font: { fontFamily: "Menlo", fontSize: 12 },
+            placement: "tab",
+          })
+        }
+        result.value.terms = terms
+        result.value.nsKey = (id) => `prj-a:${id}`
+        result.value.setSelection = (id) => select(`prj-a:${id}`)
+        result.value.tabMemory = () => (remembered ? { [target]: remembered } : {})
+        result.value.activateTerminal = (id) => {
+          terms.setActiveId(id)
+          result.calls.push(`terminal:${id}`)
+        }
+
+        if (target === "local") selectLocalAction(result.value, [])
+        else selectWorktreeAction(result.value, target, [])
+
+        const expected = remembered === "terminal:second" ? remembered : "terminal:first"
+        expect(terms.activeId()).toBe(expected)
+        expect(result.calls).toEqual([`terminal:${expected}`])
+        expect(terms.current()).toHaveLength(2)
+        dispose()
+      })
+    })
+
+    it("does not select side terminals or another project's terminal", () => {
+      createRoot((dispose) => {
+        const result = deps()
+        const terms = createTerminalState(() => `prj-a:${target}`)
+        for (const placement of ["tab", "side"] as const) {
+          terms.add(`${placement === "tab" ? "prj-b" : "prj-a"}:${target}`, {
+            id: `terminal:${placement}`,
+            title: "Terminal",
+            wsUrl: "",
+            font: { fontFamily: "Menlo", fontSize: 12 },
+            placement,
+          })
+        }
+        result.value.terms = terms
+        result.value.nsKey = (id) => `prj-a:${id}`
+        result.value.activateTerminal = (id) => result.calls.push(`terminal:${id}`)
+
+        if (target === "local") selectLocalAction(result.value, [])
+        else selectWorktreeAction(result.value, target, [])
+
+        expect(terms.activeId()).toBeUndefined()
+        expect(result.calls).toEqual(target === "local" ? [] : ["reset"])
+        dispose()
+      })
+    })
+
+    it.each(["session", "review"])("preserves the %s fallback ahead of an unremembered terminal", (kind) => {
+      const result = deps()
+      result.value.terms.forSelection = () => [{ id: "terminal:first" }]
+      result.value.activateTerminal = (id) => result.calls.push(`terminal:${id}`)
+      result.value.isReviewTab = () => kind === "review"
+      result.value.setReviewActive = (active) => {
+        if (active) result.calls.push("review")
+      }
+      const ids = kind === "session" ? ["ses-1"] : []
+
+      if (target === "local") selectLocalAction(result.value, [], ids)
+      else selectWorktreeAction(result.value, target, [], ids)
+
+      expect(result.calls).not.toContain("terminal:terminal:first")
+      expect(result.calls).toContain(kind === "review" ? "review" : `${target === "local" ? "local" : "select"}:ses-1`)
+    })
+  })
+}
+
+describe("needsLocalDraft", () => {
+  it("does not create a session when Local already has a terminal tab", () => {
+    expect(needsLocalDraft([], [{ id: "terminal:local" }])).toBe(false)
+  })
+
+  it("does not create another draft when a session or draft already exists", () => {
+    expect(needsLocalDraft(["ses-1"], [])).toBe(false)
+    expect(needsLocalDraft(["pending:1"], [])).toBe(false)
+  })
+
+  it("creates a draft for an empty Local context", () => {
+    expect(needsLocalDraft([], [])).toBe(true)
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -82,7 +82,13 @@ import { createProjectLive } from "./project/live"
 import { createProjectSessionsLive } from "./project/sessions-live"
 import { worktreeSessionIds as worktreeMembership, worktreeSessions } from "./project/session-filter"
 import { applyProjectSelection, createTargetRememberer } from "./project/selection"
-import { createLocalSessions, persistLocalTabs, projectLocalIds, projectLocalSessions } from "./project/local-tabs"
+import {
+  createLocalSessions,
+  needsLocalDraft,
+  persistLocalTabs,
+  projectLocalIds,
+  projectLocalSessions,
+} from "./project/local-tabs"
 import { createProjectRegistry, type PersistedProjectTabs } from "./project/registry"
 import type { WorktreeBusyState } from "./project/store"
 import { rememberTarget, restoreProjectTarget } from "./project/restore"
@@ -1143,7 +1149,7 @@ const AgentManagerContent: Component = () => {
       applyTabOrder,
     )
     if (restored) setLocalSessionIDs(restored)
-    if (switched === "switched" && localSessionIDs().length === 0) addPendingTab()
+    if (switched === "switched" && needsLocalDraft(localSessionIDs(), terms.forSelection(nsKey(LOCAL)))) addPendingTab()
     if (switched !== "same") {
       restoreProjectTarget(state, {
         selectLocal,

--- a/packages/kilo-vscode/webview-ui/agent-manager/project/local-tabs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/project/local-tabs.ts
@@ -59,6 +59,10 @@ export function createLocalSessions(opts: {
   })
 }
 
+export function needsLocalDraft(sessions: readonly string[], terminals: readonly { id: string }[]): boolean {
+  return sessions.length === 0 && terminals.length === 0
+}
+
 export function projectLocalIds(state: AgentManagerStateMessage | undefined): string[] {
   return state?.sessions.filter((item) => item.worktreeId === null).map((item) => item.id) ?? []
 }

--- a/packages/kilo-vscode/webview-ui/agent-manager/selection-actions.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/selection-actions.ts
@@ -10,6 +10,7 @@ import { batch } from "solid-js"
 import { LOCAL } from "./navigate"
 
 interface TermState {
+  forSelection: (sel: string) => { id: string }[]
   hasRemembered: (sel: string, remembered: string | undefined) => boolean
   setActiveId: (id: string | undefined) => void
 }
@@ -119,6 +120,18 @@ export function createSessionRestore<T extends SessionLike>(deps: {
   }
 }
 
+function terminal(
+  deps: SelectionActionDeps<SessionLike>,
+  selection: string,
+  remembered: string | undefined,
+  empty: boolean,
+): string | undefined {
+  const key = deps.nsKey(selection)
+  if (deps.terms.hasRemembered(key, remembered)) return remembered
+  if (!empty || deps.isReviewTab(remembered, selection)) return
+  return deps.terms.forSelection(key).at(0)?.id
+}
+
 /** Select the Local context: restore its remembered tab or fall back to the first session/draft. */
 export function selectLocalAction<T extends SessionLike>(
   deps: SelectionActionDeps<T>,
@@ -131,8 +144,9 @@ export function selectLocalAction<T extends SessionLike>(
   batch(() => {
     deps.setReviewActive(false)
     deps.setSelection(LOCAL)
-    if (deps.terms.hasRemembered(deps.nsKey(LOCAL), remembered)) {
-      deps.activateTerminal(remembered!)
+    const id = terminal(deps, LOCAL, remembered, locals.length === 0 && ids.length === 0)
+    if (id) {
+      deps.activateTerminal(id)
       return
     }
     deps.terms.setActiveId(undefined)
@@ -169,8 +183,9 @@ export function selectWorktreeAction<T extends SessionLike>(
   const remembered = deps.tabMemory()[worktreeId]
   batch(() => {
     deps.setSelection(worktreeId)
-    if (deps.terms.hasRemembered(deps.nsKey(worktreeId), remembered)) {
-      deps.activateTerminal(remembered!)
+    const id = terminal(deps, worktreeId, remembered, sessions.length === 0 && ids.length === 0)
+    if (id) {
+      deps.activateTerminal(id)
       return
     }
     deps.terms.setActiveId(undefined)


### PR DESCRIPTION
## What Problem This Solves
Returning to a project with only a Local terminal tab added an unwanted New Session tab. Local and worktree contexts could also show a blank chat instead of their existing terminal when remembered tab state was missing or stale.

## Why This Change Was Made
Terminal-only contexts already have usable content. Project restoration now checks the project-scoped central terminal tabs before creating a Local draft. Context selection restores a live terminal when no session or draft is available, while preserving remembered terminal, session, and review selection behavior. Side terminals and terminals from other projects are excluded from the fallback.

## User Impact
Switching between Local, worktrees, and projects keeps terminal-only contexts usable without extra session tabs. Terminal focus and typed input are retained. Empty Local contexts still receive their initial draft.

## Evidence
Reproduced the extra Local draft in an isolated VS Code self-test before the fix. After rebuilding and reloading, verified Local and worktree terminal-only restoration, missing-memory fallback, cross-project return, and keyboard navigation. Each return retained one terminal tab, input focus, and unsubmitted marker text.

Before, returning from another project adds a New Session tab beside the terminal:

<img width="700" alt="Before the fix, a terminal-only Local context gains an unwanted New Session tab" src="https://marius-kilocode.github.io/pr-assets/20260902-terminal-only-before-54689a5.png" />

After, the same return keeps only the terminal with its input intact:

<img width="700" alt="After the fix, the Local terminal remains the only tab and retains typed input" src="https://marius-kilocode.github.io/pr-assets/20260902-terminal-only-after-54689a5.png" />

The GitHub authentication notification is from the disposable test workspace and does not affect the terminal flow. No prompts were submitted to a model.

Validation:
- `bun run compile`, including extension/webview typechecks and lint.
- `bun run test:unit`: 4,661 passed, 1 skipped, 0 failed.
- Focused selection, terminal-state, and project-restore tests: 56 passed.
- `bun run typecheck`, `bun run lint`, `bun run knip`, and `bun run check-kilocode-change`.
- Formatting and whitespace checks passed.
- Read-only local review found no issues.