### PR TITLE
feat(cli): add /autocompact auto-compaction threshold command

### DIFF
--- a/.changeset/autocompact-cli-command.md
+++ b/.changeset/autocompact-cli-command.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Add a `/autocompact` command to pick the context window percentage at which compaction runs automatically.

--- a/packages/opencode/src/kilocode/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/app.tsx
@@ -22,6 +22,7 @@ import { Link } from "@tui/ui/link"
 import { isKiloError, showKiloErrorToast } from "@/kilocode/kilo-errors"
 import { registerKiloCommands } from "@/kilocode/kilo-commands"
 import { initializeTUIDependencies } from "@kilocode/kilo-gateway/tui"
+import { DialogAutocompact } from "@/kilocode/cli/cmd/tui/component/dialog-autocompact"
 import { DialogProcessList } from "@/kilocode/cli/cmd/tui/component/dialog-process-list"
 import { useIndexingWarnings } from "@/kilocode/cli/cmd/tui/indexing-warning"
 import { KiloTerminalTitle } from "./terminal-title"
@@ -311,6 +312,21 @@ export function init() {
             return
           }
           dialog.clear()
+        },
+      },
+      {
+        namespace: "palette",
+        name: "compaction.auto_threshold",
+        get title() {
+          const percent = sync.data.config.compaction?.threshold_percent
+          return typeof percent === "number" ? `Auto-compact threshold (${percent}%)` : "Auto-compact threshold"
+        },
+        desc: "Pick the context window percentage that triggers automatic compaction",
+        category: "System",
+        slashName: "autocompact",
+        slashAliases: ["auto-compact"],
+        run: () => {
+          dialog.replace(() => <DialogAutocompact />)
         },
       },
     ],

