### PR TITLE
fix(agent-manager): reference update-from-base in introduction

### DIFF
--- a/.changeset/agent-manager-intro-base-update.md
+++ b/.changeset/agent-manager-intro-base-update.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Reference /update-from-base in the Agent Manager introduction to explain how to merge the latest base branch changes into a worktree.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/introduction-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/introduction-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1828e124d08620b4a6a93089f8fc56b6bf503d4664888c206c56fef726289742
-size 52056
+oid sha256:79f6f5395d0f8346f3607d2d5c26d76c8adfb99d63811245daecee07cfd60e17
+size 54321

--- a/packages/kilo-vscode/tests/unit/agent-manager-i18n-split.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-i18n-split.test.ts
@@ -154,7 +154,7 @@ describe("Agent Manager i18n split", () => {
 
   it("references the base update command in every introduction locale", () => {
     for (const [locale, dict] of Object.entries(locales)) {
-      expect(dict["agentManager.intro.conflictText"], `${locale}: base update command`).toContain("/update-from-base")
+      expect(dict["agentManager.intro.updateText"], `${locale}: base update command`).toContain("/update-from-base")
     }
   })
 

--- a/packages/kilo-vscode/tests/unit/agent-manager-i18n-split.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-i18n-split.test.ts
@@ -152,6 +152,12 @@ describe("Agent Manager i18n split", () => {
     }
   })
 
+  it("references the base update command in every introduction locale", () => {
+    for (const [locale, dict] of Object.entries(locales)) {
+      expect(dict["agentManager.intro.conflictText"], `${locale}: base update command`).toContain("/update-from-base")
+    }
+  })
+
   it("contains required core keys in every locale", () => {
     const required = [
       "agentManager.local",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -275,7 +275,7 @@ export const dict = {
   "agentManager.intro.graph.pr": "طلب سحب",
   "agentManager.intro.graph.conflict": "إذا تعارضت التغييرات",
   "agentManager.intro.conflictText":
-    "اطلب من الوكيل في worktree دمج فرعه الأساسي الأصلي وحل التعارضات، ثم راجع النتيجة. تجنب git stash: فعمليات stash مشتركة بين worktrees.",
+    "استخدم /update-from-base في دردشة worktree لتطلب من الوكيل جلب فرعه الأساسي المحفوظ ودمجه. راجع نتائج حل أي تعارضات. تجنب git stash: فعمليات stash مشتركة بين worktrees.",
   "agentManager.intro.stage1.title": "مستودعك",
   "agentManager.intro.stage1.text": "تبقى الملفات المحلية دون تغيير",
   "agentManager.intro.stage2.title": "مثال: مهمتان بالتوازي",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -273,9 +273,9 @@ export const dict = {
     "worktree هو مجلد وفرع منفصلان لمهمة. يمكن لوكلائك العمل جنبًا إلى جنب دون تعديل الملفات نفسها.",
   "agentManager.intro.graph.agent": "وكيل Kilo",
   "agentManager.intro.graph.pr": "طلب سحب",
-  "agentManager.intro.updateTitle": "حلّ التعارضات باستخدام وكيل worktree",
+  "agentManager.intro.updateTitle": "حلّ التعارضات باستخدام Kilo",
   "agentManager.intro.updateText":
-    "قبل تطبيق التغييرات على Local أو دمج طلب سحب، شغّل /update-from-base في جلسة الـ worktree المعني. يدمج الوكيل أحدث تغييرات الفرع الأساسي ويحلّ التعارضات داخل الـ worktree نفسه أولًا.",
+    "قبل تطبيق التغييرات على Local أو دمج طلب سحب، شغّل /update-from-base في جلسة الـ worktree المعني. يدمج Kilo أحدث تغييرات الفرع الأساسي ويحلّ التعارضات داخل الـ worktree نفسه أولًا.",
   "agentManager.intro.stage1.title": "مستودعك",
   "agentManager.intro.stage1.text": "تبقى الملفات المحلية دون تغيير",
   "agentManager.intro.stage2.title": "مثال: مهمتان بالتوازي",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -273,8 +273,9 @@ export const dict = {
     "worktree هو مجلد وفرع منفصلان لمهمة. يمكن لوكلائك العمل جنبًا إلى جنب دون تعديل الملفات نفسها.",
   "agentManager.intro.graph.agent": "وكيل Kilo",
   "agentManager.intro.graph.pr": "طلب سحب",
-  "agentManager.intro.updateTitle": "تحديث worktree من الفرع الأساسي",
-  "agentManager.intro.updateText": "شغّل /update-from-base في جلسته لدمج أحدث تغييرات الفرع الأساسي.",
+  "agentManager.intro.updateTitle": "حلّ التعارضات باستخدام وكيل worktree",
+  "agentManager.intro.updateText":
+    "قبل تطبيق التغييرات على Local أو دمج طلب سحب، شغّل /update-from-base في جلسة الـ worktree المعني. يدمج الوكيل أحدث تغييرات الفرع الأساسي ويحلّ التعارضات داخل الـ worktree نفسه أولًا.",
   "agentManager.intro.stage1.title": "مستودعك",
   "agentManager.intro.stage1.text": "تبقى الملفات المحلية دون تغيير",
   "agentManager.intro.stage2.title": "مثال: مهمتان بالتوازي",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ar.ts
@@ -273,9 +273,8 @@ export const dict = {
     "worktree هو مجلد وفرع منفصلان لمهمة. يمكن لوكلائك العمل جنبًا إلى جنب دون تعديل الملفات نفسها.",
   "agentManager.intro.graph.agent": "وكيل Kilo",
   "agentManager.intro.graph.pr": "طلب سحب",
-  "agentManager.intro.graph.conflict": "إذا تعارضت التغييرات",
-  "agentManager.intro.conflictText":
-    "استخدم /update-from-base في دردشة worktree لتطلب من الوكيل جلب فرعه الأساسي المحفوظ ودمجه. راجع نتائج حل أي تعارضات. تجنب git stash: فعمليات stash مشتركة بين worktrees.",
+  "agentManager.intro.updateTitle": "تحديث worktree من الفرع الأساسي",
+  "agentManager.intro.updateText": "شغّل /update-from-base في جلسته لدمج أحدث تغييرات الفرع الأساسي.",
   "agentManager.intro.stage1.title": "مستودعك",
   "agentManager.intro.stage1.text": "تبقى الملفات المحلية دون تغيير",
   "agentManager.intro.stage2.title": "مثال: مهمتان بالتوازي",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -278,9 +278,9 @@ export const dict = {
     "Um worktree é uma pasta e branch separadas para uma tarefa. Seus agentes podem trabalhar lado a lado sem editar os mesmos arquivos.",
   "agentManager.intro.graph.agent": "agente Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Atualizar um worktree a partir da base",
+  "agentManager.intro.updateTitle": "Resolva conflitos com o agente do worktree",
   "agentManager.intro.updateText":
-    "Execute /update-from-base na sessão do worktree para mesclar as alterações mais recentes da branch base.",
+    "Antes de aplicar alterações no Local ou mesclar um pull request, execute /update-from-base na sessão desse worktree. O agente mescla as alterações mais recentes da base e resolve os conflitos primeiro dentro desse worktree.",
   "agentManager.intro.stage1.title": "Seu repositório",
   "agentManager.intro.stage1.text": "Os arquivos locais permanecem inalterados",
   "agentManager.intro.stage2.title": "Exemplo: duas tarefas em paralelo",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -278,9 +278,9 @@ export const dict = {
     "Um worktree é uma pasta e branch separadas para uma tarefa. Seus agentes podem trabalhar lado a lado sem editar os mesmos arquivos.",
   "agentManager.intro.graph.agent": "agente Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "Se as alterações entrarem em conflito",
-  "agentManager.intro.conflictText":
-    "Use /update-from-base no chat do worktree para pedir ao agente que busque e mescle sua branch base salva. Revise as resoluções de conflitos. Evite git stash: os stashes são compartilhados entre os worktrees.",
+  "agentManager.intro.updateTitle": "Atualizar um worktree a partir da base",
+  "agentManager.intro.updateText":
+    "Execute /update-from-base na sessão do worktree para mesclar as alterações mais recentes da branch base.",
   "agentManager.intro.stage1.title": "Seu repositório",
   "agentManager.intro.stage1.text": "Os arquivos locais permanecem inalterados",
   "agentManager.intro.stage2.title": "Exemplo: duas tarefas em paralelo",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -278,9 +278,9 @@ export const dict = {
     "Um worktree é uma pasta e branch separadas para uma tarefa. Seus agentes podem trabalhar lado a lado sem editar os mesmos arquivos.",
   "agentManager.intro.graph.agent": "agente Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Resolva conflitos com o agente do worktree",
+  "agentManager.intro.updateTitle": "Resolva conflitos com o Kilo",
   "agentManager.intro.updateText":
-    "Antes de aplicar alterações no Local ou mesclar um pull request, execute /update-from-base na sessão desse worktree. O agente mescla as alterações mais recentes da base e resolve os conflitos primeiro dentro desse worktree.",
+    "Antes de aplicar alterações no Local ou mesclar um pull request, execute /update-from-base na sessão desse worktree. O Kilo mescla as alterações mais recentes da base e resolve os conflitos primeiro dentro desse worktree.",
   "agentManager.intro.stage1.title": "Seu repositório",
   "agentManager.intro.stage1.text": "Os arquivos locais permanecem inalterados",
   "agentManager.intro.stage2.title": "Exemplo: duas tarefas em paralelo",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/br.ts
@@ -280,7 +280,7 @@ export const dict = {
   "agentManager.intro.graph.pr": "Pull request",
   "agentManager.intro.graph.conflict": "Se as alterações entrarem em conflito",
   "agentManager.intro.conflictText":
-    "Peça ao agente no worktree para mesclar sua branch base original e resolver os conflitos, depois revise o resultado. Evite git stash: os stashes são compartilhados entre os worktrees.",
+    "Use /update-from-base no chat do worktree para pedir ao agente que busque e mescle sua branch base salva. Revise as resoluções de conflitos. Evite git stash: os stashes são compartilhados entre os worktrees.",
   "agentManager.intro.stage1.title": "Seu repositório",
   "agentManager.intro.stage1.text": "Os arquivos locais permanecem inalterados",
   "agentManager.intro.stage2.title": "Exemplo: duas tarefas em paralelo",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -276,9 +276,9 @@ export const dict = {
     "Worktree je zaseban folder i grana za zadatak. Agenti mogu raditi usporedno bez uređivanja istih datoteka.",
   "agentManager.intro.graph.agent": "Kilo agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Riješite konflikte pomoću agenta u worktree-u",
+  "agentManager.intro.updateTitle": "Riješite konflikte uz Kilo",
   "agentManager.intro.updateText":
-    "Prije nego što primijenite promjene na Local ili spojite pull request, pokrenite /update-from-base u sesiji tog worktree-a. Agent spaja najnovije promjene iz baze i prvo rješava konflikte unutar tog worktree-a.",
+    "Prije nego što primijenite promjene na Local ili spojite pull request, pokrenite /update-from-base u sesiji tog worktree-a. Kilo spaja najnovije promjene iz baze i prvo rješava konflikte unutar tog worktree-a.",
   "agentManager.intro.stage1.title": "Vaš repozitorij",
   "agentManager.intro.stage1.text": "Lokalne datoteke ostaju nepromijenjene",
   "agentManager.intro.stage2.title": "Primjer: dva zadatka paralelno",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -278,7 +278,7 @@ export const dict = {
   "agentManager.intro.graph.pr": "Pull request",
   "agentManager.intro.graph.conflict": "Ako se promjene sukobe",
   "agentManager.intro.conflictText":
-    "Zamolite agenta u worktree-u da spoji svoju originalnu osnovnu granu i riješi konflikte, a zatim pregledajte rezultat. Izbjegavajte git stash: stash-ovi se dijele između worktree-a.",
+    "Koristite /update-from-base u chatu worktree-a da zamolite agenta da preuzme i spoji njegovu sačuvanu osnovnu granu. Pregledajte sva rješenja konflikata. Izbjegavajte git stash: stash-ovi se dijele između worktree-a.",
   "agentManager.intro.stage1.title": "Vaš repozitorij",
   "agentManager.intro.stage1.text": "Lokalne datoteke ostaju nepromijenjene",
   "agentManager.intro.stage2.title": "Primjer: dva zadatka paralelno",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -276,9 +276,9 @@ export const dict = {
     "Worktree je zaseban folder i grana za zadatak. Agenti mogu raditi usporedno bez uređivanja istih datoteka.",
   "agentManager.intro.graph.agent": "Kilo agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "Ako se promjene sukobe",
-  "agentManager.intro.conflictText":
-    "Koristite /update-from-base u chatu worktree-a da zamolite agenta da preuzme i spoji njegovu sačuvanu osnovnu granu. Pregledajte sva rješenja konflikata. Izbjegavajte git stash: stash-ovi se dijele između worktree-a.",
+  "agentManager.intro.updateTitle": "Ažurirajte worktree iz osnovne grane",
+  "agentManager.intro.updateText":
+    "Pokrenite /update-from-base u njegovoj sesiji da spojite najnovije promjene osnovne grane.",
   "agentManager.intro.stage1.title": "Vaš repozitorij",
   "agentManager.intro.stage1.text": "Lokalne datoteke ostaju nepromijenjene",
   "agentManager.intro.stage2.title": "Primjer: dva zadatka paralelno",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/bs.ts
@@ -276,9 +276,9 @@ export const dict = {
     "Worktree je zaseban folder i grana za zadatak. Agenti mogu raditi usporedno bez uređivanja istih datoteka.",
   "agentManager.intro.graph.agent": "Kilo agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Ažurirajte worktree iz osnovne grane",
+  "agentManager.intro.updateTitle": "Riješite konflikte pomoću agenta u worktree-u",
   "agentManager.intro.updateText":
-    "Pokrenite /update-from-base u njegovoj sesiji da spojite najnovije promjene osnovne grane.",
+    "Prije nego što primijenite promjene na Local ili spojite pull request, pokrenite /update-from-base u sesiji tog worktree-a. Agent spaja najnovije promjene iz baze i prvo rješava konflikte unutar tog worktree-a.",
   "agentManager.intro.stage1.title": "Vaš repozitorij",
   "agentManager.intro.stage1.text": "Lokalne datoteke ostaju nepromijenjene",
   "agentManager.intro.stage2.title": "Primjer: dva zadatka paralelno",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -278,9 +278,9 @@ export const dict = {
     "Et worktree er en separat mappe og branch til en opgave. Dine agenter kan arbejde side om side uden at redigere de samme filer.",
   "agentManager.intro.graph.agent": "Kilo-agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Opdater et worktree fra base-branchen",
+  "agentManager.intro.updateTitle": "Løs konflikter med worktree-agenten",
   "agentManager.intro.updateText":
-    "Kør /update-from-base i worktreets session for at flette de seneste ændringer fra base-branchen.",
+    "Før du anvender ændringer på Local eller fletter en pull request, skal du køre /update-from-base i sessionen for det pågældende worktree. Agenten fletter de seneste ændringer fra base-branchen og løser først konflikter i dette worktree.",
   "agentManager.intro.stage1.title": "Dit repository",
   "agentManager.intro.stage1.text": "Lokale filer forbliver uændrede",
   "agentManager.intro.stage2.title": "Eksempel: to opgaver parallelt",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -278,9 +278,9 @@ export const dict = {
     "Et worktree er en separat mappe og branch til en opgave. Dine agenter kan arbejde side om side uden at redigere de samme filer.",
   "agentManager.intro.graph.agent": "Kilo-agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Løs konflikter med worktree-agenten",
+  "agentManager.intro.updateTitle": "Løs konflikter med Kilo",
   "agentManager.intro.updateText":
-    "Før du anvender ændringer på Local eller fletter en pull request, skal du køre /update-from-base i sessionen for det pågældende worktree. Agenten fletter de seneste ændringer fra base-branchen og løser først konflikter i dette worktree.",
+    "Før du anvender ændringer på Local eller fletter en pull request, skal du køre /update-from-base i sessionen for det pågældende worktree. Kilo fletter de seneste ændringer fra base-branchen og løser først konflikter i dette worktree.",
   "agentManager.intro.stage1.title": "Dit repository",
   "agentManager.intro.stage1.text": "Lokale filer forbliver uændrede",
   "agentManager.intro.stage2.title": "Eksempel: to opgaver parallelt",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -278,9 +278,9 @@ export const dict = {
     "Et worktree er en separat mappe og branch til en opgave. Dine agenter kan arbejde side om side uden at redigere de samme filer.",
   "agentManager.intro.graph.agent": "Kilo-agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "Hvis ændringer giver konflikter",
-  "agentManager.intro.conflictText":
-    "Brug /update-from-base i worktree-chatten til at bede agenten om at hente og flette den gemte base-branch. Gennemgå eventuelle konfliktløsninger. Undgå git stash: stash deles mellem worktrees.",
+  "agentManager.intro.updateTitle": "Opdater et worktree fra base-branchen",
+  "agentManager.intro.updateText":
+    "Kør /update-from-base i worktreets session for at flette de seneste ændringer fra base-branchen.",
   "agentManager.intro.stage1.title": "Dit repository",
   "agentManager.intro.stage1.text": "Lokale filer forbliver uændrede",
   "agentManager.intro.stage2.title": "Eksempel: to opgaver parallelt",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/da.ts
@@ -280,7 +280,7 @@ export const dict = {
   "agentManager.intro.graph.pr": "Pull request",
   "agentManager.intro.graph.conflict": "Hvis ændringer giver konflikter",
   "agentManager.intro.conflictText":
-    "Bed agenten i worktree om at flette sin oprindelige base-branch og løse konflikter, og gennemgå derefter resultatet. Undgå git stash: stash deles mellem worktrees.",
+    "Brug /update-from-base i worktree-chatten til at bede agenten om at hente og flette den gemte base-branch. Gennemgå eventuelle konfliktløsninger. Undgå git stash: stash deles mellem worktrees.",
   "agentManager.intro.stage1.title": "Dit repository",
   "agentManager.intro.stage1.text": "Lokale filer forbliver uændrede",
   "agentManager.intro.stage2.title": "Eksempel: to opgaver parallelt",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -281,7 +281,6 @@ export const dict = {
     "Ein Worktree ist ein separater Ordner und Branch für eine Aufgabe. Ihre Agenten können nebeneinander arbeiten, ohne dieselben Dateien zu ändern.",
   "agentManager.intro.graph.agent": "Kilo-Agent",
   "agentManager.intro.graph.pr": "Pull Request",
-  "agentManager.intro.graph.conflict": "Bei Konflikten",
   "agentManager.intro.stage1.title": "Ihr Repository",
   "agentManager.intro.stage1.text": "Lokale Dateien bleiben unverändert",
   "agentManager.intro.stage2.title": "Beispiel: zwei Aufgaben parallel",
@@ -292,8 +291,9 @@ export const dict = {
   "agentManager.intro.stage4.title": "Änderungen zurückholen, wenn Sie bereit sind",
   "agentManager.intro.stage4.text":
     "Bitten Sie den Agenten in jedem Worktree, einen Pull Request zu öffnen. Oder verwenden Sie Apply im Diff-Panel, um Änderungen nach Local zu kopieren.",
-  "agentManager.intro.conflictText":
-    "Verwenden Sie /update-from-base im Worktree-Chat, um den Agenten zu bitten, den gespeicherten Basis-Branch des Worktrees abzurufen und zu mergen. Prüfen Sie alle Konfliktlösungen. Vermeiden Sie git stash: Stashes werden zwischen Worktrees geteilt.",
+  "agentManager.intro.updateTitle": "Einen Worktree vom Basis-Branch aktualisieren",
+  "agentManager.intro.updateText":
+    "Führen Sie /update-from-base in dessen Sitzung aus, um die neuesten Änderungen des Basis-Branches zu mergen.",
   "agentManager.intro.prDetection":
     "PR-Abzeichen werden für jeden Worktree-Branch automatisch aktualisiert (GitHub CLI-Anmeldung erforderlich).",
   "agentManager.intro.checksRunning": "Prüfungen laufen",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -291,9 +291,9 @@ export const dict = {
   "agentManager.intro.stage4.title": "Änderungen zurückholen, wenn Sie bereit sind",
   "agentManager.intro.stage4.text":
     "Bitten Sie den Agenten in jedem Worktree, einen Pull Request zu öffnen. Oder verwenden Sie Apply im Diff-Panel, um Änderungen nach Local zu kopieren.",
-  "agentManager.intro.updateTitle": "Einen Worktree vom Basis-Branch aktualisieren",
+  "agentManager.intro.updateTitle": "Konflikte mit dem Worktree-Agenten lösen",
   "agentManager.intro.updateText":
-    "Führen Sie /update-from-base in dessen Sitzung aus, um die neuesten Änderungen des Basis-Branches zu mergen.",
+    "Bevor Sie Änderungen auf Local anwenden oder einen Pull Request mergen, führen Sie /update-from-base in der Sitzung dieses Worktrees aus. Der Agent mergt die neuesten Änderungen des Basis-Branches und löst Konflikte zuerst in diesem Worktree.",
   "agentManager.intro.prDetection":
     "PR-Abzeichen werden für jeden Worktree-Branch automatisch aktualisiert (GitHub CLI-Anmeldung erforderlich).",
   "agentManager.intro.checksRunning": "Prüfungen laufen",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -291,9 +291,9 @@ export const dict = {
   "agentManager.intro.stage4.title": "Änderungen zurückholen, wenn Sie bereit sind",
   "agentManager.intro.stage4.text":
     "Bitten Sie den Agenten in jedem Worktree, einen Pull Request zu öffnen. Oder verwenden Sie Apply im Diff-Panel, um Änderungen nach Local zu kopieren.",
-  "agentManager.intro.updateTitle": "Konflikte mit dem Worktree-Agenten lösen",
+  "agentManager.intro.updateTitle": "Konflikte mit Kilo lösen",
   "agentManager.intro.updateText":
-    "Bevor Sie Änderungen auf Local anwenden oder einen Pull Request mergen, führen Sie /update-from-base in der Sitzung dieses Worktrees aus. Der Agent mergt die neuesten Änderungen des Basis-Branches und löst Konflikte zuerst in diesem Worktree.",
+    "Bevor Sie Änderungen auf Local anwenden oder einen Pull Request mergen, führen Sie /update-from-base in der Sitzung dieses Worktrees aus. Kilo mergt die neuesten Änderungen des Basis-Branches und löst Konflikte zuerst in diesem Worktree.",
   "agentManager.intro.prDetection":
     "PR-Abzeichen werden für jeden Worktree-Branch automatisch aktualisiert (GitHub CLI-Anmeldung erforderlich).",
   "agentManager.intro.checksRunning": "Prüfungen laufen",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/de.ts
@@ -293,7 +293,7 @@ export const dict = {
   "agentManager.intro.stage4.text":
     "Bitten Sie den Agenten in jedem Worktree, einen Pull Request zu öffnen. Oder verwenden Sie Apply im Diff-Panel, um Änderungen nach Local zu kopieren.",
   "agentManager.intro.conflictText":
-    "Bitten Sie den Agenten im Worktree, seinen ursprünglichen Basis-Branch zu mergen und Konflikte zu lösen, und prüfen Sie anschließend das Ergebnis. Vermeiden Sie git stash: Stashes werden zwischen Worktrees geteilt.",
+    "Verwenden Sie /update-from-base im Worktree-Chat, um den Agenten zu bitten, den gespeicherten Basis-Branch des Worktrees abzurufen und zu mergen. Prüfen Sie alle Konfliktlösungen. Vermeiden Sie git stash: Stashes werden zwischen Worktrees geteilt.",
   "agentManager.intro.prDetection":
     "PR-Abzeichen werden für jeden Worktree-Branch automatisch aktualisiert (GitHub CLI-Anmeldung erforderlich).",
   "agentManager.intro.checksRunning": "Prüfungen laufen",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -287,9 +287,9 @@ export const dict = {
   "agentManager.intro.stage4.title": "Bring changes back when you are ready",
   "agentManager.intro.stage4.text":
     "Ask the agent in each worktree to open a pull request. Or use Apply in the diff panel to copy changes to Local.",
-  "agentManager.intro.updateTitle": "Resolve conflicts with the worktree agent",
+  "agentManager.intro.updateTitle": "Resolve conflicts with Kilo",
   "agentManager.intro.updateText":
-    "Before applying changes to Local or merging a pull request, run /update-from-base in that worktree's session. The agent merges the latest base changes and resolves conflicts there first.",
+    "Before applying changes to Local or merging a pull request, run /update-from-base in that worktree's session. Kilo merges the latest base changes and resolves conflicts there first.",
   "agentManager.intro.prDetection":
     "PR badges update automatically for each worktree branch (GitHub CLI sign-in required).",
   "agentManager.intro.checksRunning": "Checks running",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -287,8 +287,9 @@ export const dict = {
   "agentManager.intro.stage4.title": "Bring changes back when you are ready",
   "agentManager.intro.stage4.text":
     "Ask the agent in each worktree to open a pull request. Or use Apply in the diff panel to copy changes to Local.",
-  "agentManager.intro.updateTitle": "Update a worktree from base",
-  "agentManager.intro.updateText": "Run /update-from-base in its session to merge the latest base branch changes.",
+  "agentManager.intro.updateTitle": "Resolve conflicts with the worktree agent",
+  "agentManager.intro.updateText":
+    "Before applying changes to Local or merging a pull request, run /update-from-base in that worktree's session. The agent merges the latest base changes and resolves conflicts there first.",
   "agentManager.intro.prDetection":
     "PR badges update automatically for each worktree branch (GitHub CLI sign-in required).",
   "agentManager.intro.checksRunning": "Checks running",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -277,7 +277,6 @@ export const dict = {
     "A worktree is a separate folder and branch for a task. Your agents can work side by side without editing the same files.",
   "agentManager.intro.graph.agent": "Kilo agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "If changes conflict",
   "agentManager.intro.stage1.title": "Your repository",
   "agentManager.intro.stage1.text": "Local files stay unchanged",
   "agentManager.intro.stage2.title": "Example: two tasks in parallel",
@@ -288,8 +287,8 @@ export const dict = {
   "agentManager.intro.stage4.title": "Bring changes back when you are ready",
   "agentManager.intro.stage4.text":
     "Ask the agent in each worktree to open a pull request. Or use Apply in the diff panel to copy changes to Local.",
-  "agentManager.intro.conflictText":
-    "Use /update-from-base in the worktree chat to ask the agent to fetch and merge its saved base branch. Review any conflict resolutions. Avoid git stash: stashes are shared across worktrees.",
+  "agentManager.intro.updateTitle": "Update a worktree from base",
+  "agentManager.intro.updateText": "Run /update-from-base in its session to merge the latest base branch changes.",
   "agentManager.intro.prDetection":
     "PR badges update automatically for each worktree branch (GitHub CLI sign-in required).",
   "agentManager.intro.checksRunning": "Checks running",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/en.ts
@@ -289,7 +289,7 @@ export const dict = {
   "agentManager.intro.stage4.text":
     "Ask the agent in each worktree to open a pull request. Or use Apply in the diff panel to copy changes to Local.",
   "agentManager.intro.conflictText":
-    "Ask the agent in the worktree to merge its original base branch and resolve conflicts, then review the result. Avoid git stash: stashes are shared across worktrees.",
+    "Use /update-from-base in the worktree chat to ask the agent to fetch and merge its saved base branch. Review any conflict resolutions. Avoid git stash: stashes are shared across worktrees.",
   "agentManager.intro.prDetection":
     "PR badges update automatically for each worktree branch (GitHub CLI sign-in required).",
   "agentManager.intro.checksRunning": "Checks running",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -290,9 +290,9 @@ export const dict = {
   "agentManager.intro.stage4.title": "Devuelve los cambios cuando estés listo",
   "agentManager.intro.stage4.text":
     "Pide al agente de cada worktree que abra un pull request. O usa Apply en el panel de diff para copiar los cambios a Local.",
-  "agentManager.intro.updateTitle": "Actualizar un worktree desde la rama base",
+  "agentManager.intro.updateTitle": "Resuelve los conflictos con el agente del worktree",
   "agentManager.intro.updateText":
-    "Ejecuta /update-from-base en su sesión para fusionar los cambios más recientes de la rama base.",
+    "Antes de aplicar cambios a Local o fusionar una pull request, ejecuta /update-from-base en la sesión de ese worktree. El agente fusiona los últimos cambios de la rama base y resuelve primero los conflictos dentro de ese worktree.",
   "agentManager.intro.prDetection":
     "Las insignias de PR se actualizan automáticamente para cada rama de worktree (se requiere iniciar sesión en GitHub CLI).",
   "agentManager.intro.checksRunning": "Comprobaciones en curso",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -290,9 +290,9 @@ export const dict = {
   "agentManager.intro.stage4.title": "Devuelve los cambios cuando estés listo",
   "agentManager.intro.stage4.text":
     "Pide al agente de cada worktree que abra un pull request. O usa Apply en el panel de diff para copiar los cambios a Local.",
-  "agentManager.intro.updateTitle": "Resuelve los conflictos con el agente del worktree",
+  "agentManager.intro.updateTitle": "Resuelve los conflictos con Kilo",
   "agentManager.intro.updateText":
-    "Antes de aplicar cambios a Local o fusionar una pull request, ejecuta /update-from-base en la sesión de ese worktree. El agente fusiona los últimos cambios de la rama base y resuelve primero los conflictos dentro de ese worktree.",
+    "Antes de aplicar cambios a Local o fusionar una pull request, ejecuta /update-from-base en la sesión de ese worktree. Kilo fusiona los últimos cambios de la rama base y resuelve primero los conflictos dentro de ese worktree.",
   "agentManager.intro.prDetection":
     "Las insignias de PR se actualizan automáticamente para cada rama de worktree (se requiere iniciar sesión en GitHub CLI).",
   "agentManager.intro.checksRunning": "Comprobaciones en curso",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -280,7 +280,6 @@ export const dict = {
     "Un worktree es una carpeta y una rama separadas para una tarea. Tus agentes pueden trabajar juntos sin modificar los mismos archivos.",
   "agentManager.intro.graph.agent": "Agente de Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "Si hay conflictos",
   "agentManager.intro.stage1.title": "Tu repositorio",
   "agentManager.intro.stage1.text": "Los archivos locales no cambian",
   "agentManager.intro.stage2.title": "Ejemplo: dos tareas en paralelo",
@@ -291,8 +290,9 @@ export const dict = {
   "agentManager.intro.stage4.title": "Devuelve los cambios cuando estés listo",
   "agentManager.intro.stage4.text":
     "Pide al agente de cada worktree que abra un pull request. O usa Apply en el panel de diff para copiar los cambios a Local.",
-  "agentManager.intro.conflictText":
-    "Usa /update-from-base en el chat del worktree para pedir al agente que obtenga y fusione su rama base guardada. Revisa cómo se han resuelto los conflictos. Evita git stash: los stashes se comparten entre worktrees.",
+  "agentManager.intro.updateTitle": "Actualizar un worktree desde la rama base",
+  "agentManager.intro.updateText":
+    "Ejecuta /update-from-base en su sesión para fusionar los cambios más recientes de la rama base.",
   "agentManager.intro.prDetection":
     "Las insignias de PR se actualizan automáticamente para cada rama de worktree (se requiere iniciar sesión en GitHub CLI).",
   "agentManager.intro.checksRunning": "Comprobaciones en curso",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/es.ts
@@ -292,7 +292,7 @@ export const dict = {
   "agentManager.intro.stage4.text":
     "Pide al agente de cada worktree que abra un pull request. O usa Apply en el panel de diff para copiar los cambios a Local.",
   "agentManager.intro.conflictText":
-    "Pide al agente del worktree que fusione su rama base original y resuelva los conflictos, y luego revisa el resultado. Evita git stash: los stashes se comparten entre worktrees.",
+    "Usa /update-from-base en el chat del worktree para pedir al agente que obtenga y fusione su rama base guardada. Revisa cómo se han resuelto los conflictos. Evita git stash: los stashes se comparten entre worktrees.",
   "agentManager.intro.prDetection":
     "Las insignias de PR se actualizan automáticamente para cada rama de worktree (se requiere iniciar sesión en GitHub CLI).",
   "agentManager.intro.checksRunning": "Comprobaciones en curso",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
@@ -279,8 +279,9 @@ export const dict = {
     "worktree برای هر وظیفه یک پوشه و شاخه جداست. عامل‌ها بدون ویرایش فایل‌های یکسان کنار هم کار می‌کنند.",
   "agentManager.intro.graph.agent": "عامل Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "به‌روزرسانی worktree از شاخه پایه",
-  "agentManager.intro.updateText": "برای ادغام آخرین تغییرات شاخه پایه، /update-from-base را در جلسه آن اجرا کنید.",
+  "agentManager.intro.updateTitle": "رفع تعارض‌ها با عامل worktree",
+  "agentManager.intro.updateText":
+    "پیش از اعمال تغییرات در Local یا ادغام pull request، /update-from-base را در جلسه همان worktree اجرا کنید. عامل آخرین تغییرات شاخه پایه را ادغام می‌کند و ابتدا تعارض‌ها را در همان worktree برطرف می‌کند.",
   "agentManager.intro.stage1.title": "مخزن شما",
   "agentManager.intro.stage1.text": "فایل‌های محلی بدون تغییر می‌مانند",
   "agentManager.intro.stage2.title": "مثال: دو وظیفه به‌صورت موازی",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
@@ -281,7 +281,7 @@ export const dict = {
   "agentManager.intro.graph.pr": "Pull request",
   "agentManager.intro.graph.conflict": "اگر تغییرات تعارض داشته باشند",
   "agentManager.intro.conflictText":
-    "از عامل در worktree بخواهید شاخهٔ پایهٔ اصلی خود را merge کند و تعارض‌ها را حل کند، سپس نتیجه را بررسی کنید. از git stash پرهیز کنید: stashها بین worktreeها مشترک هستند.",
+    "در چت worktree از /update-from-base استفاده کنید تا از عامل بخواهید شاخهٔ پایهٔ ذخیره‌شدهٔ آن را fetch و merge کند. نتیجهٔ حل هرگونه تعارض را بررسی کنید. از git stash پرهیز کنید: stashها بین worktreeها مشترک هستند.",
   "agentManager.intro.stage1.title": "مخزن شما",
   "agentManager.intro.stage1.text": "فایل‌های محلی بدون تغییر می‌مانند",
   "agentManager.intro.stage2.title": "مثال: دو وظیفه به‌صورت موازی",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
@@ -279,9 +279,9 @@ export const dict = {
     "worktree برای هر وظیفه یک پوشه و شاخه جداست. عامل‌ها بدون ویرایش فایل‌های یکسان کنار هم کار می‌کنند.",
   "agentManager.intro.graph.agent": "عامل Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "رفع تعارض‌ها با عامل worktree",
+  "agentManager.intro.updateTitle": "رفع تعارض‌ها با Kilo",
   "agentManager.intro.updateText":
-    "پیش از اعمال تغییرات در Local یا ادغام pull request، /update-from-base را در جلسه همان worktree اجرا کنید. عامل آخرین تغییرات شاخه پایه را ادغام می‌کند و ابتدا تعارض‌ها را در همان worktree برطرف می‌کند.",
+    "پیش از اعمال تغییرات در Local یا ادغام pull request، /update-from-base را در جلسه همان worktree اجرا کنید. Kilo آخرین تغییرات شاخه پایه را ادغام می‌کند و ابتدا تعارض‌ها را در همان worktree برطرف می‌کند.",
   "agentManager.intro.stage1.title": "مخزن شما",
   "agentManager.intro.stage1.text": "فایل‌های محلی بدون تغییر می‌مانند",
   "agentManager.intro.stage2.title": "مثال: دو وظیفه به‌صورت موازی",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fa.ts
@@ -279,9 +279,8 @@ export const dict = {
     "worktree برای هر وظیفه یک پوشه و شاخه جداست. عامل‌ها بدون ویرایش فایل‌های یکسان کنار هم کار می‌کنند.",
   "agentManager.intro.graph.agent": "عامل Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "اگر تغییرات تعارض داشته باشند",
-  "agentManager.intro.conflictText":
-    "در چت worktree از /update-from-base استفاده کنید تا از عامل بخواهید شاخهٔ پایهٔ ذخیره‌شدهٔ آن را fetch و merge کند. نتیجهٔ حل هرگونه تعارض را بررسی کنید. از git stash پرهیز کنید: stashها بین worktreeها مشترک هستند.",
+  "agentManager.intro.updateTitle": "به‌روزرسانی worktree از شاخه پایه",
+  "agentManager.intro.updateText": "برای ادغام آخرین تغییرات شاخه پایه، /update-from-base را در جلسه آن اجرا کنید.",
   "agentManager.intro.stage1.title": "مخزن شما",
   "agentManager.intro.stage1.text": "فایل‌های محلی بدون تغییر می‌مانند",
   "agentManager.intro.stage2.title": "مثال: دو وظیفه به‌صورت موازی",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -293,7 +293,7 @@ export const dict = {
   "agentManager.intro.stage4.text":
     "Demandez à l'agent de chaque worktree d'ouvrir une pull request. Ou utilisez Apply dans le panneau de diff pour copier les modifications vers Local.",
   "agentManager.intro.conflictText":
-    "Demandez à l'agent du worktree de fusionner sa branche de base d'origine et de résoudre les conflits, puis examinez le résultat. Évitez git stash : les stashes sont partagés entre les worktrees.",
+    "Utilisez /update-from-base dans le chat du worktree pour demander à l'agent de récupérer et de fusionner sa branche de base enregistrée. Examinez les résolutions de conflits. Évitez git stash : les stashes sont partagés entre les worktrees.",
   "agentManager.intro.prDetection":
     "Les badges PR se mettent à jour automatiquement pour chaque branche de worktree (connexion à GitHub CLI requise).",
   "agentManager.intro.checksRunning": "Vérifications en cours",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -281,7 +281,6 @@ export const dict = {
     "Un worktree est un dossier et une branche séparés pour une tâche. Vos agents peuvent travailler côte à côte sans modifier les mêmes fichiers.",
   "agentManager.intro.graph.agent": "Agent Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "En cas de conflit",
   "agentManager.intro.stage1.title": "Votre dépôt",
   "agentManager.intro.stage1.text": "Les fichiers locaux restent inchangés",
   "agentManager.intro.stage2.title": "Exemple : deux tâches en parallèle",
@@ -292,8 +291,9 @@ export const dict = {
   "agentManager.intro.stage4.title": "Rapportez les modifications quand vous êtes prêt",
   "agentManager.intro.stage4.text":
     "Demandez à l'agent de chaque worktree d'ouvrir une pull request. Ou utilisez Apply dans le panneau de diff pour copier les modifications vers Local.",
-  "agentManager.intro.conflictText":
-    "Utilisez /update-from-base dans le chat du worktree pour demander à l'agent de récupérer et de fusionner sa branche de base enregistrée. Examinez les résolutions de conflits. Évitez git stash : les stashes sont partagés entre les worktrees.",
+  "agentManager.intro.updateTitle": "Mettre à jour un worktree depuis la branche de base",
+  "agentManager.intro.updateText":
+    "Exécutez /update-from-base dans sa session pour fusionner les dernières modifications de la branche de base.",
   "agentManager.intro.prDetection":
     "Les badges PR se mettent à jour automatiquement pour chaque branche de worktree (connexion à GitHub CLI requise).",
   "agentManager.intro.checksRunning": "Vérifications en cours",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -291,9 +291,9 @@ export const dict = {
   "agentManager.intro.stage4.title": "Rapportez les modifications quand vous êtes prêt",
   "agentManager.intro.stage4.text":
     "Demandez à l'agent de chaque worktree d'ouvrir une pull request. Ou utilisez Apply dans le panneau de diff pour copier les modifications vers Local.",
-  "agentManager.intro.updateTitle": "Résolvez les conflits avec l'agent du worktree",
+  "agentManager.intro.updateTitle": "Résolvez les conflits avec Kilo",
   "agentManager.intro.updateText":
-    "Avant d'appliquer des modifications à Local ou de fusionner une pull request, exécutez /update-from-base dans la session de ce worktree. L'agent fusionne les dernières modifications de la branche de base et résout d'abord les conflits dans ce worktree.",
+    "Avant d'appliquer des modifications à Local ou de fusionner une pull request, exécutez /update-from-base dans la session de ce worktree. Kilo fusionne les dernières modifications de la branche de base et résout d'abord les conflits dans ce worktree.",
   "agentManager.intro.prDetection":
     "Les badges PR se mettent à jour automatiquement pour chaque branche de worktree (connexion à GitHub CLI requise).",
   "agentManager.intro.checksRunning": "Vérifications en cours",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/fr.ts
@@ -291,9 +291,9 @@ export const dict = {
   "agentManager.intro.stage4.title": "Rapportez les modifications quand vous êtes prêt",
   "agentManager.intro.stage4.text":
     "Demandez à l'agent de chaque worktree d'ouvrir une pull request. Ou utilisez Apply dans le panneau de diff pour copier les modifications vers Local.",
-  "agentManager.intro.updateTitle": "Mettre à jour un worktree depuis la branche de base",
+  "agentManager.intro.updateTitle": "Résolvez les conflits avec l'agent du worktree",
   "agentManager.intro.updateText":
-    "Exécutez /update-from-base dans sa session pour fusionner les dernières modifications de la branche de base.",
+    "Avant d'appliquer des modifications à Local ou de fusionner une pull request, exécutez /update-from-base dans la session de ce worktree. L'agent fusionne les dernières modifications de la branche de base et résout d'abord les conflits dans ce worktree.",
   "agentManager.intro.prDetection":
     "Les badges PR se mettent à jour automatiquement pour chaque branche de worktree (connexion à GitHub CLI requise).",
   "agentManager.intro.checksRunning": "Vérifications en cours",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
@@ -296,9 +296,9 @@ export const dict = {
   "agentManager.intro.stage4.title": "Riporta le modifiche quando sei pronto",
   "agentManager.intro.stage4.text":
     "Chiedi all'agente di ogni worktree di aprire una pull request. Oppure usa Apply nel pannello diff per copiare le modifiche in Local.",
-  "agentManager.intro.updateTitle": "Risolvi i conflitti con l'agente del worktree",
+  "agentManager.intro.updateTitle": "Risolvi i conflitti con Kilo",
   "agentManager.intro.updateText":
-    "Prima di applicare le modifiche a Local o fare il merge di una pull request, esegui /update-from-base nella sessione di quel worktree. L'agente unisce le ultime modifiche del branch di base e risolve prima i conflitti all'interno di quel worktree.",
+    "Prima di applicare le modifiche a Local o fare il merge di una pull request, esegui /update-from-base nella sessione di quel worktree. Kilo unisce le ultime modifiche del branch di base e risolve prima i conflitti all'interno di quel worktree.",
   "agentManager.intro.prDetection":
     "I badge PR si aggiornano automaticamente per ogni branch del worktree (è richiesto l'accesso a GitHub CLI).",
   "agentManager.intro.checksRunning": "Controlli in corso",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
@@ -296,9 +296,9 @@ export const dict = {
   "agentManager.intro.stage4.title": "Riporta le modifiche quando sei pronto",
   "agentManager.intro.stage4.text":
     "Chiedi all'agente di ogni worktree di aprire una pull request. Oppure usa Apply nel pannello diff per copiare le modifiche in Local.",
-  "agentManager.intro.updateTitle": "Aggiornare un worktree dal branch di base",
+  "agentManager.intro.updateTitle": "Risolvi i conflitti con l'agente del worktree",
   "agentManager.intro.updateText":
-    "Esegui /update-from-base nella sua sessione per unire le ultime modifiche del branch di base.",
+    "Prima di applicare le modifiche a Local o fare il merge di una pull request, esegui /update-from-base nella sessione di quel worktree. L'agente unisce le ultime modifiche del branch di base e risolve prima i conflitti all'interno di quel worktree.",
   "agentManager.intro.prDetection":
     "I badge PR si aggiornano automaticamente per ogni branch del worktree (è richiesto l'accesso a GitHub CLI).",
   "agentManager.intro.checksRunning": "Controlli in corso",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
@@ -286,7 +286,6 @@ export const dict = {
     "Un worktree è una cartella e un branch separati per un'attività. I tuoi agenti possono lavorare fianco a fianco senza modificare gli stessi file.",
   "agentManager.intro.graph.agent": "Agente Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "In caso di conflitti",
   "agentManager.intro.stage1.title": "Il tuo repository",
   "agentManager.intro.stage1.text": "I file locali restano invariati",
   "agentManager.intro.stage2.title": "Esempio: due attività in parallelo",
@@ -297,8 +296,9 @@ export const dict = {
   "agentManager.intro.stage4.title": "Riporta le modifiche quando sei pronto",
   "agentManager.intro.stage4.text":
     "Chiedi all'agente di ogni worktree di aprire una pull request. Oppure usa Apply nel pannello diff per copiare le modifiche in Local.",
-  "agentManager.intro.conflictText":
-    "Usa /update-from-base nella chat del worktree per chiedere all'agente di recuperare e unire il suo branch di base salvato. Controlla come sono stati risolti gli eventuali conflitti. Evita git stash: gli stash sono condivisi tra i worktree.",
+  "agentManager.intro.updateTitle": "Aggiornare un worktree dal branch di base",
+  "agentManager.intro.updateText":
+    "Esegui /update-from-base nella sua sessione per unire le ultime modifiche del branch di base.",
   "agentManager.intro.prDetection":
     "I badge PR si aggiornano automaticamente per ogni branch del worktree (è richiesto l'accesso a GitHub CLI).",
   "agentManager.intro.checksRunning": "Controlli in corso",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/it.ts
@@ -298,7 +298,7 @@ export const dict = {
   "agentManager.intro.stage4.text":
     "Chiedi all'agente di ogni worktree di aprire una pull request. Oppure usa Apply nel pannello diff per copiare le modifiche in Local.",
   "agentManager.intro.conflictText":
-    "Chiedi all'agente nel worktree di unire il proprio branch di base originale e risolvere i conflitti, poi controlla il risultato. Evita git stash: gli stash sono condivisi tra i worktree.",
+    "Usa /update-from-base nella chat del worktree per chiedere all'agente di recuperare e unire il suo branch di base salvato. Controlla come sono stati risolti gli eventuali conflitti. Evita git stash: gli stash sono condivisi tra i worktree.",
   "agentManager.intro.prDetection":
     "I badge PR si aggiornano automaticamente per ogni branch del worktree (è richiesto l'accesso a GitHub CLI).",
   "agentManager.intro.checksRunning": "Controlli in corso",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -289,9 +289,9 @@ export const dict = {
   "agentManager.intro.stage4.title": "準備ができたら変更を戻す",
   "agentManager.intro.stage4.text":
     "各 worktree のエージェントに pull request を開くよう依頼します。または差分パネルで Apply を使い、変更を Local にコピーします。",
-  "agentManager.intro.updateTitle": "worktree のエージェントで競合を解決",
+  "agentManager.intro.updateTitle": "Kilo で競合を解決",
   "agentManager.intro.updateText":
-    "Local に変更を適用するか、pull request をマージする前に、その worktree のセッションで /update-from-base を実行してください。エージェントがベースブランチの最新変更をマージし、まずその worktree 内で競合を解決します。",
+    "Local に変更を適用するか、pull request をマージする前に、その worktree のセッションで /update-from-base を実行してください。Kilo がベースブランチの最新変更をマージし、まずその worktree 内で競合を解決します。",
   "agentManager.intro.prDetection":
     "PR バッジは各 worktree ブランチで自動的に更新されます（GitHub CLI へのサインインが必要です）。",
   "agentManager.intro.checksRunning": "チェック実行中",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -289,9 +289,9 @@ export const dict = {
   "agentManager.intro.stage4.title": "準備ができたら変更を戻す",
   "agentManager.intro.stage4.text":
     "各 worktree のエージェントに pull request を開くよう依頼します。または差分パネルで Apply を使い、変更を Local にコピーします。",
-  "agentManager.intro.updateTitle": "ベースブランチから worktree を更新",
+  "agentManager.intro.updateTitle": "worktree のエージェントで競合を解決",
   "agentManager.intro.updateText":
-    "そのセッションで /update-from-base を実行して、ベースブランチの最新変更をマージしてください。",
+    "Local に変更を適用するか、pull request をマージする前に、その worktree のセッションで /update-from-base を実行してください。エージェントがベースブランチの最新変更をマージし、まずその worktree 内で競合を解決します。",
   "agentManager.intro.prDetection":
     "PR バッジは各 worktree ブランチで自動的に更新されます（GitHub CLI へのサインインが必要です）。",
   "agentManager.intro.checksRunning": "チェック実行中",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -291,7 +291,7 @@ export const dict = {
   "agentManager.intro.stage4.text":
     "各 worktree のエージェントに pull request を開くよう依頼します。または差分パネルで Apply を使い、変更を Local にコピーします。",
   "agentManager.intro.conflictText":
-    "worktree のエージェントに元のベースブランチをマージして競合を解決するよう依頼し、その後結果を確認してください。git stash は worktree 間で共有されるため、使用は避けてください。",
+    "worktree のチャットで /update-from-base を使い、保存されているベースブランチをフェッチしてマージするようエージェントに依頼してください。競合が解決された場合は、その内容を確認してください。stash は worktree 間で共有されるため、git stash の使用は避けてください。",
   "agentManager.intro.prDetection":
     "PR バッジは各 worktree ブランチで自動的に更新されます（GitHub CLI へのサインインが必要です）。",
   "agentManager.intro.checksRunning": "チェック実行中",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ja.ts
@@ -279,7 +279,6 @@ export const dict = {
     "worktree はタスク用の分離されたフォルダとブランチです。エージェントは同じファイルを編集せず、並行して作業できます。",
   "agentManager.intro.graph.agent": "Kilo エージェント",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "変更が競合する場合",
   "agentManager.intro.stage1.title": "あなたのリポジトリ",
   "agentManager.intro.stage1.text": "ローカルファイルは変更されません",
   "agentManager.intro.stage2.title": "例：2 つのタスクを並行実行",
@@ -290,8 +289,9 @@ export const dict = {
   "agentManager.intro.stage4.title": "準備ができたら変更を戻す",
   "agentManager.intro.stage4.text":
     "各 worktree のエージェントに pull request を開くよう依頼します。または差分パネルで Apply を使い、変更を Local にコピーします。",
-  "agentManager.intro.conflictText":
-    "worktree のチャットで /update-from-base を使い、保存されているベースブランチをフェッチしてマージするようエージェントに依頼してください。競合が解決された場合は、その内容を確認してください。stash は worktree 間で共有されるため、git stash の使用は避けてください。",
+  "agentManager.intro.updateTitle": "ベースブランチから worktree を更新",
+  "agentManager.intro.updateText":
+    "そのセッションで /update-from-base を実行して、ベースブランチの最新変更をマージしてください。",
   "agentManager.intro.prDetection":
     "PR バッジは各 worktree ブランチで自動的に更新されます（GitHub CLI へのサインインが必要です）。",
   "agentManager.intro.checksRunning": "チェック実行中",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -276,7 +276,7 @@ export const dict = {
   "agentManager.intro.graph.pr": "Pull request",
   "agentManager.intro.graph.conflict": "변경 사항이 충돌하면",
   "agentManager.intro.conflictText":
-    "worktree의 에이전트에게 원래 base branch를 병합하고 충돌을 해결하도록 요청한 다음 결과를 검토하세요. git stash는 worktree 간에 공유되므로 사용하지 마세요.",
+    "worktree 채팅에서 /update-from-base를 사용해 에이전트에게 해당 worktree의 저장된 base branch를 가져와 병합하도록 요청하세요. 충돌이 해결되었다면 그 내용을 검토하세요. stash는 worktree 간에 공유되므로 git stash 사용을 피하세요.",
   "agentManager.intro.stage1.title": "내 저장소",
   "agentManager.intro.stage1.text": "로컬 파일은 변경되지 않습니다",
   "agentManager.intro.stage2.title": "예: 두 작업을 병렬로",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -274,9 +274,9 @@ export const dict = {
     "worktree는 작업을 위한 별도 폴더와 브랜치입니다. 에이전트가 같은 파일을 편집하지 않고 나란히 작업할 수 있습니다.",
   "agentManager.intro.graph.agent": "Kilo 에이전트",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "변경 사항이 충돌하면",
-  "agentManager.intro.conflictText":
-    "worktree 채팅에서 /update-from-base를 사용해 에이전트에게 해당 worktree의 저장된 base branch를 가져와 병합하도록 요청하세요. 충돌이 해결되었다면 그 내용을 검토하세요. stash는 worktree 간에 공유되므로 git stash 사용을 피하세요.",
+  "agentManager.intro.updateTitle": "베이스 브랜치에서 worktree 업데이트",
+  "agentManager.intro.updateText":
+    "해당 세션에서 /update-from-base 명령을 실행하여 베이스 브랜치의 최신 변경 사항을 병합하세요.",
   "agentManager.intro.stage1.title": "내 저장소",
   "agentManager.intro.stage1.text": "로컬 파일은 변경되지 않습니다",
   "agentManager.intro.stage2.title": "예: 두 작업을 병렬로",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -274,9 +274,9 @@ export const dict = {
     "worktree는 작업을 위한 별도 폴더와 브랜치입니다. 에이전트가 같은 파일을 편집하지 않고 나란히 작업할 수 있습니다.",
   "agentManager.intro.graph.agent": "Kilo 에이전트",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "베이스 브랜치에서 worktree 업데이트",
+  "agentManager.intro.updateTitle": "worktree 에이전트로 충돌 해결",
   "agentManager.intro.updateText":
-    "해당 세션에서 /update-from-base 명령을 실행하여 베이스 브랜치의 최신 변경 사항을 병합하세요.",
+    "Local에 변경 사항을 적용하거나 pull request를 병합하기 전에 해당 worktree의 세션에서 /update-from-base 명령을 실행하세요. 에이전트가 베이스 브랜치의 최신 변경 사항을 병합하고 먼저 해당 worktree 안에서 충돌을 해결합니다.",
   "agentManager.intro.stage1.title": "내 저장소",
   "agentManager.intro.stage1.text": "로컬 파일은 변경되지 않습니다",
   "agentManager.intro.stage2.title": "예: 두 작업을 병렬로",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ko.ts
@@ -274,9 +274,9 @@ export const dict = {
     "worktree는 작업을 위한 별도 폴더와 브랜치입니다. 에이전트가 같은 파일을 편집하지 않고 나란히 작업할 수 있습니다.",
   "agentManager.intro.graph.agent": "Kilo 에이전트",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "worktree 에이전트로 충돌 해결",
+  "agentManager.intro.updateTitle": "Kilo로 충돌 해결",
   "agentManager.intro.updateText":
-    "Local에 변경 사항을 적용하거나 pull request를 병합하기 전에 해당 worktree의 세션에서 /update-from-base 명령을 실행하세요. 에이전트가 베이스 브랜치의 최신 변경 사항을 병합하고 먼저 해당 worktree 안에서 충돌을 해결합니다.",
+    "Local에 변경 사항을 적용하거나 pull request를 병합하기 전에 해당 worktree의 세션에서 /update-from-base 명령을 실행하세요. Kilo가 베이스 브랜치의 최신 변경 사항을 병합하고 먼저 해당 worktree 안에서 충돌을 해결합니다.",
   "agentManager.intro.stage1.title": "내 저장소",
   "agentManager.intro.stage1.text": "로컬 파일은 변경되지 않습니다",
   "agentManager.intro.stage2.title": "예: 두 작업을 병렬로",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
@@ -284,7 +284,7 @@ export const dict = {
   "agentManager.intro.graph.pr": "Pull request",
   "agentManager.intro.graph.conflict": "Als wijzigingen conflicteren",
   "agentManager.intro.conflictText":
-    "Vraag de agent in de worktree om zijn oorspronkelijke basisbranch te mergen en conflicten op te lossen, en controleer daarna het resultaat. Vermijd git stash: stashes worden gedeeld tussen worktrees.",
+    "Gebruik /update-from-base in de worktree-chat om de agent te vragen de opgeslagen basisbranch op te halen en te mergen. Controleer hoe eventuele conflicten zijn opgelost. Vermijd git stash: stashes worden gedeeld tussen worktrees.",
   "agentManager.intro.stage1.title": "Je repository",
   "agentManager.intro.stage1.text": "Lokale bestanden blijven ongewijzigd",
   "agentManager.intro.stage2.title": "Voorbeeld: twee taken parallel",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
@@ -282,9 +282,9 @@ export const dict = {
     "Een worktree is een aparte map en branch voor een taak. Je agents kunnen naast elkaar werken zonder dezelfde bestanden te bewerken.",
   "agentManager.intro.graph.agent": "Kilo-agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "Als wijzigingen conflicteren",
-  "agentManager.intro.conflictText":
-    "Gebruik /update-from-base in de worktree-chat om de agent te vragen de opgeslagen basisbranch op te halen en te mergen. Controleer hoe eventuele conflicten zijn opgelost. Vermijd git stash: stashes worden gedeeld tussen worktrees.",
+  "agentManager.intro.updateTitle": "Een worktree bijwerken vanuit de basisbranch",
+  "agentManager.intro.updateText":
+    "Voer /update-from-base uit in de bijbehorende sessie om de nieuwste wijzigingen van de basisbranch te mergen.",
   "agentManager.intro.stage1.title": "Je repository",
   "agentManager.intro.stage1.text": "Lokale bestanden blijven ongewijzigd",
   "agentManager.intro.stage2.title": "Voorbeeld: twee taken parallel",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
@@ -282,9 +282,9 @@ export const dict = {
     "Een worktree is een aparte map en branch voor een taak. Je agents kunnen naast elkaar werken zonder dezelfde bestanden te bewerken.",
   "agentManager.intro.graph.agent": "Kilo-agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Een worktree bijwerken vanuit de basisbranch",
+  "agentManager.intro.updateTitle": "Los conflicten op met de worktree-agent",
   "agentManager.intro.updateText":
-    "Voer /update-from-base uit in de bijbehorende sessie om de nieuwste wijzigingen van de basisbranch te mergen.",
+    "Voer /update-from-base uit in de sessie van die worktree voordat je wijzigingen toepast op Local of een pull request samenvoegt. De agent voegt de nieuwste wijzigingen van de basisbranch samen en lost conflicten eerst in die worktree op.",
   "agentManager.intro.stage1.title": "Je repository",
   "agentManager.intro.stage1.text": "Lokale bestanden blijven ongewijzigd",
   "agentManager.intro.stage2.title": "Voorbeeld: twee taken parallel",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/nl.ts
@@ -282,9 +282,9 @@ export const dict = {
     "Een worktree is een aparte map en branch voor een taak. Je agents kunnen naast elkaar werken zonder dezelfde bestanden te bewerken.",
   "agentManager.intro.graph.agent": "Kilo-agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Los conflicten op met de worktree-agent",
+  "agentManager.intro.updateTitle": "Los conflicten op met Kilo",
   "agentManager.intro.updateText":
-    "Voer /update-from-base uit in de sessie van die worktree voordat je wijzigingen toepast op Local of een pull request samenvoegt. De agent voegt de nieuwste wijzigingen van de basisbranch samen en lost conflicten eerst in die worktree op.",
+    "Voer /update-from-base uit in de sessie van die worktree voordat je wijzigingen toepast op Local of een pull request samenvoegt. Kilo voegt de nieuwste wijzigingen van de basisbranch samen en lost conflicten eerst in die worktree op.",
   "agentManager.intro.stage1.title": "Je repository",
   "agentManager.intro.stage1.text": "Lokale bestanden blijven ongewijzigd",
   "agentManager.intro.stage2.title": "Voorbeeld: twee taken parallel",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -275,9 +275,9 @@ export const dict = {
     "Et worktree er en separat mappe og branch for en oppgave. Agentene dine kan jobbe side om side uten å redigere de samme filene.",
   "agentManager.intro.graph.agent": "Kilo-agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "Hvis endringer kommer i konflikt",
-  "agentManager.intro.conflictText":
-    "Bruk /update-from-base i worktree-chatten for å be agenten om å hente og slå sammen den lagrede base-branchen. Gå gjennom eventuelle konfliktløsninger. Unngå git stash: stash deles mellom worktrees.",
+  "agentManager.intro.updateTitle": "Oppdater et worktree fra base-branchen",
+  "agentManager.intro.updateText":
+    "Kjør /update-from-base i worktreets økt for å slå sammen de nyeste endringene fra base-branchen.",
   "agentManager.intro.stage1.title": "Ditt repositorium",
   "agentManager.intro.stage1.text": "Lokale filer forblir uendret",
   "agentManager.intro.stage2.title": "Eksempel: to oppgaver parallelt",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -275,9 +275,9 @@ export const dict = {
     "Et worktree er en separat mappe og branch for en oppgave. Agentene dine kan jobbe side om side uten å redigere de samme filene.",
   "agentManager.intro.graph.agent": "Kilo-agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Oppdater et worktree fra base-branchen",
+  "agentManager.intro.updateTitle": "Løs konflikter med worktree-agenten",
   "agentManager.intro.updateText":
-    "Kjør /update-from-base i worktreets økt for å slå sammen de nyeste endringene fra base-branchen.",
+    "Før du bruker endringer på Local eller slår sammen en pull request, må du kjøre /update-from-base i økten for det worktree-et. Agenten slår sammen de nyeste endringene fra base-branchen og løser konflikter inne i worktree-et først.",
   "agentManager.intro.stage1.title": "Ditt repositorium",
   "agentManager.intro.stage1.text": "Lokale filer forblir uendret",
   "agentManager.intro.stage2.title": "Eksempel: to oppgaver parallelt",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -277,7 +277,7 @@ export const dict = {
   "agentManager.intro.graph.pr": "Pull request",
   "agentManager.intro.graph.conflict": "Hvis endringer kommer i konflikt",
   "agentManager.intro.conflictText":
-    "Be agenten i worktree-et om å slå sammen den opprinnelige base-branchen og løse konflikter, og gå deretter gjennom resultatet. Unngå git stash: stash deles mellom worktrees.",
+    "Bruk /update-from-base i worktree-chatten for å be agenten om å hente og slå sammen den lagrede base-branchen. Gå gjennom eventuelle konfliktløsninger. Unngå git stash: stash deles mellom worktrees.",
   "agentManager.intro.stage1.title": "Ditt repositorium",
   "agentManager.intro.stage1.text": "Lokale filer forblir uendret",
   "agentManager.intro.stage2.title": "Eksempel: to oppgaver parallelt",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/no.ts
@@ -275,9 +275,9 @@ export const dict = {
     "Et worktree er en separat mappe og branch for en oppgave. Agentene dine kan jobbe side om side uten å redigere de samme filene.",
   "agentManager.intro.graph.agent": "Kilo-agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Løs konflikter med worktree-agenten",
+  "agentManager.intro.updateTitle": "Løs konflikter med Kilo",
   "agentManager.intro.updateText":
-    "Før du bruker endringer på Local eller slår sammen en pull request, må du kjøre /update-from-base i økten for det worktree-et. Agenten slår sammen de nyeste endringene fra base-branchen og løser konflikter inne i worktree-et først.",
+    "Før du bruker endringer på Local eller slår sammen en pull request, må du kjøre /update-from-base i økten for det worktree-et. Kilo slår sammen de nyeste endringene fra base-branchen og løser konflikter inne i worktree-et først.",
   "agentManager.intro.stage1.title": "Ditt repositorium",
   "agentManager.intro.stage1.text": "Lokale filer forblir uendret",
   "agentManager.intro.stage2.title": "Eksempel: to oppgaver parallelt",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -278,7 +278,7 @@ export const dict = {
   "agentManager.intro.graph.pr": "Pull request",
   "agentManager.intro.graph.conflict": "Jeśli zmiany powodują konflikt",
   "agentManager.intro.conflictText":
-    "Poproś agenta w worktree o scalenie jego oryginalnej gałęzi bazowej i rozwiązanie konfliktów, a następnie przejrzyj wynik. Unikaj git stash: stash jest współdzielony między worktree.",
+    "Użyj /update-from-base na czacie worktree, aby poprosić agenta o pobranie i scalenie zapisanej gałęzi bazowej tego worktree. Przejrzyj wszystkie rozwiązania konfliktów. Unikaj git stash: stashe są współdzielone między worktree.",
   "agentManager.intro.stage1.title": "Twoje repozytorium",
   "agentManager.intro.stage1.text": "Lokalne pliki pozostają niezmienione",
   "agentManager.intro.stage2.title": "Przykład: dwa zadania równolegle",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -276,9 +276,9 @@ export const dict = {
     "Worktree to osobny folder i gałąź dla zadania. Agenci mogą pracować obok siebie bez edytowania tych samych plików.",
   "agentManager.intro.graph.agent": "agent Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Rozwiąż konflikty za pomocą agenta worktree",
+  "agentManager.intro.updateTitle": "Rozwiąż konflikty z Kilo",
   "agentManager.intro.updateText":
-    "Zanim zastosujesz zmiany w Local lub scalisz pull request, uruchom /update-from-base w sesji tego worktree. Agent scala najnowsze zmiany z gałęzi bazowej i najpierw rozwiązuje konflikty w tym worktree.",
+    "Zanim zastosujesz zmiany w Local lub scalisz pull request, uruchom /update-from-base w sesji tego worktree. Kilo scala najnowsze zmiany z gałęzi bazowej i najpierw rozwiązuje konflikty w tym worktree.",
   "agentManager.intro.stage1.title": "Twoje repozytorium",
   "agentManager.intro.stage1.text": "Lokalne pliki pozostają niezmienione",
   "agentManager.intro.stage2.title": "Przykład: dwa zadania równolegle",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -276,9 +276,9 @@ export const dict = {
     "Worktree to osobny folder i gałąź dla zadania. Agenci mogą pracować obok siebie bez edytowania tych samych plików.",
   "agentManager.intro.graph.agent": "agent Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "Jeśli zmiany powodują konflikt",
-  "agentManager.intro.conflictText":
-    "Użyj /update-from-base na czacie worktree, aby poprosić agenta o pobranie i scalenie zapisanej gałęzi bazowej tego worktree. Przejrzyj wszystkie rozwiązania konfliktów. Unikaj git stash: stashe są współdzielone między worktree.",
+  "agentManager.intro.updateTitle": "Zaktualizuj worktree z gałęzi bazowej",
+  "agentManager.intro.updateText":
+    "Uruchom /update-from-base w jego sesji, aby scalić najnowsze zmiany z gałęzi bazowej.",
   "agentManager.intro.stage1.title": "Twoje repozytorium",
   "agentManager.intro.stage1.text": "Lokalne pliki pozostają niezmienione",
   "agentManager.intro.stage2.title": "Przykład: dwa zadania równolegle",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/pl.ts
@@ -276,9 +276,9 @@ export const dict = {
     "Worktree to osobny folder i gałąź dla zadania. Agenci mogą pracować obok siebie bez edytowania tych samych plików.",
   "agentManager.intro.graph.agent": "agent Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Zaktualizuj worktree z gałęzi bazowej",
+  "agentManager.intro.updateTitle": "Rozwiąż konflikty za pomocą agenta worktree",
   "agentManager.intro.updateText":
-    "Uruchom /update-from-base w jego sesji, aby scalić najnowsze zmiany z gałęzi bazowej.",
+    "Zanim zastosujesz zmiany w Local lub scalisz pull request, uruchom /update-from-base w sesji tego worktree. Agent scala najnowsze zmiany z gałęzi bazowej i najpierw rozwiązuje konflikty w tym worktree.",
   "agentManager.intro.stage1.title": "Twoje repozytorium",
   "agentManager.intro.stage1.text": "Lokalne pliki pozostają niezmienione",
   "agentManager.intro.stage2.title": "Przykład: dwa zadania równolegle",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -280,7 +280,7 @@ export const dict = {
   "agentManager.intro.graph.pr": "Pull request",
   "agentManager.intro.graph.conflict": "Если изменения конфликтуют",
   "agentManager.intro.conflictText":
-    "Попросите агента в worktree слить его исходную базовую ветку и разрешить конфликты, затем проверьте результат. Избегайте git stash: stash используется совместно между worktree.",
+    "Используйте /update-from-base в чате worktree, чтобы попросить агента получить и слить сохранённую базовую ветку этого worktree. Проверьте результаты разрешения конфликтов. Избегайте git stash: записи stash общие для всех worktree.",
   "agentManager.intro.stage1.title": "Ваш репозиторий",
   "agentManager.intro.stage1.text": "Локальные файлы остаются без изменений",
   "agentManager.intro.stage2.title": "Пример: две задачи параллельно",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -278,9 +278,9 @@ export const dict = {
     "Worktree — это отдельная папка и ветка для задачи. Агенты могут работать рядом, не редактируя одни и те же файлы.",
   "agentManager.intro.graph.agent": "агент Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Обновить worktree из базовой ветки",
+  "agentManager.intro.updateTitle": "Разрешайте конфликты с помощью агента worktree",
   "agentManager.intro.updateText":
-    "Выполните /update-from-base в его сессии, чтобы слить последние изменения базовой ветки.",
+    "Перед применением изменений к Local или слиянием pull request выполните /update-from-base в сессии этого worktree. Агент сначала сольёт последние изменения базовой ветки и разрешит конфликты внутри этого worktree.",
   "agentManager.intro.stage1.title": "Ваш репозиторий",
   "agentManager.intro.stage1.text": "Локальные файлы остаются без изменений",
   "agentManager.intro.stage2.title": "Пример: две задачи параллельно",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -278,9 +278,9 @@ export const dict = {
     "Worktree — это отдельная папка и ветка для задачи. Агенты могут работать рядом, не редактируя одни и те же файлы.",
   "agentManager.intro.graph.agent": "агент Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "Если изменения конфликтуют",
-  "agentManager.intro.conflictText":
-    "Используйте /update-from-base в чате worktree, чтобы попросить агента получить и слить сохранённую базовую ветку этого worktree. Проверьте результаты разрешения конфликтов. Избегайте git stash: записи stash общие для всех worktree.",
+  "agentManager.intro.updateTitle": "Обновить worktree из базовой ветки",
+  "agentManager.intro.updateText":
+    "Выполните /update-from-base в его сессии, чтобы слить последние изменения базовой ветки.",
   "agentManager.intro.stage1.title": "Ваш репозиторий",
   "agentManager.intro.stage1.text": "Локальные файлы остаются без изменений",
   "agentManager.intro.stage2.title": "Пример: две задачи параллельно",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/ru.ts
@@ -278,9 +278,9 @@ export const dict = {
     "Worktree — это отдельная папка и ветка для задачи. Агенты могут работать рядом, не редактируя одни и те же файлы.",
   "agentManager.intro.graph.agent": "агент Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Разрешайте конфликты с помощью агента worktree",
+  "agentManager.intro.updateTitle": "Разрешайте конфликты с помощью Kilo",
   "agentManager.intro.updateText":
-    "Перед применением изменений к Local или слиянием pull request выполните /update-from-base в сессии этого worktree. Агент сначала сольёт последние изменения базовой ветки и разрешит конфликты внутри этого worktree.",
+    "Перед применением изменений к Local или слиянием pull request выполните /update-from-base в сессии этого worktree. Kilo сначала сольёт последние изменения базовой ветки и разрешит конфликты внутри этого worktree.",
   "agentManager.intro.stage1.title": "Ваш репозиторий",
   "agentManager.intro.stage1.text": "Локальные файлы остаются без изменений",
   "agentManager.intro.stage2.title": "Пример: две задачи параллельно",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -271,9 +271,9 @@ export const dict = {
     "worktree คือโฟลเดอร์และ branch แยกสำหรับงานหนึ่งงาน เอเจนต์ทำงานเคียงข้างกันได้โดยไม่แก้ไฟล์เดียวกัน",
   "agentManager.intro.graph.agent": "Kilo agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "อัปเดต worktree จากสาขาฐาน",
+  "agentManager.intro.updateTitle": "แก้ไขข้อขัดแย้งด้วยเอเจนต์ใน worktree",
   "agentManager.intro.updateText":
-    "เรียกใช้ /update-from-base ในเซสชันของ worktree เพื่อผสานการเปลี่ยนแปลงล่าสุดของสาขาฐาน.",
+    "ก่อนนำการเปลี่ยนแปลงไปใช้กับ Local หรือผสาน pull request ให้เรียกใช้ /update-from-base ในเซสชันของ worktree นั้น เอเจนต์จะผสานการเปลี่ยนแปลงล่าสุดจากสาขาฐานและแก้ไขข้อขัดแย้งใน worktree นั้นก่อน",
   "agentManager.intro.stage1.title": "repository ของคุณ",
   "agentManager.intro.stage1.text": "ไฟล์ในเครื่องจะไม่เปลี่ยนแปลง",
   "agentManager.intro.stage2.title": "ตัวอย่าง: สองงานทำพร้อมกัน",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -273,7 +273,7 @@ export const dict = {
   "agentManager.intro.graph.pr": "Pull request",
   "agentManager.intro.graph.conflict": "หากการเปลี่ยนแปลงขัดแย้งกัน",
   "agentManager.intro.conflictText":
-    "ขอให้ agent ใน worktree merge base branch เดิมของตนและแก้ไขความขัดแย้ง จากนั้นตรวจสอบผลลัพธ์ หลีกเลี่ยง git stash: stash ใช้ร่วมกันระหว่าง worktree",
+    "ใช้ /update-from-base ในแชทของ worktree เพื่อขอให้ agent fetch และ merge base branch ที่บันทึกไว้สำหรับ worktree นั้น ตรวจสอบผลการแก้ไขความขัดแย้ง หลีกเลี่ยง git stash: stash ใช้ร่วมกันระหว่าง worktree",
   "agentManager.intro.stage1.title": "repository ของคุณ",
   "agentManager.intro.stage1.text": "ไฟล์ในเครื่องจะไม่เปลี่ยนแปลง",
   "agentManager.intro.stage2.title": "ตัวอย่าง: สองงานทำพร้อมกัน",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -271,9 +271,9 @@ export const dict = {
     "worktree คือโฟลเดอร์และ branch แยกสำหรับงานหนึ่งงาน เอเจนต์ทำงานเคียงข้างกันได้โดยไม่แก้ไฟล์เดียวกัน",
   "agentManager.intro.graph.agent": "Kilo agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "แก้ไขข้อขัดแย้งด้วยเอเจนต์ใน worktree",
+  "agentManager.intro.updateTitle": "แก้ไขข้อขัดแย้งด้วย Kilo",
   "agentManager.intro.updateText":
-    "ก่อนนำการเปลี่ยนแปลงไปใช้กับ Local หรือผสาน pull request ให้เรียกใช้ /update-from-base ในเซสชันของ worktree นั้น เอเจนต์จะผสานการเปลี่ยนแปลงล่าสุดจากสาขาฐานและแก้ไขข้อขัดแย้งใน worktree นั้นก่อน",
+    "ก่อนนำการเปลี่ยนแปลงไปใช้กับ Local หรือผสาน pull request ให้เรียกใช้ /update-from-base ในเซสชันของ worktree นั้น Kilo จะผสานการเปลี่ยนแปลงล่าสุดจากสาขาฐานและแก้ไขข้อขัดแย้งใน worktree นั้นก่อน",
   "agentManager.intro.stage1.title": "repository ของคุณ",
   "agentManager.intro.stage1.text": "ไฟล์ในเครื่องจะไม่เปลี่ยนแปลง",
   "agentManager.intro.stage2.title": "ตัวอย่าง: สองงานทำพร้อมกัน",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/th.ts
@@ -271,9 +271,9 @@ export const dict = {
     "worktree คือโฟลเดอร์และ branch แยกสำหรับงานหนึ่งงาน เอเจนต์ทำงานเคียงข้างกันได้โดยไม่แก้ไฟล์เดียวกัน",
   "agentManager.intro.graph.agent": "Kilo agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "หากการเปลี่ยนแปลงขัดแย้งกัน",
-  "agentManager.intro.conflictText":
-    "ใช้ /update-from-base ในแชทของ worktree เพื่อขอให้ agent fetch และ merge base branch ที่บันทึกไว้สำหรับ worktree นั้น ตรวจสอบผลการแก้ไขความขัดแย้ง หลีกเลี่ยง git stash: stash ใช้ร่วมกันระหว่าง worktree",
+  "agentManager.intro.updateTitle": "อัปเดต worktree จากสาขาฐาน",
+  "agentManager.intro.updateText":
+    "เรียกใช้ /update-from-base ในเซสชันของ worktree เพื่อผสานการเปลี่ยนแปลงล่าสุดของสาขาฐาน.",
   "agentManager.intro.stage1.title": "repository ของคุณ",
   "agentManager.intro.stage1.text": "ไฟล์ในเครื่องจะไม่เปลี่ยนแปลง",
   "agentManager.intro.stage2.title": "ตัวอย่าง: สองงานทำพร้อมกัน",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
@@ -285,9 +285,9 @@ export const dict = {
     "Worktree, bir görev için ayrı bir klasör ve daldır. Agentlar aynı dosyaları düzenlemeden yan yana çalışabilir.",
   "agentManager.intro.graph.agent": "Kilo agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Worktree'yi temel daldan güncelle",
+  "agentManager.intro.updateTitle": "Çakışmaları worktree agentiyle çözün",
   "agentManager.intro.updateText":
-    "Temel daldaki en son değişiklikleri birleştirmek için ilgili oturumda /update-from-base komutunu çalıştırın.",
+    "Değişiklikleri Local'e uygulamadan veya bir pull request'i birleştirmeden önce ilgili worktree oturumunda /update-from-base komutunu çalıştırın. Agent en son temel dal değişikliklerini birleştirir ve çakışmaları önce aynı worktree içinde çözer.",
   "agentManager.intro.stage1.title": "Deponuz",
   "agentManager.intro.stage1.text": "Yerel dosyalar değişmeden kalır",
   "agentManager.intro.stage2.title": "Örnek: iki görev paralel",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
@@ -285,9 +285,9 @@ export const dict = {
     "Worktree, bir görev için ayrı bir klasör ve daldır. Agentlar aynı dosyaları düzenlemeden yan yana çalışabilir.",
   "agentManager.intro.graph.agent": "Kilo agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Çakışmaları worktree agentiyle çözün",
+  "agentManager.intro.updateTitle": "Çakışmaları Kilo ile çözün",
   "agentManager.intro.updateText":
-    "Değişiklikleri Local'e uygulamadan veya bir pull request'i birleştirmeden önce ilgili worktree oturumunda /update-from-base komutunu çalıştırın. Agent en son temel dal değişikliklerini birleştirir ve çakışmaları önce aynı worktree içinde çözer.",
+    "Değişiklikleri Local'e uygulamadan veya bir pull request'i birleştirmeden önce ilgili worktree oturumunda /update-from-base komutunu çalıştırın. Kilo en son temel dal değişikliklerini birleştirir ve çakışmaları önce aynı worktree içinde çözer.",
   "agentManager.intro.stage1.title": "Deponuz",
   "agentManager.intro.stage1.text": "Yerel dosyalar değişmeden kalır",
   "agentManager.intro.stage2.title": "Örnek: iki görev paralel",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
@@ -287,7 +287,7 @@ export const dict = {
   "agentManager.intro.graph.pr": "Pull request",
   "agentManager.intro.graph.conflict": "Değişiklikler çakışırsa",
   "agentManager.intro.conflictText":
-    "worktree'deki ajandan özgün temel dalını birleştirmesini ve çakışmaları çözmesini isteyin, ardından sonucu inceleyin. git stash kullanmaktan kaçının: stash'ler worktree'ler arasında paylaşılır.",
+    "Worktree sohbetinde /update-from-base kullanarak ajandan kayıtlı temel dalını getirip birleştirmesini isteyin. Çakışma çözümlerini gözden geçirin. git stash kullanmaktan kaçının: stash'ler worktree'ler arasında paylaşılır.",
   "agentManager.intro.stage1.title": "Deponuz",
   "agentManager.intro.stage1.text": "Yerel dosyalar değişmeden kalır",
   "agentManager.intro.stage2.title": "Örnek: iki görev paralel",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/tr.ts
@@ -285,9 +285,9 @@ export const dict = {
     "Worktree, bir görev için ayrı bir klasör ve daldır. Agentlar aynı dosyaları düzenlemeden yan yana çalışabilir.",
   "agentManager.intro.graph.agent": "Kilo agent",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "Değişiklikler çakışırsa",
-  "agentManager.intro.conflictText":
-    "Worktree sohbetinde /update-from-base kullanarak ajandan kayıtlı temel dalını getirip birleştirmesini isteyin. Çakışma çözümlerini gözden geçirin. git stash kullanmaktan kaçının: stash'ler worktree'ler arasında paylaşılır.",
+  "agentManager.intro.updateTitle": "Worktree'yi temel daldan güncelle",
+  "agentManager.intro.updateText":
+    "Temel daldaki en son değişiklikleri birleştirmek için ilgili oturumda /update-from-base komutunu çalıştırın.",
   "agentManager.intro.stage1.title": "Deponuz",
   "agentManager.intro.stage1.text": "Yerel dosyalar değişmeden kalır",
   "agentManager.intro.stage2.title": "Örnek: iki görev paralel",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
@@ -285,9 +285,8 @@ export const dict = {
     "Worktree — це окрема папка та гілка для завдання. Агенти можуть працювати поруч, не редагуючи одні й ті самі файли.",
   "agentManager.intro.graph.agent": "агент Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "Якщо зміни конфліктують",
-  "agentManager.intro.conflictText":
-    "Використайте /update-from-base у чаті worktree, щоб попросити агента отримати та злити збережену базову гілку цього worktree. Перевірте результати вирішення конфліктів. Уникайте git stash: записи stash є спільними для всіх worktree.",
+  "agentManager.intro.updateTitle": "Оновити робоче дерево з базової гілки",
+  "agentManager.intro.updateText": "Виконайте /update-from-base у його сесії, щоб злити останні зміни базової гілки.",
   "agentManager.intro.stage1.title": "Ваш репозиторій",
   "agentManager.intro.stage1.text": "Локальні файли залишаються без змін",
   "agentManager.intro.stage2.title": "Приклад: два завдання паралельно",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
@@ -285,9 +285,9 @@ export const dict = {
     "Worktree — це окрема папка та гілка для завдання. Агенти можуть працювати поруч, не редагуючи одні й ті самі файли.",
   "agentManager.intro.graph.agent": "агент Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Розв’язуйте конфлікти за допомогою агента worktree",
+  "agentManager.intro.updateTitle": "Розв’язуйте конфлікти за допомогою Kilo",
   "agentManager.intro.updateText":
-    "Перш ніж застосовувати зміни до Local або зливати pull request, виконайте /update-from-base у сесії цього worktree. Агент спочатку зіллє останні зміни базової гілки та розв’яже конфлікти всередині цього worktree.",
+    "Перш ніж застосовувати зміни до Local або зливати pull request, виконайте /update-from-base у сесії цього worktree. Kilo спочатку зіллє останні зміни базової гілки та розв’яже конфлікти всередині цього worktree.",
   "agentManager.intro.stage1.title": "Ваш репозиторій",
   "agentManager.intro.stage1.text": "Локальні файли залишаються без змін",
   "agentManager.intro.stage2.title": "Приклад: два завдання паралельно",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
@@ -287,7 +287,7 @@ export const dict = {
   "agentManager.intro.graph.pr": "Pull request",
   "agentManager.intro.graph.conflict": "Якщо зміни конфліктують",
   "agentManager.intro.conflictText":
-    "Попросіть агента в worktree злити його початкову базову гілку та вирішити конфлікти, а потім перегляньте результат. Уникайте git stash: stash є спільним для worktree.",
+    "Використайте /update-from-base у чаті worktree, щоб попросити агента отримати та злити збережену базову гілку цього worktree. Перевірте результати вирішення конфліктів. Уникайте git stash: записи stash є спільними для всіх worktree.",
   "agentManager.intro.stage1.title": "Ваш репозиторій",
   "agentManager.intro.stage1.text": "Локальні файли залишаються без змін",
   "agentManager.intro.stage2.title": "Приклад: два завдання паралельно",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/uk.ts
@@ -285,8 +285,9 @@ export const dict = {
     "Worktree — це окрема папка та гілка для завдання. Агенти можуть працювати поруч, не редагуючи одні й ті самі файли.",
   "agentManager.intro.graph.agent": "агент Kilo",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "Оновити робоче дерево з базової гілки",
-  "agentManager.intro.updateText": "Виконайте /update-from-base у його сесії, щоб злити останні зміни базової гілки.",
+  "agentManager.intro.updateTitle": "Розв’язуйте конфлікти за допомогою агента worktree",
+  "agentManager.intro.updateText":
+    "Перш ніж застосовувати зміни до Local або зливати pull request, виконайте /update-from-base у сесії цього worktree. Агент спочатку зіллє останні зміни базової гілки та розв’яже конфлікти всередині цього worktree.",
   "agentManager.intro.stage1.title": "Ваш репозиторій",
   "agentManager.intro.stage1.text": "Локальні файли залишаються без змін",
   "agentManager.intro.stage2.title": "Приклад: два завдання паралельно",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -268,9 +268,8 @@ export const dict = {
   "agentManager.intro.subtitle": "worktree 是用于任务的独立文件夹和分支。代理可以并行工作，不会编辑相同文件。",
   "agentManager.intro.graph.agent": "Kilo 代理",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "如果更改发生冲突",
-  "agentManager.intro.conflictText":
-    "请在 worktree 聊天中使用 /update-from-base，让代理获取并合并该 worktree 已保存的基础分支。请检查所有冲突的解决结果。请避免使用 git stash，因为 stash 会在 worktree 之间共享。",
+  "agentManager.intro.updateTitle": "从基础分支更新 worktree",
+  "agentManager.intro.updateText": "在其会话中运行 /update-from-base，以合并基础分支的最新更改。",
   "agentManager.intro.stage1.title": "你的仓库",
   "agentManager.intro.stage1.text": "本地文件保持不变",
   "agentManager.intro.stage2.title": "示例：两个任务并行",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -268,8 +268,9 @@ export const dict = {
   "agentManager.intro.subtitle": "worktree 是用于任务的独立文件夹和分支。代理可以并行工作，不会编辑相同文件。",
   "agentManager.intro.graph.agent": "Kilo 代理",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "从基础分支更新 worktree",
-  "agentManager.intro.updateText": "在其会话中运行 /update-from-base，以合并基础分支的最新更改。",
+  "agentManager.intro.updateTitle": "使用 worktree 代理解决冲突",
+  "agentManager.intro.updateText":
+    "将更改应用到 Local 或合并 pull request 前，请在该 worktree 的会话中运行 /update-from-base。代理会先在该 worktree 中合并基础分支的最新更改并解决冲突。",
   "agentManager.intro.stage1.title": "你的仓库",
   "agentManager.intro.stage1.text": "本地文件保持不变",
   "agentManager.intro.stage2.title": "示例：两个任务并行",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -268,9 +268,9 @@ export const dict = {
   "agentManager.intro.subtitle": "worktree 是用于任务的独立文件夹和分支。代理可以并行工作，不会编辑相同文件。",
   "agentManager.intro.graph.agent": "Kilo 代理",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "使用 worktree 代理解决冲突",
+  "agentManager.intro.updateTitle": "使用 Kilo 解决冲突",
   "agentManager.intro.updateText":
-    "将更改应用到 Local 或合并 pull request 前，请在该 worktree 的会话中运行 /update-from-base。代理会先在该 worktree 中合并基础分支的最新更改并解决冲突。",
+    "将更改应用到 Local 或合并 pull request 前，请在该 worktree 的会话中运行 /update-from-base。Kilo 会先在该 worktree 中合并基础分支的最新更改并解决冲突。",
   "agentManager.intro.stage1.title": "你的仓库",
   "agentManager.intro.stage1.text": "本地文件保持不变",
   "agentManager.intro.stage2.title": "示例：两个任务并行",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zh.ts
@@ -270,7 +270,7 @@ export const dict = {
   "agentManager.intro.graph.pr": "Pull request",
   "agentManager.intro.graph.conflict": "如果更改发生冲突",
   "agentManager.intro.conflictText":
-    "请让 worktree 中的代理合并其原始基础分支并解决冲突，然后检查结果。请避免使用 git stash，因为 stash 会在 worktree 之间共享。",
+    "请在 worktree 聊天中使用 /update-from-base，让代理获取并合并该 worktree 已保存的基础分支。请检查所有冲突的解决结果。请避免使用 git stash，因为 stash 会在 worktree 之间共享。",
   "agentManager.intro.stage1.title": "你的仓库",
   "agentManager.intro.stage1.text": "本地文件保持不变",
   "agentManager.intro.stage2.title": "示例：两个任务并行",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -267,9 +267,9 @@ export const dict = {
   "agentManager.intro.subtitle": "worktree 是工作專用的個別資料夾與分支。代理可並行工作，不會編輯相同檔案。",
   "agentManager.intro.graph.agent": "Kilo 代理",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "使用 worktree 代理解決衝突",
+  "agentManager.intro.updateTitle": "使用 Kilo 解決衝突",
   "agentManager.intro.updateText":
-    "將變更套用至 Local 或合併 pull request 前，請在該 worktree 的工作階段中執行 /update-from-base。代理會先在該 worktree 中合併基底分支的最新變更並解決衝突。",
+    "將變更套用至 Local 或合併 pull request 前，請在該 worktree 的工作階段中執行 /update-from-base。Kilo 會先在該 worktree 中合併基底分支的最新變更並解決衝突。",
   "agentManager.intro.stage1.title": "你的儲存庫",
   "agentManager.intro.stage1.text": "本機檔案保持不變",
   "agentManager.intro.stage2.title": "範例：兩個工作平行進行",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -267,9 +267,8 @@ export const dict = {
   "agentManager.intro.subtitle": "worktree 是工作專用的個別資料夾與分支。代理可並行工作，不會編輯相同檔案。",
   "agentManager.intro.graph.agent": "Kilo 代理",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.graph.conflict": "如果變更發生衝突",
-  "agentManager.intro.conflictText":
-    "請在 worktree 聊天中使用 /update-from-base，讓代理程式擷取並合併該 worktree 已儲存的基底分支。請檢查所有衝突的解決結果。請避免使用 git stash，因為 stash 會在 worktree 之間共用。",
+  "agentManager.intro.updateTitle": "從基底分支更新 worktree",
+  "agentManager.intro.updateText": "在其工作階段中執行 /update-from-base，以合併基底分支的最新變更。",
   "agentManager.intro.stage1.title": "你的儲存庫",
   "agentManager.intro.stage1.text": "本機檔案保持不變",
   "agentManager.intro.stage2.title": "範例：兩個工作平行進行",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -269,7 +269,7 @@ export const dict = {
   "agentManager.intro.graph.pr": "Pull request",
   "agentManager.intro.graph.conflict": "如果變更發生衝突",
   "agentManager.intro.conflictText":
-    "請讓 worktree 中的代理程式合併其原始基礎分支並解決衝突，然後檢查結果。請避免使用 git stash，因為 stash 會在 worktree 之間共用。",
+    "請在 worktree 聊天中使用 /update-from-base，讓代理程式擷取並合併該 worktree 已儲存的基底分支。請檢查所有衝突的解決結果。請避免使用 git stash，因為 stash 會在 worktree 之間共用。",
   "agentManager.intro.stage1.title": "你的儲存庫",
   "agentManager.intro.stage1.text": "本機檔案保持不變",
   "agentManager.intro.stage2.title": "範例：兩個工作平行進行",

--- a/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/i18n/zht.ts
@@ -267,8 +267,9 @@ export const dict = {
   "agentManager.intro.subtitle": "worktree 是工作專用的個別資料夾與分支。代理可並行工作，不會編輯相同檔案。",
   "agentManager.intro.graph.agent": "Kilo 代理",
   "agentManager.intro.graph.pr": "Pull request",
-  "agentManager.intro.updateTitle": "從基底分支更新 worktree",
-  "agentManager.intro.updateText": "在其工作階段中執行 /update-from-base，以合併基底分支的最新變更。",
+  "agentManager.intro.updateTitle": "使用 worktree 代理解決衝突",
+  "agentManager.intro.updateText":
+    "將變更套用至 Local 或合併 pull request 前，請在該 worktree 的工作階段中執行 /update-from-base。代理會先在該 worktree 中合併基底分支的最新變更並解決衝突。",
   "agentManager.intro.stage1.title": "你的儲存庫",
   "agentManager.intro.stage1.text": "本機檔案保持不變",
   "agentManager.intro.stage2.title": "範例：兩個工作平行進行",

--- a/packages/kilo-vscode/webview-ui/agent-manager/intro/AgentManagerIntro.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/intro/AgentManagerIntro.tsx
@@ -122,9 +122,9 @@ function Introduction(props: IntroProps) {
         </div>
         <div class="am-intro-detail">
           <h3>
-            {t("agentManager.updateBase.title")} <code class="am-intro-command">/update-from-base</code>
+            {t("agentManager.intro.updateTitle")} <code class="am-intro-command">/update-from-base</code>
           </h3>
-          <p>{t("agentManager.intro.conflictText")}</p>
+          <p>{t("agentManager.intro.updateText")}</p>
         </div>
       </div>
       <div class="am-intro-footer">
@@ -147,13 +147,13 @@ function Introduction(props: IntroProps) {
           triggerProps={{ variant: "ghost", size: "small", icon: "branch", class: "am-intro-help" }}
           trigger={
             <span>
-              {t("agentManager.updateBase.title")} <code class="am-intro-command">/update-from-base</code>
+              {t("agentManager.intro.updateTitle")} <code class="am-intro-command">/update-from-base</code>
             </span>
           }
-          title={t("agentManager.updateBase.title")}
+          title={t("agentManager.intro.updateTitle")}
         >
           <div class="am-intro-tip-body">
-            <p>{t("agentManager.intro.conflictText")}</p>
+            <p>{t("agentManager.intro.updateText")}</p>
           </div>
         </Popover>
         <Button

--- a/packages/kilo-vscode/webview-ui/agent-manager/intro/AgentManagerIntro.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/intro/AgentManagerIntro.tsx
@@ -121,7 +121,9 @@ function Introduction(props: IntroProps) {
           <p>{t("agentManager.intro.stage4.text")}</p>
         </div>
         <div class="am-intro-detail">
-          <h3>{t("agentManager.intro.graph.conflict")}</h3>
+          <h3>
+            {t("agentManager.updateBase.title")} <code class="am-intro-command">/update-from-base</code>
+          </h3>
           <p>{t("agentManager.intro.conflictText")}</p>
         </div>
       </div>
@@ -142,9 +144,13 @@ function Introduction(props: IntroProps) {
           placement="top-start"
           class="am-intro-tip"
           triggerAs={Button}
-          triggerProps={{ variant: "ghost", size: "small", icon: "help", class: "am-intro-help" }}
-          trigger={t("agentManager.intro.graph.conflict")}
-          title={t("agentManager.intro.graph.conflict")}
+          triggerProps={{ variant: "ghost", size: "small", icon: "branch", class: "am-intro-help" }}
+          trigger={
+            <span>
+              {t("agentManager.updateBase.title")} <code class="am-intro-command">/update-from-base</code>
+            </span>
+          }
+          title={t("agentManager.updateBase.title")}
         >
           <div class="am-intro-tip-body">
             <p>{t("agentManager.intro.conflictText")}</p>

--- a/packages/kilo-vscode/webview-ui/agent-manager/intro/intro.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/intro/intro.css
@@ -216,6 +216,15 @@
   font-weight: 600;
 }
 
+.am-intro-command {
+  padding: 1px 4px;
+  border: 1px solid var(--border-weak-base);
+  border-radius: var(--radius-sm);
+  background: var(--surface-inset-base);
+  font-size: var(--kilo-font-size-12);
+  font-weight: 400;
+}
+
 .am-intro-detail p {
   margin: 0;
 }


### PR DESCRIPTION
## What Problem This Solves

Beginners can reach conflicts through either Agent Manager return path: Apply can conflict in Local, while a pull request can require conflict resolution on GitHub. The onboarding did not explain that Kilo can resolve those conflicts in the worktree before either step.

## Why This Change Was Made

Add **Resolve conflicts with Kilo `/update-from-base`** as a visible onboarding item. Its explanation tells users to run the command in that worktree session before applying changes to Local or merging a pull request. Kilo then merges the latest base changes and resolves conflicts in the isolated worktree first.

## User Impact

New Agent Manager sessions now teach where conflict resolution should happen and how to delegate it to Kilo. Compact layouts open the explanation in a popover; larger layouts show it inline. The copy is localized in all 21 Agent Manager locales.

## Evidence

- Host and webview type checks, lint, bundling, Knip, and the ownership-marker guard pass.
- 33 focused i18n and slash-command tests pass.
- The Linux visual-regression workflow regenerated and passed the Agent Manager introduction baseline. The final image was reviewed locally.
- Verified the compact onboarding item and popover plus the larger inline layout in isolated VS Code. No command was executed. The isolated instance was cleaned up.
- VS Code logged only its existing Node `url.parse()` deprecation warning during the manual check.

<img width="700" alt="Agent Manager onboarding explaining how Kilo resolves conflicts in a worktree before Apply or pull request merge" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260904-agent-manager-resolve-conflicts-with-kilo.png" />