### PR TITLE
fix(ci): download release archives before smoke tests

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -70,31 +70,25 @@ jobs:
             exit 1
           fi
 
-      - name: Resolve CLI asset URL
+      - name: Download CLI archive
         id: cli
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          VERSION: ${{ inputs.cli_version }}
         run: |
-          VERSION="${{ inputs.cli_version }}"
           if [[ -z "$VERSION" ]]; then
-            echo "cli_url=" >> "$GITHUB_OUTPUT"
+            echo "cli_path=" >> "$GITHUB_OUTPUT"
             echo "::notice::Testing latest CLI from npm"
             exit 0
           fi
-          # Resolve the release asset via the API so this works for draft
-          # releases too (browser /releases/download/... URLs 404 on drafts).
-          # The installer passes Accept: application/octet-stream + bearer
-          # auth, which is what the API asset endpoint expects.
-          # The tag_name filter yields at most one release and one asset,
-          # so --jq returns a single URL without needing head/pipefail games.
-          URL=$(gh api "repos/${{ github.repository }}/releases" \
-            --jq ".[] | select(.tag_name == \"v${VERSION}\") | .assets[] | select(.name == \"kilo-linux-x64.tar.gz\") | .url")
-          if [[ -z "$URL" ]]; then
-            echo "::error::asset kilo-linux-x64.tar.gz not found for v${VERSION}"
-            exit 1
-          fi
-          echo "cli_url=$URL" >> "$GITHUB_OUTPUT"
-          echo "::notice::Testing CLI v${VERSION} via asset API: $URL"
+          ARCHIVE="$RUNNER_TEMP/kilo-cli.tar.gz"
+          gh release download "v$VERSION" \
+            --repo "$GH_REPO" \
+            --pattern kilo-linux-x64.tar.gz \
+            --output "$ARCHIVE"
+          echo "cli_path=$ARCHIVE" >> "$GITHUB_OUTPUT"
+          echo "::notice::Testing CLI v${VERSION} from local archive"
 
       # Harbor's default agent-setup timeout is 360s. The hello-world container
       # (FROM ubuntu:24.04) needs apt-get update + apt-get install + a NodeSource
@@ -108,8 +102,7 @@ jobs:
       # limits so this is harmless.
       - name: Run smoke test — hello-world
         env:
-          KILO_CLI_URL: ${{ steps.cli.outputs.cli_url }}
-          KILO_CLI_GITHUB_TOKEN: ${{ github.token }}
+          KILO_CLI_PATH: ${{ steps.cli.outputs.cli_path }}
         run: |
           ./scripts/run_eval.sh \
             -m kilo/anthropic/claude-sonnet-4.6 \
@@ -119,8 +112,7 @@ jobs:
 
       - name: Run smoke test — log-summary-date-ranges
         env:
-          KILO_CLI_URL: ${{ steps.cli.outputs.cli_url }}
-          KILO_CLI_GITHUB_TOKEN: ${{ github.token }}
+          KILO_CLI_PATH: ${{ steps.cli.outputs.cli_path }}
         run: |
           ./scripts/run_eval.sh \
             -m kilo/anthropic/claude-sonnet-4.6 \


### PR DESCRIPTION
## What Problem This Solves

The [September 4 prerelease smoke test](https://github.com/Kilo-Org/kilocode/actions/runs/33866603432/job/101003786641) failed before either eval could run, reporting `Gateway proxy or CLI preparation failed`. The workflow supplied a GitHub API release-asset URL, but the test runner rejects that URL format. All eight platform validation jobs passed; the end-to-end release gate still blocked publishing.

## Why This Change Was Made

Download the selected `kilo-linux-x64.tar.gz` asset on the runner with authenticated `gh release download`, then pass its absolute path through the supported `KILO_CLI_PATH` input. This works with draft releases without passing the release URL or GitHub token to either eval step.

## User Impact

Restore the draft-release smoke-test setup without disabling the publish gate. Both existing evals remain required. Leaving the version blank still selects the latest npm release. No shipped application code changes.

## Evidence

- The [September 2 prerelease smoke test](https://github.com/Kilo-Org/kilocode/actions/runs/33628536443/job/100243343139) passed; the linked September 4 failure stops during setup, before producing eval results.
- Executed the actual updated workflow step locally against draft `v7.5.10`: download succeeded and the archive contained the CLI binary. Also checked a temporary path containing spaces.
- Verified that a blank version produces an empty path without downloading, and a nonexistent release fails before publishing a path.
- Verified both eval steps receive the local archive path and publishing still depends on the smoke-test job.
- Actionlint/ShellCheck passed with only the existing custom runner-label diagnostic excluded. Prettier, workflow allowlist, annotation checks, and `git diff --check` passed. Repository lint had zero errors.
- Root typecheck failed in untouched extension code on missing module/SDK declarations, including `@kilocode/kilo-memory/schema` and `ProviderUsage`.
- Full evals were not run locally because they require CI secrets. After merging, start a new release run to use the updated workflow, and require both smoke tests to pass before publishing.
