### PR TITLE
fix(agent-manager): remove toolbar help icon

### DIFF
--- a/.changeset/remove-agent-manager-help-icon.md
+++ b/.changeset/remove-agent-manager-help-icon.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Remove the help icon from the Agent Manager toolbar.

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2330,7 +2330,6 @@ const AgentManagerContent: Component = () => {
             t={t}
             onSearchRef={(ref) => (sidebarSearchMenu = ref)}
             onShortcuts={handleShowKeyboardShortcuts}
-            onHelp={intro.open}
             onHistory={openHistory}
             shortcutMap={projectShortcutMap}
             activityFor={activity.project}
@@ -2362,7 +2361,6 @@ const AgentManagerContent: Component = () => {
             onNewSection={newSection}
             onShortcuts={metrics.click("keyboard_shortcuts", "worktrees_header", handleShowKeyboardShortcuts)}
             onHistory={() => openHistory()}
-            onHelp={intro.open}
             projectId={activeProjectId()}
             sections={sections}
             sortedWorktrees={sortedWorktrees}

--- a/packages/kilo-vscode/webview-ui/agent-manager/ProjectList.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ProjectList.tsx
@@ -1,6 +1,6 @@
 import { createMemo, type Component } from "solid-js"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
-import { Tooltip, TooltipKeybind } from "@kilocode/kilo-ui/tooltip"
+import { TooltipKeybind } from "@kilocode/kilo-ui/tooltip"
 import type {
   AgentManagerSidebarTarget,
   AgentManagerStateMessage,
@@ -57,7 +57,6 @@ interface Props {
   t: LanguageContextValue["t"]
   onSearchRef: (ref: SidebarSearchMenuRef) => void
   onShortcuts: () => void
-  onHelp: () => void
   onHistory: (projectId: string) => void
   shortcutMap?: () => Map<string, number>
 }
@@ -204,15 +203,6 @@ export const ProjectList: Component<Props> = (props) => {
               onClick={props.onShortcuts}
             />
           </TooltipKeybind>
-          <Tooltip value={props.t("agentManager.intro.reopen")} placement="bottom">
-            <IconButton
-              icon="help"
-              size="small"
-              variant="ghost"
-              aria-label={props.t("agentManager.intro.reopen")}
-              onClick={props.onHelp}
-            />
-          </Tooltip>
         </>
       }
       onAdd={() => vscode.postMessage({ type: "agentManager.addProject" })}

--- a/packages/kilo-vscode/webview-ui/agent-manager/SidebarBody.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/SidebarBody.tsx
@@ -63,7 +63,6 @@ export interface SidebarBodyProps {
   onNewSection: () => void
   onShortcuts: () => void
   onHistory: () => void
-  onHelp: () => void
   sections: () => SectionState[]
   sortedWorktrees: () => WorktreeState[]
   worktrees: () => WorktreeState[]
@@ -197,7 +196,6 @@ export const SidebarBody: Component<SidebarBodyProps> = (props) => {
               onSection={props.onNewSection}
               onShortcuts={props.onShortcuts}
               onHistory={props.onHistory}
-              onHelp={props.onHelp}
               onSettings={() =>
                 vscode.postMessage({ type: "openSettingsPanel", tab: "agentManager", projectId: props.projectId })
               }

--- a/packages/kilo-vscode/webview-ui/agent-manager/WorktreeSectionActions.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/WorktreeSectionActions.tsx
@@ -18,7 +18,6 @@ interface WorktreeSectionActionsProps extends WorktreeCreateProps {
   onShortcuts: () => void
   onSettings: () => void
   onHistory: () => void
-  onHelp: () => void
 }
 
 export const WorktreeSectionActions: Component<WorktreeSectionActionsProps> = (props) => (
@@ -59,15 +58,6 @@ export const WorktreeSectionActions: Component<WorktreeSectionActionsProps> = (p
           variant="ghost"
           aria-label={props.t("session.showHistory")}
           onClick={props.onHistory}
-        />
-      </Tooltip>
-      <Tooltip value={props.t("agentManager.intro.reopen")} placement="bottom">
-        <IconButton
-          icon="help"
-          size="small"
-          variant="ghost"
-          aria-label={props.t("agentManager.intro.reopen")}
-          onClick={props.onHelp}
         />
       </Tooltip>
       <IconButton

--- a/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
@@ -1961,7 +1961,6 @@ export const MultiProjectSidebar: Story = {
             t={t}
             onSearchRef={() => {}}
             onShortcuts={() => {}}
-            onHelp={() => {}}
             onHistory={() => {}}
           />
         </div>


### PR DESCRIPTION
## What Problem This Solves
The Agent Manager toolbar includes a help icon that adds clutter beside the worktree actions.

## Why This Change Was Made
Remove the introduction shortcut from both the single-project and multi-project toolbars. Keep first-use onboarding and the welcome-screen introduction link unchanged.

## User Impact
The toolbar no longer shows the "How Agent Manager works" icon. Search, worktree creation, keyboard shortcuts, history, and settings remain available.

## Evidence
- Extension build, host/webview type checks, lint, Knip, and annotation guard passed. Agent Manager architecture tests: 75 passed.
- Isolated VS Code self-test confirmed that both toolbars omit the help icon. Keyboard shortcuts still open, and dismissing then reopening the introduction from the welcome screen works.
- Console inspection showed only an extension-host Node deprecation warning, with no webview errors.

Single-project toolbar:

<img width="484" alt="Agent Manager worktree toolbar without the help icon" src="https://marius-kilocode.github.io/pr-assets/20260904-agent-manager-toolbar-help-removed-1054.png" />

Multi-project toolbar:

<img width="484" alt="Agent Manager projects toolbar without the help icon" src="https://marius-kilocode.github.io/pr-assets/20260904-agent-manager-projects-help-removed-1055.png" />