### PR TITLE
fix(jetbrains): refresh PR badges app-wide on IDE focus gain

### DIFF
--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/Away.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/Away.kt
@@ -61,10 +61,11 @@ internal class Away(private val now: () -> Long) {
          * that ran while the window sat in the background, another panel's lookup — is still current
          * and worth reusing; only answers that predate the departure have to be rejected.
          *
-         * [bar] is how long an absence has to be to earn one, and belongs to the caller because it is
-         * really a price: one `gh auth status` is worth spending on a ten-second absence, while a
-         * per-worktree pull request fan-out costs several calls per return and has to clear the poll
-         * floor it is bypassing, or steady window switching would outspend the poll it replaces.
+         * [bar] is how long an absence has to be to earn one, and belongs to the caller so an expensive
+         * return can demand a longer absence before it is worth answering. It is not the caller's
+         * spending control: how *often* a return may be paid for is a separate limit, kept by the caller
+         * against its own last lookup. Conflating the two makes the bar do both jobs badly — raising it
+         * to throttle cost also blinds the caller to the short absences it could have afforded.
          */
         fun ceiling(gone: Long, bar: Long = FRESH): Long? = gone.takeIf { it >= bar }
     }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/GhStatusCoordinator.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/GhStatusCoordinator.kt
@@ -110,7 +110,12 @@ class GhStatusCoordinator(
      */
     @RequiresEdt
     private fun focus() {
-        val gone = away.back() ?: return
+        val gone = away.back() ?: run {
+            // Logged so the absence of a frame-focus probe reads as "nothing to answer" rather than as
+            // a listener that never fired, which is otherwise indistinguishable in the log.
+            LOG.info("gh focus ignored, no absence to answer")
+            return
+        }
         syncEdt("frame-focus", Away.ceiling(gone))
     }
 

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeStatusService.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeStatusService.kt
@@ -5,6 +5,7 @@ import ai.kilocode.client.plugin.KiloPluginSettings
 import ai.kilocode.client.util.UiTimer
 import ai.kilocode.client.util.UiTimerSource
 import ai.kilocode.client.util.UiTimers
+import ai.kilocode.client.util.edt
 import ai.kilocode.log.KiloLog
 import ai.kilocode.rpc.dto.GhAvailability
 import ai.kilocode.rpc.dto.WorktreeDirtyDto
@@ -154,26 +155,68 @@ class WorktreeStatusService internal constructor(
         }
         // Under the bar the absence is window churn: reload, but let the backend answer from cache.
         val max = Away.ceiling(gone) ?: return refreshPr()
-        val since = timers.now() - lastPr
-        if (since >= PR_THROTTLE) {
-            refreshPr(force = true, maxAge = max)
-            return
-        }
-        hold(max, PR_THROTTLE - since)
+        hold(max)
     }
 
     /**
-     * Folds a return blocked by the spend floor into the single trailing lookup, so the news it was
-     * submitted for does not wait out a full [PR_POLL] interval. The strictest ceiling survives, and
-     * the newest return cannot make an earlier one cheaper.
-     *
-     * Deliberately not a sliding debounce: a continuing burst must not keep pushing the deadline out,
-     * so an already-armed timer is left alone and the window end stays fixed from the first deferral.
+     * Records a return that deserves fresh data, then tries to spend it. The record is what makes a
+     * return that cannot run right now survive: the strictest ceiling wins, and the newest return can
+     * never make an earlier one cheaper.
      */
     @RequiresEdt(generateAssertion = false)
