### PR TITLE
fix(vscode): restore Agent Manager build within line cap

### DIFF
--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -24,6 +24,7 @@ const CSS_FILES = [
 ]
 const TSX_FILES = [
   path.join(ROOT, "webview-ui/agent-manager/AgentManagerApp.tsx"),
+  path.join(ROOT, "webview-ui/agent-manager/ShortcutsDialog.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/intro/AgentManagerIntro.tsx"),
   path.join(ROOT, "webview-ui/agent-manager/intro/IntroGraph.tsx"),
   path.join(ROOT, "webview-ui/src/components/chat/MessageList.tsx"),

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -235,7 +235,7 @@ const REVIEW_TAB_ID = "review"
 /** Sidebar selection: LOCAL for local repo, worktree ID for a worktree, or null for an unassigned session. */
 type SidebarSelection = typeof LOCAL | string | null
 const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent)
-import { parseBindingTokens } from "./keybind-tokens"
+import { ShortcutsDialog } from "./ShortcutsDialog"
 import { defaultBindings } from "./keybind-defaults"
 const AgentManagerContent: Component = () => {
   const { t } = useLanguage()
@@ -1764,33 +1764,7 @@ const AgentManagerContent: Component = () => {
 
   const handleShowKeyboardShortcuts = () => {
     const categories = buildShortcutCategories(kb(), t)
-    dialog.show(() => (
-      <Dialog title={t("agentManager.shortcuts.title")} fit>
-        <div class="am-shortcuts">
-          <For each={categories}>
-            {(category) => (
-              <div class="am-shortcuts-category">
-                <div class="am-shortcuts-category-title">{category.title}</div>
-                <div class="am-shortcuts-list">
-                  <For each={category.shortcuts}>
-                    {(shortcut) => (
-                      <div class="am-shortcuts-row">
-                        <span class="am-shortcuts-label">{shortcut.label}</span>
-                        <span class="am-shortcuts-keys">
-                          <For each={parseBindingTokens(shortcut.binding)}>
-                            {(token) => <kbd class="am-kbd">{token}</kbd>}
-                          </For>
-                        </span>
-                      </div>
-                    )}
-                  </For>
-                </div>
-              </div>
-            )}
-          </For>
-        </div>
-      </Dialog>
-    ))
+    dialog.show(() => <ShortcutsDialog title={t("agentManager.shortcuts.title")} categories={categories} />)
   }
 
   const loaded = () => worktreesLoaded() && sessionsLoaded()

--- a/packages/kilo-vscode/webview-ui/agent-manager/ShortcutsDialog.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ShortcutsDialog.tsx
@@ -1,0 +1,32 @@
+import { For, type Component } from "solid-js"
+import { Dialog } from "@kilocode/kilo-ui/dialog"
+import { parseBindingTokens } from "./keybind-tokens"
+import type { ShortcutCategory } from "./shortcuts"
+
+export const ShortcutsDialog: Component<{ title: string; categories: ShortcutCategory[] }> = (props) => (
+  <Dialog title={props.title} fit>
+    <div class="am-shortcuts">
+      <For each={props.categories}>
+        {(category) => (
+          <div class="am-shortcuts-category">
+            <div class="am-shortcuts-category-title">{category.title}</div>
+            <div class="am-shortcuts-list">
+              <For each={category.shortcuts}>
+                {(shortcut) => (
+                  <div class="am-shortcuts-row">
+                    <span class="am-shortcuts-label">{shortcut.label}</span>
+                    <span class="am-shortcuts-keys">
+                      <For each={parseBindingTokens(shortcut.binding)}>
+                        {(token) => <kbd class="am-kbd">{token}</kbd>}
+                      </For>
+                    </span>
+                  </div>
+                )}
+              </For>
+            </div>
+          </div>
+        )}
+      </For>
+    </div>
+  </Dialog>
+)


### PR DESCRIPTION
## What Problem This Solves
The VS Code extension build on main fails because AgentManagerApp.tsx has 2,818 lines, above its 2,800-line ESLint limit.

## Why This Change Was Made
Extract the keyboard shortcuts dialog into a focused component. Keep the existing line cap, shortcut data snapshot, translations, markup, and styling unchanged. Include the component in the CSS architecture checks.

## User Impact
Restore extension builds without changing Agent Manager behavior. AgentManagerApp.tsx now has 2,792 lines. This is a build-only refactor, so no release changeset is needed.

## Evidence
- Reproduced the max-lines error on current main.
- Full `bun run compile` passes, including CLI preparation, SDK preparation, host/webview typechecks, lint, and bundling.
- Unit suite: 4,721 passed, 1 skipped, 0 failed.
- Knip, kilocode-change guard, and touched-file formatting checks pass.
- Initial missing-dependency failures were resolved with a worktree-local frozen-lockfile install.
- No interactive VS Code smoke test was run. Manual check: open Agent Manager keyboard shortcuts, verify categories and key badges, then close and reopen the dialog.