--- a/packages/opencode/src/kilocode/cli/cmd/tui/component/dialog-autocompact.tsx
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/component/dialog-autocompact.tsx
@@ -1,0 +1,156 @@
+// kilocode_change - new file
+/**
+ * Auto-Compact Threshold Dialog
+ *
+ * Lets the user pick the percentage of the context window at which
+ * compaction runs automatically. Saves to the global config overlay via
+ * `config.overlayUpdate`, so sibling compaction keys survive the patch.
+ */
+
+import { useDialog } from "@tui/ui/dialog"
+import { DialogSelect, type DialogSelectOption } from "@tui/ui/dialog-select"
+import { DialogPrompt } from "@tui/ui/dialog-prompt"
+import { useSDK } from "@tui/context/sdk"
+import { useSync } from "@tui/context/sync"
+import { useToast } from "@tui/ui/toast"
+import { reconcile } from "solid-js/store"
+
+/** Preset percentages offered in the menu. */
+export const AUTOCOMPACT_PRESETS: number[] = [50, 60, 70, 80, 90, 95]
+
+/**
+ * Parse a percentage typed into the custom prompt.
+ * Returns `null` for an empty input (disable the percentage trigger),
+ * `undefined` for a non-numeric input, otherwise the value clamped to [1, 100]
+ * exactly like the VS Code context tab (`Math.min(100, Math.max(1, percent))`).
+ */
+export function parsePercent(raw: string): number | null | undefined {
+  let text = raw.trim()
+  if (!text) return null
+  if (text.endsWith("%")) {
+    text = text.slice(0, -1).trim()
+    if (!text) return undefined
+  }
+  const percent = Number(text)
+  if (!Number.isFinite(percent)) return undefined
+  return Math.min(100, Math.max(1, percent))
+}
+
+export type ThresholdPatch = ReturnType<typeof thresholdPatch>
+
+/**
+ * Build the overlay patch for a threshold.
+ * `patchJsonc` merges per key, so sibling compaction keys survive.
+ */
+export function thresholdPatch(percent: number | null) {
+  if (percent === null) return { unset: [["compaction", "threshold_percent"]] }
+  return { set: { compaction: { threshold_percent: percent } } }
+}
+
+/** Display label for a threshold value: `"80%"` or `"Only when full"`. */
+export function thresholdLabel(percent: number | null | undefined): string {
+  if (typeof percent === "number") return `${percent}%`
+  return "Only when full"
+}
+
+/** Menu options: presets, a custom entry, and the default "off" entry. */
+export function thresholdOptions(current: number | null | undefined): DialogSelectOption<number | "custom" | "off">[] {
+  const options: DialogSelectOption<number | "custom" | "off">[] = AUTOCOMPACT_PRESETS.map((preset) => ({
+    value: preset,
+    title: thresholdLabel(preset),
+    category: "Threshold",
+    description: preset === current ? "(current)" : undefined,
+  }))
+  options.push({ value: "custom", title: "Custom…", category: "Threshold" })
+  const off = current === null || current === undefined
+  options.push({
+    value: "off",
+    title: "Only when full",
+    category: "Threshold",
+    description: off
+      ? "Compact when the context window is nearly full (default) (current)"
+      : "Compact when the context window is nearly full (default)",
+  })
+  return options
+}
+
+export type ThresholdSaveDeps = {
+  overlayUpdate: (input: { scope: "global" } & ThresholdPatch) => Promise<{ error?: unknown }>
+  getConfig: () => Promise<{ data?: unknown }>
+  getGlobalConfig: () => Promise<{ data?: unknown }>
+  setStore: (key: "config" | "globalConfig", value: unknown) => void
+  toast: (input: { message: string; variant: "success" | "error" }) => void
+}
+
+/**
+ * Write the threshold to the global config overlay, then refetch both config
+ * stores. Returns `false` when the write failed; the caller keeps the dialog
+ * open so the user can retry.
+ */
+export async function saveThreshold(percent: number | null, deps: ThresholdSaveDeps): Promise<boolean> {
+  const result = await deps.overlayUpdate({ scope: "global", ...thresholdPatch(percent) })
+  if (result.error) {
+    deps.toast({ message: "Failed to save auto-compact threshold", variant: "error" })
+    return false
+  }
+  const [configResponse, globalResponse] = await Promise.all([deps.getConfig(), deps.getGlobalConfig()])
+  if (configResponse.data) deps.setStore("config", reconcile(configResponse.data))
+  if (globalResponse.data) deps.setStore("globalConfig", reconcile(globalResponse.data))
+  const label = percent === null ? thresholdLabel(percent).toLowerCase() : thresholdLabel(percent)
+  deps.toast({ message: `Auto-compact set to ${label}`, variant: "success" })
+  return true
+}
+
+export function DialogAutocompact() {
+  const dialog = useDialog()
+  const sync = useSync()
+  const sdk = useSDK()
+  const toast = useToast()
+
+  const current = (): number | null => {
+    const value = sync.data.config.compaction?.threshold_percent
+    return typeof value === "number" ? value : null
+  }
+
+  async function save(percent: number | null) {
+    const saved = await saveThreshold(percent, {
+      overlayUpdate: (input) => sdk.client.config.overlayUpdate(input),
+      getConfig: () => sdk.client.config.get({}),
+      getGlobalConfig: () => sdk.client.global.config.get({}),
+      setStore: (key, value) => sync.set(key, value as never),
+      toast: (input) => toast.show(input),
+    })
+    if (!saved) return
+    dialog.clear()
+  }
+
+  return (
+    <DialogSelect
+      title="Auto-Compact Threshold"
+      options={thresholdOptions(current())}
+      skipFilter
+      onSelect={async (option) => {
+        const value = option.value
+        if (value === "custom") {
+          const result = await DialogPrompt.show(dialog, "Auto-compact threshold (%)", {
+            value: typeof current() === "number" ? String(current()) : "",
+            placeholder: "1–100, empty to disable",
+          })
+          if (result === null) {
+            dialog.replace(() => <DialogAutocompact />)
+            return
+          }
+          const percent = parsePercent(result)
+          if (percent === undefined) {
+            toast.show({ message: `Invalid percentage: "${result.trim()}"`, variant: "error" })
+            dialog.replace(() => <DialogAutocompact />)
+            return
+          }
+          await save(percent)
+          return
+        }
+        await save(value === "off" ? null : value)
+      }}
+    />
+  )
+}

