### PR TITLE
fix(agent-manager): handle unanswered update questions

### DIFF
--- a/.changeset/update-from-base-questions.md
+++ b/.changeset/update-from-base-questions.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Allow Update from base to dismiss unanswered questions without bypassing permission approvals.

--- a/packages/kilo-vscode/src/agent-manager/base-update.ts
+++ b/packages/kilo-vscode/src/agent-manager/base-update.ts
@@ -90,6 +90,7 @@ export async function handleBaseUpdate(msg: BaseUpdateRequest, ctx: ProjectConte
       sessionID: id,
       text: baseUpdatePrompt(worktree),
       messageID: randomUUID(),
+      questions: "dismiss",
     })
   } catch (err) {
     host.log("Update from base failed:", err)

--- a/packages/kilo-vscode/src/agent-manager/orchestration-domain.ts
+++ b/packages/kilo-vscode/src/agent-manager/orchestration-domain.ts
@@ -355,7 +355,7 @@ function truncate(value: string, max: number): string {
   return value.length <= max ? value : `${value.slice(0, max - 1)}…`
 }
 
-async function blocked(input: Target, dir: string, name: string): Promise<string | undefined> {
+async function blocked(input: Target, dir: string, name: string, questions?: "dismiss"): Promise<string | undefined> {
   const [perms, qs] = await Promise.all([
     input.client.permission.list({ directory: dir }),
     input.client.question.list({ directory: dir }),
@@ -363,7 +363,7 @@ async function blocked(input: Target, dir: string, name: string): Promise<string
   if (perms.error || qs.error)
     throw new OrchestrationError("host_error", "The managed session blockers could not be read")
   const mine = (qs.data ?? []).filter((value) => value.sessionID === input.sessionID)
-  const first = mine[0]
+  const first = questions === "dismiss" ? undefined : mine.at(0)
   if (first) {
     const detail = mine
       .map((value) => {
@@ -395,10 +395,11 @@ export async function prompt(input: {
   messageID: string
   signal?: AbortSignal
   managed?: ManagedSession
+  questions?: "dismiss"
 }): Promise<void> {
   if (input.signal?.aborted) return
   const target = await locate(input)
-  const blocker = await blocked(input, target.dir, target.name)
+  const blocker = await blocked(input, target.dir, target.name, input.questions)
   if (blocker) throw new OrchestrationError("unavailable_session", blocker)
   if (input.signal?.aborted) return
   await input.client.session.promptAsync(

--- a/packages/kilo-vscode/tests/unit/base-update.test.ts
+++ b/packages/kilo-vscode/tests/unit/base-update.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, realpathSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { execFileSync } from "node:child_process"
-import { createKiloClient } from "@kilocode/sdk/v2/client"
+import { createKiloClient, type QuestionRequest } from "@kilocode/sdk/v2/client"
 import { ProjectContext } from "../../src/agent-manager/project/context"
 import { baseUpdatePrompt, handleBaseUpdate } from "../../src/agent-manager/base-update"
 import type { BaseUpdateRequest } from "../../webview-ui/src/types/messages/agent-manager"
@@ -41,22 +41,24 @@ afterEach(async () => {
   rmSync(root, { recursive: true, force: true })
 })
 
-function backend() {
-  const requests: Array<{ path: string; directory: string | null; body?: unknown }> = []
+function backend(failure?: string) {
+  const requests: Array<{ method: string; path: string; directory: string | null; body?: unknown }> = []
   const errors: string[] = []
   const routes: unknown[] = []
   const statuses: Record<string, { type: string }> = {}
   const permissions: unknown[] = []
+  const questions: QuestionRequest[] = []
   const server = Bun.serve({
     port: 0,
     async fetch(request) {
       const url = new URL(request.url)
       const directory = url.searchParams.get("directory")
-      const body = request.method === "POST" ? await request.json() : undefined
-      requests.push({ path: url.pathname, directory, body })
+      const body = request.headers.get("content-type")?.includes("application/json") ? await request.json() : undefined
+      requests.push({ method: request.method, path: url.pathname, directory, body })
+      if (url.pathname === failure) return Response.json({ message: "Blocker unavailable" }, { status: 500 })
       if (url.pathname === "/session/status") return Response.json(statuses)
       if (url.pathname === "/permission") return Response.json(permissions)
-      if (url.pathname === "/question") return Response.json([])
+      if (url.pathname === "/question") return Response.json(questions)
       if (url.pathname === "/mcp") return Response.json({})
       if (url.pathname.endsWith("/prompt_async")) return new Response(null, { status: 204 })
       return Response.json({ id: "ses_target", title: "Target", directory, time: { created: 1, updated: 1 } })
@@ -86,7 +88,7 @@ function backend() {
     },
   }
   const request: BaseUpdateRequest = { type: "agentManager.updateFromBase", projectId: ctx.id, worktreeId: wt.id }
-  return { requests, errors, routes, statuses, permissions, host, request }
+  return { requests, errors, routes, statuses, permissions, questions, host, request }
 }
 
 it("uses the saved base and remote, not the current default or cleanup branch", () => {
@@ -201,6 +203,61 @@ it("creates a session in the target worktree without replacing the user's active
   expect(ctx.stateManager().getSession("ses_target")?.worktreeId).toBe(wt.id)
   expect(api.requests.filter((item) => item.path === "/session")).toHaveLength(1)
   expect(api.requests.filter((item) => item.path.endsWith("/prompt_async"))).toHaveLength(1)
+})
+
+it("lets the backend queue the update prompt before dismissing target questions", async () => {
+  const api = backend()
+  ctx.stateManager().addSession("ses_other", wt.id)
+  ctx.stateManager().addSession("ses_target", wt.id)
+  api.statuses.ses_target = { type: "busy" }
+  api.permissions.push({ id: "perm_other", sessionID: "ses_other" })
+  api.questions.push(
+    { id: "que_other", sessionID: "ses_other", questions: [] },
+    ...["que_first", "que_second"].map((id) => ({
+      id,
+      sessionID: "ses_target",
+      questions: [
+        { header: "Plan", question: "Ready to implement?", options: [{ label: "Yes", description: "Start" }] },
+      ],
+    })),
+  )
+  await handleBaseUpdate({ ...api.request, sessionId: "ses_target" }, ctx, api.host)
+  expect(api.errors).toEqual([])
+  expect(api.requests.every((item) => item.directory === wt.path)).toBe(true)
+  expect(api.requests.filter((item) => item.method === "POST").map((item) => item.path)).toEqual([
+    "/session/ses_target/prompt_async",
+  ])
+})
+
+it.each(["/question", "/permission"])("does not prompt when blocker lookup fails at %s", async (failure) => {
+  const api = backend(failure)
+  ctx.stateManager().addSession("ses_target", wt.id)
+  api.questions.push({
+    id: "que_target",
+    sessionID: "ses_target",
+    questions: [{ header: "Plan", question: "Ready to implement?", options: [] }],
+  })
+  await handleBaseUpdate(api.request, ctx, api.host)
+  expect(api.errors).toHaveLength(1)
+  expect(api.requests.map((item) => item.path)).toContain(failure)
+  expect(api.requests.some((item) => item.method === "POST")).toBe(false)
+  expect(api.questions).toHaveLength(1)
+})
+
+it("leaves questions pending when a permission blocks the target session", async () => {
+  const api = backend()
+  ctx.stateManager().addSession("ses_target", wt.id)
+  api.permissions.push({ id: "perm_target", sessionID: "ses_target" })
+  api.questions.push({
+    id: "que_target",
+    sessionID: "ses_target",
+    questions: [{ header: "Plan", question: "Ready to implement?", options: [] }],
+  })
+  await handleBaseUpdate(api.request, ctx, api.host)
+  expect(api.errors).toHaveLength(1)
+  expect(api.errors.at(0)).toContain("pending permission")
+  expect(api.requests.some((item) => item.method === "POST")).toBe(false)
+  expect(api.questions).toHaveLength(1)
 })
 
 it("rejects wrong ownership, competing sessions, and pending permissions", async () => {


### PR DESCRIPTION
## What Problem This Solves
`/update-from-base` surfaced an internal Agent Manager blocker error when the target session had an unanswered question.

## Why This Change Was Made
Treat this explicit user action as a follow-up prompt that can dismiss target questions through the backend queue, while preserving permission blockers and agent-to-agent question requirements.

## User Impact
Update from base proceeds when only unanswered questions are pending. Pending permissions still block the update.

## Evidence
- 145 focused Agent Manager tests pass
- Extension lint passes
- Markdown table and diff checks pass
- Typecheck/build are currently blocked by pre-existing workspace dependency and SDK type mismatches