### PR TITLE
refactor(vscode): share session tab layout styles

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1302,43 +1302,9 @@ html[data-theme="kilo-vscode"]
   border-right: 1px solid var(--border-weak-base);
 }
 
-.am-tab-list {
-  --am-tab-max-width: 240px;
-  --am-tab-width: clamp(72px, calc(100% / var(--tab-count, 1)), var(--am-tab-max-width));
-  display: flex;
-  align-items: stretch;
-  flex: 0 1 calc(var(--tab-count, 1) * var(--am-tab-max-width));
-  min-width: 0;
-  overflow-x: auto;
-  height: 100%;
-
-  /* Hide scrollbar while keeping scroll functionality */
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
-
-.am-tab-list-wrap {
-  display: flex;
-  align-items: stretch;
-  min-width: 0;
-  flex: 0 1 auto;
-  max-width: 100%;
-  height: 100%;
-}
-
-.am-tab-list::-webkit-scrollbar {
-  display: none;
-}
-
-/* Wrapper that positions overflow fade indicators */
+.am-tab-list-wrap,
 .am-tab-scroll-area {
-  position: relative;
-  display: flex;
-  min-width: 0;
   flex: 0 1 auto;
-  align-items: stretch;
-  height: 100%;
-  overflow: hidden;
 }
 
 /* Fixed add-button area after the scrollable tab list */
@@ -1536,21 +1502,6 @@ html[data-theme="kilo-vscode"]
 }
 
 /* Drag-and-drop sortable tab wrapper */
