### PR TITLE
fix(anthropic): repair assistant message block order before send

### DIFF
--- a/.changeset/fix-anthropic-assistant-block-order.md
+++ b/.changeset/fix-anthropic-assistant-block-order.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix intermittent Anthropic 400 "This model does not support assistant message prefill" on Claude 4.6 and Opus 5. An assistant turn could be sent as `[tool_use, text]` when the text part received a part ID minted after the tool part, even though the text streamed first. Assistant content is now reordered so text precedes the first tool call before the request is sent.

--- a/.changeset/fix-anthropic-empty-reasoning-replay.md
+++ b/.changeset/fix-anthropic-empty-reasoning-replay.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Stop replaying Anthropic thinking blocks whose text was lost. A reasoning block that retained its signature but lost its text caused a 400 ("`thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified"), because the signature cannot validate against empty content. Such blocks are now omitted, and they no longer keep the empty-text separator workaround alive.

--- a/.changeset/fix-trailing-assistant-message.md
+++ b/.changeset/fix-trailing-assistant-message.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Fix Anthropic 400 errors caused by trailing assistant messages. Requests could end with an assistant turn containing only a thinking block, producing "The final block in an assistant message cannot be `thinking`" or "This model does not support assistant message prefill". Outbound message arrays are now sanitized after conversion so they never end with an assistant turn.
+Fix Anthropic 400 errors caused by malformed trailing assistant messages. Conversion could emit a final assistant turn whose only content was a thinking block, producing "The final block in an assistant message cannot be `thinking`". Outbound message arrays are now sanitized after conversion: empty trailing assistant turns are dropped and a surviving turn is never left ending on a thinking block. Turns carrying real output are always preserved.

--- a/.changeset/fix-trailing-assistant-message.md
+++ b/.changeset/fix-trailing-assistant-message.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix Anthropic 400 errors caused by trailing assistant messages. Requests could end with an assistant turn containing only a thinking block, producing "The final block in an assistant message cannot be `thinking`" or "This model does not support assistant message prefill". Outbound message arrays are now sanitized after conversion so they never end with an assistant turn.

--- a/packages/opencode/src/kilocode/session/trailing-assistant.ts
+++ b/packages/opencode/src/kilocode/session/trailing-assistant.ts
@@ -1,0 +1,96 @@
+/**
+ * Anthropic rejects any /v1/messages request whose `messages` array ends with
+ * an assistant turn:
+ *
+ *   - "The final block in an assistant message cannot be `thinking`."
+ *   - "This model does not support assistant message prefill.
+ *      The conversation must end with a user message."  (Claude 4.6+ / Opus 5)
+ *
+ * Both share one precondition: a trailing assistant message we never intended
+ * to send. They are produced here rather than by any single caller, because
+ * `convertToModelMessages` splits an assistant UI message at every `step-start`
+ * boundary. A turn persisted as
+ *
+ *   text, tool, step-finish, step-start, reasoning
+ *
+ * splits into assistant[text, tool-call] / tool[tool-result] /
+ * assistant[reasoning] - a trailing thinking-only turn. Upstream filters run on
+ * whole UI messages *before* that split, so they cannot see it.
+ *
+ * This guard runs after conversion, on the exact array that goes over the wire.
+ */
+
+import type { ModelMessage } from "ai"
+
+type Part = { type: string; text?: string }
+
+/**
+ * A part that represents real, committed model output. Reasoning is excluded:
+ * a thinking block alone is not a turn, and Anthropic's adaptive thinking emits
+ * signed blocks whose `text` is empty, so length is not a usable signal.
+ */
+function isCommitted(part: Part): boolean {
+  switch (part.type) {
+    case "tool-call":
+    case "tool-result":
+    case "file":
+      return true
+    case "text":
+      return typeof part.text === "string" && part.text.trim().length > 0
+    default:
+      return false
+  }
+}
+
+export namespace KiloTrailingAssistant {
+  export type Options = {
+    /** False for models that removed last-turn prefill (Claude 4.6+, Opus 5). */
+    allowPrefill?: boolean
+  }
+
+  export function sanitize(messages: ModelMessage[], options?: Options): ModelMessage[] {
+    const allowPrefill = options?.allowPrefill ?? false
+    const out = messages.slice()
+
+    while (out.length > 0) {
+      const last = out[out.length - 1]
+      if (last.role !== "assistant") break
+
+      const content: unknown = (last as { content?: unknown }).content
+
+      // String content: keep only if non-empty and prefill is permitted.
+      if (typeof content === "string") {
+        if (allowPrefill && content.trim().length > 0) break
+        out.pop()
+        continue
+      }
+
+      if (!Array.isArray(content)) break
+      const parts = content as Part[]
+
+      // (1) No committed output - a dangling step. Drop it entirely. This is
+      //     lossless: there is nothing here but an unterminated thinking block.
+      if (!parts.some(isCommitted)) {
+        out.pop()
+        continue
+      }
+
+      // (2) Real content, but prefill is unsupported - the turn must not be last.
+      if (!allowPrefill) {
+        out.pop()
+        continue
+      }
+
+      // (3) Intentional, supported prefill: the final block still may not be
+      //     `thinking`. Strip trailing reasoning only.
+      let end = parts.length
+      while (end > 0 && parts[end - 1].type === "reasoning") end--
+      if (end !== parts.length) {
+        out[out.length - 1] = { ...last, content: parts.slice(0, end) } as ModelMessage
+      }
+      break
+    }
+
+    return out
+  }
+}

