### PR TITLE
fix(vscode): cache and bound change badge file reads

### DIFF
--- a/.changeset/quiet-badge-scans.md
+++ b/.changeset/quiet-badge-scans.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Reduce change-badge overhead in large repositories by reusing unchanged file counts and limiting concurrent file reads.

--- a/packages/kilo-vscode/src/agent-manager/GitOps.ts
+++ b/packages/kilo-vscode/src/agent-manager/GitOps.ts
@@ -12,6 +12,7 @@ import {
   type BranchListItem,
 } from "./git-import"
 import type { Semaphore } from "./semaphore"
+import { lines } from "./git-stats-snapshot"
 
 interface GitOpsOptions {
   log: (...args: unknown[]) => void
@@ -388,20 +389,7 @@ export class GitOps {
     if (!untracked) return tracked
 
     const paths = untracked.split("\n").filter((line) => line.trim())
-    const counts = await Promise.all(
-      paths.map(async (p) => {
-        try {
-          const full = nodePath.resolve(cwd, p)
-          const stat = await fs.stat(full)
-          if (stat.size > 1_000_000) return 0
-          const content = await fs.readFile(full, "utf-8")
-          return content.split("\n").length
-        } catch (err) {
-          this.log(`Failed to read untracked file ${p}:`, err)
-          return 0
-        }
-      }),
-    )
+    const counts = await Promise.all(paths.map((file) => lines(nodePath.resolve(cwd, file))))
 
     return {
       files: tracked.files + paths.length,

--- a/packages/kilo-vscode/src/agent-manager/git-stats-snapshot.ts
+++ b/packages/kilo-vscode/src/agent-manager/git-stats-snapshot.ts
@@ -119,7 +119,7 @@ function records(raw: Buffer): { branch: string; head: string; paths: PathState[
 }
 
 function stamp(stat: BigIntStats): string {
-  return `${stat.dev}:${stat.ino}:${stat.mode}:${stat.size}:${stat.mtimeNs}:${stat.ctimeNs}`
+  return [stat.dev, stat.ino, stat.mode, stat.size, stat.mtimeNs, stat.ctimeNs].join(":")
 }
 
 async function fingerprint(dir: string, raw: Buffer, paths: PathState[]): Promise<string | undefined> {
@@ -164,12 +164,12 @@ export async function lines(file: string): Promise<number> {
       cache.delete(file)
       return 0
     }
+    if (stat.size === 0n || stat.size > MAX_BYTES) return 0
     const key = stamp(stat)
     const hit = cache.get(file)
     if (hit?.stamp === key) return hit.count
 
     const count = await (async () => {
-      if (stat.size === 0n || stat.size > MAX_BYTES) return 0
       if (await binaryFile(file)) return 0
       const content = stat.isSymbolicLink() ? await fs.readlink(file) : await fs.readFile(file, "utf8")
       if (!content) return 0

--- a/packages/kilo-vscode/src/agent-manager/git-stats-snapshot.ts
+++ b/packages/kilo-vscode/src/agent-manager/git-stats-snapshot.ts
@@ -1,10 +1,15 @@
 import { createHash } from "crypto"
+import type { BigIntStats } from "fs"
 import * as fs from "fs/promises"
+import { LRUCache } from "lru-cache"
 import { binaryFile } from "../diff/shared/binary"
 import { resolveInside } from "../diff/shared/path"
 import type { GitOps } from "./GitOps"
+import { Semaphore } from "./semaphore"
 
-const MAX_BYTES = 1_000_000
+const MAX_BYTES = 1_000_000n
+const reads = new Semaphore(16)
+const cache = new LRUCache<string, { stamp: string; count: number }>({ max: 10_000 })
 
 export interface DiffStats {
   files: number
@@ -113,6 +118,10 @@ function records(raw: Buffer): { branch: string; head: string; paths: PathState[
   return { branch, head, paths, untracked }
 }
 
+function stamp(stat: BigIntStats): string {
+  return `${stat.dev}:${stat.ino}:${stat.mode}:${stat.size}:${stat.mtimeNs}:${stat.ctimeNs}`
+}
+
 async function fingerprint(dir: string, raw: Buffer, paths: PathState[]): Promise<string | undefined> {
   const hash = createHash("sha256").update(raw)
   const unique = new Map(paths.map((item) => [item.file, item]))
@@ -127,7 +136,7 @@ async function fingerprint(dir: string, raw: Buffer, paths: PathState[]): Promis
       hash.update(`\0${item.file}\0missing`)
       continue
     }
-    hash.update(`\0${item.file}\0${stat.dev}:${stat.ino}:${stat.mode}:${stat.size}:${stat.mtimeNs}:${stat.ctimeNs}`)
+    hash.update(`\0${item.file}\0${stamp(stat)}`)
   }
   return hash.digest("hex")
 }
@@ -148,15 +157,30 @@ function numstat(raw: Buffer): DiffStats {
   return result
 }
 
-async function lines(file: string): Promise<number> {
-  const stat = await fs.lstat(file).catch(() => undefined)
-  if (!stat || stat.size === 0 || stat.size > MAX_BYTES) return 0
-  if (await binaryFile(file)) return 0
-  const content = stat.isSymbolicLink()
-    ? await fs.readlink(file).catch(() => "")
-    : await fs.readFile(file, "utf8").catch(() => "")
-  if (!content) return 0
-  return content.endsWith("\n") ? content.split("\n").length - 1 : content.split("\n").length
+export async function lines(file: string): Promise<number> {
+  return reads.run(async () => {
+    const stat = await fs.lstat(file, { bigint: true }).catch(() => undefined)
+    if (!stat) {
+      cache.delete(file)
+      return 0
+    }
+    const key = stamp(stat)
+    const hit = cache.get(file)
+    if (hit?.stamp === key) return hit.count
+
+    const count = await (async () => {
+      if (stat.size === 0n || stat.size > MAX_BYTES) return 0
+      if (await binaryFile(file)) return 0
+      const content = stat.isSymbolicLink() ? await fs.readlink(file) : await fs.readFile(file, "utf8")
+      if (!content) return 0
+      return content.endsWith("\n") ? content.split("\n").length - 1 : content.split("\n").length
+    })().catch(() => undefined)
+    if (count === undefined) return 0
+
+    const current = await fs.lstat(file, { bigint: true }).catch(() => undefined)
+    if (current && stamp(current) === key) cache.set(file, { stamp: key, count })
+    return count
+  })
 }
 
 export function refOID(refs: RefSnapshot | undefined, ref: string): string | undefined {

--- a/packages/kilo-vscode/tests/unit/git-stats-snapshot.test.ts
+++ b/packages/kilo-vscode/tests/unit/git-stats-snapshot.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test"
+import { describe, expect, it, spyOn } from "bun:test"
 import * as fs from "fs/promises"
 import * as os from "os"
 import * as path from "path"
@@ -84,6 +84,89 @@ describe("GitStatsSnapshot", () => {
       await fs.writeFile(path.join(dir, "tracked.txt"), "modified twice and larger\n")
       const second = await snapshots.status(dir)
       expect(second.fingerprint).not.toBe(first.fingerprint)
+    })
+  })
+
+  it("reuses unchanged untracked counts when another file changes", async () => {
+    await repo(async (dir, base) => {
+      const git = new GitOps({ log: () => undefined })
+      const snapshots = new GitStatsSnapshot(git)
+      const files = ["stable.txt", "changing.txt"]
+      await Promise.all(files.map((file) => fs.writeFile(path.join(dir, file), "one\ntwo\n")))
+      const read = spyOn(fs, "readFile")
+      try {
+        expect(await snapshots.diff(dir, base, files)).toEqual({ files: 2, additions: 4, deletions: 0 })
+        expect(read).toHaveBeenCalledTimes(2)
+        read.mockClear()
+
+        await fs.writeFile(path.join(dir, "tracked.txt"), "one\nchanged\n")
+        expect(await snapshots.diff(dir, base, files)).toEqual({ files: 3, additions: 5, deletions: 1 })
+        expect(await git.workingTreeStats(dir)).toEqual({ files: 3, additions: 5, deletions: 1 })
+        expect(read).not.toHaveBeenCalled()
+
+        await fs.writeFile(path.join(dir, "changing.txt"), "12345678")
+        expect((await snapshots.diff(dir, base, files)).additions).toBe(4)
+        expect(read).toHaveBeenCalledTimes(1)
+        read.mockClear()
+        await fs.writeFile(path.join(dir, "changing.txt"), "one\ntwo\nthree\n")
+        expect(await snapshots.diff(dir, base, files)).toEqual({ files: 3, additions: 6, deletions: 1 })
+        expect(read).toHaveBeenCalledTimes(1)
+        expect(read.mock.calls.at(0)?.at(0)).toBe(path.join(dir, "changing.txt"))
+
+        await fs.unlink(path.join(dir, "changing.txt"))
+        expect(await snapshots.diff(dir, base, ["stable.txt"])).toEqual({ files: 2, additions: 3, deletions: 1 })
+        await fs.writeFile(path.join(dir, "changing.txt"), "replacement\n")
+        expect(await snapshots.diff(dir, base, files)).toEqual({ files: 3, additions: 4, deletions: 1 })
+      } finally {
+        read.mockRestore()
+      }
+    })
+  })
+
+  it("does not cache failed untracked reads", async () => {
+    await repo(async (dir, base) => {
+      const snapshots = new GitStatsSnapshot(new GitOps({ log: () => undefined }))
+      await fs.writeFile(path.join(dir, "new.txt"), "one\ntwo\n")
+      const read = spyOn(fs, "readFile").mockRejectedValueOnce(new Error("temporary read failure"))
+      try {
+        expect((await snapshots.diff(dir, base, ["new.txt"])).additions).toBe(0)
+        expect((await snapshots.diff(dir, base, ["new.txt"])).additions).toBe(2)
+        expect(read).toHaveBeenCalledTimes(2)
+      } finally {
+        read.mockRestore()
+      }
+    })
+  })
+
+  it("bounds concurrent untracked file probes", async () => {
+    await repo(async (dir, base) => {
+      const snapshots = new GitStatsSnapshot(new GitOps({ log: () => undefined }))
+      const files = Array.from({ length: 64 }, (_, i) => `${i}.txt`)
+      await Promise.all(files.map((file) => fs.writeFile(path.join(dir, file), "one\ntwo\n")))
+      const open = fs.open
+      let active = 0
+      let peak = 0
+      const probe = spyOn(fs, "open").mockImplementation(async (...args) => {
+        const handle = await open(...args)
+        peak = Math.max(peak, ++active)
+        const close = handle.close.bind(handle)
+        handle.close = async () => {
+          try {
+            return await close()
+          } finally {
+            active--
+          }
+        }
+        return handle
+      })
+      try {
+        expect(await snapshots.diff(dir, base, files)).toEqual({ files: 64, additions: 128, deletions: 0 })
+        expect(peak).toBeGreaterThan(1)
+        expect(peak).toBeLessThanOrEqual(16)
+        expect(active).toBe(0)
+      } finally {
+        probe.mockRestore()
+      }
     })
   })
 

--- a/packages/kilo-vscode/tests/unit/git-stats-snapshot.test.ts
+++ b/packages/kilo-vscode/tests/unit/git-stats-snapshot.test.ts
@@ -138,6 +138,25 @@ describe("GitStatsSnapshot", () => {
     })
   })
 
+  it("skips extra metadata reads for empty and oversized files", async () => {
+    await repo(async (dir, base) => {
+      const snapshots = new GitStatsSnapshot(new GitOps({ log: () => undefined }))
+      const files = ["empty.txt", "large.txt"]
+      await fs.writeFile(path.join(dir, "empty.txt"), "")
+      await fs.writeFile(path.join(dir, "large.txt"), Buffer.alloc(1_000_001, 0x61))
+      const stat = spyOn(fs, "lstat")
+      try {
+        expect(await snapshots.diff(dir, base, files)).toEqual({ files: 2, additions: 0, deletions: 0 })
+        expect(stat).toHaveBeenCalledTimes(2)
+        await fs.writeFile(path.join(dir, "empty.txt"), "one\n")
+        await fs.writeFile(path.join(dir, "large.txt"), "two\nthree\n")
+        expect(await snapshots.diff(dir, base, files)).toEqual({ files: 2, additions: 3, deletions: 0 })
+      } finally {
+        stat.mockRestore()
+      }
+    })
+  })
+
   it("bounds concurrent untracked file probes", async () => {
     await repo(async (dir, base) => {
       const snapshots = new GitStatsSnapshot(new GitOps({ log: () => undefined }))


### PR DESCRIPTION
## What Problem This Solves

Addresses the badge-polling part of #13720. A change to one tracked or untracked file invalidates the aggregate Git statistics cache. Previously, the next scan could read every eligible untracked text file again through an unbounded `Promise.all`, even when those files had not changed.

## Why This Change Was Made

Keep the fix within the existing badge readers:

- Cache numeric line counts for up to 10,000 paths, keyed by the same precise file metadata used by the existing fingerprint. Do not retain file contents or failed reads.
- Limit filesystem counting to 16 concurrent operations across badge readers. This gate is separate from the Git subprocess semaphore and is not acquired around nested Git commands.
- Reuse the reader in the no-base-branch fallback instead of maintaining a second unbounded implementation.

The shared gate deliberately trades some badge-update latency between projects for bounded filesystem pressure. A slow project can queue ahead of another project, and a filesystem operation that never settles can retain a slot. This change does not add filesystem timeouts or cancellation, and prompt submission does not use this gate.

## User Impact

Repeated badge scans no longer reread stable untracked files when a neighboring file changes. The normal branch-comparison totals are preserved. The fallback now uses the same binary, symlink, empty-file, and trailing-newline rules as the normal badge path.

The initial scan still reads eligible files. Workloads with constant changes to every file or more paths than the cache can retain still require reads, but concurrent reads remain bounded. There are no CLI, SSE, or cloud synchronization changes. The separate 7.5.9 prompt-send failure was not reproduced, so this PR does not claim to resolve that part of #13720.

## Evidence

### Paired local measurement

Measured the actual `GitStatsSnapshot.status()` and `diff()` implementation under Node 25.2.1 on macOS ARM64, using the same disposable Git repository before and after the patch:

- 2,048 untracked text files, each 160 KiB with 8,192 lines, totaling 320 MiB.
- One tracked file changed before every scan. All untracked files stayed unchanged.
- Separate before/after bundles, executed sequentially with VS Code closed and no concurrent build or test commands.
- The first scan starts with a fresh in-process cache. Warm results are medians of the next three scans. The filesystem cache was not flushed.
- CPU profiles were captured with `node --cpu-prof`. CPU time is process user plus system time; event-loop delay was measured with `monitorEventLoopDelay`.

| Measurement | Before | After |
|---|---|---|
| Warm scan elapsed time, median | 577 ms | 114 ms |
| Warm scan CPU time, median | 888 ms | 67 ms |
| Maximum event-loop delay across warm scans | 150 ms | 11 ms |
| First scan elapsed time | 585 ms | 567 ms |
| First scan maximum event-loop delay | 179 ms | 16 ms |

The warm median elapsed time fell by about **80%**. Every measured normal-path scan returned the same totals: **2,049 files, +16,777,217, -1**. This is a small local sample, not a cross-platform benchmark or a reproduction of all 55 reported worktrees. The timing improvement is from the Node reproduction, not the webview renderer profile.

### Regression and manual checks

The new regression test failed before the fix because changing a tracked file reread both unchanged untracked files. It now passes and also covers same-size changes, replacement/deletion, shared fallback reuse, failed reads, and bounded real filesystem probes.

91 focused tests passed. Extension compile, lint, typecheck, Knip, formatting, and the Kilo change-marker guard passed.

In isolated VS Code, the 2,048-file fixture remained usable during repeated tracked-file churn. Adding an untracked file and editing an already-counted untracked file updated the badges correctly. The cropped screenshot below shows the final live update; it is not performance evidence.

<img width="480" alt="Agent Manager local badge after tracked and untracked file updates" src="https://marius-kilocode.github.io/pr-assets/20260903-badge-scan-cache-live-counts-0c72ddd.png" />
