### PR TITLE
feat(agent-manager): update worktrees from their saved base

### DIFF
--- a/.changeset/agent-manager-update-from-base.md
+++ b/.changeset/agent-manager-update-from-base.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Ask the worktree agent to update from its saved base branch with `/update-from-base`, the worktree menu, or Command Palette, without stashing or discarding uncommitted work.

--- a/packages/kilo-docs/pages/automate/agent-manager.md
+++ b/packages/kilo-docs/pages/automate/agent-manager.md
@@ -55,6 +55,14 @@ See [Authentication](/docs/getting-started/setup-authentication), [AI Providers]
 
 Each Agent Manager session runs in an isolated git worktree on a separate branch, keeping your main branch clean.
 
+### Update from the base branch
+
+In a managed worktree's chat, type `/update-from-base` and select the action to ask its agent to fetch and merge the saved base branch. The worktree's right-click menu and **Agent Manager: Update from base** in the Command Palette run the same action.
+
+The saved base stays the same if you switch branches in Local or change the project's default base. For example, a worktree created from `main` still updates from `main` when Local has `release` checked out. If you switch branches inside the managed worktree, the agent updates that worktree's current branch, not its original branch. Select the intended worktree before running the command; it does not update Local.
+
+The agent uses the recorded remote, or the saved base branch's upstream if no remote was recorded. It asks for a source if the base is local-only or unavailable. The request prohibits stashing, discarding uncommitted work, and pushing. Existing merge or rebase operations and blocking dirty changes require your input. Normal tool approvals still apply.
+
 ### Worktree Location
 
 Managed worktrees are created under `.kilo/worktrees/` in your project. Kilo also stores Agent Manager UI state in `.kilo/agent-manager.json`.

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -321,6 +321,12 @@
         "category": "Kilo Code"
       },
       {
+        "command": "kilo-code.new.agentManager.updateFromBase",
+        "title": "Agent Manager: Update from base",
+        "category": "Kilo Code",
+        "enablement": "activeWebviewPanelId == 'kilo-code.new.AgentManagerPanel'"
+      },
+      {
         "command": "kilo-code.new.agentManager.openPR",
         "title": "Agent Manager: Open Pull Request",
         "category": "Kilo Code"

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -22,6 +22,7 @@ import {
   type LifecycleHost,
 } from "./provider-lifecycle"
 import { normalizeBaseBranch } from "./base-branch"
+import { handleBaseUpdate } from "./base-update"
 import { GitStatsPoller, type LocalStats, type WorktreePresenceResult, type WorktreeStats } from "./GitStatsPoller"
 import { PRStatusBridge } from "./pr-status-bridge"
 import { createPollers, type ProjectPollers } from "./project/pollers"
@@ -517,6 +518,7 @@ export class AgentManagerProvider implements Disposable {
       }
     }
     this.onBranchPrompt(m)
+    if (m.type === "agentManager.updateFromBase") return handleBaseUpdate(m, ctx, this.lifecycleHost)
 
     const worktree = await this.onWorktreeMessage(m)
     if (worktree !== undefined) return worktree
