### PR TITLE
fix(agent-manager): preserve collapsed sections after deletion

### DIFF
--- a/.changeset/preserve-sections-after-deletion.md
+++ b/.changeset/preserve-sections-after-deletion.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep Agent Manager sections collapsed when deleting worktrees and select the nearest visible worktree with a session instead.

--- a/packages/kilo-vscode/tests/unit/next-selection-after-delete.test.ts
+++ b/packages/kilo-vscode/tests/unit/next-selection-after-delete.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test"
 import { nextSelectionAfterDelete, LOCAL } from "../../webview-ui/agent-manager/navigate"
+import { buildSidebarOrder, buildTopLevelItems } from "../../webview-ui/agent-manager/section-helpers"
 
 describe("nextSelectionAfterDelete", () => {
   it("selects the worktree below when deleting from the middle", () => {
@@ -54,5 +55,44 @@ describe("nextSelectionAfterDelete", () => {
 
   it("falls back to LOCAL when no remaining worktree is available", () => {
     expect(nextSelectionAfterDelete("a", ["a", "empty", "deleting", "stale"], (id) => id === "a")).toBe(LOCAL)
+  })
+
+  it.each([
+    { deleted: "above", collapsed: ["hidden"], expected: "below" },
+    { deleted: "below", collapsed: ["hidden"], expected: "above" },
+    { deleted: "above", collapsed: ["hidden", "after"], expected: LOCAL },
+    { deleted: "hidden-a", collapsed: ["hidden"], expected: "below" },
+    { deleted: "hidden-a", collapsed: ["before", "hidden", "after"], expected: LOCAL },
+  ])("selects $expected after deleting $deleted with collapsed sections $collapsed", (test) => {
+    const sections = ["before", "hidden", "after"].map((id, order) => ({
+      id,
+      name: id,
+      color: null,
+      order,
+      collapsed: test.collapsed.includes(id),
+    }))
+    const worktrees = [
+      { id: "above", sectionId: "before" },
+      { id: "hidden-a", sectionId: "hidden" },
+      { id: "hidden-b", sectionId: "hidden" },
+      { id: "below", sectionId: "after" },
+    ].map((item) => ({
+      ...item,
+      branch: item.id,
+      path: `/tmp/${item.id}`,
+      parentBranch: "main",
+      createdAt: "2024-01-01",
+    }))
+    const items = buildTopLevelItems(sections, [], worktrees, [])
+    const order = buildSidebarOrder(
+      items,
+      worktrees,
+      sections,
+      (id) => worktrees.filter((wt) => wt.sectionId === id),
+      test.deleted,
+    )
+      .filter((item) => item.type === "wt")
+      .map((item) => item.id)
+    expect(nextSelectionAfterDelete(test.deleted, order)).toBe(test.expected)
   })
 })

--- a/packages/kilo-vscode/tests/unit/section-helpers.test.ts
+++ b/packages/kilo-vscode/tests/unit/section-helpers.test.ts
@@ -214,14 +214,18 @@ describe("buildSidebarOrder", () => {
     ])
   })
 
-  it("includes collapsed section members when choosing a deletion fallback", () => {
+  it.each(["visible", "hidden"])("keeps only the %s deletion anchor and visible worktrees", (anchor) => {
     const section = sec("s1", 0, { collapsed: true })
     const hidden = wt("hidden", { sectionId: "s1" })
+    const sibling = wt("sibling", { sectionId: "s1" })
     const visible = wt("visible")
-    const sorted = [hidden, visible]
+    const sorted = [hidden, sibling, visible]
     const items = buildTopLevelItems([section], [visible], sorted, [])
-    const result = buildSidebarOrder(items, sorted, [section], () => [hidden], true)
-    expect(result.map((item) => item.id)).toEqual(["local", "visible", "hidden"])
+    const result = buildSidebarOrder(items, sorted, [section], () => [hidden, sibling], anchor)
+    expect(result.map((item) => item.id)).toEqual(
+      anchor === "hidden" ? ["local", "visible", "hidden"] : ["local", "visible"],
+    )
+    expect(section.collapsed).toBe(true)
   })
 
   it("respects section order after ungrouped worktrees", () => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1795,7 +1795,7 @@ const AgentManagerContent: Component = () => {
   const selectAfterDelete = (id: string) => {
     if (selection() !== id) return
     const ids = new Set(managedSessions().map((item) => item.worktreeId))
-    const order = buildSidebarOrder(topLevelItems(), sortedWorktrees(), sections(), worktreesInSection, true)
+    const order = buildSidebarOrder(topLevelItems(), sortedWorktrees(), sections(), worktreesInSection, id)
       .filter((item) => item.type === "wt")
       .map((item) => item.id)
     const next = nextSelectionAfterDelete(
@@ -1804,10 +1804,6 @@ const AgentManagerContent: Component = () => {
       (id) => ids.has(id) && !busyWorktrees().has(id) && !staleWorktreeIds().has(id),
     )
     if (next === LOCAL) return selectLocal()
-    const section = sections().find((item) => item.id === worktrees().find((wt) => wt.id === next)?.sectionId)
-    if (section?.collapsed) {
-      vscode.postMessage({ type: "agentManager.toggleSectionCollapsed", sectionId: section.id })
-    }
     selectWorktree(next)
   }
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/ProjectSidebarBody.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ProjectSidebarBody.tsx
@@ -125,7 +125,7 @@ export const ProjectSidebarBody: Component<Props> = (props) => {
   const selectAfterDelete = (id: string) => {
     if (!active() || props.selection !== id) return
     const ids = new Set(store.managedSessions().map((item) => item.worktreeId))
-    const order = buildSidebarOrder(top(), sorted(), sections(), members, true)
+    const order = buildSidebarOrder(top(), sorted(), sections(), members, id)
       .filter((item) => item.type === "wt")
       .map((item) => item.id)
     const next = nextSelectionAfterDelete(
@@ -134,8 +134,6 @@ export const ProjectSidebarBody: Component<Props> = (props) => {
       (id) => ids.has(id) && !props.busy(id) && !store.staleWorktreeIds().has(id),
     )
     if (next === LOCAL) return props.onSelectLocal(props.project.id)
-    const section = sections().find((item) => item.id === worktrees().find((wt) => wt.id === next)?.sectionId)
-    if (section?.collapsed) post({ type: "agentManager.toggleSectionCollapsed", sectionId: section.id })
     props.onSelectWorktree(props.project.id, next)
   }
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/section-helpers.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/section-helpers.ts
@@ -118,14 +118,15 @@ export function buildSidebarOrder(
   sorted: WorktreeState[],
   sections: SectionState[],
   members: (id: string) => WorktreeState[],
-  includeCollapsed = false,
+  anchor?: string,
 ): SidebarItem[] {
   const result: SidebarItem[] = [{ type: "local", id: "local" }]
   if (sections.length > 0) {
     for (const item of items) {
       if (item.kind === "section") {
-        if (includeCollapsed || !item.section.collapsed) {
+        if (!item.section.collapsed || anchor) {
           for (const wt of members(item.section.id)) {
+            if (item.section.collapsed && wt.id !== anchor) continue
             result.push({ type: "wt", id: wt.id })
           }
         }


### PR DESCRIPTION
## What Problem This Solves

Deleting a selected Agent Manager worktree could select a session inside a collapsed section and open that section.

## Why This Change Was Made

The nearest-session fallback from #13714 remains useful, but its candidate order now includes only visible worktrees plus the deleted worktree as a positional anchor. The explicit section expansion request was removed. This preserves collapsed-section state while still selecting the nearest available visible session, including when the deleted worktree itself was hidden.

## User Impact

- Collapsed sections stay collapsed after worktree deletion or stale-worktree removal.
- A nearby visible worktree with a session is selected when available.
- Agent Manager falls back to Local when no eligible visible worktree remains.
- The same behavior applies to legacy and multi-project sidebars.

## Evidence

- Baseline isolated VS Code run reproduced the section expansion.
- Fixed isolated VS Code runs passed visible-neighbor selection, Local fallback, inactive deletion, and keyboard deletion of a selected hidden worktree in both sidebar modes.
- Full extension unit suite: 4,727 passed, 1 skipped, 0 failed.
- Extension compile, lint, typecheck, Knip, and Kilo change-marker guard passed.
- Independent review found no issues.