### PR TITLE
refactor(vscode): share question resolution routing

### DIFF
--- a/packages/kilo-vscode/src/kilo-provider/handlers/question.ts
+++ b/packages/kilo-vscode/src/kilo-provider/handlers/question.ts
@@ -109,12 +109,12 @@ export async function fetchAndSendPendingQuestions(
   }
 }
 
-/** Handle question reply from the webview. */
-export async function handleQuestionReply(
+async function resolve(
   ctx: QuestionContext,
   requestID: string,
-  answers: string[][],
-  sessionID?: string,
+  sessionID: string | undefined,
+  operation: "reply to" | "reject",
+  request: (question: KiloClient["question"], directory: string) => Promise<unknown>,
 ): Promise<boolean> {
   if (!ctx.client) {
     ctx.postMessage({ type: "questionError", requestID })
@@ -125,7 +125,7 @@ export async function handleQuestionReply(
   const dir = ctx.getQuestionDirectory(requestID) ?? ctx.getWorkspaceDirectory(sid)
 
   try {
-    await ctx.client.question.reply({ requestID, answers, directory: dir }, { throwOnError: true })
+    await request(ctx.client.question, dir)
     ctx.clearQuestionDirectory(requestID)
     return true
   } catch (error) {
@@ -133,19 +133,31 @@ export async function handleQuestionReply(
     if (route?.kind === "stale") return false
     if (route?.kind === "retry" && route.dir !== dir) {
       try {
-        await ctx.client.question.reply({ requestID, answers, directory: route.dir }, { throwOnError: true })
+        await request(ctx.client.question, route.dir)
         ctx.clearQuestionDirectory(requestID)
         return true
       } catch (retry) {
-        console.error("[Kilo New] KiloProvider: Failed to reply to recovered question:", retry)
+        console.error(`[Kilo New] KiloProvider: Failed to ${operation} recovered question:`, retry)
         ctx.postMessage({ type: "questionError", requestID })
         return false
       }
     }
-    console.error("[Kilo New] KiloProvider: Failed to reply to question:", error)
+    console.error(`[Kilo New] KiloProvider: Failed to ${operation} question:`, error)
     ctx.postMessage({ type: "questionError", requestID })
     return false
   }
+}
+
+/** Handle question reply from the webview. */
+export async function handleQuestionReply(
+  ctx: QuestionContext,
+  requestID: string,
+  answers: string[][],
+  sessionID?: string,
+): Promise<boolean> {
+  return resolve(ctx, requestID, sessionID, "reply to", (question, directory) =>
+    question.reply({ requestID, answers, directory }, { throwOnError: true }),
+  )
 }
 
 /** Handle question reject (dismiss) from the webview. */
@@ -154,34 +166,7 @@ export async function handleQuestionReject(
   requestID: string,
   sessionID?: string,
 ): Promise<boolean> {
-  if (!ctx.client) {
-    ctx.postMessage({ type: "questionError", requestID })
-    return false
-  }
-
-  const sid = sessionID ?? ctx.currentSessionId
-  const dir = ctx.getQuestionDirectory(requestID) ?? ctx.getWorkspaceDirectory(sid)
-
-  try {
-    await ctx.client.question.reject({ requestID, directory: dir }, { throwOnError: true })
-    ctx.clearQuestionDirectory(requestID)
-    return true
-  } catch (error) {
-    const route = isNotFoundError(error, true) ? await recover(ctx, requestID) : undefined
-    if (route?.kind === "stale") return false
-    if (route?.kind === "retry" && route.dir !== dir) {
-      try {
-        await ctx.client.question.reject({ requestID, directory: route.dir }, { throwOnError: true })
-        ctx.clearQuestionDirectory(requestID)
-        return true
-      } catch (retry) {
-        console.error("[Kilo New] KiloProvider: Failed to reject recovered question:", retry)
-        ctx.postMessage({ type: "questionError", requestID })
-        return false
-      }
-    }
-    console.error("[Kilo New] KiloProvider: Failed to reject question:", error)
-    ctx.postMessage({ type: "questionError", requestID })
-    return false
-  }
+  return resolve(ctx, requestID, sessionID, "reject", (question, directory) =>
+    question.reject({ requestID, directory }, { throwOnError: true }),
+  )
 }

--- a/packages/kilo-vscode/tests/unit/question-handler.test.ts
+++ b/packages/kilo-vscode/tests/unit/question-handler.test.ts
@@ -297,20 +297,25 @@ describe("question handlers", () => {
     expect(messages).not.toContainEqual({ type: "questionResolved", requestID: "req-unknown" })
   })
 
-  it("keeps non-404 failures retryable", async () => {
-    const error = new Error("Internal server error", {
-      cause: { status: 500, body: { name: "InternalServerError" } },
+  it.each([500, 404])("keeps HTTP %s failures retryable without retrying the same directory", async (status) => {
+    const error = new Error("Question request failed", { cause: { status } })
+    const dir = "/workspace/.kilo/worktrees/origin"
+    const { fake, messages, rejects, questionDirs } = ctx({
+      extra: [dir],
+      pending: { [dir]: [pending("req-error", "ses-root")] },
+      errors: { reject: error },
     })
-    const { fake, messages, questionDirs } = ctx({ errors: { reject: error } })
     const spy = spyOn(console, "error").mockImplementation(() => {})
-    questionDirs.set("req-error", "/workspace/.kilo/worktrees/origin")
+    questionDirs.set("req-error", dir)
 
     const ok = await handleQuestionReject(fake, "req-error", "ses-root")
     spy.mockRestore()
 
     expect(ok).toBe(false)
-    expect(questionDirs.get("req-error")).toBe("/workspace/.kilo/worktrees/origin")
+    expect(rejects).toHaveLength(1)
+    expect(questionDirs.get("req-error")).toBe(dir)
     expect(messages).toContainEqual({ type: "questionError", requestID: "req-error" })
+    expect(messages).not.toContainEqual({ type: "questionResolved", requestID: "req-error" })
   })
 })
 


### PR DESCRIPTION
## What Problem This Solves
Question reply and reject handlers duplicate origin-directory routing, recovery, one-time retry, route cleanup, and error signaling. Separate implementations can drift when one path changes.

## Why This Change Was Made
Extract one private question-only resolution helper with an endpoint callback and operation label. Keep the public signatures, operation-specific logs, and existing recovery scan unchanged. Retry only when recovery finds a different directory. An incomplete scan must not prove staleness; stale requests still return false, and failures remain retryable. Permission handling stays separate because its save-always-rules ordering and stale/error behavior differ.

## User Impact
No intended behavior change. Replies and dismissals retain their original session and request-directory routing. The change removes 15 production lines and 10 total lines, including a small same-directory recovery regression case.

## Evidence
- 80 focused question and adjacent recovery/UI-contract tests pass.
- Extension and webview typecheck, lint, knip, and bundles pass after rebasing onto current main.
- Duplication reports before and after retain 21 pairs, 404 duplicated lines, and 2,758 duplicated tokens. This semantic duplicate is below the scanner threshold; the scanner and allowlist are unchanged. The duplication gate passes.
- All 115 open PRs were checked during the initial audit, with relevant adjacent patches reviewed; none overlapped this extraction.
- Real UI routing was not exercised: no ready deterministic pending-question fixture exists, and the self-test profile inherits Kilo storage and credentials. No self-test instance was started.

Manual verification: reply to and dismiss worktree questions after switching sessions; verify the correct session continues. Stale questions should clear, while temporary failures must leave questions available for retry.