@@ -1632,9 +1634,7 @@ export class AgentManagerProvider implements Disposable {
 
   /** Open a worktree directory directly in VS Code. */
   private openWorktreeDirectory(worktreeId: string): void {
-    const state = this.getStateManager()
-    if (!state) return
-    const worktree = state.getWorktree(worktreeId)
+    const worktree = this.getStateManager()?.getWorktree(worktreeId)
     if (!worktree) return
     const target = path.normalize(worktree.path)
     if (!fs.existsSync(target)) {

--- a/packages/kilo-vscode/src/agent-manager/base-update.ts
+++ b/packages/kilo-vscode/src/agent-manager/base-update.ts
@@ -1,0 +1,101 @@
+import { randomUUID } from "crypto"
+import type { ProjectContext } from "./project/context"
+import type { LifecycleHost } from "./provider-lifecycle"
+import type { Worktree } from "./WorktreeStateManager"
+import { prompt } from "./orchestration-domain"
+import { startSession } from "./mcp-warmup"
+import { PLATFORM } from "./constants"
+
+import type { BaseUpdateRequest } from "../../webview-ui/src/types/messages/agent-manager"
+
+type Host = Pick<LifecycleHost, "client" | "metadata" | "register" | "sessions" | "push" | "notify" | "log">
+const pending = new WeakSet<Worktree>()
+
+export function baseUpdatePrompt(worktree: Worktree): string {
+  return [
+    `Update the current branch in worktree ${JSON.stringify(worktree.path)} from its saved base branch ${JSON.stringify(worktree.parentBranch)}. Do not use today's project default or the worktree's own upstream.`,
+    worktree.remote
+      ? `Use the recorded remote ${JSON.stringify(worktree.remote)} and exact base ref ${JSON.stringify(`refs/heads/${worktree.parentBranch}`)}.`
+      : `Resolve the upstream of the saved base branch ${JSON.stringify(worktree.parentBranch)} to its remote and exact branch ref. If the base is local-only or cannot be resolved, stop and ask me which source to use. Do not guess a remote or silently use a local branch.`,
+    "Check the worktree's current branch and Git status first. Do not switch branches. If HEAD is detached or a merge or rebase is already in progress, stop and ask rather than starting a competing operation.",
+    "Fetch the exact remote base, then resolve FETCH_HEAD^{commit} and merge that freshly fetched commit ID. If fetch or ref resolution fails, stop. Never merge a stale tracking ref, switch sources silently, or use git pull.",
+    "Never use git stash, --autostash, or automatic stashing. Disable merge.autoStash for the merge. Do not discard, overwrite, stage, or commit pre-existing edits. If uncommitted changes in this worktree block the merge, stop and ask how to preserve them.",
+    "Resolve conflicts while preserving both branches' intent. If the intended resolution is unclear, stop and ask. Then run relevant tests, lint, and type checks. Keep normal tool permissions and approvals. Do not push, merge a PR, or apply this worktree into the base.",
+  ].join("\n\n")
+}
+
+export async function handleBaseUpdate(msg: BaseUpdateRequest, ctx: ProjectContext, host: Host): Promise<null> {
+  const state = ctx.peekState()
+  const worktree = state?.getWorktree(msg.worktreeId)
+  if (!state || !worktree || (msg.projectId && msg.projectId !== ctx.id)) {
+    host.notify("Select an available managed worktree to update from base.")
+    return null
+  }
+  if (pending.has(worktree)) return null
+  pending.add(worktree)
+  try {
+    const generation = ctx.generation
+    const client = host.client()
+    const target = await (async () => {
+      const statuses = await client.session.status({ directory: worktree.path }, { throwOnError: true })
+      const sessions = state.getSessions(worktree.id)
+      const selected = msg.sessionId ? state.getSession(msg.sessionId) : undefined
+      if (msg.sessionId && selected?.worktreeId !== worktree.id)
+        throw new Error("The target session changed worktrees.")
+      const busy = Object.entries(statuses.data)
+        .filter(([, status]) => status.type !== "idle")
+        .map(([id]) => id)
+      const id = selected?.id ?? sessions.find((session) => busy.includes(session.id))?.id ?? sessions.at(0)?.id
+      if (busy.some((item) => item !== id))
+        throw new Error("Another session in this worktree is busy. Wait for it to finish.")
+      return id
+    })()
+    const current = () => {
+      if (!ctx.isCurrent(generation) || state.getWorktree(worktree.id) !== worktree)
+        throw new Error("The worktree is no longer available.")
+    }
+    current()
+    const id =
+      target ??
+      (await (async () => {
+        const metadata = await host.metadata(client, worktree.path)
+        const { data } = await startSession(
+          client,
+          worktree.path,
+          () => {
+            current()
+            if (state.getSessions(worktree.id).length)
+              throw new Error("A session was added. Try Update from base again.")
+            return client.session.create(
+              { directory: worktree.path, platform: PLATFORM, metadata },
+              { throwOnError: true },
+            )
+          },
+          host.log,
+        )
+        current()
+        state.addSession(data.id, worktree.id)
+        host.register(data.id, worktree.path)
+        ctx.invalidateSessions()
+        host.push()
+        return data.id
+      })())
+    current()
+    if (state.getSession(id)?.worktreeId !== worktree.id) throw new Error("The target session changed worktrees.")
+    host.sessions.registerSessionRoute?.({ projectId: ctx.id, sessionId: id }, worktree.path, generation)
+    await prompt({
+      client,
+      root: ctx.root,
+      state,
+      sessionID: id,
+      text: baseUpdatePrompt(worktree),
+      messageID: randomUUID(),
+    })
+  } catch (err) {
+    host.log("Update from base failed:", err)
+    host.notify(err instanceof Error ? err.message : String(err))
+  } finally {
+    pending.delete(worktree)
+  }
+  return null
+}

--- a/packages/kilo-vscode/src/agent-manager/base-update.ts
+++ b/packages/kilo-vscode/src/agent-manager/base-update.ts
@@ -42,9 +42,9 @@ export async function handleBaseUpdate(msg: BaseUpdateRequest, ctx: ProjectConte
       const selected = msg.sessionId ? state.getSession(msg.sessionId) : undefined
       if (msg.sessionId && selected?.worktreeId !== worktree.id)
         throw new Error("The target session changed worktrees.")
-      const busy = Object.entries(statuses.data)
-        .filter(([, status]) => status.type !== "idle")
-        .map(([id]) => id)
+      const busy = sessions
+        .filter((session) => (statuses.data[session.id]?.type ?? "idle") !== "idle")
+        .map((session) => session.id)
       const id = selected?.id ?? sessions.find((session) => busy.includes(session.id))?.id ?? sessions.at(0)?.id
       if (busy.some((item) => item !== id))
         throw new Error("Another session in this worktree is busy. Wait for it to finish.")

--- a/packages/kilo-vscode/src/agent-manager/project/state-gate.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/state-gate.ts
@@ -4,6 +4,7 @@
  */
 export const STATE_GATED = new Set<string>([
   "agentManager.createWorktree",
+  "agentManager.updateFromBase",
   "agentManager.promoteSession",
   "agentManager.createMultiVersion",
   "agentManager.deleteWorktree",

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -1154,6 +1154,7 @@ interface BrowserRequestIn {
 
 /** All messages the Agent Manager expects from the webview (onMessage input). */
 export type AgentManagerInMessage =
+  | import("../../webview-ui/src/types/messages/agent-manager").BaseUpdateRequest
   | CreateWorktreeIn
   | RequestProjectsIn
   | AddProjectIn

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -565,6 +565,9 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("kilo-code.new.agentManager.openWorktree", () => {
       agentManagerProvider.postMessage({ type: "action", action: "openWorktree" })
     }),
+    vscode.commands.registerCommand("kilo-code.new.agentManager.updateFromBase", () => {
+      agentManagerProvider.postMessage({ type: "action", action: "updateFromBase" })
+    }),
     vscode.commands.registerCommand("kilo-code.new.agentManager.openPR", () => {
       agentManagerProvider.postMessage({ type: "action", action: "openPR" })
     }),

--- a/packages/kilo-vscode/tests/unit/base-update.test.ts
+++ b/packages/kilo-vscode/tests/unit/base-update.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, expect, it } from "bun:test"
+import { mkdtempSync, mkdirSync, realpathSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { execFileSync } from "node:child_process"
+import { createKiloClient } from "@kilocode/sdk/v2/client"
+import { ProjectContext } from "../../src/agent-manager/project/context"
+import { baseUpdatePrompt, handleBaseUpdate } from "../../src/agent-manager/base-update"
+import type { BaseUpdateRequest } from "../../webview-ui/src/types/messages/agent-manager"
+
+const command = (cwd: string, ...args: string[]) =>
+  execFileSync("git", args, { cwd, encoding: "utf8", windowsHide: true }).trim()
+const servers: Array<{ stop(force: boolean): void }> = []
+let root: string
+let ctx: ProjectContext
+let wt: ReturnType<ReturnType<ProjectContext["stateManager"]>["addWorktree"]>
+
+beforeEach(() => {
+  root = realpathSync(mkdtempSync(join(tmpdir(), "base-update-")))
+  command(root, "init", "-q", "-b", "release")
+  command(
+    root,
+    "-c",
+    "user.name=Fixture",
+    "-c",
+    "user.email=fixture@example.test",
+    "commit",
+    "-qm",
+    "base",
+    "--allow-empty",
+  )
+  command(root, "worktree", "add", "-q", "-b", "feature", join(root, "worktree"), "release")
+  mkdirSync(join(root, ".kilo"))
+  ctx = new ProjectContext("owner", root, true, { log: () => undefined })
+  wt = ctx.stateManager().addWorktree({ branch: "feature", path: join(root, "worktree"), parentBranch: "release" })
+})
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) server.stop(true)
+  await ctx.stateManager().flush()
+  rmSync(root, { recursive: true, force: true })
+})
+
+function backend() {
+  const requests: Array<{ path: string; directory: string | null; body?: unknown }> = []
+  const errors: string[] = []
+  const routes: unknown[] = []
+  const statuses: Record<string, { type: string }> = {}
+  const permissions: unknown[] = []
+  const server = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url)
+      const directory = url.searchParams.get("directory")
+      const body = request.method === "POST" ? await request.json() : undefined
+      requests.push({ path: url.pathname, directory, body })
+      if (url.pathname === "/session/status") return Response.json(statuses)
+      if (url.pathname === "/permission") return Response.json(permissions)
+      if (url.pathname === "/question") return Response.json([])
+      if (url.pathname === "/mcp") return Response.json({})
+      if (url.pathname.endsWith("/prompt_async")) return new Response(null, { status: 204 })
+      return Response.json({ id: "ses_target", title: "Target", directory, time: { created: 1, updated: 1 } })
+    },
+  })
+  servers.push(server)
+  const client = createKiloClient({ baseUrl: server.url.href })
+  const host: Parameters<typeof handleBaseUpdate>[2] = {
+    client: () => client,
+    metadata: async () => ({}),
+    notify: (msg) => errors.push(msg),
+    register: (id, directory) => routes.push({ id, directory }),
+    push: () => undefined,
+    log: () => undefined,
+    sessions: {
+      register: () => {
+        throw new Error("Must not replace the active session or draft")
+      },
+      setSessionDirectory: () => {
+        throw new Error("Must not reset the current session")
+      },
+      registerSessionRoute: (ref, directory, generation) => routes.push({ ref, directory, generation }),
+      clearDirectory: () => undefined,
+      directories: () => undefined,
+      abort: async () => undefined,
+      forget: () => undefined,
+    },
+  }
+  const request: BaseUpdateRequest = { type: "agentManager.updateFromBase", projectId: ctx.id, worktreeId: wt.id }
+  return { requests, errors, routes, statuses, permissions, host, request }
+}
+
+it("uses the saved base and remote, not the current default or cleanup branch", () => {
+  ctx.stateManager().setDefaultBaseBranch("other")
+  wt.originalBranch = "cleanup-only"
+  wt.remote = "upstream"
+  const text = baseUpdatePrompt(wt)
+  expect(text).toContain('saved base branch "release"')
+  expect(text).toContain('recorded remote "upstream"')
+  expect(text).toContain('"refs/heads/release"')
+  expect(text).not.toContain("cleanup-only")
+  expect(text).not.toContain('"other"')
+})
+
+it("asks the agent to resolve the saved base upstream and stop for local-only or unavailable sources", () => {
+  const text = baseUpdatePrompt(wt)
+  expect(text).toContain('upstream of the saved base branch "release"')
+  expect(text).toContain("local-only or cannot be resolved, stop and ask")
+  expect(text).toContain("If fetch or ref resolution fails, stop")
+  expect(text).toContain("Never merge a stale tracking ref")
+  for (const safeguard of [
+    "FETCH_HEAD^{commit}",
+    "git stash, --autostash",
+    "merge.autoStash",
+    "Do not discard",
+    "stage, or commit pre-existing edits",
+    "uncommitted changes in this worktree block",
+    "intended resolution is unclear, stop and ask",
+    "merge or rebase is already in progress",
+    "HEAD is detached",
+    "both branches' intent",
+    "tests, lint, and type checks",
+    "normal tool permissions",
+    "Do not push",
+  ])
+    expect(text).toContain(safeguard)
+})
+
+it("sends one prompt to the owning worktree, queues on its busy session, and leaves drafts alone", async () => {
+  const api = backend()
+  ctx.stateManager().addSession("ses_target", wt.id)
+  api.statuses.ses_target = { type: "busy" }
+  const head = command(wt.path, "rev-parse", "HEAD")
+  await Bun.write(join(wt.path, "draft.txt"), "uncommitted work")
+  const status = command(wt.path, "status", "--porcelain")
+  await handleBaseUpdate(api.request, ctx, api.host)
+  expect(api.errors).toEqual([])
+  expect(api.requests.every((item) => item.directory === wt.path)).toBe(true)
+  expect(api.requests.filter((item) => item.path.endsWith("/prompt_async"))).toHaveLength(1)
+  expect(api.requests.some((item) => item.path === "/session")).toBe(false)
+  expect(api.routes).toContainEqual({
+    ref: { projectId: "owner", sessionId: "ses_target" },
+    directory: wt.path,
+    generation: ctx.generation,
+  })
+  expect(command(wt.path, "rev-parse", "HEAD")).toBe(head)
+  expect(command(wt.path, "status", "--porcelain")).toBe(status)
+})
+
+it.each([
+  { base: "main", local: "main", current: "feature", remote: "origin" },
+  { base: "main", local: "release", current: "feature", remote: "upstream" },
+  { base: "release", local: "main", current: "feature", remote: undefined },
+  { base: "main", local: "release", current: "another-feature", remote: "upstream" },
+])(
+  "keeps saved base $base when Local is $local and the worktree is $current",
+  async ({ base, local, current, remote }) => {
+    command(root, "branch", "main")
+    command(root, "checkout", "-q", local)
+    if (current !== "feature") command(wt.path, "checkout", "-qb", current)
+    wt.parentBranch = base
+    wt.remote = remote
+    ctx.stateManager().setDefaultBaseBranch("unrelated-default")
+    ctx.stateManager().addSession("ses_target", wt.id)
+    const api = backend()
+    await handleBaseUpdate(api.request, ctx, api.host)
+    expect(api.errors).toEqual([])
+    const sent = api.requests.find((item) => item.path.endsWith("/prompt_async"))
+    const text = (sent?.body as { parts: Array<{ text: string }> }).parts.at(0)?.text
+    expect(sent?.directory).toBe(wt.path)
+    expect(text).toContain(`saved base branch "${base}"`)
+    expect(text).toContain("worktree's current branch")
+    expect(text).toContain("Do not switch branches")
+    expect(text).not.toContain("unrelated-default")
+    expect(command(root, "branch", "--show-current")).toBe(local)
+    expect(command(wt.path, "branch", "--show-current")).toBe(current)
+  },
+)
+
+it("keeps the requested worktree when a different worktree is selected", async () => {
+  const path = join(root, "other")
+  command(root, "worktree", "add", "-q", "-b", "other", path)
+  const state = ctx.stateManager()
+  const other = state.addWorktree({ branch: "other", path, parentBranch: "other-base" })
+  state.addSession("ses_other", other.id)
+  state.addSession("ses_target", wt.id)
+  state.setActiveTarget({ kind: "worktree", projectId: ctx.id, worktreeId: other.id })
+  const api = backend()
+  await handleBaseUpdate(api.request, ctx, api.host)
+  expect(api.errors).toEqual([])
+  expect(api.requests.every((item) => item.directory === wt.path)).toBe(true)
+  expect(api.requests.some((item) => item.path === "/session/ses_target/prompt_async")).toBe(true)
+  expect(api.requests.some((item) => item.path.includes("ses_other"))).toBe(false)
+})
+
+it("creates a session in the target worktree without replacing the user's active draft", async () => {
+  const api = backend()
+  await handleBaseUpdate(api.request, ctx, api.host)
+  expect(api.errors).toEqual([])
+  expect(ctx.stateManager().getSession("ses_target")?.worktreeId).toBe(wt.id)
+  expect(api.requests.filter((item) => item.path === "/session")).toHaveLength(1)
+  expect(api.requests.filter((item) => item.path.endsWith("/prompt_async"))).toHaveLength(1)
+})
+
+it("rejects wrong ownership, competing sessions, and pending permissions", async () => {
+  const api = backend()
+  ctx.stateManager().addSession("ses_local", null)
+  ctx.stateManager().addSession("ses_target", wt.id)
+  await handleBaseUpdate({ ...api.request, projectId: "other" }, ctx, api.host)
+  await handleBaseUpdate({ ...api.request, sessionId: "ses_local" }, ctx, api.host)
+  api.statuses.ses_other = { type: "busy" }
+  await handleBaseUpdate(api.request, ctx, api.host)
+  delete api.statuses.ses_other
+  api.permissions.push({ id: "perm", sessionID: "ses_target" })
+  await handleBaseUpdate(api.request, ctx, api.host)
+  expect(api.errors).toHaveLength(4)
+  expect(api.errors.at(-1)).toContain("pending permission")
+  expect(api.requests.some((item) => item.body)).toBe(false)
+})