--- a/packages/opencode/src/kilocode/cli/cmd/tui/component/dialog-autocompact.tsx
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/component/dialog-autocompact.tsx
@@ -53,6 +53,16 @@ export function thresholdLabel(percent: number | null | undefined): string {
   return "Only when full"
 }
 
+/**
+ * Map a threshold value to the menu option that represents it:
+ * a preset number returns itself, any other number returns `"custom"`,
+ * and `null`/`undefined` return `"off"`.
+ */
+export function currentOption(current: number | null | undefined): number | "custom" | "off" {
+  if (current === null || current === undefined) return "off"
+  return AUTOCOMPACT_PRESETS.includes(current) ? current : "custom"
+}
+
 /** Menu options: presets, a custom entry, and the default "off" entry. */
 export function thresholdOptions(current: number | null | undefined): DialogSelectOption<number | "custom" | "off">[] {
   const options: DialogSelectOption<number | "custom" | "off">[] = AUTOCOMPACT_PRESETS.map((preset) => ({
@@ -61,7 +71,8 @@ export function thresholdOptions(current: number | null | undefined): DialogSele
     category: "Threshold",
     description: preset === current ? "(current)" : undefined,
   }))
-  options.push({ value: "custom", title: "Custom…", category: "Threshold" })
+  const customTitle = currentOption(current) === "custom" ? `Custom (${current}%)` : "Custom…"
+  options.push({ value: "custom", title: customTitle, category: "Threshold" })
   const off = current === null || current === undefined
   options.push({
     value: "off",
@@ -128,6 +139,7 @@ export function DialogAutocompact() {
     <DialogSelect
       title="Auto-Compact Threshold"
       options={thresholdOptions(current())}
+      current={currentOption(current())}
       skipFilter
       onSelect={async (option) => {
         const value = option.value

--- a/packages/opencode/src/kilocode/cli/cmd/tui/component/dialog-autocompact.tsx
+++ b/packages/opencode/src/kilocode/cli/cmd/tui/component/dialog-autocompact.tsx
@@ -112,6 +112,39 @@ export async function saveThreshold(percent: number | null, deps: ThresholdSaveD
   return true
 }
 
+export type CustomThresholdDeps = {
+  /** Opens the custom prompt; resolves with the typed text, or `null` on cancel. */
+  showPrompt: () => Promise<string | null>
+  /** Writes the threshold; returns `false` when the save failed. */
+  save: (percent: number | null) => Promise<boolean>
+  toast: (input: { message: string; variant: "success" | "error" }) => void
+  /** Reopens the threshold picker, e.g. `dialog.replace(() => <DialogAutocompact />)`. */
+  openPicker: () => void
+}
+
+/**
+ * Drive the custom-threshold flow. Cancel, an invalid value, and a failed save
+ * each restore the picker via `openPicker` so the user can retry. The prompt
+ * stays mounted after `showPrompt` resolves, so a failed save must reopen the
+ * picker like the cancel/invalid branches do. A successful save leaves the
+ * dialog closed (the caller's `save` clears it).
+ */
+export async function runCustomThreshold(deps: CustomThresholdDeps): Promise<void> {
+  const result = await deps.showPrompt()
+  if (result === null) {
+    deps.openPicker()
+    return
+  }
+  const percent = parsePercent(result)
+  if (percent === undefined) {
+    deps.toast({ message: `Invalid percentage: "${result.trim()}"`, variant: "error" })
+    deps.openPicker()
+    return
+  }
+  const saved = await deps.save(percent)
+  if (!saved) deps.openPicker()
+}
+
 export function DialogAutocompact() {
   const dialog = useDialog()
   const sync = useSync()
@@ -131,8 +164,9 @@ export function DialogAutocompact() {
       setStore: (key, value) => sync.set(key, value as never),
       toast: (input) => toast.show(input),
     })
-    if (!saved) return
+    if (!saved) return false
     dialog.clear()
+    return true
   }
 
   return (
@@ -144,21 +178,16 @@ export function DialogAutocompact() {
       onSelect={async (option) => {
         const value = option.value
         if (value === "custom") {
-          const result = await DialogPrompt.show(dialog, "Auto-compact threshold (%)", {
-            value: typeof current() === "number" ? String(current()) : "",
-            placeholder: "1–100, empty to disable",
+          await runCustomThreshold({
+            showPrompt: () =>
+              DialogPrompt.show(dialog, "Auto-compact threshold (%)", {
+                value: typeof current() === "number" ? String(current()) : "",
+                placeholder: "1–100, empty to disable",
+              }),
+            save,
+            toast: (input) => toast.show(input),
+            openPicker: () => dialog.replace(() => <DialogAutocompact />),
           })
-          if (result === null) {
-            dialog.replace(() => <DialogAutocompact />)
-            return
-          }
-          const percent = parsePercent(result)
-          if (percent === undefined) {
-            toast.show({ message: `Invalid percentage: "${result.trim()}"`, variant: "error" })
-            dialog.replace(() => <DialogAutocompact />)
-            return
-          }
-          await save(percent)
           return
         }
         await save(value === "off" ? null : value)

--- a/packages/opencode/test/kilocode/cli/cmd/tui/dialog-autocompact.test.ts
+++ b/packages/opencode/test/kilocode/cli/cmd/tui/dialog-autocompact.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test"
+import {
+  AUTOCOMPACT_PRESETS,
+  parsePercent,
+  saveThreshold,
+  thresholdLabel,
+  thresholdOptions,
+  thresholdPatch,
+  type ThresholdSaveDeps,
+} from "@/kilocode/cli/cmd/tui/component/dialog-autocompact"
+
+describe("autocompact parsePercent", () => {
+  test("parses plain and percent-suffixed input", () => {
+    expect(parsePercent("80")).toBe(80)
+    expect(parsePercent(" 72.5% ")).toBe(72.5)
+    expect(parsePercent("95%")).toBe(95)
+  })
+
+  test("empty input disables the percentage trigger", () => {
+    expect(parsePercent("")).toBeNull()
+    expect(parsePercent("   ")).toBeNull()
+  })
+
+  test("non-numeric input is invalid", () => {
+    expect(parsePercent("abc")).toBeUndefined()
+    expect(parsePercent("1e999")).toBeUndefined()
+    expect(parsePercent("%")).toBeUndefined()
+  })
+
+  test("clamps to the schema bounds [1, 100]", () => {
+    expect(parsePercent("0")).toBe(1)
+    expect(parsePercent("-5")).toBe(1)
+    expect(parsePercent("150")).toBe(100)
+  })
+})
+
+describe("autocompact thresholdPatch", () => {
+  test("a number writes the threshold key", () => {
+    expect(thresholdPatch(80)).toEqual({ set: { compaction: { threshold_percent: 80 } } })
+  })
+
+  test("null unsets only the threshold key so sibling compaction keys survive", () => {
+    expect(thresholdPatch(null)).toEqual({ unset: [["compaction", "threshold_percent"]] })
+  })
+
+  test("the patch is stable, so a failed save can be retried unchanged", () => {
+    expect(thresholdPatch(70)).toEqual(thresholdPatch(70))
+    expect(thresholdPatch(null)).toEqual(thresholdPatch(null))
+  })
+})
+
+describe("autocompact thresholdLabel", () => {
+  test("formats a number as a percentage", () => {
+    expect(thresholdLabel(80)).toBe("80%")
+  })
+
+  test("null and undefined mean the default trigger", () => {
+    expect(thresholdLabel(null)).toBe("Only when full")
+    expect(thresholdLabel(undefined)).toBe("Only when full")
+  })
+})
+
+describe("autocompact thresholdOptions", () => {
+  test("lists one option per preset and always offers custom and off", () => {
+    const options = thresholdOptions(undefined)
+    expect(options.map((option) => option.value)).toEqual([...AUTOCOMPACT_PRESETS, "custom", "off"])
+    expect(options.every((option) => option.category === "Threshold")).toBe(true)
+  })
+
+  test("marks exactly the current preset", () => {
+    const options = thresholdOptions(80)
+    const marked = options.filter((option) => option.description?.includes("(current)"))
+    expect(marked).toHaveLength(1)
+    expect(marked[0]?.value).toBe(80)
+  })
+
+  test("marks Only when full when the current value is null", () => {
+    for (const current of [null, undefined]) {
+      const options = thresholdOptions(current)
+      const marked = options.filter((option) => option.description?.includes("(current)"))
+      expect(marked).toHaveLength(1)
+      expect(marked[0]?.value).toBe("off")
+      expect(marked[0]?.title).toBe("Only when full")
+    }
+  })
+
+  test("a custom current value marks nothing", () => {
+    const options = thresholdOptions(75)
+    expect(options.filter((option) => option.description?.includes("(current)"))).toHaveLength(0)
+  })
+})
+
+describe("autocompact saveThreshold", () => {
+  function harness(overlayError: unknown) {
+    const calls: unknown[] = []
+    const toasts: { message: string; variant: string }[] = []
+    const stored: ["config" | "globalConfig", unknown][] = []
+    let refetches = 0
+    const deps: ThresholdSaveDeps = {
+      overlayUpdate: async (input) => {
+        calls.push(input)
+        return overlayError ? { error: overlayError } : {}
+      },
+      getConfig: async () => {
+        refetches++
+        return { data: { model: "cfg" } }
+      },
+      getGlobalConfig: async () => {
+        refetches++
+        return { data: { model: "global" } }
+      },
+      setStore: (key, value) => stored.push([key, value]),
+      toast: (input) => toasts.push(input),
+    }
+    return { calls, toasts, stored, refetches: () => refetches, deps }
+  }
+
+  test("sends the thresholdPatch output as the overlay body", async () => {
+    const h = harness(undefined)
+    expect(await saveThreshold(80, h.deps)).toBe(true)
+    expect(h.calls).toEqual([{ scope: "global", set: { compaction: { threshold_percent: 80 } } }])
+  })
+
+  test("an overlay error toasts and skips the refetch", async () => {
+    const h = harness({ name: "Conflict" })
+    expect(await saveThreshold(80, h.deps)).toBe(false)
+    expect(h.toasts).toEqual([{ message: "Failed to save auto-compact threshold", variant: "error" }])
+    expect(h.refetches()).toBe(0)
+    expect(h.stored).toEqual([])
+  })
+
+  test("a retry after a failed save sends the same patch", async () => {
+    const failing = harness({ name: "Conflict" })
+    expect(await saveThreshold(70, failing.deps)).toBe(false)
+    const retry = harness(undefined)
+    expect(await saveThreshold(70, retry.deps)).toBe(true)
+    expect(retry.calls[0]).toEqual(failing.calls[0])
+  })
+
+  test("success refetches both configs and toasts the percentage label", async () => {
+    const h = harness(undefined)
+    expect(await saveThreshold(90, h.deps)).toBe(true)
+    expect(h.refetches()).toBe(2)
+    expect(h.stored.map(([key]) => key)).toEqual(["config", "globalConfig"])
+    expect(h.toasts).toEqual([{ message: "Auto-compact set to 90%", variant: "success" }])
+  })
+
+  test("disabling stores the unset patch and toasts the default label", async () => {
+    const h = harness(undefined)
+    expect(await saveThreshold(null, h.deps)).toBe(true)
+    expect(h.calls).toEqual([{ scope: "global", unset: [["compaction", "threshold_percent"]] }])
+    expect(h.toasts).toEqual([{ message: "Auto-compact set to only when full", variant: "success" }])
+  })
+})

--- a/packages/opencode/test/kilocode/cli/cmd/tui/dialog-autocompact.test.ts
+++ b/packages/opencode/test/kilocode/cli/cmd/tui/dialog-autocompact.test.ts
@@ -3,6 +3,7 @@ import {
   AUTOCOMPACT_PRESETS,
   currentOption,
   parsePercent,
+  runCustomThreshold,
   saveThreshold,
   thresholdLabel,
   thresholdOptions,
@@ -182,5 +183,64 @@ describe("autocompact saveThreshold", () => {
     expect(await saveThreshold(null, h.deps)).toBe(true)
     expect(h.calls).toEqual([{ scope: "global", unset: [["compaction", "threshold_percent"]] }])
     expect(h.toasts).toEqual([{ message: "Auto-compact set to only when full", variant: "success" }])
+  })
+})
+
+describe("autocompact runCustomThreshold", () => {
+  function harness(promptResult: string | null, saveResult: boolean) {
+    const saved: (number | null)[] = []
+    const toasts: { message: string; variant: string }[] = []
+    let opened = 0
+    const deps = {
+      showPrompt: async () => promptResult,
+      save: async (percent: number | null) => {
+        saved.push(percent)
+        return saveResult
+      },
+      toast: (input: { message: string; variant: "success" | "error" }) => toasts.push(input),
+      openPicker: () => {
+        opened++
+      },
+    }
+    return { saved, toasts, openedCount: () => opened, deps }
+  }
+
+  test("cancel restores the picker without saving", async () => {
+    const h = harness(null, true)
+    await runCustomThreshold(h.deps)
+    expect(h.saved).toEqual([])
+    expect(h.openedCount()).toBe(1)
+  })
+
+  test("invalid input toasts and restores the picker without saving", async () => {
+    const h = harness("abc", true)
+    await runCustomThreshold(h.deps)
+    expect(h.saved).toEqual([])
+    expect(h.toasts).toEqual([{ message: 'Invalid percentage: "abc"', variant: "error" }])
+    expect(h.openedCount()).toBe(1)
+  })
+
+  test("a failed custom save restores the picker so the user can retry", async () => {
+    // Regression: DialogPrompt.show resolves without closing, so a failed save
+    // must reopen the picker like the cancel/invalid branches. Without this the
+    // second submit is a no-op on the already-settled promise.
+    const h = harness("70", false)
+    await runCustomThreshold(h.deps)
+    expect(h.saved).toEqual([70])
+    expect(h.openedCount()).toBe(1)
+  })
+
+  test("a successful custom save does not restore the picker", async () => {
+    const h = harness("70", true)
+    await runCustomThreshold(h.deps)
+    expect(h.saved).toEqual([70])
+    expect(h.openedCount()).toBe(0)
+  })
+
+  test("empty input saves the disable value and does not restore the picker", async () => {
+    const h = harness("", true)
+    await runCustomThreshold(h.deps)
+    expect(h.saved).toEqual([null])
+    expect(h.openedCount()).toBe(0)
   })
 })

--- a/packages/opencode/test/kilocode/cli/cmd/tui/dialog-autocompact.test.ts
+++ b/packages/opencode/test/kilocode/cli/cmd/tui/dialog-autocompact.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   AUTOCOMPACT_PRESETS,
+  currentOption,
   parsePercent,
   saveThreshold,
   thresholdLabel,
@@ -60,11 +61,42 @@ describe("autocompact thresholdLabel", () => {
   })
 })
 
+describe("autocompact currentOption", () => {
+  test("a preset number returns itself", () => {
+    expect(currentOption(80)).toBe(80)
+    for (const preset of AUTOCOMPACT_PRESETS) {
+      expect(currentOption(preset)).toBe(preset)
+    }
+  })
+
+  test("a non-preset number returns custom", () => {
+    expect(currentOption(72.5)).toBe("custom")
+    expect(currentOption(75)).toBe("custom")
+  })
+
+  test("null and undefined return off", () => {
+    expect(currentOption(null)).toBe("off")
+    expect(currentOption(undefined)).toBe("off")
+  })
+})
+
 describe("autocompact thresholdOptions", () => {
   test("lists one option per preset and always offers custom and off", () => {
     const options = thresholdOptions(undefined)
     expect(options.map((option) => option.value)).toEqual([...AUTOCOMPACT_PRESETS, "custom", "off"])
     expect(options.every((option) => option.category === "Threshold")).toBe(true)
+  })
+
+  test("a custom current value retitles the custom row with the value", () => {
+    const custom = thresholdOptions(72.5).find((option) => option.value === "custom")
+    expect(custom?.title).toBe("Custom (72.5%)")
+  })
+
+  test("a preset or absent current value keeps the plain custom title", () => {
+    for (const current of [80, undefined, null]) {
+      const custom = thresholdOptions(current).find((option) => option.value === "custom")
+      expect(custom?.title).toBe("Custom…")
+    }
   })
 
   test("marks exactly the current preset", () => {


### PR DESCRIPTION
## What changed

- The CLI gains a `/autocompact` command. It opens a menu that lets the user pick the context window percentage at which compaction runs automatically.
- The menu offers preset percentages: 50, 60, 70, 80, 90, and 95.
- The user can enter a custom percentage from 1 to 100, or leave the input empty to turn the percentage trigger off.
- Empty input stores the `unset` patch for `compaction.threshold_percent`. The `unset` patch keeps sibling compaction keys intact.
- The command saves the choice to the global config overlay and shows a success or error toast.

## Why

Users cannot set an auto-compaction threshold from the CLI. The VS Code extension already exposes this threshold in its context tab. This command gives the CLI the same control.

## Verification

- Per-slice checks passed.
- CLI `test:ci` run: the command tests passed, and the run failed only on files that also fail on clean main (pre-existing); advisory.

## Notes for the reviewer

- The `test:ci` failures are pre-existing and not introduced by this change. The driver marks that result advisory.

## Evidence (TUI screenshots, deterministic pty capture)

![slash palette](https://github.com/user-attachments/assets/f42e4e5f-2322-4705-b3bd-8696a4f7093c)
![autocompact dialog](https://github.com/user-attachments/assets/a2f02af9-b072-4752-b17b-0207ebe1c861)


## Live verification (kwf verifier, 2026-09-03)

Ran on the built CLI from this branch in a pty with an isolated `KILO_CONFIG_DIR`; inference on `kilo/z-ai/glm-5.3-flash`. 10 of 10 scenarios passed.

- Dialog lists 50–95, Custom…, Only when full; the current value carries the ● marker; the palette title shows the current state.
- Select 80 → `compaction.threshold_percent: 80` written, sibling keys (`auto`, `prune`) kept, toast shown.
- Only when full → key removed; Custom 72.5 → saved and shown as "Custom (72.5%)"; `abc` → "Invalid percentage", no write.
- Read-only config → "Failed to save auto-compact threshold", dialog stays open; retry after restore succeeds.
- Threshold takes effect: with `threshold_percent: 5` (cap 65,536 tokens on glm-5.3-flash), turn 1 grew to 144,671 tokens; turn 2 compacted first: its first step ran at 7,363 tokens and the session gained a `summary: true` message.

![tui-2](https://github.com/user-attachments/assets/01d0d783-b273-4126-bd55-8e95f770af38)

![tui-3](https://github.com/user-attachments/assets/ae42b793-6ef7-4c57-b331-a0c0b71cfdec)

![tui-4](https://github.com/user-attachments/assets/9da3c107-14df-48bf-916a-edcc38c233a0)

![tui-3](https://github.com/user-attachments/assets/87e670ba-bb1f-4d40-975d-53efe814d65c)