### PR TITLE
fix(cli): clarify Explore execution limits

### DIFF
--- a/.changeset/fix-explore-execution-limits.md
+++ b/.changeset/fix-explore-execution-limits.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Clarify Explore's Bash allowlist and when to select an agent with the required execution permissions while preserving the no-change scope.

--- a/packages/opencode/src/kilocode/agent/index.ts
+++ b/packages/opencode/src/kilocode/agent/index.ts
@@ -532,6 +532,7 @@ export function patchAgents(
   if (agents.explore) {
     agents.explore = {
       ...agents.explore,
+      description: `${agents.explore.description} Bash is limited to an allowlist of read-only commands. For required scripts, tests, or binary-analysis commands outside that allowlist, select an available agent whose permissions allow them while preserving the requested no-change scope.`,
       permission: Permission.merge(
         defaults,
         Permission.fromConfig({

--- a/packages/opencode/test/kilocode/agent-config-metadata.test.ts
+++ b/packages/opencode/test/kilocode/agent-config-metadata.test.ts
@@ -1,5 +1,40 @@
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { Agent } from "../../src/agent/agent"
 import { processConfigItem } from "../../src/kilocode/agent"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(AppNodeBuilder.build(Agent.node))
+
+it.instance("default Explore description explains its Bash limits", () =>
+  Effect.gen(function* () {
+    const svc = yield* Agent.Service
+    const agent = yield* svc.get("explore")
+    expect(agent.description).toContain("Fast agent specialized for exploring codebases.")
+    expect(agent.description).toContain("Bash is limited to an allowlist of read-only commands.")
+    expect(agent.description).toContain(
+      "For required scripts, tests, or binary-analysis commands outside that allowlist, select an available agent whose permissions allow them while preserving the requested no-change scope.",
+    )
+  }),
+)
+
+it.instance(
+  "explicit Explore description overrides the default capability description",
+  () =>
+    Effect.gen(function* () {
+      const svc = yield* Agent.Service
+      const agent = yield* svc.get("explore")
+      expect(agent.description).toBe("Custom Explore description")
+    }),
+  {
+    config: {
+      agent: {
+        explore: { description: "Custom Explore description" },
+      },
+    },
+  },
+)
 
 describe("processConfigItem", () => {
   test("lifts legacy options-based metadata to typed fields and strips it", () => {


### PR DESCRIPTION
## What Problem This Solves

Task lists agent names and descriptions, but Explore did not advertise its restrictive Bash allowlist. Read-only investigation can still require scripts, tests, or binary-analysis commands that Explore cannot execute.

## Why This Change Was Made

Append a short capability clarification to the built-in Explore description. Direct execution-dependent work outside the allowlist to an available agent whose permissions allow it, while retaining the requested no-change scope. Keep the existing search guidance and explicit custom description overrides.

## User Impact

Parents receive accurate capability guidance when selecting Explore. This is a description-only fix: permissions, models, worker prompts, routing, and Swarm behavior are unchanged. No benchmark or cost improvement is claimed.

## Evidence

- 87 focused tests pass across the Kilo metadata, Task catalog, agent configuration, and plan/subagent permission suites.
- CLI typecheck, changed-file oxlint, annotation guard, and diff whitespace checks pass.
- Live self-test with two isolated worktree-source backends: `/agent` and `/experimental/tool` expose the new default guidance and preserve an explicit custom Explore description exactly. No LLM requests or real credentials were used; both backends were stopped.
- Includes a patch changeset for `@kilocode/cli`.