--- a/packages/kilo-vscode/tests/unit/base-update.test.ts
+++ b/packages/kilo-vscode/tests/unit/base-update.test.ts
@@ -129,6 +129,7 @@ it("sends one prompt to the owning worktree, queues on its busy session, and lea
   const api = backend()
   ctx.stateManager().addSession("ses_target", wt.id)
   api.statuses.ses_target = { type: "busy" }
+  api.statuses.ses_child = { type: "busy" }
   const head = command(wt.path, "rev-parse", "HEAD")
   await Bun.write(join(wt.path, "draft.txt"), "uncommitted work")
   const status = command(wt.path, "status", "--porcelain")
@@ -185,6 +186,7 @@ it("keeps the requested worktree when a different worktree is selected", async (
   state.addSession("ses_target", wt.id)
   state.setActiveTarget({ kind: "worktree", projectId: ctx.id, worktreeId: other.id })
   const api = backend()
+  api.statuses.ses_other = { type: "busy" }
   await handleBaseUpdate(api.request, ctx, api.host)
   expect(api.errors).toEqual([])
   expect(api.requests.every((item) => item.directory === wt.path)).toBe(true)
@@ -207,8 +209,9 @@ it("rejects wrong ownership, competing sessions, and pending permissions", async
   ctx.stateManager().addSession("ses_target", wt.id)
   await handleBaseUpdate({ ...api.request, projectId: "other" }, ctx, api.host)
   await handleBaseUpdate({ ...api.request, sessionId: "ses_local" }, ctx, api.host)
+  ctx.stateManager().addSession("ses_other", wt.id)
   api.statuses.ses_other = { type: "busy" }
-  await handleBaseUpdate(api.request, ctx, api.host)
+  await handleBaseUpdate({ ...api.request, sessionId: "ses_target" }, ctx, api.host)
   delete api.statuses.ses_other
   api.permissions.push({ id: "perm", sessionID: "ses_target" })
   await handleBaseUpdate(api.request, ctx, api.host)

--- a/packages/kilo-vscode/tests/unit/use-slash-command.test.ts
+++ b/packages/kilo-vscode/tests/unit/use-slash-command.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
-import { useSlashCommand } from "../../webview-ui/src/hooks/useSlashCommand"
+import { useSlashCommand, type SlashCommandEntry } from "../../webview-ui/src/hooks/useSlashCommand"
 import type { ExtensionMessage, WebviewMessage } from "../../webview-ui/src/types/messages"
 
 function setup(
   sandbox: () => void,
-  options: { enabled?: () => boolean; exclude?: () => Set<string>; include?: Set<string> } = {},
+  options: {
+    enabled?: () => boolean
+    exclude?: () => Set<string>
+    include?: Set<string>
+    extra?: SlashCommandEntry[]
+  } = {},
 ) {
   const sent: WebviewMessage[] = []
   const handlers = new Set<(message: ExtensionMessage) => void>()
@@ -22,6 +27,8 @@ function setup(
       { action: sandbox, enabled: options.enabled ?? (() => true) },
       options.exclude,
       options.include,
+      undefined,
+      options.extra,
     ),
   }))
   const fire = (message: ExtensionMessage) => {
@@ -29,6 +36,71 @@ function setup(
   }
   return { ...root, fire, sent }
 }
+
+describe("worktree update slash action", () => {
+  it("uses the current worktree selection and preserves text after the action", () => {
+    const state = { selected: "first", sent: "", text: "/update-from-base keep this draft" }
+    const ctx = setup(() => {}, {
+      extra: [
+        {
+          name: "update-from-base",
+          hints: [],
+          action: () => {
+            state.sent = state.selected
+          },
+        },
+      ],
+    })
+    const textarea = {
+      value: state.text,
+      setSelectionRange: () => {},
+    } as unknown as HTMLTextAreaElement
+    ctx.slash.onInput(state.text, "/update-from-base".length)
+    state.selected = "second"
+    const entry = ctx.slash.results().find((item) => item.name === "update-from-base")!
+    ctx.slash.select(entry, textarea, (text) => {
+      state.text = text
+    })
+    expect(state.sent).toBe("second")
+    expect(state.text).toBe(" keep this draft")
+    expect(ctx.sent).toEqual([{ type: "requestCommands" }])
+    ctx.dispose()
+  })
+
+  it("keeps the draft when a worktree action becomes unavailable", () => {
+    const state = { text: "/update-from-base", sent: false }
+    const ctx = setup(() => {}, {
+      extra: [
+        {
+          name: "update-from-base",
+          hints: [],
+          enabled: () => false,
+          action: () => {
+            state.sent = true
+          },
+        },
+      ],
+    })
+    const textarea = { value: state.text } as HTMLTextAreaElement
+    ctx.slash.onInput(state.text, state.text.length)
+    ctx.slash.select(ctx.slash.results()[0]!, textarea, (text) => {
+      state.text = text
+    })
+    expect(state.sent).toBe(false)
+    expect(state.text).toBe("/update-from-base")
+    ctx.dispose()
+  })
+
+  it("hides the worktree action in Local and other prompt surfaces", () => {
+    const ctx = setup(() => {}, {
+      extra: [{ name: "update-from-base", hints: [], action: () => {} }],
+      exclude: () => new Set(["update-from-base"]),
+    })
+    ctx.slash.onInput("/update-from-base", 17)
+    expect(ctx.slash.results()).toEqual([])
+    ctx.dispose()
+  })
+})
 
 describe("useSlashCommand sandbox action", () => {
   it("supports the singular model alias", () => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -74,6 +74,7 @@ import { ProviderShell } from "../src/context/provider-shell"
 import { ChatView } from "../src/components/chat"
 import HistoryView from "../src/components/history/HistoryView"
 import { NewWorktreeDialog } from "./NewWorktreeDialog"
+import { useBaseUpdate } from "./update-from-base"
 import { createModeRouter } from "./mode-router"
 import { ProjectList } from "./ProjectList"
 import { SidebarBody } from "./SidebarBody"
@@ -239,6 +240,13 @@ const AgentManagerContent: Component = () => {
   const session = useSession()
   const vscode = useVSCode()
   const dialog = useDialog()
+  const updateBase = useBaseUpdate()
+  const update = () =>
+    updateBase(
+      selection(),
+      activeProjectId(),
+      managedSessions().find((item) => item.worktreeId === selection() && item.id === session.currentSessionID())?.id,
+    )
   const mode = createModeRouter()
   let sidebarSearchMenu: SidebarSearchMenuRef | undefined
   const [kb, setKb] = createSignal<Record<string, string>>(defaultBindings)
@@ -1214,6 +1222,7 @@ const AgentManagerContent: Component = () => {
       else if (msg.action === "newWorktree") showNewWorktreeDialog()
       else if (msg.action === "quickWorktree") handleCreateWorktree()
       else if (msg.action === "openWorktree") openWorktreeDirectory()
+      else if (msg.action === "updateFromBase") update()
       else if (msg.action === "openPR") openSelectedPR()
       else if (msg.action === "runScript") runSelected()
       else if (msg.action === "advancedWorktree") showNewWorktreeDialog()
@@ -2540,6 +2549,7 @@ const AgentManagerContent: Component = () => {
                     readonly={readOnly()}
                     continueInWorktree={selection() === LOCAL}
                     worktree={worktrees().some((wt) => wt.id === selection())}
+                    onUpdateBase={update}
                     promptBoxId={`agent-manager:${selection() ?? "unassigned"}`}
                     terminalContext={() => selection() ?? undefined}
                     deferFocusToQuestion={hasQuestionOption}

--- a/packages/kilo-vscode/webview-ui/agent-manager/ProjectSidebarBody.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ProjectSidebarBody.tsx
@@ -24,6 +24,7 @@ import { useVSCode } from "../src/context/vscode"
 import SectionHeader from "./SectionHeader"
 import { SidebarSectionHeader } from "./SidebarSectionHeader"
 import { WorktreeItem } from "./WorktreeItem"
+import { useBaseUpdate } from "./update-from-base"
 import { ProjectActions } from "./ProjectActions"
 import { StatsSkeleton, WorktreeSkeleton } from "./Skeleton"
 import { applyTabOrder, firstOrderedTitle, reorderTabs } from "./tab-order"
@@ -62,6 +63,7 @@ interface Props {
 /** Permanent real sidebar body for one expanded project. */
 export const ProjectSidebarBody: Component<Props> = (props) => {
   const vscode = useVSCode()
+  const updateBase = useBaseUpdate()
   const store = props.store ?? createProjectStore(props.project.id)
   if (!props.store) {
     createEffect(() => {
@@ -279,6 +281,15 @@ export const ProjectSidebarBody: Component<Props> = (props) => {
           onCommitRename={() => commitRename(worktree.id)}
           onCancelRename={cancelRename}
           onRemoveStale={() => post({ type: "agentManager.removeStaleWorktree", worktreeId: worktree.id })}
+          onUpdateBase={() =>
+            updateBase(
+              worktree.id,
+              props.project.id,
+              state()?.sessions.find(
+                (item) => item.worktreeId === worktree.id && item.id === props.currentSessionID?.(),
+              )?.id,
+            )
+          }
           onCopyPath={() => navigator.clipboard.writeText(worktree.path)}
           onOpen={() => post({ type: "agentManager.openWorktree", worktreeId: worktree.id })}
           onOpenPR={() => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/SidebarBody.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/SidebarBody.tsx
@@ -28,6 +28,7 @@ import { useVSCode } from "../src/context/vscode"
 import SectionHeader from "./SectionHeader"
 import { SidebarSectionHeader } from "./SidebarSectionHeader"
 import { WorktreeItem } from "./WorktreeItem"
+import { useBaseUpdate } from "./update-from-base"
 import { WorktreeSectionActions } from "./WorktreeSectionActions"
 import { StatsSkeleton, WorktreeSkeleton } from "./Skeleton"
 import type { SidebarSearchMenuRef } from "./SidebarSearchMenu"
@@ -96,6 +97,7 @@ export interface SidebarBodyProps {
 /** Legacy single-project sidebar body: local repo, worktrees, unassigned sessions. */
 export const SidebarBody: Component<SidebarBodyProps> = (props) => {
   const vscode = useVSCode()
+  const updateBase = useBaseUpdate()
   const localState = () => props.activityFor(null)
 
   return (
@@ -359,6 +361,13 @@ export const SidebarBody: Component<SidebarBodyProps> = (props) => {
                                 onCommitRename={() => commitRename(wt.id)}
                                 onCancelRename={cancelRename}
                                 onRemoveStale={() => props.confirmRemoveStaleWorktree(wt.id)}
+                                onUpdateBase={() =>
+                                  updateBase(
+                                    wt.id,
+                                    props.projectId,
+                                    wtSessions().find((item) => item.id === props.currentSessionID())?.id,
+                                  )
+                                }
                                 onCopyPath={() => navigator.clipboard.writeText(wt.path)}
                                 onOpen={props.track("open_worktree_window", "worktree_menu", () =>
                                   vscode.postMessage({ type: "agentManager.openWorktree", worktreeId: wt.id }),

--- a/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/WorktreeItem.tsx
@@ -81,6 +81,7 @@ interface WorktreeItemProps {
   onRemoveStale: () => void
   onCopyPath: () => void
   onOpen: () => void
+  onUpdateBase?: () => void
 }
 
 const MAX_SHORTCUT = 9
@@ -556,6 +557,12 @@ export const WorktreeItem: Component<WorktreeItemProps> = (props) => {
                 </span>
               </Show>
             </ContextMenu.Item>
+            <Show when={props.onUpdateBase && !props.stale}>
+              <ContextMenu.Item onSelect={() => props.onUpdateBase?.()}>
+                <Icon name="branch" size="small" />
+                <ContextMenu.ItemLabel>{t("agentManager.updateBase.title")}</ContextMenu.ItemLabel>
+              </ContextMenu.Item>
+            </Show>
             <ContextMenu.Item onSelect={() => props.onCopyPath()}>
               <Icon name="copy" size="small" />
               <ContextMenu.ItemLabel>{t("agentManager.worktree.copyPath")}</ContextMenu.ItemLabel>

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -17,6 +17,10 @@ export const dict = {
   "agentManager.project.remove": "إزالة من Agent Manager",
   "agentManager.project.missing": "المستودع غير موجود",
   "agentManager.notGitRepo": "ليس مستودع git",
+
+  "agentManager.updateBase.title": "تحديث من الفرع الأساسي",
+  "agentManager.updateBase.selectWorktree": "اختر أولًا worktree مُدارًا.",
+
   "agentManager.worktree.settings": "إعدادات Worktree",
   "agentManager.worktree.new": "Worktree جديد",
   "agentManager.worktree.setupScript": "سكربت إعداد Worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -18,6 +18,10 @@ export const dict = {
   "agentManager.project.remove": "Remover do Agent Manager",
   "agentManager.project.missing": "Repositório não encontrado",
   "agentManager.notGitRepo": "Não é um repositório git",
+
+  "agentManager.updateBase.title": "Atualizar a partir da base",
+  "agentManager.updateBase.selectWorktree": "Selecione primeiro um worktree gerenciado.",
+
   "agentManager.worktree.settings": "Configurações do Worktree",
   "agentManager.worktree.new": "Novo Worktree",
   "agentManager.worktree.setupScript": "Script de configuração do Worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -17,6 +17,10 @@ export const dict = {
   "agentManager.project.remove": "Ukloni iz Agent Manager-a",
   "agentManager.project.missing": "Repozitorij nije pronađen",
   "agentManager.notGitRepo": "Nije git repozitorij",
+
+  "agentManager.updateBase.title": "Ažuriraj iz baze",
+  "agentManager.updateBase.selectWorktree": "Prvo odaberite worktree kojim upravlja Agent Manager.",
+
   "agentManager.worktree.settings": "Postavke Worktree-a",
   "agentManager.worktree.new": "Novi Worktree",
   "agentManager.worktree.setupScript": "Skripta za postavljanje Worktree-a",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -17,6 +17,10 @@ export const dict = {
   "agentManager.project.remove": "Fjern fra Agent Manager",
   "agentManager.project.missing": "Repository ikke fundet",
   "agentManager.notGitRepo": "Ikke et git-repository",
+
+  "agentManager.updateBase.title": "Opdater fra base",
+  "agentManager.updateBase.selectWorktree": "Vælg først et administreret worktree.",
+
   "agentManager.worktree.settings": "Worktree-indstillinger",
   "agentManager.worktree.new": "Nyt Worktree",
   "agentManager.worktree.setupScript": "Worktree-opsætningsscript",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -19,6 +19,10 @@ export const dict = {
   "agentManager.project.remove": "Aus Agent Manager entfernen",
   "agentManager.project.missing": "Repository nicht gefunden",
   "agentManager.notGitRepo": "Kein Git-Repository",
+
+  "agentManager.updateBase.title": "Von der Basis aktualisieren",
+  "agentManager.updateBase.selectWorktree": "Wählen Sie zuerst einen verwalteten Worktree aus.",
+
   "agentManager.worktree.settings": "Worktree-Einstellungen",
   "agentManager.worktree.new": "Neuer Worktree",
   "agentManager.worktree.setupScript": "Worktree-Einrichtungsskript",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -18,6 +18,9 @@ export const dict = {
   "agentManager.project.missing": "Repository not found",
   "agentManager.notGitRepo": "Not a git repository",
 
+  "agentManager.updateBase.title": "Update from base",
+  "agentManager.updateBase.selectWorktree": "Select a managed worktree first.",
+
   "agentManager.worktree.settings": "Worktree settings",
   "agentManager.worktree.new": "New Worktree",
   "agentManager.worktree.setupScript": "Worktree Setup Script",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -18,6 +18,10 @@ export const dict = {
   "agentManager.project.remove": "Eliminar de Agent Manager",
   "agentManager.project.missing": "Repositorio no encontrado",
   "agentManager.notGitRepo": "No es un repositorio git",
+
+  "agentManager.updateBase.title": "Actualizar desde la base",
+  "agentManager.updateBase.selectWorktree": "Selecciona primero un worktree gestionado.",
+
   "agentManager.worktree.settings": "Configuración de Worktree",
   "agentManager.worktree.new": "Nuevo Worktree",
   "agentManager.worktree.setupScript": "Script de configuración de Worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
@@ -19,6 +19,9 @@ export const dict = {
   "agentManager.project.missing": "مخزن یافت نشد",
   "agentManager.notGitRepo": "این یک مخزن git نیست",
 
+  "agentManager.updateBase.title": "به‌روزرسانی از پایه",
+  "agentManager.updateBase.selectWorktree": "ابتدا یک worktree تحت مدیریت انتخاب کنید.",
+
   "agentManager.worktree.settings": "تنظیمات Worktree",
   "agentManager.worktree.new": "Worktree جدید",
   "agentManager.worktree.setupScript": "اسکریپت راه‌اندازی Worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -19,6 +19,10 @@ export const dict = {
   "agentManager.project.remove": "Retirer d'Agent Manager",
   "agentManager.project.missing": "Dépôt introuvable",
   "agentManager.notGitRepo": "Ce n'est pas un dépôt git",
+
+  "agentManager.updateBase.title": "Mettre à jour depuis la base",
+  "agentManager.updateBase.selectWorktree": "Sélectionnez d'abord un worktree géré.",
+
   "agentManager.worktree.settings": "Paramètres du Worktree",
   "agentManager.worktree.new": "Nouveau Worktree",
   "agentManager.worktree.setupScript": "Script de configuration du Worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
@@ -20,6 +20,9 @@ export const dict = {
   "agentManager.project.missing": "Repository non trovata",
   "agentManager.notGitRepo": "Non è una repository git",
 
+  "agentManager.updateBase.title": "Aggiorna dalla base",
+  "agentManager.updateBase.selectWorktree": "Seleziona prima un worktree gestito.",
+
   "agentManager.worktree.settings": "Impostazioni worktree",
   "agentManager.worktree.new": "Nuovo worktree",
   "agentManager.worktree.setupScript": "Script di setup del worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -17,6 +17,10 @@ export const dict = {
   "agentManager.project.remove": "Agent Managerから削除",
   "agentManager.project.missing": "リポジトリが見つかりません",
   "agentManager.notGitRepo": "gitリポジトリではありません",
+
+  "agentManager.updateBase.title": "ベースから更新",
+  "agentManager.updateBase.selectWorktree": "最初に管理対象の worktree を選択してください。",
+
   "agentManager.worktree.settings": "Worktree設定",
   "agentManager.worktree.new": "新しいWorktree",
   "agentManager.worktree.setupScript": "Worktreeセットアップスクリプト",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -17,6 +17,10 @@ export const dict = {
   "agentManager.project.remove": "Agent Manager에서 제거",
   "agentManager.project.missing": "저장소를 찾을 수 없음",
   "agentManager.notGitRepo": "git 저장소가 아닙니다",
+
+  "agentManager.updateBase.title": "베이스에서 업데이트",
+  "agentManager.updateBase.selectWorktree": "먼저 관리 중인 worktree를 선택하세요.",
+
   "agentManager.worktree.settings": "Worktree 설정",
   "agentManager.worktree.new": "새 Worktree",
   "agentManager.worktree.setupScript": "Worktree 설정 스크립트",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
@@ -19,6 +19,9 @@ export const dict = {
   "agentManager.project.missing": "Repository niet gevonden",
   "agentManager.notGitRepo": "Geen git repository",
 
+  "agentManager.updateBase.title": "Bijwerken vanuit de basis",
+  "agentManager.updateBase.selectWorktree": "Selecteer eerst een beheerde worktree.",
+
   "agentManager.worktree.settings": "Worktree instellingen",
   "agentManager.worktree.new": "Nieuwe worktree",
   "agentManager.worktree.setupScript": "Worktree setup script",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -17,6 +17,10 @@ export const dict = {
   "agentManager.project.remove": "Fjern fra Agent Manager",
   "agentManager.project.missing": "Repository ikke funnet",
   "agentManager.notGitRepo": "Ikke et git-repositorium",
+
+  "agentManager.updateBase.title": "Oppdater fra base",
+  "agentManager.updateBase.selectWorktree": "Velg først et administrert worktree.",
+
   "agentManager.worktree.settings": "Worktree-innstillinger",
   "agentManager.worktree.new": "Nytt Worktree",
   "agentManager.worktree.setupScript": "Worktree-oppsettskript",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -17,6 +17,10 @@ export const dict = {
   "agentManager.project.remove": "Usuń z Agent Manager",
   "agentManager.project.missing": "Nie znaleziono repozytorium",
   "agentManager.notGitRepo": "Nie jest repozytorium git",
+
+  "agentManager.updateBase.title": "Aktualizuj z bazy",
+  "agentManager.updateBase.selectWorktree": "Najpierw wybierz zarządzany worktree.",
+
   "agentManager.worktree.settings": "Ustawienia Worktree",
   "agentManager.worktree.new": "Nowy Worktree",
   "agentManager.worktree.setupScript": "Skrypt konfiguracji Worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -18,6 +18,10 @@ export const dict = {
   "agentManager.project.remove": "Удалить из Agent Manager",
   "agentManager.project.missing": "Репозиторий не найден",
   "agentManager.notGitRepo": "Не является git-репозиторием",
+
+  "agentManager.updateBase.title": "Обновить из базовой ветки",
+  "agentManager.updateBase.selectWorktree": "Сначала выберите управляемый worktree.",
+
   "agentManager.worktree.settings": "Настройки Worktree",
   "agentManager.worktree.new": "Новый Worktree",
   "agentManager.worktree.setupScript": "Скрипт настройки Worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -17,6 +17,10 @@ export const dict = {
   "agentManager.project.remove": "ลบออกจาก Agent Manager",
   "agentManager.project.missing": "ไม่พบ Repository",
   "agentManager.notGitRepo": "ไม่ใช่ git repository",
+
+  "agentManager.updateBase.title": "อัปเดตจากฐาน",
+  "agentManager.updateBase.selectWorktree": "เลือก worktree ที่มีการจัดการก่อน",
+
   "agentManager.worktree.settings": "ตั้งค่า Worktree",
   "agentManager.worktree.new": "Worktree ใหม่",
   "agentManager.worktree.setupScript": "สคริปต์ตั้งค่า Worktree",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
@@ -19,6 +19,9 @@ export const dict = {
   "agentManager.project.missing": "Depo bulunamadı",
   "agentManager.notGitRepo": "Bir git deposu değil",
 
+  "agentManager.updateBase.title": "Temel daldan güncelle",
+  "agentManager.updateBase.selectWorktree": "Önce yönetilen bir worktree seçin.",
+
   "agentManager.worktree.settings": "Worktree ayarları",
   "agentManager.worktree.new": "Yeni Worktree",
   "agentManager.worktree.setupScript": "Worktree Kurulum Betiği",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
@@ -19,6 +19,9 @@ export const dict = {
   "agentManager.project.missing": "Репозиторій не знайдено",
   "agentManager.notGitRepo": "Не є git-репозиторієм",
 
+  "agentManager.updateBase.title": "Оновити з базової гілки",
+  "agentManager.updateBase.selectWorktree": "Спочатку виберіть кероване робоче дерево.",
+
   "agentManager.worktree.settings": "Налаштування робочого дерева",
   "agentManager.worktree.new": "Нове робоче дерево",
   "agentManager.worktree.setupScript": "Скрипт налаштування робочого дерева",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -17,6 +17,10 @@ export const dict = {
   "agentManager.project.remove": "从 Agent Manager 移除",
   "agentManager.project.missing": "未找到仓库",
   "agentManager.notGitRepo": "不是 git 仓库",
+
+  "agentManager.updateBase.title": "从基础分支更新",
+  "agentManager.updateBase.selectWorktree": "请先选择一个受管理的 worktree。",
+
   "agentManager.worktree.settings": "Worktree 设置",
   "agentManager.worktree.new": "新建 Worktree",
   "agentManager.worktree.setupScript": "Worktree 设置脚本",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -17,6 +17,10 @@ export const dict = {
   "agentManager.project.remove": "從 Agent Manager 移除",
   "agentManager.project.missing": "找不到儲存庫",
   "agentManager.notGitRepo": "不是 git 儲存庫",
+
+  "agentManager.updateBase.title": "從基底分支更新",
+  "agentManager.updateBase.selectWorktree": "請先選擇受管理的 worktree。",
+
   "agentManager.worktree.settings": "Worktree 設定",
   "agentManager.worktree.new": "新建 Worktree",
   "agentManager.worktree.setupScript": "Worktree 設定指令碼",

--- a/packages/kilo-vscode/webview-ui/agent-manager/update-from-base.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/update-from-base.ts
@@ -1,0 +1,15 @@
+import { showToast } from "@kilocode/kilo-ui/toast"
+import { useVSCode } from "../src/context/vscode"
+import { useLanguage } from "../src/context/language"
+
+export function useBaseUpdate() {
+  const vscode = useVSCode()
+  const { t } = useLanguage()
+  return (worktreeId: string | null, projectId?: string, sessionId?: string) => {
+    if (!worktreeId || worktreeId === "local") {
+      showToast({ title: t("agentManager.updateBase.title"), description: t("agentManager.updateBase.selectWorktree") })
+      return
+    }
+    vscode.postMessage({ type: "agentManager.updateFromBase", worktreeId, projectId, sessionId })
+  }
+}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -39,6 +39,7 @@ interface ChatViewProps {
   /** When true, show the "Continue in Worktree" button. Defaults to true in the sidebar. */
   continueInWorktree?: boolean
   worktree?: boolean
+  onUpdateBase?: () => void
   promptBoxId?: string
   terminalContext?: () => string | undefined
   worktrees?: () => WorktreeReference[]
@@ -402,6 +403,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
                 suggesting={suggesting}
                 questioning={questioning}
                 worktree={props.worktree}
+                onUpdateBase={props.onUpdateBase}
                 boxId={props.promptBoxId}
                 terminalContext={props.terminalContext}
                 worktrees={props.worktrees}

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -133,6 +133,7 @@ interface PromptInputProps {
   /** When true, defer prompt focus while switching to a pending question */
   deferFocusToQuestion?: () => boolean
   worktree?: boolean
+  onUpdateBase?: () => void
   boxId?: string
   terminalContext?: () => string | undefined
   worktrees?: () => WorktreeReference[]
@@ -331,8 +332,20 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       if (session.variantList(sid()).length === 0) hidden.add("variant")
       if (!sandboxVisible()) hidden.add("sandbox")
       if (props.worktree !== true) hidden.add("review worktree")
+      if (!props.onUpdateBase || props.worktree !== true) hidden.add("update-from-base")
       return hidden
     },
+    undefined,
+    undefined,
+    [
+      {
+        name: "update-from-base",
+        description: "Ask the worktree agent to fetch and merge its saved base branch",
+        hints: [],
+        action: () => props.onUpdateBase?.(),
+        enabled: () => props.worktree === true && server.isConnected() && !locked() && !props.blocked?.(),
+      },
+    ],
   )
   const clearSandboxRequest = (sessionID: string | undefined, requestID: string) => {
     setSandboxRequests((current) => {

--- a/packages/kilo-vscode/webview-ui/src/types/messages/agent-manager.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/agent-manager.ts
@@ -1,5 +1,12 @@
 export type WorktreeErrorCode = "git_not_found" | "not_git_repo" | "lfs_missing"
 
+export interface BaseUpdateRequest {
+  type: "agentManager.updateFromBase"
+  projectId?: string
+  worktreeId: string
+  sessionId?: string
+}
+
 export interface TerminalFont {
   fontFamily: string
   fontSize: number

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -1519,6 +1519,7 @@ export interface DismissAgentMigrationBannerMessage {
 }
 
 export type WebviewMessage =
+  | import("./agent-manager").BaseUpdateRequest
   | { type: "sessionActivity"; state: Activity }
   | DocumentRequestMessage
   | DocumentOpenFileMessage


### PR DESCRIPTION
## What Problem This Solves

Updating a managed worktree currently requires writing a Git instruction by hand. Using `main`, the current project default, or the worktree branch's own upstream can select the wrong base after branches or project settings change.

## Why This Change Was Made

Add one agent-task shortcut using the worktree's saved base metadata. `/update-from-base`, the worktree context menu, and the Command Palette send the same request to the owning project and worktree session. Existing busy-session handling and tool approvals remain in place.

This is not a native Git merge button. There is no new dialog, toolbar icon, setting, background poller, or Apply-conflict integration.

## User Impact

- Offer the slash action only in managed worktree chats, not Local or the sidebar.
- Use the recorded remote, or ask the agent to inspect the saved base branch's upstream. Require a choice for local-only or unresolved sources.
- Fetch the exact remote base before merging; stop on failed fetch/ref resolution, detached HEAD, existing merge/rebase, or blocking uncommitted changes.
- Instruct the agent not to stash, discard, stage, or commit pre-existing edits, and not to push or apply the worktree into its base. Ask when conflict intent is unclear.
- Preserve existing chat drafts. Include a short usage note and release note.

## Evidence

150 focused tests passed. After resolving the conflict with current `main`, the full VS Code unit suite passed: 4,687 passed, 1 skipped, 0 failed. Extension compilation (types, lint, build), knip, change-marker and Markdown guards passed. Documentation type checking passed; documentation lint reported only existing warnings in unchanged files.

Isolated VS Code tests exercised actual fetches and merges in disposable repositories with a scripted local provider and normal one-shot Git approvals:
- Saved `main` while Local had an unrelated branch and the project default was `release`.
- Saved `release` with no recorded remote, resolved through that base's upstream.
- A different branch checked out inside the worktree, updating that current branch without switching back.

The remote revisions were merged rather than stale local base refs. Local's branch and draft remained unchanged, and no stash was created. Final UI checks confirmed the slash action is hidden in Local and visible in worktrees. Test instances and fixtures were cleaned up.

The scripted provider validates routing and Git execution, not a live model's conflict-resolution judgment. Safeguards remain agent instructions rather than native Git enforcement.

<img width="700" alt="Update from base slash action in a managed worktree" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260903-agent-manager-update-base-slash-0958.png" />

<img width="360" alt="Update from base in the worktree right-click menu" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260903-agent-manager-update-base-context-1007.png" />
