### PR TITLE
feat: support preselected question answers

### DIFF
--- a/.changeset/question-default-answer.md
+++ b/.changeset/question-default-answer.md
@@ -1,0 +1,7 @@
+---
+"@kilocode/cli": minor
+"@kilocode/sdk": minor
+"kilo-code": minor
+---
+
+Support agent-defined default answers for single-select questions, with Enter confirmation in the CLI and VS Code.

--- a/packages/kilo-vscode/tests/fixtures/question-dock-disposal.tsx
+++ b/packages/kilo-vscode/tests/fixtures/question-dock-disposal.tsx
@@ -11,6 +11,7 @@ Object.assign(globalThis, {
   Element: window.Element,
   HTMLElement: window.HTMLElement,
   SVGElement: window.SVGElement,
+  Event: window.Event,
   requestAnimationFrame: (callback: FrameRequestCallback) => frames.push(callback),
 })
 
@@ -101,4 +102,75 @@ if (calls.length !== 1 || calls[0]?.id !== request.id || calls[0]?.answers[0]?.[
   throw new Error(`Unexpected question reply: ${JSON.stringify(calls)}`)
 }
 if (root.querySelector('[data-component="question-dock"]')) throw new Error("Question dock did not unmount")
+
+const defaults: QuestionRequest = {
+  ...request,
+  questions: [
+    {
+      question: "Choose a format",
+      header: "Format",
+      options: [
+        { label: "Text", description: "Plain text" },
+        { label: "JSON", description: "Structured output" },
+      ],
+      default: "JSON",
+    },
+  ],
+}
+for (const value of ["", "Draft in progress"]) {
+  prompt.value = value
+  prompt.focus()
+  setActive(defaults)
+  flush()
+  if (document.activeElement !== prompt) throw new Error("Default answer stole composer focus")
+  setActive(structuredClone(defaults))
+  flush()
+  if (document.activeElement !== prompt) throw new Error("Repeated default answer stole composer focus")
+  setActive(undefined)
+  prompt.blur()
+  setActive(defaults)
+  prompt.focus()
+  flush()
+  if (document.activeElement !== prompt) throw new Error("Scheduled default focus interrupted typing")
+  setActive(undefined)
+}
+prompt.value = ""
+prompt.blur()
+setActive(defaults)
+flush()
+const picked = root.querySelector<HTMLButtonElement>('button[data-picked="true"]')
+if (!picked || picked.textContent?.includes("JSON") !== true) throw new Error("Default answer was not selected")
+if (document.activeElement !== picked) throw new Error("Default answer was not focused")
+if (calls.length !== 1) throw new Error("Default answer was submitted without confirmation")
+picked.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Enter", bubbles: true, isComposing: true }))
+if (calls.length !== 1) throw new Error("IME Enter submitted the default answer")
+picked.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Enter", bubbles: true }))
+if (calls.at(-1)?.answers[0]?.[0] !== "JSON") throw new Error("Enter did not submit the default answer")
+if (root.querySelector('[data-component="question-dock"]')) throw new Error("Default answer was not submitted")
+
+setActive(structuredClone(defaults))
+flush()
+const replacement = root.querySelector<HTMLButtonElement>('[data-slot="question-option"]')
+if (!replacement) throw new Error("Replacement option missing")
+replacement.click()
+if (replacement.dataset.picked !== "true") throw new Error("Could not override the default answer")
+setActive(structuredClone(defaults))
+flush()
+const retained = root.querySelector<HTMLButtonElement>('button[data-picked="true"]')
+if (!retained?.textContent?.includes("Text")) throw new Error("Repeated question reset the user's selection")
+retained.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Enter", bubbles: true }))
+if (calls.at(-1)?.answers[0]?.[0] !== "Text") throw new Error("Enter did not submit the replacement")
+
+for (const question of [
+  { ...defaults.questions.at(0)!, default: "Missing" },
+  { ...defaults.questions.at(0)!, multiple: true },
+  { ...defaults.questions.at(0)!, default: undefined },
+]) {
+  setActive({ ...request, questions: [question] })
+  flush()
+  if (root.querySelector('button[data-picked="true"]')) throw new Error("Unexpected default selection")
+  const button = root.querySelector<HTMLButtonElement>('[data-slot="question-footer-actions"] button')
+  if (!button?.disabled) throw new Error("Unanswered question enabled submission")
+  setActive(undefined)
+}
 dispose()

--- a/packages/kilo-vscode/tests/fixtures/question-dock-disposal.tsx
+++ b/packages/kilo-vscode/tests/fixtures/question-dock-disposal.tsx
@@ -171,6 +171,11 @@ for (const question of [
   if (root.querySelector('button[data-picked="true"]')) throw new Error("Unexpected default selection")
   const button = root.querySelector<HTMLButtonElement>('[data-slot="question-footer-actions"] button')
   if (!button?.disabled) throw new Error("Unanswered question enabled submission")
+  const option = root.querySelector<HTMLButtonElement>('[data-slot="question-option"]')
+  if (!option) throw new Error("Question option missing")
+  option.click()
+  option.dispatchEvent(new window.KeyboardEvent("keydown", { key: "Enter", bubbles: true }))
+  if (!root.querySelector('[data-component="question-dock"]')) throw new Error("Ignored default changed Enter behavior")
   setActive(undefined)
 }
 dispose()

--- a/packages/kilo-vscode/tests/unit/agent-manager-focus.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-focus.test.ts
@@ -29,6 +29,7 @@ describe("Agent Manager focus", () => {
     dock.setAttribute("data-component", "question-dock")
     const option = document.createElement("button")
     option.setAttribute("data-slot", "question-option")
+    option.setAttribute("data-picked", "true")
     dock.append(option)
     document.body.append(prompt, dock)
     const focus = createChatFocus({ term: () => undefined, history: () => false, review: () => false })
@@ -81,6 +82,22 @@ describe("Agent Manager focus", () => {
 
     expect(focusQuestionOption(root)).toBe(true)
     expect(root.ownerDocument.activeElement).toBe(option)
+  })
+
+  it("focuses the selected answer before the first option", () => {
+    const window = new Window()
+    const dock = window.document.createElement("div")
+    dock.setAttribute("data-component", "question-dock")
+    const first = window.document.createElement("button")
+    const selected = window.document.createElement("button")
+    first.setAttribute("data-slot", "question-option")
+    selected.setAttribute("data-slot", "question-option")
+    selected.setAttribute("data-picked", "true")
+    dock.append(first, selected)
+    window.document.body.append(dock)
+
+    expect(focusQuestionOption(dock)).toBe(true)
+    expect(window.document.activeElement).toBe(selected)
   })
 
   it("ignores collapsed question bodies", () => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/focus.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/focus.ts
@@ -105,10 +105,11 @@ export function hasQuestionOption(root: ParentNode = document): boolean {
 
 /** Focus the first enabled option in the visible question dock, if one exists. */
 export function focusQuestionOption(root: ParentNode = document): boolean {
-  for (const option of root.querySelectorAll<HTMLButtonElement>(OPTION)) {
-    if (option.disabled || option.closest("[inert]")) continue
-    option.focus({ preventScroll: true })
-    return true
-  }
-  return false
+  const options = [...root.querySelectorAll<HTMLButtonElement>(OPTION)].filter(
+    (option) => !option.disabled && !option.closest("[inert]"),
+  )
+  const option = options.find((option) => option.dataset.picked === "true") ?? options.at(0)
+  if (!option) return false
+  option.focus({ preventScroll: true })
+  return true
 }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -239,7 +239,7 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
   const onKey = (e: KeyboardEvent) => {
     if (
       single() &&
-      question()?.default !== undefined &&
+      question()?.options.some((opt) => opt.label === question()?.default) &&
       isEnterKeyCommitNotIme(e) &&
       !e.metaKey &&
       !e.ctrlKey &&

--- a/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/QuestionDock.tsx
@@ -34,7 +34,10 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
 
   const [store, setStore] = createStore({
     tab: 0,
-    answers: [] as string[][],
+    answers: questions().map((q) => {
+      const option = !q.multiple && q.options.find((opt) => opt.label === q.default)
+      return option ? [option.label] : []
+    }),
     custom: [] as string[],
     kinds: [] as Record<string, "option" | "custom">[],
     editing: false,
@@ -125,6 +128,8 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
   }
 
   const submit = () => {
+    if (store.sending) return
+    syncAgent(store.answers)
     reply(questions().map((_, i) => [...(store.answers[i] ?? [])]))
   }
 
@@ -232,6 +237,19 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
   }
 
   const onKey = (e: KeyboardEvent) => {
+    if (
+      single() &&
+      question()?.default !== undefined &&
+      isEnterKeyCommitNotIme(e) &&
+      !e.metaKey &&
+      !e.ctrlKey &&
+      (e.target as HTMLElement).matches("button[data-picked='true']:not([data-custom])")
+    ) {
+      e.preventDefault()
+      e.stopPropagation()
+      submit()
+      return
+    }
     if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return
     if ((e.target as HTMLElement).tagName === "INPUT") return
     e.preventDefault()
@@ -329,8 +347,10 @@ export const QuestionDock: Component<{ request: QuestionRequest }> = (props) => 
     void store.tab
     if (store.collapsed || store.editing || confirm()) return
     requestAnimationFrame(() => {
-      if (!document.hasFocus() || isTextControl(document.activeElement)) return
-      const btn = root?.querySelector<HTMLButtonElement>("button[data-slot='question-option']:not(:disabled)")
+      if (!document.hasFocus() || isTextControl(document.activeElement) || !root?.isConnected) return
+      const selector = "button[data-slot='question-option']:not(:disabled)"
+      const picked = root?.querySelector<HTMLButtonElement>(`${selector}[data-picked='true']`)
+      const btn = picked ?? root?.querySelector<HTMLButtonElement>(selector)
       btn?.focus({ preventScroll: true })
     })
   })

--- a/packages/kilo-vscode/webview-ui/src/types/messages/questions.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/questions.ts
@@ -21,6 +21,7 @@ export interface QuestionInfo {
   header: string
   options: QuestionOption[]
   multiple?: boolean
+  default?: string
   custom?: boolean
   // Optional i18n keys for question text and header (see QuestionOption for details).
   questionKey?: string

--- a/packages/opencode/src/cli/cmd/run/footer.question.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.question.tsx
@@ -14,6 +14,7 @@
 // This component just renders it and dispatches keyboard events.
 /** @jsxImportSource @opentui/solid */
 import type { TextareaRenderable } from "@opentui/core"
+import type { ScrollBoxRenderable } from "@opentui/core" // kilocode_change
 import { useKeyboard, useTerminalDimensions } from "@opentui/solid"
 import { For, Show, createEffect, createMemo, createSignal } from "solid-js"
 import type { QuestionRequest } from "@kilocode/sdk/v2"
@@ -76,6 +77,24 @@ export function RunQuestionBody(props: {
     return "confirm"
   })
   let area: TextareaRenderable | undefined
+  // kilocode_change start
+  let scroll: ScrollBoxRenderable | undefined
+  createEffect(() => {
+    const selected = state().selected
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (!scroll || scroll.isDestroyed || state().selected !== selected) return
+        const option = scroll
+          .getChildren()
+          .at(0)
+          ?.getChildren()
+          .filter((child) => child.visible)
+          .at(selected)
+        if (option) scroll.scrollChildIntoView(option.id)
+      })
+    })
+  })
+  // kilocode_change end
 
   createEffect(() => {
     setState((prev) => questionSync(prev, props.request.id, props.request.questions.at(0))) // kilocode_change
@@ -363,6 +382,7 @@ export function RunQuestionBody(props: {
 
             <box flexGrow={1} flexShrink={1}>
               <scrollbox
+                ref={(el) => (scroll = el) /* kilocode_change */}
                 width="100%"
                 height="100%"
                 verticalScrollbarOptions={{

--- a/packages/opencode/src/cli/cmd/run/footer.question.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.question.tsx
@@ -51,7 +51,7 @@ export function RunQuestionBody(props: {
   onReject: (input: QuestionReject) => void | Promise<void>
 }) {
   const dims = useTerminalDimensions()
-  const [state, setState] = createSignal(createQuestionBodyState(props.request.id))
+  const [state, setState] = createSignal(createQuestionBodyState(props.request.id, props.request.questions.at(0))) // kilocode_change
   const single = createMemo(() => questionSingle(props.request))
   const confirm = createMemo(() => questionConfirm(props.request, state()))
   const info = createMemo(() => questionInfo(props.request, state()))
@@ -78,11 +78,11 @@ export function RunQuestionBody(props: {
   let area: TextareaRenderable | undefined
 
   createEffect(() => {
-    setState((prev) => questionSync(prev, props.request.id))
+    setState((prev) => questionSync(prev, props.request.id, props.request.questions.at(0))) // kilocode_change
   })
 
   const setTab = (tab: number) => {
-    setState((prev) => questionSetTab(prev, tab))
+    setState((prev) => questionSetTab(prev, tab, props.request.questions.at(tab))) // kilocode_change
   }
 
   const move = (dir: -1 | 1) => {

--- a/packages/opencode/src/cli/cmd/run/question.shared.ts
+++ b/packages/opencode/src/cli/cmd/run/question.shared.ts
@@ -31,24 +31,32 @@ export type QuestionStep = {
   reply?: QuestionReply
 }
 
-export function createQuestionBodyState(requestID: string): QuestionBodyState {
+// kilocode_change start
+export function createQuestionBodyState(requestID: string, question?: QuestionInfo): QuestionBodyState {
+  // kilocode_change end
   return {
     requestID,
     tab: 0,
     answers: [],
     custom: [],
-    selected: 0,
+    // kilocode_change start
+    selected: question?.multiple
+      ? 0
+      : Math.max(0, question?.options.findIndex((option) => option.label === question.default) ?? 0),
+    // kilocode_change end
     editing: false,
     submitting: false,
   }
 }
 
-export function questionSync(state: QuestionBodyState, requestID: string): QuestionBodyState {
+// kilocode_change start
+export function questionSync(state: QuestionBodyState, requestID: string, question?: QuestionInfo): QuestionBodyState {
+  // kilocode_change end
   if (state.requestID === requestID) {
     return state
   }
 
-  return createQuestionBodyState(requestID)
+  return createQuestionBodyState(requestID, question) // kilocode_change
 }
 
 export function questionSingle(request: QuestionRequest): boolean {
@@ -106,11 +114,17 @@ export function questionAnswers(state: QuestionBodyState, count: number): string
   return Array.from({ length: count }, (_, idx) => state.answers[idx] ?? [])
 }
 
-export function questionSetTab(state: QuestionBodyState, tab: number): QuestionBodyState {
+// kilocode_change start
+export function questionSetTab(state: QuestionBodyState, tab: number, question?: QuestionInfo): QuestionBodyState {
+  // kilocode_change end
   return {
     ...state,
     tab,
-    selected: 0,
+    // kilocode_change start
+    selected: question?.multiple
+      ? 0
+      : Math.max(0, question?.options.findIndex((option) => option.label === question.default) ?? 0),
+    // kilocode_change end
     editing: false,
   }
 }
@@ -188,7 +202,7 @@ function questionPick(
   }
 
   return {
-    state: questionSetTab(next, state.tab + 1),
+    state: questionSetTab(next, state.tab + 1, request.questions.at(state.tab + 1)), // kilocode_change
   }
 }
 

--- a/packages/opencode/src/kilocode/question/index.ts
+++ b/packages/opencode/src/kilocode/question/index.ts
@@ -20,6 +20,7 @@ export namespace KiloQuestion {
     const text = (value: string) => value.replace(/\r\n/g, "\n").replace(/\r/g, " ")
     return {
       ...info,
+      ...(info.default == null ? {} : { default: line(info.default) }),
       question: text(info.question),
       header: line(info.header),
       options: info.options.map((option) => ({

--- a/packages/opencode/test/kilocode/cli/cmd/run/question-default.test.tsx
+++ b/packages/opencode/test/kilocode/cli/cmd/run/question-default.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import type { QuestionRequest } from "@kilocode/sdk/v2"
+import { RunQuestionBody } from "@/cli/cmd/run/footer.question"
+import { RUN_THEME_FALLBACK } from "@/cli/cmd/run/theme"
+import {
+  createQuestionBodyState,
+  questionConfirm,
+  questionSelect,
+  questionSetSelected,
+  questionSetTab,
+  questionSubmit,
+  questionSync,
+} from "@/cli/cmd/run/question.shared"
+
+const question = {
+  question: "Mode?",
+  header: "Mode",
+  options: [
+    { label: "chunked", description: "Incremental output" },
+    { label: "direct", description: "Direct output" },
+  ],
+  default: "direct",
+}
+const request = {
+  id: "question-1",
+  sessionID: "session-1",
+  questions: [question],
+} satisfies QuestionRequest
+
+describe("question defaults", () => {
+  test.each([
+    ["direct", false, 1, "direct"],
+    ["unknown", false, 0, "chunked"],
+    ["direct", true, 0, "chunked"],
+  ] as const)("initializes default %s with multiple=%s", (value, multiple, selected, label) => {
+    const info = { ...question, default: value, multiple }
+    const ask = { ...request, questions: [info] }
+    const state = createQuestionBodyState(ask.id, info)
+    expect(state.selected).toBe(selected)
+    const out = questionSelect(state, ask)
+    expect(out.state.answers).toEqual([[label]])
+    if (multiple) {
+      expect(out.reply).toBeUndefined()
+      expect(questionSelect(out.state, ask).state.answers).toEqual([[]])
+      return
+    }
+    expect(out.reply).toEqual({ requestID: ask.id, answers: [[label]] })
+  })
+
+  test("uses defaults on tab changes and resets without replacing user navigation", () => {
+    const ask = { ...request, questions: [question, question] }
+    const state = createQuestionBodyState(ask.id, question)
+    const next = questionSelect(state, ask).state
+    expect(next.tab).toBe(1)
+    expect(next.selected).toBe(1)
+    expect(questionSetTab(next, 0, question).selected).toBe(1)
+    const confirm = questionSelect(next, ask).state
+    expect(questionConfirm(ask, confirm)).toBe(true)
+    expect(confirm.selected).toBe(0)
+    expect(questionSubmit(ask, confirm).answers).toEqual([["direct"], ["direct"]])
+
+    const moved = questionSetSelected(state, 0)
+    expect(questionSync(moved, ask.id, question)).toBe(moved)
+    expect(questionSelect(moved, ask).state.answers).toEqual([["chunked"]])
+    const reset = questionSync(moved, "question-2", question)
+    expect(reset.selected).toBe(1)
+    expect(reset.answers).toEqual([])
+  })
+
+  test("direct question body accepts the default on Enter", async () => {
+    const replies: unknown[] = []
+    const app = await testRender(
+      () => (
+        <RunQuestionBody
+          request={request}
+          theme={RUN_THEME_FALLBACK.footer}
+          onReply={(input) => {
+            replies.push(input)
+          }}
+          onReject={() => {}}
+        />
+      ),
+      { width: 100, height: 12 },
+    )
+
+    try {
+      expect(replies).toEqual([])
+      app.mockInput.pressEnter()
+      await app.renderOnce()
+      expect(replies).toEqual([{ requestID: request.id, answers: [["direct"]] }])
+      expect(app.captureCharFrame()).toContain("direct ✓")
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+})

--- a/packages/opencode/test/kilocode/cli/cmd/run/question-default.test.tsx
+++ b/packages/opencode/test/kilocode/cli/cmd/run/question-default.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { testRender } from "@opentui/solid"
+import { createSignal } from "solid-js"
 import type { QuestionRequest } from "@kilocode/sdk/v2"
 import { RunQuestionBody } from "@/cli/cmd/run/footer.question"
 import { RUN_THEME_FALLBACK } from "@/cli/cmd/run/theme"
@@ -66,6 +67,63 @@ describe("question defaults", () => {
     const reset = questionSync(moved, "question-2", question)
     expect(reset.selected).toBe(1)
     expect(reset.answers).toEqual([])
+  })
+
+  test("direct question body reveals off-screen defaults and follows navigation and resets", async () => {
+    const [ask, setAsk] = createSignal({
+      ...request,
+      questions: [
+        {
+          ...question,
+          options: Array.from({ length: 9 }, (_, index) => ({
+            label: `Option ${index + 1}`,
+            description: `Description ${index + 1}`,
+          })),
+          default: "Option 9",
+          custom: false,
+        },
+      ],
+    })
+    const replies: unknown[] = []
+    const app = await testRender(
+      () => (
+        <RunQuestionBody
+          request={ask()}
+          theme={RUN_THEME_FALLBACK.footer}
+          onReply={(input) => {
+            replies.push(input)
+          }}
+          onReject={() => {}}
+        />
+      ),
+      { width: 100, height: 16 },
+    )
+
+    try {
+      await app.renderOnce()
+      await app.renderOnce()
+      expect(app.captureCharFrame()).toContain("Option 9")
+      expect(app.captureCharFrame()).toContain("Description 9")
+      expect(replies).toEqual([])
+
+      app.mockInput.pressKey("j")
+      await app.renderOnce()
+      await app.renderOnce()
+      expect(app.captureCharFrame()).toContain("Option 1")
+      app.mockInput.pressEnter()
+      await app.renderOnce()
+      expect(replies).toEqual([{ requestID: request.id, answers: [["Option 1"]] }])
+
+      setAsk({ ...ask(), id: "question-2" })
+      await app.renderOnce()
+      await app.renderOnce()
+      expect(app.captureCharFrame()).toContain("Option 9")
+      app.mockInput.pressEnter()
+      await app.renderOnce()
+      expect(replies.at(-1)).toEqual({ requestID: "question-2", answers: [["Option 9"]] })
+    } finally {
+      app.renderer.destroy()
+    }
   })
 
   test("direct question body accepts the default on Enter", async () => {

--- a/packages/opencode/test/kilocode/question-normalize.test.ts
+++ b/packages/opencode/test/kilocode/question-normalize.test.ts
@@ -72,6 +72,7 @@ it.instance(
         question: "How\rshould we merge?\r\nKeep the history?",
         questionKey: "merge.question",
         headerKey: "merge.header",
+        default: " Squash \r merge\n(Recommended) ",
         multiple: true,
         custom: false,
         options: [
@@ -94,6 +95,7 @@ it.instance(
       expect(request.questions).toEqual([
         {
           ...input,
+          default: "Squash merge (Recommended)",
           header: "Merge method",
           question: "How should we merge?\nKeep the history?",
           options: [

--- a/packages/opencode/test/kilocode/question-option-schema.test.ts
+++ b/packages/opencode/test/kilocode/question-option-schema.test.ts
@@ -23,11 +23,24 @@ import { describe, test, expect } from "bun:test"
 import { Schema } from "effect"
 import fs from "node:fs"
 import path from "node:path"
-import { Option } from "../../src/question"
+import { Info, Option, Prompt } from "../../src/question"
 
 const SOURCE = path.resolve(import.meta.dir, "../../../schema/src/v1/question.ts")
 
 describe("QuestionOption schema — Kilo-specific field contract", () => {
+  test("question defaults survive tool and wire schemas and omit undefined", () => {
+    const raw = {
+      question: "Choose a format",
+      header: "Format",
+      options: [{ label: "JSON", description: "Structured output" }],
+      default: "JSON",
+    }
+    for (const schema of [Info, Prompt]) {
+      expect(Schema.decodeUnknownSync(schema)(raw).default).toBe("JSON")
+      expect(Schema.encodeSync(schema)({ ...raw, default: undefined })).not.toHaveProperty("default")
+    }
+  })
+
   test("Option class accepts and round-trips the mode field", () => {
     const raw = { label: "Continue here", description: "Implement the plan in this session", mode: "code" }
     const decoded = Schema.decodeUnknownSync(Option)(raw)

--- a/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
+++ b/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
@@ -245,6 +245,10 @@ exports[`tool parameters JSON Schema (wire shape) question 1`] = `
       "description": "Questions to ask",
       "items": {
         "properties": {
+          "default": {
+            "description": "Exact option label to preselect for a single-select question. Use for a recommended answer; the user must still confirm. Ignored when multiple is true or the label is unknown.",
+            "type": "string",
+          },
           "header": {
             "description": "Very short label (max 30 chars)",
             "type": "string",

--- a/packages/schema/src/v1/question.ts
+++ b/packages/schema/src/v1/question.ts
@@ -4,6 +4,7 @@ import { Schema } from "effect"
 import { define, inventory } from "../event"
 import { ascending } from "../identifier"
 import { statics } from "../schema"
+import { optional } from "../schema" // kilocode_change
 import { SessionID } from "../session-id"
 import { SessionV1 } from "./session"
 
@@ -31,7 +32,13 @@ const base = {
   header: Schema.String.annotate({ description: "Very short label (max 30 chars)" }),
   options: Schema.Array(Option).annotate({ description: "Available choices" }),
   multiple: Schema.optional(Schema.Boolean).annotate({ description: "Allow selecting multiple choices" }),
-  // kilocode_change start - optional Kilo client localization keys
+  // kilocode_change start - optional Kilo client hints
+  default: optional(
+    Schema.String.annotate({
+      description:
+        "Exact option label to preselect for a single-select question. Use for a recommended answer; the user must still confirm. Ignored when multiple is true or the label is unknown.",
+    }),
+  ),
   questionKey: Schema.optional(Schema.String).annotate({
     description: "Optional i18n key for the question text; clients fall back to `question` when missing",
   }),

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1140,6 +1140,10 @@ export type QuestionInfo = {
    */
   options: Array<QuestionOption>
   multiple?: boolean
+  /**
+   * Exact option label to preselect for a single-select question. Use for a recommended answer; the user must still confirm. Ignored when multiple is true or the label is unknown.
+   */
+  default?: string
   questionKey?: string
   headerKey?: string
   custom?: boolean

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -30153,6 +30153,10 @@
           "multiple": {
             "type": "boolean"
           },
+          "default": {
+            "type": "string",
+            "description": "Exact option label to preselect for a single-select question. Use for a recommended answer; the user must still confirm. Ignored when multiple is true or the label is unknown."
+          },
           "questionKey": {
             "type": "string"
           },

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -81,8 +81,7 @@ export function QuestionPrompt(props: {
       })
       return
     }
-    setStore("tab", store.tab + 1)
-    setStore("selected", 0)
+    selectTab(store.tab + 1) // kilocode_change
   }
 
   function toggle(answer: string) {
@@ -102,7 +101,13 @@ export function QuestionPrompt(props: {
 
   function selectTab(index: number) {
     setStore("tab", index)
-    setStore("selected", 0)
+    // kilocode_change start
+    const item = questions().at(index)
+    setStore(
+      "selected",
+      item?.multiple ? 0 : Math.max(0, item?.options.findIndex((option) => option.label === item.default) ?? 0),
+    )
+    // kilocode_change end
   }
 
   function selectOption() {
@@ -129,6 +134,7 @@ export function QuestionPrompt(props: {
   }
 
   onMount(() => {
+    selectTab(0) // kilocode_change
     const popMode = modeStack.push(QUESTION_MODE)
     onCleanup(popMode)
   })


### PR DESCRIPTION
## What Problem This Solves

A recommended answer is currently only a label convention. Models cannot explicitly preselect an option, so accepting a non-first recommendation requires a separate selection step.

## Why This Change Was Made

Add one optional `default` field containing an exact option label. The model-facing tool schema explains when to use it and that the user must still confirm. This avoids interpreting recommendation text or introducing another setting. New CLI regression coverage stays in Kilo-owned test paths. Shared upstream test code remains unchanged; only the generated question-schema snapshot is updated.

## User Impact

- Single-select questions can preselect an answer in VS Code, the full CLI, and mini CLI. The user can still choose another answer.
- Enter confirms the selected answer when the question has keyboard focus. Preselection never submits automatically or takes focus from a text field, including an empty message composer.
- Omitting `default` preserves existing behavior. Unknown labels and defaults on multi-select questions are ignored.

## Evidence

- 108 focused CLI/schema tests and 43 extension tests passed, along with typechecks, extension build/lint, formatting, unused-export, and fork-annotation checks. The full local extension test run exceeded its 120-second execution limit; CI covers the full suite.
- Real-renderer coverage checks that a last-option default in a scrollable mini-CLI question is visible, and that navigation and new requests keep the selected answer in view.
- Real full and mini CLI sessions passed default + Enter, arrow-key override, and no-default scenarios. Saved answers were checked through the API and SQLite using a deterministic local provider.
- Isolated VS Code self-tests passed in both sidebar and Agent Manager: empty and non-empty drafts retain focus across repeated question updates, clearing/retyping still works, and keyboard navigation to the selected answer followed by Enter confirms it. This focus replay uses synthetic question events in the real UI, not an external model.

JSON remains selected while the composer retains typing focus:

<img width="700" alt="JSON is preselected while the message composer retains keyboard focus" src="https://marius-kilocode.github.io/pr-assets/20260903-question-default-preserve-focus-0812.png" />