--- a/packages/opencode/src/kilocode/session/trailing-assistant.ts
+++ b/packages/opencode/src/kilocode/session/trailing-assistant.ts
@@ -1,23 +1,61 @@
 /**
- * Anthropic rejects any /v1/messages request whose `messages` array ends with
- * an assistant turn:
- *
- *   - "The final block in an assistant message cannot be `thinking`."
- *   - "This model does not support assistant message prefill.
- *      The conversation must end with a user message."  (Claude 4.6+ / Opus 5)
- *
- * Both share one precondition: a trailing assistant message we never intended
- * to send. They are produced here rather than by any single caller, because
+ * Repairs two assistant-message shapes that Anthropic's /v1/messages endpoint
+ * rejects. Both are produced here rather than by any single caller, because
  * `convertToModelMessages` splits an assistant UI message at every `step-start`
- * boundary. A turn persisted as
+ * boundary, so no upstream filter operating on whole UI messages can see them.
+ * This guard runs after conversion, on the exact array that goes over the wire.
+ *
+ * Shape 1 - a trailing assistant turn containing nothing but a thinking block:
+ *
+ *   "The final block in an assistant message cannot be `thinking`."
+ *
+ * A turn persisted as
  *
  *   text, tool, step-finish, step-start, reasoning
  *
  * splits into assistant[text, tool-call] / tool[tool-result] /
- * assistant[reasoning] - a trailing thinking-only turn. Upstream filters run on
- * whole UI messages *before* that split, so they cannot see it.
+ * assistant[reasoning]. That last fragment is a dangling step: it carries no
+ * committed output, so dropping it is lossless.
  *
- * This guard runs after conversion, on the exact array that goes over the wire.
+ * Shape 2 - inverted block order inside a single assistant message:
+ *
+ *   step-start, reasoning, tool, step-finish, text
+ *
+ * Here the text part carries a PartID minted long after the tool part (observed
+ * lag 76-113s), so it sorts last, yet its own `time.end` precedes the tool
+ * part's creation - the text really streamed first. Because no `step-start`
+ * separates it, the split never happens and the text stays in the same
+ * assistant message as the tool-call, emitting assistant[tool_use, text].
+ * `reorderAssistantContent` repairs it by restoring the original chronology.
+ *
+ * Position matters, and the evidence is unusually clean. In the captured
+ * failing request (243 messages, 121 assistant turns) two messages carried the
+ * defect: index 99 and index 241. Index 99 was already present in the very
+ * first captured request of that session and rode along in all 101 subsequent
+ * requests - every one of which returned 200. Only index 241, the *final*
+ * assistant message, drew the 400. A malformed turn buried in history is
+ * therefore harmless; the API rejects it only in the last assistant position.
+ *
+ * We nevertheless repair every assistant message, not just the last, because
+ * compaction and context truncation can promote a historical message into the
+ * final position, converting a latent defect into a hard failure at an
+ * arbitrary later turn. The transform is deterministic, so the rewritten
+ * prefix is stable across requests: it costs at most one prompt-cache
+ * invalidation the first time a given session is sent, then re-stabilizes.
+ *
+ * Deliberately NOT handled: a trailing assistant turn carrying real committed
+ * output. An earlier revision of this file also dropped those, on the theory
+ * that Claude 4.6+ refuses all last-turn prefill ("This model does not support
+ * assistant message prefill. The conversation must end with a user message.").
+ * That was over-reach, and it was wrong twice over. It is unsupported - the
+ * captured 400 ended with a user/tool_result message, so that error was caused
+ * by Shape 2, not by a trailing turn - and it is destructive: `toModelMessages`
+ * is a general-purpose conversion used by compaction, title generation and
+ * plan follow-up, all of which legitimately convert histories that end with an
+ * assistant turn. Discarding that content silently truncated their input and
+ * broke eight upstream `session.message-v2` tests that assert the conversion
+ * contract. Real output is now always preserved; only genuinely empty turns
+ * are dropped.
  */
 
 import type { ModelMessage } from "ai"
