### PR TITLE
fix(cli): bound the piped-stdin wait in kilo run

### DIFF
--- a/.changeset/bound-run-stdin-read.md
+++ b/.changeset/bound-run-stdin-read.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Bound the piped-stdin wait of `kilo run` when the prompt comes from argv, so a launcher-held-open stdin pipe cannot hang the boot.

--- a/packages/opencode/script/kilocode/repro-run-stdin-hang.sh
+++ b/packages/opencode/script/kilocode/repro-run-stdin-hang.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Repro: `kilo run` hangs at boot when stdin is a held-open pipe.
+#
+# Recipe:
+#   1. Isolate config in a temp KILO_CONFIG_DIR (kilo.json only:
+#      snapshot off, permission {"*":"allow"}; remote and MCP are
+#      deliberately absent, they are ruled out as causes).
+#   2. Warm bun's transpile cache with one discarded /dev/null boot.
+#   3. Boot `bun run --conditions=browser ./src/index.ts run ... --format json --auto`
+#      RUNS times with `sleep (TIMEOUT_SEC+5)` piped into stdin, so the
+#      pipe never EOFs before the timeout fires.
+#   4. A run HANGS when rc=124 (timeout killed it) or when its log holds
+#      no `"type":"text"` event line.
+#   5. On the first hang, rerun once with `--print-logs --log-level DEBUG`
+#      against the same held-open stdin and save stderr for inspection.
+#   6. Report `hangs: X / RUNS` and `step0: Y / RUNS` (Y = ok runs whose
+#      first step_start event landed within 20000 ms of the run start).
+#
+# Usage:
+#   packages/opencode/script/kilocode/repro-run-stdin-hang.sh [RUNS] [TIMEOUT_SEC]
+#
+# Env:
+#   KILO_REPRO_MODEL  model for the boot (default: kilo/z-ai/glm-5.3-flash)
+#
+# Pinned root cause:
+#   The never-resolving await is `await Bun.stdin.text()` in `loadInput()`
+#   at packages/opencode/src/cli/cmd/run.ts:442. A held-open pipe never
+#   EOFs, and Bun 1.4.0 on macOS never delivers FIFO EOF (bare-bun probe
+#   evidence), so the CLI blocks before the session starts.
+#   The hung debug log tail is `project copy refresh done` /
+#   `booting location services` (+ `remote-ws connected` when
+#   remote_control is on), then only heartbeat lines.
+#
+# Known-good evidence from planning:
+#   - 20/20 boots with /dev/null stdin pass.
+#   - 3/3 FIFO-stdin boots and 1/1 held-open-pipe boot hang with the
+#     exact observed signature.
+#   - The installed kilo 7.5.6 hangs too.
+set -euo pipefail
+
+RUNS=${1:-10}
+TIMEOUT_SEC=${2:-60}
+
+case $RUNS in
+  ''|*[!0-9]*) echo "error: RUNS must be a non-negative integer, got: $RUNS" >&2; exit 2 ;;
+esac
+case $TIMEOUT_SEC in
+  ''|*[!0-9]*) echo "error: TIMEOUT_SEC must be a non-negative integer, got: $TIMEOUT_SEC" >&2; exit 2 ;;
+esac
+
+# packages/opencode, resolved from script/kilocode of this script.
+PKG_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$PKG_DIR"
+
+command -v bun >/dev/null 2>&1 || { echo "error: bun is required but not installed" >&2; exit 2; }
+command -v timeout >/dev/null 2>&1 || { echo "error: timeout is required but not installed (brew install coreutils)" >&2; exit 2; }
+
+MODEL=${KILO_REPRO_MODEL:-kilo/z-ai/glm-5.3-flash}
+PROMPT="Reply with one word: hi"
+WARMUP_TIMEOUT_SEC=60
+
+# Isolated config dir: no remote, no MCP, no snapshots, all permissions allowed.
+KILO_CONFIG_DIR=$(mktemp -d)
+export KILO_CONFIG_DIR
+export KILO_DISABLE_AUTOUPDATE=1
+# shellcheck disable=SC2016  # $schema is a literal JSON key, not a shell expansion.
+printf '%s\n' '{"$schema":"https://app.kilo.ai/config.json","snapshot":false,"permission":{"*":"allow"}}' >"$KILO_CONFIG_DIR/kilo.json"
+
+# Per-run logs stay out of the git worktree.
+LOG_DIR=$(mktemp -d)
+# $TEMP/kilo-hang-debug.log, per the repro recipe; fall back to TMPDIR then /tmp.
+TEMP_DIR=${TEMP:-${TMPDIR:-/tmp}}
+TEMP_DIR=${TEMP_DIR%/}
+DEBUG_LOG="$TEMP_DIR/kilo-hang-debug.log"
+
+# Epoch milliseconds. BSD date has no %N, so fall back to python3, then perl.
+now_ms() {
+  local t
+  t=$(date +%s%3N 2>/dev/null) || t=""
+  case $t in
+    ''|*[!0-9]*) ;;
+    *) printf '%s\n' "$t"; return ;;
+  esac
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import time; print(int(time.time()*1000))'
+    return
+  fi
+  perl -MTime::HiRes=time -e 'printf "%d\n", time()*1000'
+}
+
+echo "repro: $PKG_DIR, runs=$RUNS, timeout=${TIMEOUT_SEC}s, model=$MODEL"
+echo "warmup: one discarded boot with /dev/null stdin (warms bun transpile cache)..."
+timeout "$WARMUP_TIMEOUT_SEC" bun run --conditions=browser ./src/index.ts run "$PROMPT" \
+  -m "$MODEL" --format json --auto </dev/null >/dev/null 2>&1 || true
+
+hangs=0
+step0=0
+debug_done=0
+
+for ((i = 1; i <= RUNS; i++)); do
+  log="$LOG_DIR/run-$i.log"
+  start_ms=$(now_ms)
+  rc=0
+  # The sleep keeps the write end of stdin open, so the pipe never EOFs.
+  sleep $((TIMEOUT_SEC + 5)) | timeout "$TIMEOUT_SEC" bun run --conditions=browser ./src/index.ts run "$PROMPT" \
+    -m "$MODEL" --format json --auto >"$log" 2>&1 || rc=$?
+
+  hung=0
+  if [ "$rc" -eq 124 ]; then hung=1; fi
+  if ! grep -q '"type":"text"' "$log"; then hung=1; fi
+
+  if [ "$hung" -eq 1 ]; then
+    hangs=$((hangs + 1))
+    echo "run $i: HANG (rc=$rc, log=$log)"
+    if [ "$debug_done" -eq 0 ]; then
+      debug_done=1
+      echo "first hang: rerun once with --print-logs --log-level DEBUG (stderr -> $DEBUG_LOG)"
+      drc=0
+      sleep $((TIMEOUT_SEC + 5)) | timeout "$TIMEOUT_SEC" bun run --conditions=browser ./src/index.ts run "$PROMPT" \
+        -m "$MODEL" --format json --auto --print-logs --log-level DEBUG >/dev/null 2>"$DEBUG_LOG" || drc=$?
+      echo "--- last 30 lines of $DEBUG_LOG (debug rerun rc=$drc) ---"
+      tail -n 30 "$DEBUG_LOG" || true
+      echo "--- debug log file: $DEBUG_LOG ---"
+    fi
+    continue
+  fi
+
+  # Ok run: first step_start timestamp minus run start must be <= 20000 ms.
+  line=$(grep -m1 '"type":"step_start"' "$log" || true)
+  if [ -n "$line" ]; then
+    rest=${line#*'"timestamp":'}
+    ts=${rest%%[!0-9]*}
+    if [ -n "$ts" ] && [ $((ts - start_ms)) -le 20000 ]; then
+      step0=$((step0 + 1))
+    fi
+  fi
+  echo "run $i: ok"
+done
+
+echo "logs: $LOG_DIR"
+echo "hangs: $hangs / $RUNS"
+echo "step0: $step0 / $RUNS"

--- a/packages/opencode/src/cli/cmd/run-stdin.ts
+++ b/packages/opencode/src/cli/cmd/run-stdin.ts
@@ -1,0 +1,34 @@
+// kilocode_change - bounded piped-stdin read for headless `kilo run`
+//
+// `loadInput()` in run.ts consumes non-TTY stdin as prompt input. When a
+// launcher keeps the write end of the stdin pipe open (the workflow driver's
+// spawn), `Bun.stdin.text()` never resolves: the pipe never EOFs, and Bun
+// 1.4.0 on macOS never delivers FIFO EOF either, so the run hangs forever
+// before the prompt. When argv already carries a message or a command, the
+// piped text is only an append, so the wait can be bounded: race the read
+// against a silence timer and proceed without the append if the timer wins.
+// When stdin is the sole input, keep the upstream wait-for-EOF semantics.
+//
+// A dangling read after the timer wins is harmless: the run proceeds and
+// src/index.ts exits hard when the session ends.
+
+export async function readPipedStdin(opts: {
+  bound: boolean
+  timeoutMs?: number
+  read?: () => Promise<string | undefined>
+}): Promise<string | undefined> {
+  const read = opts.read ?? (() => Bun.stdin.text())
+  if (!opts.bound) return await read()
+  const timeoutMs = opts.timeoutMs ?? 1000
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      read(),
+      new Promise<undefined>((resolve) => {
+        timer = setTimeout(() => resolve(undefined), timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}

--- a/packages/opencode/src/cli/cmd/run-stdin.ts
+++ b/packages/opencode/src/cli/cmd/run-stdin.ts
@@ -11,26 +11,54 @@
 // against a silence timer and proceed without the append if the timer wins.
 // When stdin is the sole input, keep the upstream wait-for-EOF semantics.
 //
-// A dangling read after the timer wins is harmless: the run proceeds and
-// src/index.ts exits hard when the session ends.
+// Promise.race does not cancel its loser, so the timer aborts the read. The
+// default reader consumes an abortable stdin stream and cancels it on abort:
+// a producer that keeps writing after the timeout is then bounded by the pipe
+// buffer instead of growing process memory until the session ends. The race
+// is already settled at that point, so a late failure cannot surface as an
+// unhandled rejection.
 
 export async function readPipedStdin(opts: {
   bound: boolean
   timeoutMs?: number
-  read?: () => Promise<string | undefined>
+  read?: (signal: AbortSignal) => Promise<string | undefined>
 }): Promise<string | undefined> {
-  const read = opts.read ?? (() => Bun.stdin.text())
-  if (!opts.bound) return await read()
+  const read = opts.read ?? readStdin
+  if (!opts.bound) return await read(new AbortController().signal)
   const timeoutMs = opts.timeoutMs ?? 1000
+  const controller = new AbortController()
   let timer: ReturnType<typeof setTimeout> | undefined
   try {
     return await Promise.race([
-      read(),
+      read(controller.signal),
       new Promise<undefined>((resolve) => {
-        timer = setTimeout(() => resolve(undefined), timeoutMs)
+        timer = setTimeout(() => {
+          controller.abort()
+          resolve(undefined)
+        }, timeoutMs)
       }),
     ])
   } finally {
     if (timer !== undefined) clearTimeout(timer)
+  }
+}
+
+// Piped stdin as one string, or undefined when aborted. Cancelling the reader
+// stops Bun from buffering later pipe data into the abandoned read.
+async function readStdin(signal: AbortSignal): Promise<string | undefined> {
+  const reader = Bun.stdin.stream().getReader()
+  const aborted = new Promise<undefined>((resolve) => {
+    signal.addEventListener("abort", () => resolve(undefined), { once: true })
+  })
+  const decoder = new TextDecoder()
+  const parts: string[] = []
+  for (;;) {
+    const next = await Promise.race([reader.read(), aborted])
+    if (next === undefined) {
+      await reader.cancel()
+      return undefined
+    }
+    if (next.done) return parts.join("") + decoder.decode()
+    parts.push(decoder.decode(next.value, { stream: true }))
   }
 }

--- a/packages/opencode/src/cli/cmd/run-stdin.ts
+++ b/packages/opencode/src/cli/cmd/run-stdin.ts
@@ -1,4 +1,6 @@
-// kilocode_change - bounded piped-stdin read for headless `kilo run`
+// kilocode_change - new file
+//
+// Bounded piped-stdin read for headless `kilo run`.
 //
 // `loadInput()` in run.ts consumes non-TTY stdin as prompt input. When a
 // launcher keeps the write end of the stdin pipe open (the workflow driver's

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -27,6 +27,7 @@ import { Filesystem } from "@/util/filesystem"
 import type { KiloClient, Session, ToolPart } from "@kilocode/sdk/v2"
 import { FormatError, FormatUnknownError } from "../error"
 import { INTERACTIVE_INPUT_ERROR, resolveInteractiveStdin } from "./run/runtime.stdin"
+import { readPipedStdin } from "./run-stdin" // kilocode_change - bounded piped-stdin read
 // kilocode_change start - Kilo implementations (createKiloClient, run-message,
 // cloud-session, run-auto, headless, KiloRun) are dynamically imported inside the
 // handler so other CLI commands don't pay their module cost at startup.
@@ -439,7 +440,12 @@ export const RunCommand = effectCmd({
       const input = { initial: undefined as string | undefined, loaded: false }
       async function loadInput() {
         if (input.loaded) return
-        const piped = process.stdin.isTTY ? undefined : await Bun.stdin.text()
+        // kilocode_change start - bound the stdin wait when argv already carries a
+        // message or command; a launcher-held-open pipe never EOFs (see run-stdin.ts)
+        const piped = process.stdin.isTTY
+          ? undefined
+          : await readPipedStdin({ bound: rawMessage.trim().length > 0 || args.command !== undefined })
+        // kilocode_change end
         message = resolveRunInput(message, piped) ?? ""
         input.initial = resolveRunInput(rawMessage, piped)
         input.loaded = true

--- a/packages/opencode/test/cli/run/run-stdin.process.test.ts
+++ b/packages/opencode/test/cli/run/run-stdin.process.test.ts
@@ -1,0 +1,96 @@
+// Subprocess regression tests for the piped-stdin read of `kilo run`.
+//
+// Root cause: loadInput() awaited `Bun.stdin.text()` unbounded. With a
+// launcher-held-open stdin pipe (the workflow driver's spawn) the stream
+// never EOFs, so the run hung forever before the prompt. The fix bounds the
+// wait when argv already carries a message or command (src/cli/cmd/
+// run-stdin.ts); stdin as the sole input still waits for EOF.
+//
+// Harness support: startRun(message, { stdin: "pipe" }) spawns the child with
+// a writable stdin; run.stdin.write/end drive it. See test/lib/cli-process.ts.
+import { describe, expect } from "bun:test"
+import { Effect } from "effect"
+import { cliIt } from "../../lib/cli-process"
+
+describe("kilo run piped stdin (subprocess)", () => {
+  // THE regression: argv message + stdin pipe held open (never write, never
+  // end). Before the fix the child blocked in `Bun.stdin.text()` and this
+  // test died on the 60s bun timeout. After the fix the bounded read fires,
+  // the run proceeds, and the first step_start lands within 20s of spawn.
+  cliIt.concurrent(
+    "completes with an argv message while piped stdin stays open (regression)",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        yield* llm.text("hello from the test llm")
+        const spawnedAt = Date.now()
+        const run = yield* opencode.startRun("say hi", { stdin: "pipe", format: "json" })
+        const result = yield* run.result
+        opencode.expectExit(result, 0)
+        expect(result.stdout).toContain("hello from the test llm")
+
+        const events = opencode.parseJsonEvents(result.stdout)
+        const stepStart = events.find((event) => event.type === "step_start")
+        expect(stepStart).toBeDefined()
+        expect(typeof stepStart!.timestamp).toBe("number")
+        expect(Number(stepStart!.timestamp) - spawnedAt).toBeLessThanOrEqual(20_000)
+      }),
+    60_000,
+  )
+
+  // Sole-input stdin keeps the upstream wait-for-EOF semantics: no argv
+  // message, so the read is unbound and the prompt arrives after stdin end().
+  cliIt.concurrent(
+    "uses the piped prompt as the run input when argv has no message",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        yield* llm.text("piped prompt received")
+        const run = yield* opencode.startRun(undefined, { stdin: "pipe" })
+        yield* Effect.promise(() => run.stdin.write("summarize the piped notes\n"))
+        run.stdin.end()
+        const result = yield* run.result
+        opencode.expectExit(result, 0)
+        expect(result.stdout).toContain("piped prompt received")
+        const input = JSON.stringify(yield* llm.inputs)
+        expect(input).toContain("summarize the piped notes")
+      }),
+    60_000,
+  )
+
+  // Append guard: the bound path must still append piped text that lands
+  // before the silence timer, so `kilo run main < extra` keeps both parts.
+  cliIt.concurrent(
+    "appends piped text to the argv message when stdin ends before the bound fires",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        yield* llm.text("append preserved")
+        const run = yield* opencode.startRun("main", { stdin: "pipe" })
+        yield* Effect.promise(() => run.stdin.write("extra"))
+        run.stdin.end()
+        const result = yield* run.result
+        opencode.expectExit(result, 0)
+        expect(result.stdout).toContain("append preserved")
+        const input = JSON.stringify(yield* llm.inputs)
+        expect(input).toContain("main")
+        expect(input).toContain("extra")
+        // The joined form ("main\nextra" in the JSON string) proves the append
+        // landed in resolveRunInput order, not a coincidental substring match.
+        expect(input).toContain("main\\nextra")
+      }),
+    60_000,
+  )
+
+  // Empty stdin EOF with no argv message: the unbound read resolves to "",
+  // so the existing usage error still fires with exit 1.
+  cliIt.concurrent(
+    "exits 1 with the usage error on empty stdin EOF and no argv message",
+    ({ opencode }) =>
+      Effect.gen(function* () {
+        const run = yield* opencode.startRun(undefined, { stdin: "pipe" })
+        run.stdin.end()
+        const result = yield* run.result
+        opencode.expectExit(result, 1)
+        expect(result.stderr).toContain("You must provide a message or a command")
+      }),
+    60_000,
+  )
+})

--- a/packages/opencode/test/cli/run/run-stdin.process.test.ts
+++ b/packages/opencode/test/cli/run/run-stdin.process.test.ts
@@ -1,3 +1,4 @@
+// kilocode_change - new file
 // Subprocess regression tests for the piped-stdin read of `kilo run`.
 //
 // Root cause: loadInput() awaited `Bun.stdin.text()` unbounded. With a

--- a/packages/opencode/test/cli/run/run-stdin.subprocess.test.ts
+++ b/packages/opencode/test/cli/run/run-stdin.subprocess.test.ts
@@ -1,0 +1,87 @@
+// kilocode_change - new file
+// Subprocess test for the abort of the abandoned piped-stdin read.
+//
+// Promise.race does not cancel its loser: before the abort (run-stdin.ts),
+// Bun kept buffering stdin into the abandoned `Bun.stdin.text()` after the
+// silence timer won — 64MB written by this harness grew the child by more
+// than the write volume of native memory (37MB RSS at the timer, 151MB at
+// exit). The timer now aborts the read and cancels the stdin stream, so the
+// same write volume must leave the child's RSS flat.
+//
+// node:child_process (not Bun.spawn) so the EPIPE from writing into the
+// cancelled stdin arrives as a catchable error event instead of killing the
+// harness.
+import { afterAll, expect, test } from "bun:test"
+import { spawn } from "node:child_process"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+const dir = mkdtempSync(join(tmpdir(), "run-stdin-abort-"))
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+const childScript = (modulePath: string) => `
+import { readPipedStdin } from ${JSON.stringify(modulePath)}
+const value = await readPipedStdin({ bound: true, timeoutMs: 200 })
+const atTimer = process.memoryUsage.rss()
+await Bun.sleep(2500)
+const after = process.memoryUsage.rss()
+process.stdout.write(JSON.stringify({ value, atTimer, after }) + "\\n")
+process.exit(0)
+`
+
+test(
+  "the abandoned stdin read stops buffering after the silence timer wins",
+  async () => {
+    const childPath = join(dir, "child.ts")
+    await Bun.write(
+      childPath,
+      childScript(join(import.meta.dir, "..", "..", "..", "src", "cli", "cmd", "run-stdin.ts")),
+    )
+    const child = spawn(process.execPath, [childPath], { stdio: ["pipe", "pipe", "pipe"] })
+
+    let epipe = false
+    child.stdin?.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "EPIPE") epipe = true
+    })
+    let out = ""
+    child.stdout?.on("data", (chunk: Buffer) => {
+      out += chunk.toString()
+    })
+    let stderr = ""
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString()
+    })
+
+    // Write 64MB while the child sits past its 200ms silence timer. Once the
+    // read is cancelled the pipe rejects further writes, so writes may stop
+    // landing; the harness must still attempt the full volume.
+    let written = 0
+    const chunk = Buffer.alloc(1024 * 1024, 0x61)
+    const writer = setInterval(() => {
+      if (written >= 64 * 1024 * 1024) {
+        clearInterval(writer)
+        return
+      }
+      child.stdin?.write(chunk)
+      written += chunk.length
+    }, 20)
+
+    await new Promise<void>((resolve) => child.on("exit", () => resolve()))
+    clearInterval(writer)
+
+    expect(stderr).toBe("")
+    expect(written).toBe(64 * 1024 * 1024)
+    expect(epipe).toBe(true)
+
+    const result: { value: string | undefined; atTimer: number; after: number } = JSON.parse(out)
+    expect(result.value).toBeUndefined()
+    // The abandoned read grew RSS by more than the write volume; with the
+    // cancel a flat RSS stays far below half of it.
+    expect(result.after - result.atTimer).toBeLessThan(32 * 1024 * 1024)
+  },
+  30_000,
+)

