### PR TITLE
refactor(agent-manager): clarify terminal restoration guards

### DIFF
--- a/packages/kilo-vscode/tests/unit/agent-manager-selection-actions.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-selection-actions.test.ts
@@ -79,7 +79,12 @@ describe("selectLocalAction", () => {
 
 for (const target of ["local", "wt-b"]) {
   describe(`${target} terminal restoration`, () => {
-    it.each([undefined, "terminal:closed", "terminal:second"])("restores a terminal with memory %s", (remembered) => {
+    it.each([
+      { remembered: undefined, ids: [] },
+      { remembered: "terminal:closed", ids: [] },
+      { remembered: "terminal:second", ids: [] },
+      { remembered: "terminal:second", ids: ["ses-1"] },
+    ])("restores a terminal with %j", (entry) => {
       createRoot((dispose) => {
         const result = deps()
         const [selection, select] = createSignal("prj-a:other")
@@ -96,16 +101,17 @@ for (const target of ["local", "wt-b"]) {
         result.value.terms = terms
         result.value.nsKey = (id) => `prj-a:${id}`
         result.value.setSelection = (id) => select(`prj-a:${id}`)
-        result.value.tabMemory = () => (remembered ? { [target]: remembered } : {})
+        result.value.tabMemory = () => (entry.remembered ? { [target]: entry.remembered } : {})
         result.value.activateTerminal = (id) => {
           terms.setActiveId(id)
           result.calls.push(`terminal:${id}`)
         }
 
-        if (target === "local") selectLocalAction(result.value, [])
-        else selectWorktreeAction(result.value, target, [])
+        const sessions = entry.ids.map((id) => ({ id }))
+        if (target === "local") selectLocalAction(result.value, sessions, entry.ids)
+        else selectWorktreeAction(result.value, target, sessions, entry.ids)
 
-        const expected = remembered === "terminal:second" ? remembered : "terminal:first"
+        const expected = entry.remembered === "terminal:second" ? entry.remembered : "terminal:first"
         expect(terms.activeId()).toBe(expected)
         expect(result.calls).toEqual([`terminal:${expected}`])
         expect(terms.current()).toHaveLength(2)

--- a/packages/kilo-vscode/webview-ui/agent-manager/selection-actions.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/selection-actions.ts
@@ -127,9 +127,9 @@ function terminal(
   empty: boolean,
 ): string | undefined {
   const key = deps.nsKey(selection)
-  if (deps.terms.hasRemembered(key, remembered)) return remembered
-  if (!empty || deps.isReviewTab(remembered, selection)) return
-  return deps.terms.forSelection(key).at(0)?.id
+  const known = deps.terms.hasRemembered(key, remembered)
+  if (!known && (!empty || deps.isReviewTab(remembered, selection))) return
+  return known ? remembered : deps.terms.forSelection(key).at(0)?.id
 }
 
 /** Select the Local context: restore its remembered tab or fall back to the first session/draft. */


### PR DESCRIPTION
Follow-up to the guard-order review on #13715, which is already merged.

Put the rejection guard before the terminal-selection return and reuse one remembered-terminal lookup. Preserve both required behaviors: missing tab memory must still fall back to an existing terminal, and a remembered terminal must still win when the context also has chat tabs. The suggested unconditional `!remembered` and `!empty` checks would prevent those cases.

Extend the existing Local/worktree regression cases to cover a remembered terminal alongside chat sessions. This is a behavior-preserving refactor, so no additional release note or UI change is needed.

Validation: 58 focused tests passed; extension/webview typechecks, lint, formatting, and the Kilo marker guard passed. No additional manual UI run was needed for this small internal refactor.