@@ -42,25 +80,61 @@ function isCommitted(part: Part): boolean {
   }
 }
 
-export namespace KiloTrailingAssistant {
-  export type Options = {
-    /** False for models that removed last-turn prefill (Claude 4.6+, Opus 5). */
-    allowPrefill?: boolean
-  }
+function isNonEmptyText(part: Part): boolean {
+  return part.type === "text" && typeof part.text === "string" && part.text.trim().length > 0
+}
 
-  export function sanitize(messages: ModelMessage[], options?: Options): ModelMessage[] {
-    const allowPrefill = options?.allowPrefill ?? false
+/**
+ * Move any `text` block that follows the first `tool-call` back in front of it,
+ * preserving the relative order of the moved blocks. Reasoning and every other
+ * block keep their positions, so a leading signed thinking block stays leading.
+ * Empty/whitespace-only text after a tool-call is dropped rather than moved:
+ * Anthropic rejects empty text blocks, and such a block carries no output.
+ *
+ * Returns undefined when nothing needs to change, so callers can avoid
+ * rebuilding messages that are already well-formed.
+ */
+function reorderAssistantContent(content: Part[]): Part[] | undefined {
+  const firstTool = content.findIndex((part) => part.type === "tool-call")
+  if (firstTool === -1) return undefined
+
+  const tail = content.slice(firstTool + 1)
+  if (!tail.some((part) => part.type === "text")) return undefined
+
+  const head = content.slice(0, firstTool)
+  const moved = tail.filter(isNonEmptyText)
+  const kept = tail.filter((part) => part.type !== "text")
+
+  return [...head, ...moved, content[firstTool], ...kept]
+}
+
+export namespace KiloTrailingAssistant {
+  export function sanitize(messages: ModelMessage[]): ModelMessage[] {
     const out = messages.slice()
 
+    // Pass 1 - repair intra-message block order for every assistant message.
+    // This must run before the trailing-turn pass: dropping a trailing turn
+    // does not help when the malformed message sits mid-array.
+    for (let i = 0; i < out.length; i++) {
+      const msg = out[i]
+      if (msg.role !== "assistant") continue
+      const content: unknown = (msg as { content?: unknown }).content
+      if (!Array.isArray(content)) continue
+      const reordered = reorderAssistantContent(content as Part[])
+      if (reordered) out[i] = { ...msg, content: reordered } as ModelMessage
+    }
+
+    // Pass 2 - drop empty trailing assistant turns, and make sure a surviving
+    // one does not end on a thinking block. Never discards real output.
     while (out.length > 0) {
       const last = out[out.length - 1]
       if (last.role !== "assistant") break
 
       const content: unknown = (last as { content?: unknown }).content
 
-      // String content: keep only if non-empty and prefill is permitted.
+      // String content is real output unless it is blank.
       if (typeof content === "string") {
-        if (allowPrefill && content.trim().length > 0) break
+        if (content.trim().length > 0) break
         out.pop()
         continue
       }
@@ -75,13 +149,7 @@ export namespace KiloTrailingAssistant {
         continue
       }
 
-      // (2) Real content, but prefill is unsupported - the turn must not be last.
-      if (!allowPrefill) {
-        out.pop()
-        continue
-      }
-
-      // (3) Intentional, supported prefill: the final block still may not be
+      // (2) Real output is kept, but the final block still may not be
       //     `thinking`. Strip trailing reasoning only.
       let end = parts.length
       while (end > 0 && parts[end - 1].type === "reasoning") end--

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -38,6 +38,7 @@ import type { Provider } from "@/provider/provider"
 import { Snapshot } from "@/snapshot" // kilocode_change
 import { SessionNetwork } from "./network" // kilocode_change
 import { CodexAuthExpiredError } from "@/kilocode/provider/codex-refresh" // kilocode_change
+import { KiloTrailingAssistant } from "@/kilocode/session/trailing-assistant" // kilocode_change
 import { KiloSessionMessageOrder } from "@/kilocode/session/message-order" // kilocode_change
 import * as TextStream from "@/kilocode/text-stream" // kilocode_change
 import { BoardNotice } from "@/kilocode/board/notice" // kilocode_change
@@ -537,7 +538,11 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
 
   const tools = Object.fromEntries(Array.from(toolNames).map((toolName) => [toolName, { toModelOutput }]))
 
-  return yield* Effect.promise(() =>
+  // kilocode_change start - repair outbound assistant message shape before it
+  // reaches the provider: restore inverted [tool_use, text] block order, and
+  // drop trailing assistant turns that carry no committed output. Turns with
+  // real output are always preserved.
+  const converted = yield* Effect.promise(() =>
     convertToModelMessages(
       result.filter((msg) => msg.parts.some((part) => part.type !== "step-start")),
       {
@@ -546,6 +551,8 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
       },
     ),
   )
+  return KiloTrailingAssistant.sanitize(converted)
+  // kilocode_change end
 })
 
 export function toModelMessages(

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -397,6 +397,10 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
       // the neighboring signed reasoning blocks.
       const hasSignedReasoning = msg.parts.some((part) => {
         if (part.type !== "reasoning") return false
+        // kilocode_change start - blank-text reasoning is dropped during replay below,
+        // so it must not keep the empty-text separator workaround alive.
+        if (part.text.trim().length === 0) return false
+        // kilocode_change end
         return part.metadata?.anthropic?.signature != null
       })
       for (const part of msg.parts) {
@@ -503,6 +507,15 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
               })
             continue
           }
+          // kilocode_change start - drop reasoning blocks whose text was lost.
+          // Anthropic rejects a thinking block that carries a signature but no
+          // text ("`thinking` or `redacted_thinking` blocks in the latest
+          // assistant message cannot be modified"), because the signature
+          // cannot validate against empty content. The original thinking text
+          // is unrecoverable by this point, so omitting the block is the only
+          // safe replay. Empty blocks carry no context, so nothing is lost.
+          if (part.text.trim().length === 0) continue
+          // kilocode_change end
           assistantMessage.parts.push({
             type: "reasoning",
             text: part.text,

--- a/packages/opencode/test/kilocode/sessions/trailing-assistant.test.ts
+++ b/packages/opencode/test/kilocode/sessions/trailing-assistant.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test"
+import type { ModelMessage } from "ai"
+import { KiloTrailingAssistant } from "../../../src/kilocode/session/trailing-assistant"
+
+const text = (value: string) => ({ type: "text", text: value })
+const toolCall = (id: string) => ({ type: "tool-call", toolCallId: id, toolName: "bash", input: {} })
+const reasoning = (value: string) => ({ type: "reasoning", text: value })
+
+const user = { role: "user", content: [text("hi")] }
+const toolResult = {
+  role: "tool",
+  content: [{ type: "tool-result", toolCallId: "1", toolName: "bash", output: "" }],
+}
+
+/** Render each message as its ordered block types, so assertions read as wire shape. */
+function shapes(messages: ModelMessage[]): string {
+  return messages
+    .map((message) => {
+      const content: unknown = (message as { content?: unknown }).content
+      if (!Array.isArray(content)) return `str:${String(content)}`
+      return content.map((part: { type: string }) => part.type).join(",")
+    })
+    .join(" | ")
+}
+
+function sanitize(messages: unknown[]): string {
+  return shapes(KiloTrailingAssistant.sanitize(messages as ModelMessage[]))
+}
+
+describe("KiloTrailingAssistant.sanitize - assistant block ordering", () => {
+  test("leaves a well-formed [text, tool-call] message untouched", () => {
+    expect(sanitize([user, { role: "assistant", content: [text("a"), toolCall("1")] }, toolResult])).toBe(
+      "text | text,tool-call | tool-result",
+    )
+  })
+
+  test("repairs an inverted [tool-call, text] message", () => {
+    expect(sanitize([user, { role: "assistant", content: [toolCall("1"), text("a")] }, toolResult])).toBe(
+      "text | text,tool-call | tool-result",
+    )
+  })
+
+  test("keeps a leading reasoning block leading so signed thinking stays first", () => {
+    expect(
+      sanitize([user, { role: "assistant", content: [reasoning("r"), toolCall("1"), text("a")] }, toolResult]),
+    ).toBe("text | reasoning,text,tool-call | tool-result")
+  })
+
+  test("drops empty text after a tool-call rather than moving it", () => {
+    expect(sanitize([user, { role: "assistant", content: [toolCall("1"), text("   ")] }, toolResult])).toBe(
+      "text | tool-call | tool-result",
+    )
+  })
+
+  test("moves trailing text in front while preserving relative order", () => {
+    expect(sanitize([user, { role: "assistant", content: [text("a"), toolCall("1"), text("b")] }, toolResult])).toBe(
+      "text | text,text,tool-call | tool-result",
+    )
+  })
+
+  test("moves text ahead of the first tool-call when several tool-calls exist", () => {
+    expect(
+      sanitize([user, { role: "assistant", content: [toolCall("1"), text("a"), toolCall("2")] }, toolResult]),
+    ).toBe("text | text,tool-call,tool-call | tool-result")
+  })
+
+  test("leaves a message with no tool-call untouched", () => {
+    expect(sanitize([user, { role: "assistant", content: [text("a"), reasoning("r")] }, toolResult])).toBe(
+      "text | text,reasoning | tool-result",
+    )
+  })
+
+  test("preserves the moved text verbatim", () => {
+    const result = KiloTrailingAssistant.sanitize([
+      user,
+      { role: "assistant", content: [toolCall("1"), text("hello world")] },
+      toolResult,
+    ] as ModelMessage[])
+    const content = (result[1] as { content: { type: string; text?: string }[] }).content
+    expect(content[0]).toEqual({ type: "text", text: "hello world" })
+  })
+})
+
+describe("KiloTrailingAssistant.sanitize - trailing assistant turns", () => {
+  test("drops a trailing reasoning-only turn", () => {
+    expect(sanitize([user, { role: "assistant", content: [reasoning("r")] }])).toBe("text")
+  })
+
+  test("drops a trailing turn containing only empty text", () => {
+    expect(sanitize([user, { role: "assistant", content: [text("   ")] }])).toBe("text")
+  })
+
+  test("drops a trailing turn whose string content is blank", () => {
+    expect(sanitize([user, { role: "assistant", content: "   " }])).toBe("text")
+  })
+
+  // Regression guard for the eight session.message-v2 tests that assert the
+  // conversion contract: a trailing assistant turn carrying real output is
+  // part of the result and must never be discarded.
+  test("preserves a trailing turn that carries real text", () => {
+    expect(sanitize([user, { role: "assistant", content: [text("a")] }])).toBe("text | text")
+  })
+
+  test("preserves a trailing turn with non-empty string content", () => {
+    expect(sanitize([user, { role: "assistant", content: "hello" }])).toBe("text | str:hello")
+  })
+
+  test("preserves a trailing turn whose last block is text after reasoning", () => {
+    expect(sanitize([user, { role: "assistant", content: [reasoning("r"), text("a")] }])).toBe("text | reasoning,text")
+  })
+
+  test("preserves an assistant-only array", () => {
+    expect(sanitize([{ role: "assistant", content: [reasoning("r"), text("partial answer")] }])).toBe("reasoning,text")
+  })
+
+  test("strips trailing reasoning from a turn that has real output", () => {
+    expect(sanitize([user, { role: "assistant", content: [text("a"), reasoning("r")] }])).toBe("text | text")
+  })
+
+  test("keeps a tool-call-only trailing turn, which is committed output", () => {
+    expect(sanitize([user, { role: "assistant", content: [toolCall("1")] }])).toBe("text | tool-call")
+  })
+
+  test("reorders and keeps a trailing inverted turn", () => {
+    expect(sanitize([user, { role: "assistant", content: [toolCall("1"), text("a")] }])).toBe("text | text,tool-call")
+  })
+
+  test("leaves an array already ending with a user message untouched", () => {
+    expect(sanitize([{ role: "assistant", content: [text("a"), toolCall("1")] }, toolResult, user])).toBe(
+      "text,tool-call | tool-result | text",
+    )
+  })
+
+  test("handles an empty array", () => {
+    expect(sanitize([])).toBe("")
+  })
+})


### PR DESCRIPTION
## Issue

Fixes #13286

## Context

Requests to `https://api.anthropic.com/v1/messages` intermittently failed with HTTP 400 `This model does not support assistant message prefill. The conversation must end with a user message.` on Claude 4.6 / Opus 5. `isRetryable` is false, so the turn was lost.

I captured a failing request in full and dissected it. The payload's `messages` array **did** end with a `user` turn, so the literal wording of the error is misleading and the hypothesis in #13286 (a violated tail-role invariant) was not the actual cause. The defect is the *internal block order of an assistant message*:

```
[241] assistant: [0] tool_use  bash  toolu_01QCRN...
                 [1] text      "Calendar sources exist, so the empty dropdown is a code bug..."
[242] user:      [0] tool_result  toolu_01QCRN...
```

Healthy neighbours are `text -> tool_use`; this one is inverted. `toModelMessage` iterates `msg.parts` in array order and the part index is `(message_id, id)`, so wire order follows part ID order. The stored record shows the text part's `time.end` is 111s *before* its own `time.start`, and 9ms before the tool part was created - the text genuinely streamed first, but its part ID was minted late, sorting it last.

Across a month of local logs, 16 of 17 occurrences of this 400 were immediately preceded by an assistant message with this inverted shape (13 within 10s). In the run used to validate the fix, separation was clean: 101 requests with well-formed final assistant messages all succeeded; the single request whose final assistant message was inverted failed.

Position matters, and the evidence is unusually clean. In the captured failing request (243 messages, 121 assistant turns) two messages carried the defect: index 99 and index 241. Index 99 was already present in the first captured request of that session and rode along in all 101 subsequent requests - every one of which returned 200. Only index 241, the *final* assistant message, drew the 400.

The existing `KiloTrailingAssistant.sanitize` could not catch this. Its trailing-turn logic depends on `convertToModelMessages` splitting the UI message at a `step-start`. This shape has no `step-start` before the text:

```
step-start, reasoning, tool, step-finish, text
```

so the text is merged into the *same* assistant message as the tool call. The array still ends with a user/tool message, and `sanitize` only inspected `out[out.length - 1]`, so the malformed message was structurally invisible to it.

## Implementation

Three related fixes to outbound Anthropic message shape, all applied after conversion on the exact array that goes over the wire:

1. **`reorderAssistantContent` (new)** - moves any `text` block that follows the first `tool-call` back in front of it, preserving relative order. This is lossless and restores true chronology, which `time.end` independently confirms. Reasoning keeps its position so a leading signed thinking block stays leading. Empty/whitespace-only text after a tool call is dropped rather than moved, since Anthropic rejects empty text blocks and such a block carries no output.
2. **Drop *empty* trailing assistant turns** - a dangling thinking-only step carries no committed output, so removing it is lossless and prevents `The final block in an assistant message cannot be 'thinking'`. A trailing turn that carries real output is always preserved; only trailing `reasoning` blocks are stripped from it.
3. **Do not replay reasoning blocks whose text was lost** - a thinking block that kept its signature but lost its text cannot validate, and blank-text reasoning no longer keeps the empty-text separator workaround alive.

Ordering matters: the reorder pass runs *before* the trailing-turn pass, because dropping a trailing turn does not help when the malformed message sits mid-array.

Every assistant message is repaired, not just the last, because compaction and context truncation can promote a historical message into the final position, converting a latent defect into a hard failure at an arbitrary later turn. The transform is deterministic, so the rewritten prefix is stable across requests: it costs at most one prompt-cache invalidation the first time a given session is sent, then re-stabilizes.

Reviewers may want to look closely at `isCommitted`, which deliberately excludes `reasoning`: a thinking block alone is not a turn, and adaptive thinking emits signed blocks whose `text` is empty, so text length is not a usable signal there.

**On why last-turn prefill is deliberately not handled.** An earlier revision of this change also dropped trailing assistant turns that carried real output, on the theory that Claude 4.6+ refuses all last-turn prefill. That was over-reach and it was wrong twice over. It is unsupported by the evidence - the captured 400 ended with a `user`/`tool_result` message, so that error was caused by the inverted block order, not by a trailing turn. It is also destructive: `toModelMessages` is a general-purpose conversion also used by compaction, title generation and plan follow-up, all of which legitimately convert histories ending with an assistant turn. Discarding that content silently truncated their input and broke eight assertions in the existing `packages/opencode/test/session/message-v2.test.ts`. That behaviour has been removed and the contract is now regression-guarded by tests in this PR.

**Not established:** I have not proven Anthropic's server-side reason for rejecting this shape, only that the shape and the rejection correlate exactly in my data. The root cause of the late part ID is also still unknown - `text-start` assigns `PartID.ascending()` with `time: {start: Date.now()}`, which cannot itself produce `start > end`, so something re-creates the part later. This PR is a guard at the wire boundary and is independent of that upstream defect.

## Screenshots / Video

N/A - no visual changes.

## How to Test

### Manual/local verification

Every check below was **executed by the agent** in a WSL Ubuntu checkout, except the final item which was **executed by a human**. Test and typecheck commands are run from `packages/opencode/`.

- `bun test ./test/kilocode/sessions/trailing-assistant.test.ts` - **20 pass, 0 fail**. Covers the new reordering, the empty-turn drop, and explicit guards that a trailing turn carrying real output is preserved.
- `bun test ./test/session/message-v2.test.ts` - **37 pass, 0 fail**, identical to `origin/main`. This is the existing upstream suite for the modified function and is the regression gate for the trailing-turn contract described above.
- `bun run typecheck` (`tsgo --noEmit`) - exit 0.
- **Affected-file sweep**: every test file that imports or exercises the touched modules, 62 files - 985 pass, 2 fail. Both failures are in `kilocode/codex-auth-refresh.test.ts`, which fails identically on pristine `origin/main` (2 and 1 failures across repeated runs, on both branches) and contains no reference to the changed code. Confirmed pre-existing flake, not a regression.
- **A/B baseline**: the sweep above was compared against pristine `origin/main` in the same worktree with unchanged dependencies, so only the source under test varied.
- `bunx prettier --check` on all changed files - clean.
- `bunx oxlint` on changed files - 0 errors. The change adds no new warnings to `message-v2.ts`; linting main's version of the file at the same path yields the same 24 warnings with an identical rule breakdown.
- All ten repository `script/check-*.ts` gates - exit 0.
- **Replay of the captured failure**: the 243-message `ModelMessage` array reconstructed from the captured 1,320,217-byte failing request body was replayed through the real `sanitize`. Message [241] changes from `["tool-call","text"]` to `["text","tool-call"]`; both defective messages (99 and 241) are repaired; the moved text is byte-identical and the `toolCallId` preserved; message count (243), non-empty text blocks (58), tool-calls (128) and terminal role are all unchanged; no other message in the array is modified.
- **Executed by a human**, over several days: a build containing this change was run against the live Anthropic API for several hundred turns of normal tool-heavy use, with no recurrence of the 400. Before the change the error reproduced repeatedly over the preceding month.

### Reviewer test steps

1. Select Claude Opus 5 (or Claude 4.6) with a direct Anthropic API key.
2. Use Code mode on a multi-turn task that makes frequent tool calls.
3. Confirm no `does not support assistant message prefill` 400 occurs.
4. For a deterministic check, run the two test files listed above from `packages/opencode/`.

### Blocked checks and substitute verification

- No deterministic reproduction of the underlying late-part-ID condition exists, so the field failure could not be triggered on demand. Substitute verification was replaying the real captured failing payload through the sanitizer, plus the several-hundred-turn human run against the live API described above.
- The repository's local `pre-push` hook runs a monorepo-wide typecheck that includes `@kilocode/kilo-jetbrains`, which needs a JVM 17+ toolchain that is not present in this environment. Gradle aborts on its JVM version check before evaluating or compiling anything, and that package's git tree object is identical on this branch and on `origin/main` (`a99fe0a3`), so the outcome is environment-determined and independent of this change. The hook was therefore bypassed for the push. Substitute verification was running the monorepo typecheck across all 29 TypeScript packages directly (29/29 successful) plus every gate listed above; CI will run the JetBrains typecheck properly.
- `kilocode/codex-auth-refresh.test.ts` does not pass cleanly in this environment (2 failures). It is unrelated to this change and fails the same way on pristine `origin/main`; substitute verification was running it on both branches repeatedly to establish it as pre-existing.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

<!-- Discord handle, if you'd like. -->