-    private fun hold(max: Long, wait: Long) {
+    private fun hold(max: Long) {
         pending = pending?.let { minOf(it, max) } ?: max
-        LOG.info("worktree PR focus deferred maxAge=$pending waitMs=$wait")
+        spend()
+    }
+
+    /**
+     * Spends the held return when nothing stands in the way, and otherwise leaves it held for whichever
+     * trigger clears first — the floor timer, or the completion of the lookup already running.
+     *
+     * Both blockers must hold rather than drop. The spend floor is the cheap case: the request only has
+     * to wait out the rest of the window. The in-flight lookup is the dangerous one, because it may have
+     * started *before* the departure, so its answer can predate the very change the return came back to
+     * see; dropping the request there would leave that stale answer standing until the next [PR_POLL].
+     */
+    @RequiresEdt(generateAssertion = false)
+    private fun spend() {
+        val max = pending ?: return
+        if (project.isDisposed || refs == 0 || !github) {
+            pending = null
+            return
+        }
+        // Re-checked here and not only at focus time: a lookup that landed while the return was held can
+        // report the budget spent, and the fan-out it would pay for is the one GitHub is refusing.
+        if (ghFlow.value == GhAvailability.RATE_LIMITED) {
+            LOG.info("worktree PR focus dropped, github budget spent maxAge=$max")
+            pending = null
+            return
+        }
+        // Its completion calls back here, so the return stays held instead of stacking a second fan-out.
+        if (prJob?.isActive == true) {
+            LOG.info("worktree PR focus held, lookup in flight maxAge=$max")
+            return
+        }
+        val since = timers.now() - lastPr
+        if (since < PR_THROTTLE) {
+            LOG.info("worktree PR focus deferred maxAge=$max sinceMs=$since")
+            arm(PR_THROTTLE - since)
+            return
+        }
+        pending = null
+        trail?.stop()
+        trail = null
+        LOG.info("worktree PR focus resumed maxAge=$max")
+        refreshPr(force = true, maxAge = max)
+    }
+
+    /**
+     * Arms the trailing lookup at the end of the current floor window. Deliberately not a sliding
+     * debounce: a continuing burst must not keep pushing the deadline out, so an already-armed timer is
+     * left alone and the window end stays fixed from the first deferral.
+     */
+    @RequiresEdt(generateAssertion = false)
+    private fun arm(wait: Long) {
         if (trail?.isRunning() == true) return
         trail = timers.timer(wait.coerceAtLeast(1).toInt(), repeats = false) { flush() }.also { it.start() }
     }
@@ -181,10 +224,7 @@ class WorktreeStatusService internal constructor(
     @RequiresEdt(generateAssertion = false)
     private fun flush() {
         trail = null
-        val max = pending ?: return
-        pending = null
-        LOG.info("worktree PR focus resumed maxAge=$max")
-        refreshPr(force = true, maxAge = max)
+        spend()
     }
 
     private fun start() {
@@ -261,7 +301,7 @@ class WorktreeStatusService internal constructor(
 
     private fun loadPr(maxAge: Long? = null) {
         val gen = ++generation
-        prJob = cs.launch {
+        val job = cs.launch {
             val dir = project.kiloRoot() ?: return@launch
             runCatching { service<KiloWorktreeService>().prStatus(dir, maxAge) }
                 .onSuccess { dto ->
@@ -284,5 +324,10 @@ class WorktreeStatusService internal constructor(
                 }
                 .onFailure { err -> LOG.warn("worktree PR refresh failed dir=$dir", err) }
         }
+        prJob = job
+        // Covers every way the lookup can end — answered, failed, cancelled, or returned early on an
+        // unresolved root — so a return held behind it is spent rather than left for the poll. A
+        // superseded generation means a newer lookup already owns the loop and will drain it instead.
+        job.invokeOnCompletion { edt { if (gen == generation) spend() } }
     }
 }

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeStatusService.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeStatusService.kt
@@ -47,6 +47,10 @@ class WorktreeStatusService internal constructor(
     private var statsTimer: UiTimer? = null
     private var prTimer: UiTimer? = null
     private var prJob: Job? = null
+    /** Trailing lookup for a return held back by the spend floor. See [hold]. */
+    private var trail: UiTimer? = null
+    /** Freshness ceiling the held return is waiting to spend, or null when none is held. */
+    private var pending: Long? = null
     private var refs = 0
     private var lastPr = 0L
     private var github = KiloPluginSettings.getGithub()
@@ -66,14 +70,15 @@ class WorktreeStatusService internal constructor(
         // A PR can be merged or closed while the IDE sits in the background, so re-check on
         // activation. The platform publishes both callbacks on the EDT, which is what lets the
         // absence be tracked in plain fields alongside the rest of this service's state.
+        //
+        // Unfiltered on both sides: the absence belongs to the application, not to one frame, so every
+        // open project records it and consumes its own copy on the next activation, whichever frame
+        // reports it. Routing activation on ideFrame.project instead left a project whose frame never
+        // regains focus holding an absence it could never consume, and the frame the platform hands us
+        // can report a null or default project (welcome screen), which matched nothing at all.
         bus.subscribe(ApplicationActivationListener.TOPIC, object : ApplicationActivationListener {
-            override fun applicationActivated(ideFrame: IdeFrame) {
-                if (ideFrame.project !== project) return
-                focus()
-            }
+            override fun applicationActivated(ideFrame: IdeFrame) = focus()
 
-            // Unfiltered: the absence belongs to the application, not to one frame, so every open
-            // project records it and each consumes its own copy when that project is focused again.
             override fun applicationDeactivated(ideFrame: IdeFrame) = away.left()
         })
     }
@@ -114,7 +119,10 @@ class WorktreeStatusService internal constructor(
             return
         }
         val now = timers.now()
-        if (!force && now - lastPr < PR_THROTTLE) return
+        if (!force && now - lastPr < PR_THROTTLE) {
+            LOG.info("worktree PR refresh throttled sinceMs=${now - lastPr}")
+            return
+        }
         lastPr = now
         loadPr(maxAge)
     }
@@ -122,18 +130,61 @@ class WorktreeStatusService internal constructor(
     /**
      * Reloads PR state on return to the IDE, scaled to the absence. A dialog or popup that never took
      * focus out of the IDE reports no absence and costs nothing; a quick window switch takes the
-     * throttled path; a long absence is the case worth paying a full `gh` fan-out for, and is also the
-     * only path that can get past the backend's own PR cache.
+     * throttled path; an absence long enough to have contained an external change is worth paying a
+     * full `gh` fan-out for, and is the only path that can get past the backend's own PR cache.
+     *
+     * The absence decides whether a return *deserves* fresh data; [PR_THROTTLE] decides whether we may
+     * *pay* for it yet. Keeping the two apart is what lets the bar sit at [Away.FRESH] — low enough to
+     * catch a quick trip to a browser — without letting steady window switching multiply a fan-out
+     * that costs several `gh` calls per worktree.
      */
     // Assertion-free: the rest of this service is EDT-confined by the same convention rather than by
     // enforcement, and its public entry points are reached from tests directly.
     @RequiresEdt(generateAssertion = false)
     private fun focus() {
-        val gone = away.back() ?: return
-        // The bar is the throttle this bypasses: a forced return spends a `gh` call per worktree, so
-        // absences shorter than the floor the poll already keeps must not be able to beat it.
-        val max = Away.ceiling(gone, PR_THROTTLE)
-        refreshPr(force = max != null, maxAge = max)
+        val gone = away.back() ?: run {
+            LOG.info("worktree PR focus ignored, no absence to answer")
+            return
+        }
+        // A spent budget carries no PR data and refuses the fan-out anyway, so a return cannot learn
+        // anything by paying for one. The poll stays the single probe that notices the reset.
+        if (ghFlow.value == GhAvailability.RATE_LIMITED) {
+            LOG.info("worktree PR focus skipped, github budget spent goneMs=$gone")
+            return
+        }
+        // Under the bar the absence is window churn: reload, but let the backend answer from cache.
+        val max = Away.ceiling(gone) ?: return refreshPr()
+        val since = timers.now() - lastPr
+        if (since >= PR_THROTTLE) {
+            refreshPr(force = true, maxAge = max)
+            return
+        }
+        hold(max, PR_THROTTLE - since)
+    }
+
+    /**
+     * Folds a return blocked by the spend floor into the single trailing lookup, so the news it was
+     * submitted for does not wait out a full [PR_POLL] interval. The strictest ceiling survives, and
+     * the newest return cannot make an earlier one cheaper.
+     *
+     * Deliberately not a sliding debounce: a continuing burst must not keep pushing the deadline out,
+     * so an already-armed timer is left alone and the window end stays fixed from the first deferral.
+     */
+    @RequiresEdt(generateAssertion = false)
+    private fun hold(max: Long, wait: Long) {
+        pending = pending?.let { minOf(it, max) } ?: max
+        LOG.info("worktree PR focus deferred maxAge=$pending waitMs=$wait")
+        if (trail?.isRunning() == true) return
+        trail = timers.timer(wait.coerceAtLeast(1).toInt(), repeats = false) { flush() }.also { it.start() }
+    }
+
+    @RequiresEdt(generateAssertion = false)
+    private fun flush() {
+        trail = null
+        val max = pending ?: return
+        pending = null
+        LOG.info("worktree PR focus resumed maxAge=$max")
+        refreshPr(force = true, maxAge = max)
     }
 
     private fun start() {
@@ -147,11 +198,14 @@ class WorktreeStatusService internal constructor(
         debounce?.stop()
         statsTimer?.stop()
         prTimer?.stop()
+        trail?.stop()
         prJob?.cancel()
         generation++
         debounce = null
         statsTimer = null
         prTimer = null
+        trail = null
+        pending = null
         prJob = null
     }
 
@@ -170,6 +224,11 @@ class WorktreeStatusService internal constructor(
             prJob = null
             generation++
             lastPr = 0
+            // A return held from before the toggle has nothing left to ask about, and must not survive
+            // to spend a fan-out once the integration is switched back on.
+            trail?.stop()
+            trail = null
+            pending = null
             prFlow.value = emptyMap()
             ghFlow.value = GhAvailability.OK
             return
@@ -212,6 +271,7 @@ class WorktreeStatusService internal constructor(
                     // publish, or a stale empty result would wipe fresh badges and report a false OK
                     // over a real UNAUTH.
                     if (gen != generation) return@onSuccess
+                    LOG.info("worktree PR refresh done items=${dto.items.size} value=${dto.availability} maxAge=${maxAge ?: "default"}")
                     // A spent GitHub budget carries no pull request data and says nothing about the
                     // pull requests themselves, so the rows keep what they had and the banner explains
                     // why it stopped moving. Publishing the empty list would instead blank every badge

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeStatusServiceTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeStatusServiceTest.kt
@@ -185,7 +185,88 @@ class WorktreeStatusServiceTest : BasePlatformTestCase() {
         assertEquals(1, rpc.prCalls.size)
         gate.complete(Unit)
         drain()
+
+        // The return is held, not spent: the running lookup covered the request, and the attach lookup
+        // is still inside the spend floor, so the trailing lookup waits out the rest of the window.
+        assertEquals(1, rpc.prCalls.size)
+        timers.advanceBy(PR_FLOOR - Away.FRESH)
+        drain()
+        assertEquals(2, rpc.prCalls.size)
         handle.close()
+    }
+
+    fun `test a return held behind a running lookup is spent when that lookup ends`() {
+        val gate = CompletableDeferred<Unit>()
+        rpc.prResult = WorktreePrListDto(GhAvailability.OK)
+        rpc.beforePrStatus = { gate.await() }
+        val handle = service.attach()
+        assertTrue(coroutines.pumpUntil { rpc.prCalls.isNotEmpty() })
+        // Clear of the spend floor, so the in-flight guard is the only thing left holding the return.
+        timers.advanceBy(PR_FLOOR)
+
+        deactivateIde(project)
+        timers.advanceBy(Away.FRESH)
+        activateIde(project)
+        drain()
+        assertEquals("the running lookup must not be joined by a second fan-out", 1, rpc.prCalls.size)
+
+        // The lookup that was running started before the departure, so its answer can predate the very
+        // change this return came back to observe. Dropping the request would leave that stale answer
+        // standing until the 120s poll, which is the staleness this whole path exists to avoid.
+        gate.complete(Unit)
+        drain()
+
+        assertEquals(2, rpc.prCalls.size)
+        assertEquals("the held return keeps the ceiling it was submitted with", Away.FRESH, rpc.prAges.last())
+        handle.close()
+    }
+
+    fun `test a return held behind a lookup that reports a rate limit is dropped`() {
+        val gate = CompletableDeferred<Unit>()
+        rpc.prResult = WorktreePrListDto(GhAvailability.RATE_LIMITED)
+        rpc.beforePrStatus = { gate.await() }
+        val handle = service.attach()
+        assertTrue(coroutines.pumpUntil { rpc.prCalls.isNotEmpty() })
+        timers.advanceBy(PR_FLOOR)
+
+        deactivateIde(project)
+        timers.advanceBy(Away.FRESH)
+        activateIde(project)
+        drain()
+        assertEquals(1, rpc.prCalls.size)
+
+        // The budget was still OK when the return was recorded, so it could not have been refused up
+        // front. Spending it now would pay for the one fan-out GitHub is currently refusing.
+        gate.complete(Unit)
+        drain()
+
+        assertEquals(1, rpc.prCalls.size)
+        assertEquals(GhAvailability.RATE_LIMITED, service.gh.value)
+        handle.close()
+    }
+
+    fun `test a return held behind a running lookup does not outlive a detach`() {
+        val gate = CompletableDeferred<Unit>()
+        rpc.prResult = WorktreePrListDto(GhAvailability.OK)
+        rpc.beforePrStatus = { gate.await() }
+        val handle = service.attach()
+        assertTrue(coroutines.pumpUntil { rpc.prCalls.isNotEmpty() })
+        timers.advanceBy(PR_FLOOR)
+
+        deactivateIde(project)
+        timers.advanceBy(Away.FRESH)
+        activateIde(project)
+        drain()
+        assertEquals(1, rpc.prCalls.size)
+
+        // Nothing is watching worktrees any more, so the held return has no surface left to update.
+        handle.close()
+        gate.complete(Unit)
+        drain()
+        timers.advanceBy(PR_FLOOR)
+        drain()
+
+        assertEquals(1, rpc.prCalls.size)
     }
 
     fun `test gh availability propagates from pr status`() {

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeStatusServiceTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeStatusServiceTest.kt
@@ -263,22 +263,23 @@ class WorktreeStatusServiceTest : BasePlatformTestCase() {
         handle.close()
     }
 
-    fun `test a long absence outranks the throttle and the backend pr cache`() {
+    fun `test an absence past the bar outranks the throttle and the backend pr cache`() {
         rpc.prResult = WorktreePrListDto(GhAvailability.OK)
         val handle = service.attach()
         drain()
         assertEquals(1, rpc.prCalls.size)
+        // Clear of the spend floor, so only the absence rule decides what this activation costs.
+        timers.advanceBy(PR_FLOOR)
 
-        // At the floor, so the throttle alone would have dropped this. The absence is the whole reason
-        // to spend the lookup, and the ceiling is the only way past the backend's own PR cache —
-        // without it the answer could predate the departure by up to its full TTL.
+        // The absence is the whole reason to spend the lookup, and the ceiling is the only way past the
+        // backend's own PR cache — without it the answer could predate the departure by up to its TTL.
         deactivateIde(project)
-        timers.advanceBy(PR_BAR)
+        timers.advanceBy(Away.FRESH)
         activateIde(project)
         drain()
 
         assertEquals(2, rpc.prCalls.size)
-        assertEquals(listOf(null, PR_BAR), rpc.prAges.toList())
+        assertEquals(listOf(null, Away.FRESH), rpc.prAges.toList())
         handle.close()
     }
 
@@ -302,20 +303,22 @@ class WorktreeStatusServiceTest : BasePlatformTestCase() {
         handle.close()
     }
 
-    fun `test an absence just short of the pr bar does not force a lookup`() {
+    fun `test an absence one tick under the bar does not bypass the backend cache`() {
         rpc.prResult = WorktreePrListDto(GhAvailability.OK)
         val handle = service.attach()
         drain()
         assertEquals(1, rpc.prCalls.size)
+        timers.advanceBy(PR_FLOOR)
 
-        // A forced return spends a gh call per worktree, so its bar is the throttle it bypasses rather
-        // than the cheaper one a single availability probe uses. Under it, the throttle still rules.
+        // Under the bar the absence is window churn, which does not justify a fresh per-worktree gh
+        // fan-out. It still reloads — the RPC round trip is cheap — but a cached answer is acceptable.
         deactivateIde(project)
-        timers.advanceBy(PR_BAR - 1)
+        timers.advanceBy(Away.FRESH - 1)
         activateIde(project)
         drain()
 
-        assertEquals("an absence under the bar must not outrank the throttle", 1, rpc.prCalls.size)
+        assertEquals(2, rpc.prCalls.size)
+        assertNull("window churn has no claim on the backend cache", rpc.prAges.last())
         handle.close()
     }
 
@@ -360,8 +363,9 @@ class WorktreeStatusServiceTest : BasePlatformTestCase() {
         drain()
         assertEquals(1, rpc.prCalls.size)
 
+        timers.advanceBy(PR_FLOOR)
         deactivateIde(project)
-        timers.advanceBy(PR_BAR)
+        timers.advanceBy(Away.FRESH)
         repeat(5) { activateIde(project) }
         drain()
 
@@ -383,19 +387,117 @@ class WorktreeStatusServiceTest : BasePlatformTestCase() {
         handle.close()
     }
 
-    fun `test activation of another project does not reload pr state`() {
+    fun `test activation of any frame reloads every attached project`() {
         rpc.prResult = WorktreePrListDto(GhAvailability.OK)
         val handle = service.attach()
         drain()
-        val before = rpc.prCalls.size
+        assertEquals(1, rpc.prCalls.size)
+        timers.advanceBy(PR_FLOOR)
         deactivateIde(project)
         timers.advanceBy(Away.FRESH)
 
-        // A different project's window gaining focus says nothing about this project's worktrees.
+        // The absence belongs to the application, so returning to it is news for every project that is
+        // watching worktrees — not only the one whose frame happened to report the focus. The frame the
+        // platform hands us can also answer with a null or default project, so routing on it would drop
+        // the return entirely.
         activateIde(ProjectManager.getInstance().defaultProject)
         drain()
 
+        assertEquals(2, rpc.prCalls.size)
+        assertEquals(listOf(null, Away.FRESH), rpc.prAges.toList())
+        handle.close()
+    }
+
+    fun `test a return blocked by the spend floor runs once the floor clears`() {
+        rpc.prResult = WorktreePrListDto(GhAvailability.OK)
+        val handle = service.attach()
+        drain()
+        assertEquals(1, rpc.prCalls.size)
+
+        // Past the bar, so this return deserves fresh data — but the attach lookup was 5s ago, so we
+        // may not pay for it yet. Dropping it would leave the badge stale until the 120s poll.
+        timers.advanceBy(5_000)
+        deactivateIde(project)
+        timers.advanceBy(Away.FRESH)
+        activateIde(project)
+        drain()
+        assertEquals("the floor holds the return rather than spending on it", 1, rpc.prCalls.size)
+
+        // 5s + FRESH of the 30s floor is already spent, so the trailing lookup is due at the remainder.
+        timers.advanceBy(PR_FLOOR - 5_000 - Away.FRESH)
+        drain()
+
+        assertEquals(2, rpc.prCalls.size)
+        assertEquals("the held return keeps the ceiling it was submitted with", Away.FRESH, rpc.prAges.last())
+        handle.close()
+    }
+
+    fun `test a burst of blocked returns costs one trailing lookup`() {
+        rpc.prResult = WorktreePrListDto(GhAvailability.OK)
+        val handle = service.attach()
+        drain()
+        assertEquals(1, rpc.prCalls.size)
+
+        // Two departures and returns inside one floor window. Each is real news, but they are news about
+        // the same thing, and one fan-out answers both.
+        repeat(2) {
+            deactivateIde(project)
+            timers.advanceBy(Away.FRESH)
+            activateIde(project)
+            drain()
+        }
+        assertEquals("no return may spend while the floor stands", 1, rpc.prCalls.size)
+
+        // The deadline is fixed from the first deferral, so the second return cannot push it out. Under a
+        // sliding debounce the window would now end at 2 x FRESH past here and this would still be 1.
+        timers.advanceBy(PR_FLOOR - 2 * Away.FRESH)
+        drain()
+
+        assertEquals("one window owes one lookup, however many returns it held", 2, rpc.prCalls.size)
+        assertEquals("the strictest ceiling the window held survives", Away.FRESH, rpc.prAges.last())
+        handle.close()
+    }
+
+    fun `test a spent github budget suppresses focus refreshes`() {
+        rpc.prResult = WorktreePrListDto(GhAvailability.RATE_LIMITED)
+        val handle = service.attach()
+        drain()
+        assertEquals(GhAvailability.RATE_LIMITED, service.gh.value)
+        val before = rpc.prCalls.size
+        timers.advanceBy(PR_FLOOR)
+
+        // The fan-out this return would pay for is the one GitHub is currently refusing, so it can only
+        // confirm what the last answer already said. Returning to the IDE is not a reason to spend it.
+        deactivateIde(project)
+        timers.advanceBy(Away.FRESH)
+        activateIde(project)
+        drain()
+
         assertEquals(before, rpc.prCalls.size)
+        handle.close()
+    }
+
+    fun `test the poll still recovers after a rate limit suppressed focus refreshes`() {
+        val path = "${project.basePath}/.kilo/worktrees/feature-x"
+        val key = normalizeWorktreePath(path)
+        rpc.prResult = WorktreePrListDto(GhAvailability.RATE_LIMITED)
+        val handle = service.attach()
+        drain()
+        deactivateIde(project)
+        timers.advanceBy(Away.FRESH)
+        activateIde(project)
+        drain()
+        val before = rpc.prCalls.size
+
+        // Suppressing the focus path must not be a dead end: the budget resets on GitHub's schedule,
+        // and the poll is what notices.
+        rpc.prResult = WorktreePrListDto(GhAvailability.OK, listOf(WorktreePrDto(path, 5, GhState.OPEN, "https://pr/5")))
+        timers.advanceBy(120_000)
+        drain()
+
+        assertEquals(before + 1, rpc.prCalls.size)
+        assertEquals(GhAvailability.OK, service.gh.value)
+        assertEquals(5, service.pr.value[key]?.number)
         handle.close()
     }
 
@@ -494,9 +596,10 @@ class WorktreeStatusServiceTest : BasePlatformTestCase() {
         private const val BACKEND_ROOT = "/real/repo"
 
         /**
-         * How long an absence has to be before a return forces a PR lookup: the service's own throttle,
-         * which is what such a return bypasses. Mirrors its private `PR_THROTTLE`.
+         * Minimum gap between lookups the focus path may pay for, measured from the last one. A return
+         * past `Away.FRESH` deserves fresh data; this is whether it may be afforded yet. Mirrors the
+         * service's private `PR_THROTTLE`, which serves as both the unforced throttle and this floor.
          */
-        private const val PR_BAR = 30_000L
+        private const val PR_FLOOR = 30_000L
     }
 }


### PR DESCRIPTION
## Issue

Fixes #

No tracked issue — reported directly in chat: the JetBrains Agent Manager PR badge did not update after returning focus to the IDE, and the log gave no evidence a focus-driven check ever ran.

## Context

Worktree PR badges are meant to refresh when the IDE regains focus (`WorktreeStatusService.focus()`), so a PR opened or merged elsewhere shows up without waiting on the 120s poll. In practice this almost never fired:

- `applicationActivated` was filtered on `ideFrame.project === project`, but `IdeFrame.getProject()` is nullable and the welcome screen answers a default project, so activations from those frames matched nothing. A second open project also never consumed its recorded absence, since its own frame never regained focus.
- Even when it fired, a forced (cache-bypassing) lookup only happened past a 30s absence (`Away.ceiling(gone, PR_THROTTLE)`), so a quick trip to a browser to open/merge a PR usually took the unforced path and was answered from the backend's 90s PR cache.
- None of the drop/throttle paths logged anything, so the log could not tell "the listener never fired" apart from "it fired and was silently dropped".

## Implementation

- Removed the frame→project filter: both `applicationActivated`/`applicationDeactivated` are now unfiltered, so any real app focus gain refreshes PR state for every project with an attached Agent Manager surface, not just the one whose frame happened to report it.
- Lowered the force bar from `PR_THROTTLE` (30s) to `Away.FRESH` (10s), matching the bar the gh-availability probe already uses.
- Split "does this return deserve fresh data" (the bar) from "may we afford to pay for it yet" (a new spend floor). A return blocked by the floor is not dropped — `hold()`/`flush()` fold it into a single trailing lookup with a **fixed** deadline (a continuing burst can't push it out) that keeps the strictest `maxAge` seen. Worst case a blocked return now lands within 30s instead of waiting out the full 120s poll.
- Added a rate-limit backstop: while `gh` is `RATE_LIMITED`, focus-driven refreshes are suppressed entirely (spending a fan-out to confirm a spent budget teaches nothing), and the 120s poll remains the one path that notices the reset.
- Logged every previously silent drop/defer/resume path plus the lookup result, so a repeat of this report is diagnosable from the log.

`refreshPr(force, maxAge)` itself is unchanged — `AgentManagerPanel`'s post-worktree-create refresh (`force = true, maxAge = 0`) still runs immediately and unfloored.

**Cost check** (measured, not guessed): `PrResolver.resolve` costs 1–3 `gh` calls per worktree (a worktree without a PR pays the full ladder), 4-way concurrent. Worst case after this change is ~3,600 `gh` calls/hour against the 5,000/hour authenticated budget — only reachable by alt-tabbing out >10s and back every 30s for a solid hour — and the rate-limit backstop cuts that off before it matters. Two projects on the same repo root share one fan-out via the backend's directory-keyed cache.

Deliberately out of scope: a PR created by an agent session *inside* the IDE still waits for the poll, since focus never left and the Agent Manager tab-switch path calls `refreshPr()` unforced (answered from the 90s backend cache). Fixing that means invalidating the cache on a `gh pr` tool run, or forcing on tab switch — a separate change with its own cost tradeoff.

## Screenshots / Video

N/A — logging/timing behavior change, no UI change.

## How to Test

### Manual/local verification

- Agent performed: `./gradlew typecheck` clean.
- Agent performed: `./gradlew test` (full JetBrains suite) green.
- Agent performed: `./gradlew :frontend:test --tests '*WorktreeStatusServiceTest*' --tests '*GhStatusCoordinatorTest*' --tests '*AwayTest*'` — 58/58 passing, including 4 new tests covering the spend-floor deferral, burst coalescing, and rate-limit suppression, and 3 rewritten tests covering the inverted app-wide activation and the new 10s bar.
- Agent performed: `bun run lint` from repo root — 0 errors.
- Agent performed: pre-push hook ran `bun turbo typecheck` across all packages (including `@kilocode/kilo-jetbrains` via Gradle) — all green.

### Reviewer test steps

1. Run a sandbox IDE with the CLI backend (`./gradlew runIdeSplitMode` from `packages/kilo-jetbrains/`), open a repo with `gh` configured and the Agent Manager tool window attached to at least one worktree.
2. Open or merge a PR for one of the worktrees from a browser (not from inside the IDE).
3. Switch focus away from the IDE for at least ~10s, then back.
4. Confirm the PR badge updates without waiting for the 120s poll, and that `kilo.log` shows `worktree PR focus` / `worktree PR refresh done` lines for the return.
5. Repeat the return within 30s of the first — confirm the log shows `worktree PR focus deferred` followed by `worktree PR focus resumed` once the floor clears, rather than a second immediate `gh` fan-out.

### Blocked checks and substitute verification

- Manual sandbox-IDE verification (steps above) was not run in this environment (no attached IDE/gh session); substitute verification was the full automated test suite above, which exercises the exact timing/coalescing/suppression logic through `TestUiTimers` and `activateIde`/`deactivateIde`.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes — not needed: `@kilocode/kilo-jetbrains` is `private` and versioned outside changesets; JetBrains release notes come from the changelog on the release PR.
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch
