### PR TITLE
fix(vscode): preserve open selectors during prompt focus recovery

### DIFF
--- a/.changeset/quiet-selector-focus.md
+++ b/.changeset/quiet-selector-focus.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep model and reasoning selectors open during automatic prompt focus restoration.

--- a/packages/kilo-vscode/tests/model-selector-accessibility.spec.ts
+++ b/packages/kilo-vscode/tests/model-selector-accessibility.spec.ts
@@ -314,6 +314,43 @@ test("variant picker focuses the selected effort as it opens", async ({ page }) 
   await expect(page.locator(".thinking-selector-item.selected")).toBeFocused()
 })
 
+for (const picker of ["model", "variant"]) {
+  test(`${picker} picker keeps focus during automatic prompt restoration`, async ({ page }) => {
+    await load(page, "prompt-input--with-thinking-420")
+
+    const trigger = page.getByRole("button", {
+      name: picker === "model" ? /^Select model:/ : "Medium",
+      exact: picker === "variant",
+    })
+    const prompt = page.locator("textarea.prompt-input")
+    await prompt.evaluate((el) => el.setAttribute("aria-disabled", "false"))
+    const popup = page.locator(".popup-selector[data-expanded]")
+    await trigger.click()
+    const choice =
+      picker === "model"
+        ? popup.locator(".model-selector-search-wrapper button")
+        : popup.locator(".thinking-selector-item.selected")
+    if (picker === "model") await popup.getByRole("combobox").press("Tab")
+    await expect(choice).toBeFocused()
+    await prompt.hover()
+    await expect(popup).toBeVisible()
+
+    await page.evaluate(() => window.dispatchEvent(new CustomEvent("focusPrompt", { detail: { restore: true } })))
+    await page.waitForTimeout(100)
+    await expect(popup).toBeVisible()
+    await expect(choice).toBeFocused()
+    await choice.press("Escape")
+    await expect(popup).toBeHidden()
+    await expect(prompt).toBeFocused()
+
+    await trigger.click()
+    await expect(popup).toBeVisible()
+    await prompt.click()
+    await expect(popup).toBeHidden()
+    await expect(prompt).toBeFocused()
+  })
+}
+
 test("slash mode picker Escape returns focus to the prompt", async ({ page }) => {
   await load(page, "prompt-input--default-420")
 

--- a/packages/kilo-vscode/tests/unit/agent-manager-focus.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-focus.test.ts
@@ -45,6 +45,25 @@ describe("Agent Manager focus", () => {
       flush()
       expect(document.activeElement).toBe(prompt)
 
+      const popup = document.createElement("div")
+      popup.className = "popup-selector"
+      popup.setAttribute("data-expanded", "")
+      const choice = document.createElement("div")
+      choice.tabIndex = 0
+      choice.setAttribute("role", "option")
+      popup.append(choice)
+      document.body.append(popup)
+      focus()
+      await Promise.resolve()
+      choice.focus()
+      flush()
+      expect(document.activeElement).toBe(choice)
+      focus()
+      await Promise.resolve()
+      flush()
+      expect(document.activeElement).toBe(choice)
+      popup.remove()
+
       prompt.blur()
       focus()
       await Promise.resolve()

--- a/packages/kilo-vscode/webview-ui/agent-manager/focus.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/focus.ts
@@ -1,4 +1,4 @@
-import { isTextControl } from "../src/utils/focus"
+import { hasPopup, isTextControl } from "../src/utils/focus"
 
 const OPTION = '[data-component="question-dock"] button[data-slot="question-option"]'
 
@@ -55,6 +55,7 @@ export function createChatFocus(deps: {
 }) {
   const focus = (force: boolean) => {
     if ((!force && (!document.hasFocus() || deps.term())) || deps.history() || deps.review()) return
+    if (hasPopup()) return
     if (preservesTextFocus(document.activeElement) || (!force && isTextControl(document.activeElement))) return
     if (!force && document.activeElement?.matches('[role="tab"]')) return
     if (!force && document.activeElement?.closest('[data-component="question-dock"]')) return

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -10,7 +10,7 @@ import { Tooltip } from "@kilocode/kilo-ui/tooltip"
 import { FileIcon } from "@kilocode/kilo-ui/file-icon"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { showToast } from "@kilocode/kilo-ui/toast"
-import { isTextControl } from "../../utils/focus"
+import { hasPopup, isTextControl } from "../../utils/focus"
 import { useSession } from "../../context/session"
 import { revertPromptState } from "../../context/session-utils"
 import { useLocalTabs } from "../../context/local-tabs"
@@ -514,7 +514,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       event instanceof CustomEvent && event.detail?.deferFocusToQuestion && props.deferFocusToQuestion?.()
     const ownsFocus = () => {
       const active = document.activeElement
-      return active !== textareaRef && isTextControl(active)
+      return hasPopup() || (active !== textareaRef && isTextControl(active))
     }
     const focus = () => {
       if (defer() || ownsFocus()) return

--- a/packages/kilo-vscode/webview-ui/src/utils/focus.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/focus.ts
@@ -1,5 +1,8 @@
 const nonText = new Set(["button", "checkbox", "file", "hidden", "image", "radio", "range", "reset", "submit"])
 
+export const hasPopup = (root: ParentNode = document): boolean =>
+  root.querySelector(".popup-selector[data-expanded]") !== null
+
 /** Whether an element owns editable text focus that should not be stolen. */
 export const isTextControl = (el: Element | null): boolean => {
   if (!el) return false


### PR DESCRIPTION
## What Problem This Solves

Automatic prompt focus recovery can close an open model or reasoning selector. The shared popover treats focus moving back to the prompt as an outside interaction. The existing protection covers text fields, but not reasoning options or buttons inside the model selector.

## Why This Change Was Made

Make automatic focus recovery and its scheduled retries yield while a selector popup is open. Apply the same guard before Agent Manager tries to focus a question or the prompt. Keep the shared popover dismissal behavior unchanged.

## User Impact

Keep selectors open during focus recovery without changing normal selection, Escape, or outside-click dismissal. Explicit host focus commands retain their existing behavior.

## Evidence

- Both new browser regression cases and the extended Agent Manager focus test fail before the fix and pass afterward.
- All 19 selector accessibility/browser tests and 7 Agent Manager focus unit tests pass.
- Extension build, host/webview type checks, lint, formatting, Knip, and the Kilo change-marker guard pass.
- Isolated VS Code: verified open menus survive pointer movement outside the prompt and injected window/prompt focus-recovery events. Verified variant selection, switching directly from variant to model, and Escape returning focus to the prompt.
- Limitation: pointer movement alone did not reproduce the original report. Window focus recovery did reproduce the unwanted closure before this change. Outside-click dismissal is covered by the browser tests; the extra isolated VS Code click attempt was blocked by the popup overlapping the click target.

The reasoning selector remains open after focus recovery:

<img width="300" alt="Reasoning selector remains open with Default focused after automatic prompt focus recovery" src="https://marius-kilocode.github.io/pr-assets/20260904-selector-focus-variant-1157.png" />
