### PR TITLE
fix(cli): keep subagents running after permission denial

### DIFF
--- a/.changeset/calm-subagent-denial.md
+++ b/.changeset/calm-subagent-denial.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Let subagents continue and return their findings when a tool permission is denied, without allowing the denied operation.

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -307,7 +307,7 @@ const layer = Layer.effect(
         })
         // kilocode_change start
         if (
-          error instanceof PermissionV1.RejectedError ||
+          (error instanceof PermissionV1.RejectedError && !(yield* session.get(ctx.sessionID)).parentID) ||
           error instanceof Question.RejectedError ||
           error instanceof Suggestion.DismissedError
         ) {

--- a/packages/opencode/test/kilocode/session-prompt-permission-refresh.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-permission-refresh.test.ts
@@ -1284,43 +1284,46 @@ it.live(
 )
 
 for (const continued of [false, true]) {
-  it.live(`root permission rejection respects continue_loop_on_deny=${continued}`, () =>
-    provideTmpdirServer(
-      Effect.fnUntraced(function* ({ dir, llm }) {
-        const prompt = yield* SessionPrompt.Service
-        const sessions = yield* Session.Service
-        const permission = yield* Permission.Service
-        yield* Effect.promise(() => Bun.write(path.join(dir, ".env"), "DENIED_ROOT_SENTINEL"))
-        yield* llm.tool("read", { filePath: path.join(dir, ".env") })
-        yield* llm.text("Skipped the denied read.")
-        const root = yield* sessions.create({ title: "Root" })
-        const fiber = yield* prompt
-          .prompt({ sessionID: root.id, agent: "build", parts: [{ type: "text", text: "Read .env" }] })
-          .pipe(Effect.forkScoped)
-        const pending = yield* pollWithTimeout(
-          Effect.gen(function* () {
-            return (yield* permission.list()).find((item) => item.sessionID === root.id)
-          }),
-          "root never requested read permission",
-        )
-        yield* permission.reply({ requestID: pending.id, reply: "reject" })
-        const result = yield* awaitWithTimeout(Fiber.join(fiber), "root did not finish")
-        expect(result.parts.some((part) => part.type === "text" && part.text === "Skipped the denied read.")).toBe(
-          continued,
-        )
-        expect(yield* llm.pending).toBe(continued ? 0 : 1)
-        expect(JSON.stringify(yield* llm.inputs)).not.toContain("DENIED_ROOT_SENTINEL")
-      }),
-      {
-        git: true,
-        config: (url) => ({
-          ...providerCfg(url),
-          model: "test/test-model",
-          permission: { read: { "*": "allow", ".env": "ask" } },
-          experimental: { continue_loop_on_deny: continued },
+  it.live(
+    `root permission rejection respects continue_loop_on_deny=${continued}`,
+    () =>
+      provideTmpdirServer(
+        Effect.fnUntraced(function* ({ dir, llm }) {
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+          const permission = yield* Permission.Service
+          yield* Effect.promise(() => Bun.write(path.join(dir, ".env"), "DENIED_ROOT_SENTINEL"))
+          yield* llm.tool("read", { filePath: path.join(dir, ".env") })
+          yield* llm.text("Skipped the denied read.")
+          const root = yield* sessions.create({ title: "Root" })
+          const fiber = yield* prompt
+            .prompt({ sessionID: root.id, agent: "build", parts: [{ type: "text", text: "Read .env" }] })
+            .pipe(Effect.forkScoped)
+          const pending = yield* pollWithTimeout(
+            Effect.gen(function* () {
+              return (yield* permission.list()).find((item) => item.sessionID === root.id)
+            }),
+            "root never requested read permission",
+          )
+          yield* permission.reply({ requestID: pending.id, reply: "reject" })
+          const result = yield* awaitWithTimeout(Fiber.join(fiber), "root did not finish")
+          expect(result.parts.some((part) => part.type === "text" && part.text === "Skipped the denied read.")).toBe(
+            continued,
+          )
+          expect(yield* llm.pending).toBe(continued ? 0 : 1)
+          expect(JSON.stringify(yield* llm.inputs)).not.toContain("DENIED_ROOT_SENTINEL")
         }),
-      },
-    ),
+        {
+          git: true,
+          config: (url) => ({
+            ...providerCfg(url),
+            model: "test/test-model",
+            permission: { read: { "*": "allow", ".env": "ask" } },
+            experimental: { continue_loop_on_deny: continued },
+          }),
+        },
+      ),
+    30_000,
   )
 }
 

--- a/packages/opencode/test/kilocode/session-prompt-permission-refresh.test.ts
+++ b/packages/opencode/test/kilocode/session-prompt-permission-refresh.test.ts
@@ -1210,6 +1210,120 @@ it.live("active tool calls use permissions changed after model streaming starts"
   ),
 )
 
+it.live(
+  "subagent continues exploration and returns findings after a rejected read",
+  () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ dir, llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const permission = yield* Permission.Service
+        const secret = "DENIED_ENV_SENTINEL"
+        yield* Effect.promise(() =>
+          Promise.all([
+            Bun.write(path.join(dir, ".env"), secret),
+            Bun.write(path.join(dir, "before.txt"), "Earlier findings"),
+            Bun.write(path.join(dir, "after.txt"), "Later findings"),
+          ]),
+        )
+        yield* llm.tool("task", {
+          description: "Explore project",
+          prompt: "Read before.txt, .env, and after.txt, then report the available findings.",
+          subagent_type: "explore",
+        })
+        yield* llm.tool("read", { filePath: path.join(dir, "before.txt") })
+        yield* llm.tool("read", { filePath: path.join(dir, ".env") })
+        yield* llm.tool("read", { filePath: path.join(dir, "after.txt") })
+        yield* llm.text("Earlier findings and later findings. Skipped the denied .env read.")
+        yield* llm.text("Received the exploration findings.")
+        const root = yield* sessions.create({ title: "Explore" })
+        const fiber = yield* prompt
+          .prompt({ sessionID: root.id, agent: "build", parts: [{ type: "text", text: "Explore with a subagent." }] })
+          .pipe(Effect.forkScoped)
+        const pending = yield* pollWithTimeout(
+          Effect.gen(function* () {
+            return (yield* permission.list()).find((item) => item.permission === "read")
+          }),
+          "subagent never requested read permission",
+        )
+        expect(pending.sessionID).not.toBe(root.id)
+        expect(pending.patterns).toEqual([".env"])
+        yield* permission.reply({ requestID: pending.id, reply: "reject" })
+        yield* awaitWithTimeout(Fiber.join(fiber), "exploration did not finish", "10 seconds")
+
+        const child = yield* sessions.messages({ sessionID: pending.sessionID })
+        const tools = child.flatMap((msg) => msg.parts).filter((part) => part.type === "tool")
+        expect(tools.map((part) => part.state.status)).toEqual(["completed", "error", "completed"])
+        expect(tools.at(1)?.state).toMatchObject({
+          error: "The user rejected permission to use this specific tool call.",
+        })
+        const parent = yield* sessions.messages({ sessionID: root.id })
+        const task = parent
+          .flatMap((msg) => msg.parts)
+          .filter((part) => part.type === "tool")
+          .find((part) => part.tool === "task")
+        expect(task?.state).toMatchObject({
+          status: "completed",
+          output: expect.stringContaining("Earlier findings and later findings."),
+        })
+        const inputs = JSON.stringify(yield* llm.inputs)
+        expect(inputs).toContain("The user rejected permission")
+        expect(inputs).not.toContain(secret)
+        expect(yield* permission.list()).toEqual([])
+      }),
+      {
+        git: true,
+        config: (url) => ({
+          ...providerCfg(url),
+          model: "test/test-model",
+          permission: { read: { "*": "allow", ".env": "ask" }, task: "allow" },
+        }),
+      },
+    ),
+  30_000,
+)
+
+for (const continued of [false, true]) {
+  it.live(`root permission rejection respects continue_loop_on_deny=${continued}`, () =>
+    provideTmpdirServer(
+      Effect.fnUntraced(function* ({ dir, llm }) {
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const permission = yield* Permission.Service
+        yield* Effect.promise(() => Bun.write(path.join(dir, ".env"), "DENIED_ROOT_SENTINEL"))
+        yield* llm.tool("read", { filePath: path.join(dir, ".env") })
+        yield* llm.text("Skipped the denied read.")
+        const root = yield* sessions.create({ title: "Root" })
+        const fiber = yield* prompt
+          .prompt({ sessionID: root.id, agent: "build", parts: [{ type: "text", text: "Read .env" }] })
+          .pipe(Effect.forkScoped)
+        const pending = yield* pollWithTimeout(
+          Effect.gen(function* () {
+            return (yield* permission.list()).find((item) => item.sessionID === root.id)
+          }),
+          "root never requested read permission",
+        )
+        yield* permission.reply({ requestID: pending.id, reply: "reject" })
+        const result = yield* awaitWithTimeout(Fiber.join(fiber), "root did not finish")
+        expect(result.parts.some((part) => part.type === "text" && part.text === "Skipped the denied read.")).toBe(
+          continued,
+        )
+        expect(yield* llm.pending).toBe(continued ? 0 : 1)
+        expect(JSON.stringify(yield* llm.inputs)).not.toContain("DENIED_ROOT_SENTINEL")
+      }),
+      {
+        git: true,
+        config: (url) => ({
+          ...providerCfg(url),
+          model: "test/test-model",
+          permission: { read: { "*": "allow", ".env": "ask" } },
+          experimental: { continue_loop_on_deny: continued },
+        }),
+      },
+    ),
+  )
+}
+
 const worker = (mode: "subagent" | "all"): AgentSvc.Info => ({
   name: "worker",
   mode,


### PR DESCRIPTION
## What Problem This Solves
Denying a tool permission inside a subagent, such as a read of `.env`, stops the entire child loop before it can finish exploration or return its findings. The parent can receive an empty task result and repeat the work.

## Why This Change Was Made
The processor treats a rejected tool call as a session stop signal. Limit that stop behavior to root sessions. A child still records the denied tool as an error, but gets another model turn to use permitted tools and report its findings. This is a one-line runtime change; permission rules, root-session continuation settings, question dismissal, and cancellation are unchanged.

## User Impact
Deny access to a file without losing the subagent exploration. The denied operation is not allowed, retried, or replaced with a successful result by the runtime.

## Evidence
- Reproduced before the fix with the real prompt, task, read, and permission services: the child completed its first read, hit a rejected `.env` read, and never reached the next permitted read.
- The regression now passes and checks that the parent receives the child summary and the denied file contents never reach model requests. Two root-session cases preserve `continue_loop_on_deny` behavior.
- 87 relevant tests and CLI typecheck pass. Scoped lint reports only existing warnings; the annotation and whitespace checks pass.
- A live source backend with a scripted local provider confirmed the same flow through the public HTTP API: reject `.env`, complete the next permitted read, return findings to the parent. The dummy secret was absent from all provider requests. No real credentials or model calls were used.

Manual check: deny a subagent `.env` read, then confirm it continues with permitted files and returns a summary.

### VS Code self-test
Reproduced both versions in the real sidebar with a disposable workspace, isolated VS Code profile, isolated Kilo storage, and a local scripted provider. The model responses were scripted; the task tool, permission dialog, Deny button, session loop, and returned task results were real.

- Before: click Deny for the child `.env` read. The child stops after two read attempts and the parent receives an empty task result.
- After: click Deny for the same read. The child completes the next permitted `after.txt` read and returns its findings. The dummy secret is absent from all provider requests.
- SHA-256 hashes of the normal Kilo config files and VS Code user settings are unchanged. The isolated instance and its temporary VS Code profiles were cleaned up.

Before / after:

<img width="300" alt="Before: denying the env read stops exploration without findings" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260903-subagent-denial-before-13744.png" /> <img width="300" alt="After: denying the env read still permits the next read and returns findings" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260903-subagent-denial-after-13744.png" />