-
-.am-tab-sortable {
-  display: flex;
-  height: 100%;
-  width: var(--am-tab-width);
-  min-width: var(--am-tab-width);
-  max-width: var(--am-tab-width);
-  flex: 0 0 var(--am-tab-width);
-  touch-action: none;
-  transition:
-    flex-basis 140ms ease,
-    max-width 140ms ease,
-    min-width 140ms ease,
-    width 140ms ease;
-}
 
 .am-tab-list[data-tab-widths-frozen] .am-tab-sortable,
 .am-tab-dragging {
@@ -5008,22 +4959,7 @@ body.vscode-high-contrast-light {
    top bar's 240px because the panel is narrow. */
 .am-inspector-tablist {
   --am-tab-max-width: 180px;
-  --am-tab-width: clamp(72px, calc(100% / var(--tab-count, 1)), var(--am-tab-max-width));
-  display: flex;
-  align-items: stretch;
-  /* No gap, like .am-tab-list: equal-share tab widths already consume
-     the full width, so any gap would leave the list a few pixels
-     scrollable and keep the overflow fade lit for nothing. */
-  flex: 0 1 calc(var(--tab-count, 1) * var(--am-tab-max-width));
-  min-width: 0;
-  height: 100%;
-  overflow-x: auto;
   overflow-y: hidden;
-  scrollbar-width: none;
-}
-
-.am-inspector-tablist::-webkit-scrollbar {
-  display: none;
 }
 
 .am-inspector-tablist[data-tab-widths-frozen] .am-tab-sortable {

--- a/packages/kilo-vscode/webview-ui/src/styles/session-tabs.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/session-tabs.css
@@ -13,27 +13,39 @@
   background: var(--surface-base);
 }
 
+.am-tab-scroll-area,
 .session-tab-bar .am-tab-scroll-area {
   position: relative;
   display: flex;
   align-items: stretch;
-  flex: 1 1 auto;
   min-width: 0;
   height: 100%;
   overflow: hidden;
 }
 
+.am-tab-list-wrap,
 .session-tab-bar .am-tab-list-wrap {
   display: flex;
   align-items: stretch;
-  flex: 1 1 auto;
   min-width: 0;
   max-width: 100%;
   height: 100%;
 }
 
+.session-tab-bar .am-tab-scroll-area,
+.session-tab-bar .am-tab-list-wrap {
+  flex: 1 1 auto;
+}
+
+.am-tab-list,
 .session-tab-bar .am-tab-list {
   --am-tab-max-width: 240px;
+  -ms-overflow-style: none;
+}
+
+.am-tab-list,
+.session-tab-bar .am-tab-list,
+.am-inspector-tablist {
   --am-tab-width: clamp(72px, calc(100% / var(--tab-count, 1)), var(--am-tab-max-width));
   display: flex;
   align-items: stretch;
@@ -42,10 +54,11 @@
   height: 100%;
   overflow-x: auto;
   scrollbar-width: none;
-  -ms-overflow-style: none;
 }
 
-.session-tab-bar .am-tab-list::-webkit-scrollbar {
+.am-tab-list::-webkit-scrollbar,
+.session-tab-bar .am-tab-list::-webkit-scrollbar,
+.am-inspector-tablist::-webkit-scrollbar {
   display: none;
 }
 
@@ -74,6 +87,7 @@
   background: linear-gradient(to left, var(--surface-base) 0%, transparent 100%);
 }
 
+.am-tab-sortable,
 .session-tab-bar .am-tab-sortable {
   display: flex;
   width: var(--am-tab-width);

--- a/script/kilocode-duplication-allowlist.json
+++ b/script/kilocode-duplication-allowlist.json
@@ -154,18 +154,6 @@
     },
     {
       "files": [
-        "packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css",
-        "packages/kilo-vscode/webview-ui/src/styles/session-tabs.css"
-      ],
-      "fingerprint": "9020d3c20123ef72",
-      "maxMatches": 1,
-      "maxTokens": 104,
-      "kind": "legacy",
-      "owner": "kilo-vscode",
-      "reason": "Existing duplication before the ratchet; remove through a focused, behavior-preserving extraction."
-    },
-    {
-      "files": [
         "packages/kilo-vscode/webview-ui/src/context/session-variant-store.ts",
         "packages/opencode/src/kilocode/cli/cmd/run/variant.ts"
       ],


### PR DESCRIPTION
## What Problem This Solves

Sidebar, main Agent Manager, and inspector tabs repeat the same equal-width sizing and horizontal-scroll declarations. Duplication fingerprint `9020d3c20123ef72` tracks part of this overlap, while the main Agent Manager strip repeats the same mechanics again.

## Why This Change Was Made

Keep those shared declarations in the existing `session-tabs.css`, which both surfaces already load through `chat.css`. Group the existing selectors without adding a tab framework, imports, helpers, or JavaScript. Remove only the resolved allowlist entry, with no scanner changes or new exceptions.

This removes **50 production CSS lines net**, or **62 lines total** including the allowlist. The PR contains one focused commit across three files.

## User Impact

No intended visual or interaction change. Preserve the 72px minimum, 240px sidebar/main cap versus 180px inspector cap, 36px main versus 32px inspector bars, and the distinct wrapper flex values. Inspector vertical clipping and close, drag, document-tab, and high-contrast rules stay surface-specific. Existing scrolling, focus, and width-freezing JavaScript is unchanged.

## Evidence

- Fresh duplication reports changed from **21 to 20 pairs**, **404 to 394 duplicated lines**, and **2,758 to 2,654 duplicated tokens**. The ratchet passes without new exceptions. The after-report was also rerun after updating the branch to `cf954237c1`.
- **60 existing Storybook layout cases** matched the original CSS geometry and checked computed styles across narrow/wide bars, long labels, overflow, dark/light, and both high-contrast themes. Existing 200px main-story clipping was unchanged. Screenshots were read.
- Isolated VS Code checks exercised close-width freezing and release, simulated pointer drag/reorder, real terminal tabs, and fixture document tabs. The self-test daemon failed before subagent verification completed. Only the owned test instance, backend, server, profiles, and fixture were cleaned up.
- Existing focused tab tests, extension typecheck/lint/knip, compile/build checks, and formatting checks passed. Linux screenshot-baseline comparison was not run on macOS; Storybook has existing runtime and dead-PTY fixture errors.

Remaining tabs retain their widths after closing the middle tab:

<img width="700" alt="Agent Manager session tabs retain their widths after closing a middle tab" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260903-session-tab-css-close-freezing-af441y.png" />

Existing inspector story at narrow, normal, and wide panel sizes in high-contrast light, including horizontal overflow:

<img width="700" alt="High-contrast light inspector tabs preserve narrow and wide layouts and scroll behavior" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260903-session-tab-css-inspector-hc-af441y.png" />
