### PR TITLE
feat(agent-manager): add PR panel refresh button

### DIFF
--- a/.changeset/agent-manager-pr-refresh.md
+++ b/.changeset/agent-manager-pr-refresh.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Add a refresh button to fetch the latest pull request state in Agent Manager.

--- a/packages/kilo-vscode/tests/fixtures/pr-comments-render.tsx
+++ b/packages/kilo-vscode/tests/fixtures/pr-comments-render.tsx
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict"
 import { Window } from "happy-dom"
-import type { PRStatus } from "../../webview-ui/src/types/messages"
+import type { PRStatus, WebviewMessage } from "../../webview-ui/src/types/messages"
 
+const refreshed: WebviewMessage[] = []
 const window = new Window({ url: "http://localhost" })
 Object.defineProperty(window, "origin", { value: window.location.origin })
 class CSSStyleSheetStub {
@@ -34,6 +35,13 @@ Object.assign(globalThis, {
   MessageEvent: window.MessageEvent,
   requestAnimationFrame: window.requestAnimationFrame.bind(window),
   cancelAnimationFrame: window.cancelAnimationFrame.bind(window),
+  acquireVsCodeApi: () => ({
+    postMessage: (message: WebviewMessage) => {
+      if (message.type === "agentManager.refreshPR") refreshed.push(message)
+    },
+    getState: () => undefined,
+    setState: () => undefined,
+  }),
 })
 
 const { render } = await import("solid-js/web")
@@ -252,7 +260,7 @@ const base: PRStatus = {
   files: 1,
 }
 const [badge, setBadge] = createSignal(base)
-const [project, setProject] = createSignal("project-a")
+const [project, setProject] = createSignal<string | undefined>("project-a")
 const [selection, setSelection] = createSignal<string | null>("local")
 const [visible, setVisible] = createSignal(false)
 const clicked: string[] = []
@@ -359,13 +367,30 @@ assert.equal(jumps, 1)
 indicator()!.click()
 await window.happyDOM.waitUntilComplete()
 assert.equal(jumps, 2)
+const panel = second.querySelector(".am-pr-panel")
+const refresh = second.querySelector<HTMLButtonElement>('.am-pr-panel-actions [aria-label="Refresh"]')
+assert.ok(refresh, "refresh button is rendered in the PR header")
+refresh.click()
+await window.happyDOM.waitUntilComplete()
+assert.deepEqual(refreshed, [{ type: "agentManager.refreshPR", ...target }])
+assert.equal(visible(), true)
+assert.equal(second.querySelector(".am-pr-panel"), panel)
 setBadge((prev) => ({ ...prev, title: "Updated" }))
 await window.happyDOM.waitUntilComplete()
+assert.equal(second.querySelector(".am-pr-panel-title")?.textContent, "Updated")
 assert.equal(jumps, 2)
 second.querySelector<HTMLElement>(".am-pr-badge-number")!.click()
 assert.equal(clicked.at(-1), "external")
 assert.ok(!clicked.includes("row"))
 setBadge((prev) => ({ ...prev, unresolvedThreads: 0 }))
 assert.equal(indicator(), null)
+setProject(undefined)
+refresh.click()
+await window.happyDOM.waitUntilComplete()
+assert.deepEqual(refreshed, [
+  { type: "agentManager.refreshPR", ...target },
+  { type: "agentManager.refreshPR", projectId: undefined, worktreeId: target.worktreeId },
+])
+assert.equal(visible(), true)
 release()
 navigation.dispose()

--- a/packages/kilo-vscode/webview-ui/agent-manager/pr/PRPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/pr/PRPanel.tsx
@@ -25,6 +25,7 @@ interface PRPanelProps {
   jump?: number
   onJump?: (id: number) => void
   onClose: () => void
+  onRefresh: () => void
   onOpenExternal: () => void
   onOpenFile?: (file: string, line?: number) => void
   onOpenUrl?: (url: string) => void
@@ -167,6 +168,15 @@ export const PRPanel: Component<PRPanelProps> = (props) => {
           <span class="am-pr-panel-number">#{props.pr.number}</span>
         </div>
         <div class="am-pr-panel-actions am-pr-row">
+          <Tooltip value={t("common.refresh")} placement="bottom">
+            <IconButton
+              icon="refresh"
+              size="small"
+              variant="ghost"
+              aria-label={t("common.refresh")}
+              onClick={props.onRefresh}
+            />
+          </Tooltip>
           <Tooltip value={t("agentManager.pr.copyLink")} placement="bottom">
             <CopyButton text={props.pr.url} label={t("agentManager.pr.copyLink")} />
           </Tooltip>

--- a/packages/kilo-vscode/webview-ui/agent-manager/pr/PRPanelHost.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/pr/PRPanelHost.tsx
@@ -84,6 +84,13 @@ export function PRPanelHost(props: Props) {
         jump={props.jump}
         onJump={props.onJump}
         onClose={props.onClose}
+        onRefresh={() =>
+          vscode.postMessage({
+            type: "agentManager.refreshPR",
+            projectId: props.projectId,
+            worktreeId: props.worktreeId,
+          })
+        }
         onOpenExternal={() => openUrl(vscode.postMessage, props.worktreeId, props.pr.url)}
         onOpenFile={(file, line) => openFile(vscode.postMessage, props.sessionId, file, line)}
         onOpenUrl={(url) => openUrl(vscode.postMessage, props.worktreeId, url)}


### PR DESCRIPTION
## What Problem This Solves

The Agent Manager PR panel has no direct way to request fresh state while it remains open.

## Why This Change Was Made

Reuse the existing cache-bypassing PR refresh request, scoped to the selected project and worktree. This keeps polling, GitHub HTTPS requests, and TLS verification unchanged. Unchanged results still avoid redundant UI updates after fetching.

## User Impact

A Refresh icon now appears beside the existing PR header actions. It uses the shared small ghost button style, translated tooltip, and accessible label. Refresh keeps the panel and comments visible.

## Evidence

- 44 focused tests pass, including correctly scoped refresh requests with and without a project ID, panel preservation, and updated PR title rendering.
- Extension compile, extension and webview typechecks, lint, formatting, knip, and the kilocode-change guard pass.
- Isolated VS Code verification covered the button style, Refresh tooltip, and clicking without closing the panel or hiding comments. This used fixture data, not an end-to-end live GitHub fetch.
- Manual check: open a real worktree PR, click Refresh, and confirm updated checks or comments appear without closing the panel.

<img width="600" alt="Agent Manager PR panel with the Refresh icon and tooltip beside existing header actions" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260904-agent-manager-pr-refresh-tooltip-0924.png" />