### PR TITLE
fix(agent-manager): show outgoing prompts before approval

### DIFF
--- a/.changeset/agent-manager-prompt-preview.md
+++ b/.changeset/agent-manager-prompt-preview.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Show the target session and full outgoing prompt when asking permission to send a prompt through Agent Manager.

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PermissionDock.tsx
@@ -299,7 +299,13 @@ export const PermissionDock: Component<{
               when={skillShellCommands().length > 0}
               fallback={
                 <>
-                  <Show when={cmdDescription()}>{(desc) => <div data-slot="permission-hint">{desc()}</div>}</Show>
+                  <Show when={cmdDescription()}>
+                    {(desc) => (
+                      <div data-slot="permission-hint" data-wrap>
+                        {desc()}
+                      </div>
+                    )}
+                  </Show>
                   <Show when={command()}>
                     {(cmd) => <PermissionCommand command={cmd()} plain={props.request.args.heredoc === true} />}
                   </Show>

--- a/packages/kilo-vscode/webview-ui/src/styles/permission-dock.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/permission-dock.css
@@ -131,6 +131,7 @@
     font-size: var(--kilo-font-size-12);
 
     &[data-wrap] {
+      white-space: pre-wrap;
       overflow-wrap: anywhere;
       word-break: normal;
     }

--- a/packages/opencode/src/kilocode/tool/agent-manager.ts
+++ b/packages/opencode/src/kilocode/tool/agent-manager.ts
@@ -281,18 +281,23 @@ export const AgentManagerTool = Tool.define<
               }
             }
             if (params.action === "prompt") {
+              const prompt = params.prompt.trim()
               yield* ctx.ask({
                 permission: "agent_manager",
                 patterns: ["prompt"],
                 always: ["prompt"],
-                metadata: { action: "prompt", sessionID: params.sessionID },
+                metadata: {
+                  action: "prompt",
+                  sessionID: params.sessionID,
+                  description: `Send a prompt to Agent Manager session ${params.sessionID}:\n\n${prompt}`,
+                },
               })
               const result = yield* run(
                 host.request({
                   operation: "prompt",
                   sessionID: ctx.sessionID,
                   targetSessionID: params.sessionID,
-                  prompt: params.prompt.trim(),
+                  prompt,
                 }),
                 ctx.abort,
               )

--- a/packages/opencode/test/kilocode/agent-manager-tool.test.ts
+++ b/packages/opencode/test/kilocode/agent-manager-tool.test.ts
@@ -501,7 +501,12 @@ describe("agent_manager tool", () => {
     await rt.dispose()
   })
 
-  test("prompts one existing session with a separate mutation permission pattern", async () => {
+  test.each([
+    { name: "single-line", prompt: "Continue the fix" },
+    { name: "multiline", prompt: 'Review <script>alert("test")</script>.\n\n  Keep `code` and **markup** literal.' },
+    { name: "long", prompt: "Review the next file.\n".repeat(500) + "Report the final result." },
+  ])("previews the full $name prompt before sending it to one session", async (item) => {
+    const prompt = item.prompt
     const requests: unknown[] = []
     const rt = makeRuntime("test", {
       request: (input) =>
@@ -519,8 +524,15 @@ describe("agent_manager tool", () => {
     const result = await rt.runPromise(
       provideTmpdirInstance(() =>
         tool.execute(
-          { action: "prompt", sessionID: SessionID.make("ses_target"), prompt: "  Continue the fix  " },
-          { ...ctx, ask: (input: unknown) => Effect.sync(() => permissions.push(input)) },
+          { action: "prompt", sessionID: SessionID.make("ses_target"), prompt: `  ${prompt}\n ` },
+          {
+            ...ctx,
+            ask: (input: unknown) =>
+              Effect.sync(() => {
+                expect(requests).toEqual([])
+                permissions.push(input)
+              }),
+          },
         ),
       ).pipe(Effect.scoped),
     )
@@ -530,7 +542,11 @@ describe("agent_manager tool", () => {
         permission: "agent_manager",
         patterns: ["prompt"],
         always: ["prompt"],
-        metadata: { action: "prompt", sessionID: "ses_target" },
+        metadata: {
+          action: "prompt",
+          sessionID: "ses_target",
+          description: `Send a prompt to Agent Manager session ses_target:\n\n${prompt}`,
+        },
       },
     ])
     expect(requests).toEqual([
@@ -538,7 +554,7 @@ describe("agent_manager tool", () => {
         operation: "prompt",
         sessionID: ctx.sessionID,
         targetSessionID: "ses_target",
-        prompt: "Continue the fix",
+        prompt,
       },
     ])
     expect(result.title).toBe("Prompt accepted")


### PR DESCRIPTION
## What Problem This Solves

Agent Manager prompt approval showed the action but not the message being sent. The permission dialog now shows the target session and the complete outgoing prompt before approval.

## Why This Change Was Made

Reuse the existing permission description and scroll area instead of adding a new renderer or transport contract. The preview and outgoing request use the same trimmed prompt. The `prompt` permission pattern, auto-approval rules, and approval-before-send order remain unchanged.

## User Impact

Multiline prompts retain line breaks and indentation. Long prompts wrap and scroll while **Allow once** and **Deny** remain visible. Prompt markup is displayed as literal text. Older requests without a description retain their existing fallback.

## Evidence

- 47 CLI tests and 151 focused extension tests passed, including short, multiline, and long prompts, exact outgoing text, and permission-before-send ordering.
- CLI typecheck, extension compile (host/webview typechecks and lint), formatting, and relevant guards passed. Targeted CLI lint reported seven existing warnings and no errors.
- Verified the real permission UI in isolated VS Code with synthetic requests: multiline text, literal HTML/Markdown, a 200-line prompt, a long unbroken word, visible approval buttons, and the legacy fallback. No prompts were sent to live agents during UI verification.

Multiline preview:

<img width="400" alt="Agent Manager permission showing the target session and multiline outgoing prompt" src="https://marius-kilocode.github.io/pr-assets/20260903-agent-prompt-permission-multiline-0842.png" />

Scrolled to the end of a long prompt, with both approval actions still visible:

<img width="400" alt="Long outgoing prompt scrolled to its final line with Allow once and Deny visible" src="https://marius-kilocode.github.io/pr-assets/20260903-agent-prompt-permission-scroll-0842.png" />
