### PR TITLE
fix(agent-manager): restore worktree delete actions

### DIFF
--- a/.changeset/fix-agent-manager-shortcut-state.md
+++ b/.changeset/fix-agent-manager-shortcut-state.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Restore worktree delete actions when Agent Manager misses a shortcut modifier key release

--- a/packages/kilo-vscode/tests/unit/agent-manager-modifier.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-modifier.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+import * as modifier from "../../webview-ui/agent-manager/modifier"
+
+const fire = (target: EventTarget, type: string, input: { key?: string; meta?: boolean; ctrl?: boolean } = {}) => {
+  const event = new Event(type)
+  Object.defineProperties(event, {
+    key: { value: input.key ?? "" },
+    metaKey: { value: input.meta ?? false },
+    ctrlKey: { value: input.ctrl ?? false },
+  })
+  target.dispatchEvent(event)
+}
+
+describe("Agent Manager shortcut modifier", () => {
+  test.each([
+    [true, "Meta", "meta"],
+    [false, "Control", "ctrl"],
+  ] as const)("recovers a lost %s keyup from pointer state", (mac, name, field) => {
+    const target = new EventTarget()
+    const values: boolean[] = []
+    const stop = modifier.watch(target as Window, mac, (held) => values.push(held))
+
+    fire(target, "keydown", { key: name, [field]: true })
+    fire(target, "pointermove", { [field]: true })
+    fire(target, "pointermove")
+
+    expect(values).toEqual([true, true, false])
+    stop()
+    fire(target, "keydown", { key: name, [field]: true })
+    expect(values).toEqual([true, true, false])
+  })
+
+  test("recovers when a later key event contains the missing modifier state", () => {
+    const target = new EventTarget()
+    const values: boolean[] = []
+    const stop = modifier.watch(target as Window, true, (held) => values.push(held))
+
+    fire(target, "keydown", { key: "1", meta: true })
+    fire(target, "keyup", { key: "1" })
+    fire(target, "blur")
+
+    expect(values).toEqual([true, false, false])
+    stop()
+  })
+})

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -78,6 +78,7 @@ import { NewWorktreeDialog } from "./NewWorktreeDialog"
 import { createIntro } from "./intro/AgentManagerIntro"
 import { useBaseUpdate } from "./update-from-base"
 import { createModeRouter } from "./mode-router"
+import * as modifier from "./modifier"
 import { ProjectList } from "./ProjectList"
 import { SidebarBody } from "./SidebarBody"
 import { TabBar } from "./TabBar"
@@ -1314,17 +1315,8 @@ const AgentManagerContent: Component = () => {
     window.addEventListener("keydown", deleteKeyHandler)
     onCleanup(() => window.removeEventListener("agentManager.openSubagent", subagent))
 
-    // Reveal the ⌘/Ctrl+1-9 jump badges on all sidebar items while the modifier is held.
-    // Capture phase so the terminal's key handlers can't swallow them; blur resets state
-    // when the keyup is lost (e.g. Cmd+Tab away).
-    const modifier = isMac ? "Meta" : "Control"
-    const modTrack = (e: KeyboardEvent) => {
-      if (e.key === modifier) setHeld(e.type === "keydown")
-    }
-    const modReset = () => setHeld(false)
-    window.addEventListener("keydown", modTrack, true)
-    window.addEventListener("keyup", modTrack, true)
-    window.addEventListener("blur", modReset)
+    // Pointer movement repairs a lost keyup before hover actions are revealed.
+    const stopModifier = modifier.watch(window, isMac, setHeld)
 
     // When the panel regains focus (e.g. returning from terminal), focus the prompt
     // and clear any stale body styles left by Kobalte modal overlays (dropdowns/dialogs
@@ -1602,9 +1594,7 @@ const AgentManagerContent: Component = () => {
       window.removeEventListener("keydown", preventDefaults, true)
       window.removeEventListener("keydown", shortcut, true)
       window.removeEventListener("keydown", deleteKeyHandler)
-      window.removeEventListener("keydown", modTrack, true)
-      window.removeEventListener("keyup", modTrack, true)
-      window.removeEventListener("blur", modReset)
+      stopModifier()
       window.removeEventListener("focus", onWindowFocus)
       window.removeEventListener("newTaskRequest", newTaskHandler, true)
       drafts.cleanup()

--- a/packages/kilo-vscode/webview-ui/agent-manager/modifier.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/modifier.ts
@@ -1,0 +1,24 @@
+export function watch(target: Window, mac: boolean, set: (held: boolean) => void) {
+  const name = mac ? "Meta" : "Control"
+  const key = (event: KeyboardEvent) => {
+    if (event.key === name) {
+      set(event.type === "keydown")
+      return
+    }
+    set(mac ? event.metaKey : event.ctrlKey)
+  }
+  const pointer = (event: PointerEvent) => set(mac ? event.metaKey : event.ctrlKey)
+  const reset = () => set(false)
+
+  target.addEventListener("keydown", key, true)
+  target.addEventListener("keyup", key, true)
+  target.addEventListener("pointermove", pointer, true)
+  target.addEventListener("blur", reset)
+
+  return () => {
+    target.removeEventListener("keydown", key, true)
+    target.removeEventListener("keyup", key, true)
+    target.removeEventListener("pointermove", pointer, true)
+    target.removeEventListener("blur", reset)
+  }
+}


### PR DESCRIPTION
**What Problem This Solves**

Agent Manager can miss a Cmd or Ctrl key-release event and leave the worktree shortcut overlay active. Every worktree then keeps its numbered shortcut badge visible, while the same overlay CSS hides every delete action. The stale state belongs to one webview instance, so another project or window can continue to work normally.

**Why This Change Was Made**

Modifier tracking now synchronizes from later keyboard and pointer events instead of depending only on the original modifier keyup. Moving the pointer toward a worktree repairs a lost release before hover actions are shown. Blur cleanup and normal held-modifier behavior remain unchanged.

**User Impact**

Worktree delete actions return automatically after a lost Cmd or Ctrl release. Shortcut badges still appear while the modifier is genuinely held.

**Evidence**

Before the change, a lost Cmd keyup left `am-show-shortcuts` enabled and the hovered close action at `display: none`. In the same isolated Agent Manager flow after the change, pointer movement cleared the stale mode and restored the close action with visible styling.

`bun run compile`, `bun run test:unit` (4,771 passed, 1 skipped), `bun run knip`, `bun run check-kilocode-change`, and the focused modifier tests pass.