--- a/packages/opencode/test/cli/run/run-stdin.subprocess.test.ts
+++ b/packages/opencode/test/cli/run/run-stdin.subprocess.test.ts
@@ -8,9 +8,8 @@
 // exit). The timer now aborts the read and cancels the stdin stream, so the
 // same write volume must leave the child's RSS flat.
 //
-// node:child_process (not Bun.spawn) so the EPIPE from writing into the
-// cancelled stdin arrives as a catchable error event instead of killing the
-// harness.
+// node:child_process (not Bun.spawn) so a write into the full or dead pipe
+// surfaces as a catchable stream error instead of killing the harness.
 import { afterAll, expect, test } from "bun:test"
 import { spawn } from "node:child_process"
 import { mkdtempSync, rmSync } from "node:fs"
@@ -43,14 +42,12 @@ test(
     )
     const child = spawn(process.execPath, [childPath], { stdio: ["pipe", "pipe", "pipe"] })
 
-    let epipe = false
-    const epipeHit = Promise.withResolvers<void>()
-    child.stdin?.on("error", (err: NodeJS.ErrnoException) => {
-      if (err.code === "EPIPE") {
-        epipe = true
-        epipeHit.resolve()
-      }
-    })
+    // A write into the full or dead pipe fails asynchronously: the child's
+    // exit closes the read end while the harness still holds backed-up
+    // writes. Bun 1.4 delivers that as EPIPE, 1.3.14 swallows it. Either way
+    // it is the expected consequence of the cancel, so this handler only
+    // keeps the stream error from killing the harness.
+    child.stdin?.on("error", () => {})
     let out = ""
     child.stdout?.on("data", (chunk: Buffer) => {
       out += chunk.toString()
@@ -61,8 +58,8 @@ test(
     })
 
     // Write 64MB while the child sits past its 200ms silence timer. Once the
-    // read is cancelled the pipe rejects further writes, so writes may stop
-    // landing; the harness must still attempt the full volume.
+    // read is cancelled the pipe stays full, so the writes stop landing in
+    // child memory; the harness must still attempt the full volume.
     let written = 0
     const chunk = Buffer.alloc(1024 * 1024, 0x61)
     const writer = setInterval(() => {
@@ -77,14 +74,8 @@ test(
     await new Promise<void>((resolve) => child.on("exit", () => resolve()))
     clearInterval(writer)
 
-    // The final EPIPE lands asynchronously: the child's exit closes the pipe
-    // read end, then the parent's pending write flush fails. Give that error
-    // event a bounded window so the assertion below does not race it.
-    await Promise.race([epipeHit.promise, Bun.sleep(250)])
-
     expect(stderr).toBe("")
     expect(written).toBe(64 * 1024 * 1024)
-    expect(epipe).toBe(true)
 
     const result: { value: string | undefined; atTimer: number; after: number } = JSON.parse(out)
     expect(result.value).toBeUndefined()

--- a/packages/opencode/test/cli/run/run-stdin.subprocess.test.ts
+++ b/packages/opencode/test/cli/run/run-stdin.subprocess.test.ts
@@ -44,8 +44,12 @@ test(
     const child = spawn(process.execPath, [childPath], { stdio: ["pipe", "pipe", "pipe"] })
 
     let epipe = false
+    const epipeHit = Promise.withResolvers<void>()
     child.stdin?.on("error", (err: NodeJS.ErrnoException) => {
-      if (err.code === "EPIPE") epipe = true
+      if (err.code === "EPIPE") {
+        epipe = true
+        epipeHit.resolve()
+      }
     })
     let out = ""
     child.stdout?.on("data", (chunk: Buffer) => {
@@ -72,6 +76,11 @@ test(
 
     await new Promise<void>((resolve) => child.on("exit", () => resolve()))
     clearInterval(writer)
+
+    // The final EPIPE lands asynchronously: the child's exit closes the pipe
+    // read end, then the parent's pending write flush fails. Give that error
+    // event a bounded window so the assertion below does not race it.
+    await Promise.race([epipeHit.promise, Bun.sleep(250)])
 
     expect(stderr).toBe("")
     expect(written).toBe(64 * 1024 * 1024)

--- a/packages/opencode/test/cli/run/run-stdin.unit.test.ts
+++ b/packages/opencode/test/cli/run/run-stdin.unit.test.ts
@@ -2,12 +2,23 @@
 // Unit tests for readPipedStdin — the bounded piped-stdin read used by
 // `kilo run`'s loadInput(). The read is injected so the tests never touch the
 // real process stdin; the never-resolving read reproduces the held-open pipe
-// that hung the CLI (see script/kilocode/repro-run-stdin-hang.sh).
+// that hung the CLI (see script/kilocode/repro-run-stdin-hang.sh). The real
+// stdin behavior of the abort is covered by run-stdin.subprocess.test.ts.
 import { describe, expect, test } from "bun:test"
 import { readPipedStdin } from "@/cli/cmd/run-stdin"
 
 function neverRead(): Promise<string> {
   return new Promise<string>(() => {})
+}
+
+// Wraps an injected read and exposes the signal the read received.
+function capture(underlying: (signal: AbortSignal) => Promise<string | undefined>) {
+  const state: { signal?: AbortSignal } = {}
+  const read = (signal: AbortSignal) => {
+    state.signal = signal
+    return underlying(signal)
+  }
+  return { state, read }
 }
 
 describe("readPipedStdin", () => {
@@ -16,6 +27,20 @@ describe("readPipedStdin", () => {
     const value = await readPipedStdin({ bound: true, timeoutMs: 50, read: neverRead })
     expect(value).toBeUndefined()
     expect(Date.now() - start).toBeGreaterThanOrEqual(40)
+  })
+
+  test("the silence timer aborts the abandoned read", async () => {
+    const { state, read } = capture(() => neverRead())
+    const value = await readPipedStdin({ bound: true, timeoutMs: 50, read })
+    expect(value).toBeUndefined()
+    expect(state.signal!.aborted).toBe(true)
+  })
+
+  test("a read that finishes before the timer is not aborted", async () => {
+    const { state, read } = capture(() => Promise.resolve("piped notes"))
+    const value = await readPipedStdin({ bound: true, timeoutMs: 1000, read })
+    expect(value).toBe("piped notes")
+    expect(state.signal!.aborted).toBe(false)
   })
 
   test("bound read returns piped text when it arrives before the timer fires", async () => {
@@ -43,5 +68,17 @@ describe("readPipedStdin", () => {
     const reject = (): Promise<string> => Promise.reject(new Error("stdin read failed"))
     await expect(readPipedStdin({ bound: true, timeoutMs: 1000, read: reject })).rejects.toThrow("stdin read failed")
     await expect(readPipedStdin({ bound: false, read: reject })).rejects.toThrow("stdin read failed")
+  })
+
+  test("a rejection after the timer won does not become an unhandled rejection", async () => {
+    const { promise, reject } = Promise.withResolvers<string>()
+    const value = await readPipedStdin({
+      bound: true,
+      timeoutMs: 50,
+      read: () => promise,
+    })
+    expect(value).toBeUndefined()
+    reject(new Error("late stdin failure"))
+    await Bun.sleep(50)
   })
 })

--- a/packages/opencode/test/cli/run/run-stdin.unit.test.ts
+++ b/packages/opencode/test/cli/run/run-stdin.unit.test.ts
@@ -1,0 +1,46 @@
+// Unit tests for readPipedStdin — the bounded piped-stdin read used by
+// `kilo run`'s loadInput(). The read is injected so the tests never touch the
+// real process stdin; the never-resolving read reproduces the held-open pipe
+// that hung the CLI (see script/kilocode/repro-run-stdin-hang.sh).
+import { describe, expect, test } from "bun:test"
+import { readPipedStdin } from "@/cli/cmd/run-stdin"
+
+function neverRead(): Promise<string> {
+  return new Promise<string>(() => {})
+}
+
+describe("readPipedStdin", () => {
+  test("bound read returns undefined when the silence timer wins", async () => {
+    const start = Date.now()
+    const value = await readPipedStdin({ bound: true, timeoutMs: 50, read: neverRead })
+    expect(value).toBeUndefined()
+    expect(Date.now() - start).toBeGreaterThanOrEqual(40)
+  })
+
+  test("bound read returns piped text when it arrives before the timer fires", async () => {
+    const value = await readPipedStdin({ bound: true, timeoutMs: 1000, read: async () => "piped notes" })
+    expect(value).toBe("piped notes")
+  })
+
+  test("bound read passes through a read that resolves to undefined", async () => {
+    const value = await readPipedStdin({ bound: true, timeoutMs: 1000, read: async () => undefined })
+    expect(value).toBeUndefined()
+  })
+
+  test("unbound read keeps waiting for EOF when the read never resolves", async () => {
+    const pending = readPipedStdin({ bound: false, read: neverRead })
+    const winner = await Promise.race([pending.then(() => "read"), Bun.sleep(100).then(() => "timer")])
+    expect(winner).toBe("timer")
+  })
+
+  test("unbound read returns piped text on EOF", async () => {
+    const value = await readPipedStdin({ bound: false, read: async () => "piped notes" })
+    expect(value).toBe("piped notes")
+  })
+
+  test("a rejecting read propagates to the caller in both modes", async () => {
+    const reject = (): Promise<string> => Promise.reject(new Error("stdin read failed"))
+    await expect(readPipedStdin({ bound: true, timeoutMs: 1000, read: reject })).rejects.toThrow("stdin read failed")
+    await expect(readPipedStdin({ bound: false, read: reject })).rejects.toThrow("stdin read failed")
+  })
+})

--- a/packages/opencode/test/cli/run/run-stdin.unit.test.ts
+++ b/packages/opencode/test/cli/run/run-stdin.unit.test.ts
@@ -1,3 +1,4 @@
+// kilocode_change - new file
 // Unit tests for readPipedStdin — the bounded piped-stdin read used by
 // `kilo run`'s loadInput(). The read is injected so the tests never touch the
 // real process stdin; the never-resolving read reproduces the held-open pipe

--- a/packages/opencode/test/kilocode/run-network.test.ts
+++ b/packages/opencode/test/kilocode/run-network.test.ts
@@ -99,12 +99,12 @@ function args() {
 
 const exitCode = process.exitCode
 const tty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY")
-const text = Bun.stdin.text
+const stream = Bun.stdin.stream
 
 afterEach(async () => {
   await mock.module("@kilocode/sdk/v2", () => actual)
   process.exitCode = exitCode ?? 0
-  Bun.stdin.text = text
+  Bun.stdin.stream = stream
   if (tty) {
     Object.defineProperty(process.stdin, "isTTY", tty)
     return
@@ -252,7 +252,8 @@ describe("cli run network retries", () => {
   test("built-in compaction uses the session model without reading stdin", async () => {
     const q = feed<Event>()
     const calls: unknown[] = []
-    Bun.stdin.text = async () => {
+    // kilocode_change - run-stdin.ts reads piped stdin through Bun.stdin.stream()
+    Bun.stdin.stream = () => {
       throw new Error("stdin should not be read")
     }
 
@@ -294,7 +295,8 @@ describe("cli run network retries", () => {
   test("custom compact commands retain piped arguments without a session", async () => {
     const q = feed<Event>()
     const calls: unknown[] = []
-    Bun.stdin.text = async () => "from stdin"
+    // kilocode_change - run-stdin.ts reads piped stdin through Bun.stdin.stream()
+    Bun.stdin.stream = () => new Response("from stdin").body!
 
     const sdk = {
       command: {

--- a/packages/opencode/test/lib/cli-process.ts
+++ b/packages/opencode/test/lib/cli-process.ts
@@ -271,7 +271,7 @@ export function withCliFixture<A, E>(
       }
     })
 
-    const runArgs = (message: string | undefined, opts?: RunOpts) => {
+    const runArgs = (message: string | undefined, opts?: RunOpts) => { // kilocode_change - accepts undefined message for stdin-only runs
       const argv: string[] = ["run"]
       if (opts?.printLogs) argv.push("--print-logs")
       argv.push("--model", opts?.model ?? testModelID)
@@ -301,7 +301,7 @@ export function withCliFixture<A, E>(
       return spawn(runArgs(message, opts), runOpts(opts))
     }
 
-    const startRun = Effect.fn("opencode.startRun")(function* (message: string | undefined, opts?: RunOpts) {
+    const startRun = Effect.fn("opencode.startRun")(function* (message: string | undefined, opts?: RunOpts) { // kilocode_change - accepts undefined message for stdin-only runs
       const start = Date.now()
       const options = runOpts(opts)
       // kilocode_change start - stdin "pipe" lets a test hold the child's stdin

--- a/packages/opencode/test/lib/cli-process.ts
+++ b/packages/opencode/test/lib/cli-process.ts
@@ -93,9 +93,25 @@ export type RunResult = {
 export type RunHandle = {
   readonly interrupt: () => void
   readonly result: Effect.Effect<RunResult>
+  // kilocode_change start - raw stdin handle, usable only when the child was
+  // spawned through startRun with stdin: "pipe". Mirrors the acp handle's
+  // proc.stdin write/end pattern.
+  readonly stdin: {
+    readonly write: (text: string) => Promise<void>
+    readonly end: () => void
+  }
+  // kilocode_change end
 }
 
-export type SpawnOpts = { readonly timeoutMs?: number; readonly env?: Record<string, string> }
+// kilocode_change start - stdin mode for startRun. Default "ignore" preserves
+// the documented dodge in spawn(); "pipe" is supported by startRun only, so a
+// test can write or hold open the child's stdin.
+export type SpawnOpts = {
+  readonly timeoutMs?: number
+  readonly env?: Record<string, string>
+  readonly stdin?: "ignore" | "pipe"
+}
+// kilocode_change end
 
 // Typed equivalent of constructing argv for `opencode run`. New flags should
 // land here so tests stay grep-able and refactor-safe.
@@ -161,7 +177,7 @@ export type AcpHandle = {
 export type OpencodeCli = {
   // High-level: run a single prompt against the test model. Short-lived.
   readonly run: (message: string, opts?: RunOpts) => Effect.Effect<RunResult>
-  readonly startRun: (message: string, opts?: RunOpts) => Effect.Effect<RunHandle, never, Scope.Scope>
+  readonly startRun: (message: string | undefined, opts?: RunOpts) => Effect.Effect<RunHandle, never, Scope.Scope> // kilocode_change - undefined message = no argv prompt
   // Spawn `opencode serve` and wait until it's listening. Long-lived: the
   // returned handle is killed when the caller's Scope closes. Fails if the
   // listening line doesn't appear within `readyTimeoutMs`.
@@ -255,7 +271,7 @@ export function withCliFixture<A, E>(
       }
     })
 
-    const runArgs = (message: string, opts?: RunOpts) => {
+    const runArgs = (message: string | undefined, opts?: RunOpts) => {
       const argv: string[] = ["run"]
       if (opts?.printLogs) argv.push("--print-logs")
       argv.push("--model", opts?.model ?? testModelID)
@@ -263,7 +279,7 @@ export function withCliFixture<A, E>(
       if (opts?.format) argv.push("--format", opts.format)
       if (opts?.command) argv.push("--command", opts.command)
       if (opts?.extraArgs) argv.push(...opts.extraArgs)
-      argv.push(message)
+      if (message !== undefined) argv.push(message) // kilocode_change - undefined message = no argv prompt (stdin-only run)
       return argv
     }
 
@@ -285,16 +301,20 @@ export function withCliFixture<A, E>(
       return spawn(runArgs(message, opts), runOpts(opts))
     }
 
-    const startRun = Effect.fn("opencode.startRun")(function* (message: string, opts?: RunOpts) {
+    const startRun = Effect.fn("opencode.startRun")(function* (message: string | undefined, opts?: RunOpts) {
       const start = Date.now()
       const options = runOpts(opts)
+      // kilocode_change start - stdin "pipe" lets a test hold the child's stdin
+      // open (never write, never end) or feed it a prompt; "ignore" (default)
+      // keeps the documented dodge in spawn().
+      const stdinMode = options?.stdin ?? "ignore"
       const proc = yield* Effect.acquireRelease(
         Effect.sync(() =>
           Bun.spawn(["bun", ...cliArgs, ...runArgs(message, opts)], {
             // kilocode_change - cliArgs carries the solid preload
             cwd: home,
             env: { ...process.env, ...env, ...options?.env },
-            stdin: "ignore",
+            stdin: stdinMode,
             stdout: "pipe",
             stderr: "pipe",
           }),
@@ -310,6 +330,20 @@ export function withCliFixture<A, E>(
 
       return {
         interrupt: () => proc.kill("SIGINT"),
+        stdin: {
+          // `proc.stdin.write` returns `number | Promise<number>`; await the
+          // promise form for backpressure, same as the acp handle's send.
+          write: async (text: string) => {
+            if (!proc.stdin) throw new Error(`startRun stdin.write: child was spawned with stdin: "${stdinMode}"`)
+            const ret = proc.stdin.write(text)
+            if (typeof ret !== "number") await ret
+          },
+          // proc.stdin.end() is idempotent in Bun; no try/catch needed.
+          end: () => {
+            if (!proc.stdin) throw new Error(`startRun stdin.end: child was spawned with stdin: "${stdinMode}"`)
+            proc.stdin.end()
+          },
+        },
         result: Effect.promise(async () => ({
           exitCode: await proc.exited,
           stdout: normalizeLines(await stdout),
@@ -317,6 +351,7 @@ export function withCliFixture<A, E>(
           durationMs: Date.now() - start,
         })),
       } satisfies RunHandle
+      // kilocode_change end
     })
 
     const serve = Effect.fn("opencode.serve")(function* (opts?: ServeOpts) {


### PR DESCRIPTION
## What changed

- `kilo run` no longer hangs at boot when the prompt comes from an argument and the launcher keeps stdin open. The piped-stdin wait now has a bound.

## Why

- A launcher can keep stdin open and never close the pipe. `kilo run` then awaited the stdin read with no bound, even when the prompt was already in the argv. The await never resolved, so the boot stopped before the prompt step. The hang was intermittent: runs started by a different process completed.

## Verification

- Driver checks: per-slice checks passed.
- `backend`: no changed service.
- `cli`: `test:ci` failed only on files that also fail on clean main. This is pre-existing and advisory.
- `cli`: the live verifier passed.

**CLI TUI screenshot 1 (tui-1): the boot completes and the terminal UI shows the session.**

![tui/tui-1.png](https://github.com/user-attachments/assets/6395fc69-fb83-4d77-9a1e-480fcd85326a)

**CLI TUI screenshot 2 (tui-0): the boot completes and the terminal UI shows the session.**

![tui/tui-0.png](https://github.com/user-attachments/assets/19645fb2-7901-4232-9f3d-175c5ded130d)
