### PR TITLE
fix(agent-manager): use consistent toolbar icon actions

### DIFF
--- a/.changeset/quiet-toolbar-icons.md
+++ b/.changeset/quiet-toolbar-icons.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Use consistent icon buttons with clear tooltips for Open, Apply, and Run in the Agent Manager toolbar.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/tab-bar-full-context-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/tab-bar-full-context-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:99d1d6d5800ef76702c66ce586a3b99814f1f36f6fe4b65a1e2fa032f58ca8c8
-size 3231
+oid sha256:b571c4468c869325ae8b3c9d6848f2dd80f9c7efe35a92f6dda4698f79891e90
+size 2985

--- a/packages/kilo-vscode/webview-ui/agent-manager/TabBar.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/TabBar.tsx
@@ -1,5 +1,4 @@
 import { For, Show, type Component, type JSX } from "solid-js"
-import { Button } from "@kilocode/kilo-ui/button"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { Spinner } from "@kilocode/kilo-ui/spinner"
@@ -143,10 +142,14 @@ export const TabBar: Component<TabBarProps> = (props) => (
               <>
                 <Show when={isWorktree()}>
                   <>
-                    <Tooltip value={props.t("agentManager.open.tooltip")} placement="bottom">
-                      <Button size="small" variant="ghost" icon="folder" onClick={props.onOpen}>
-                        {props.t("agentManager.open.button")}
-                      </Button>
+                    <Tooltip value={props.t("agentManager.open.tooltip")} placement="bottom" openDelay={0}>
+                      <IconButton
+                        size="small"
+                        variant="ghost"
+                        icon="folder"
+                        aria-label={props.t("agentManager.open.button")}
+                        onClick={props.onOpen}
+                      />
                     </Tooltip>
                     <Tooltip
                       value={
@@ -155,18 +158,22 @@ export const TabBar: Component<TabBarProps> = (props) => (
                           : props.t("agentManager.diff.applyBranchOnly")
                       }
                       placement="bottom"
+                      openDelay={0}
                     >
-                      <Button
-                        size="small"
-                        variant="ghost"
-                        onClick={props.onApply}
-                        disabled={!hasChanges() || applyBusy() || props.reviewScope() !== "branch"}
-                      >
+                      <span class="am-tab-apply">
+                        <IconButton
+                          size="small"
+                          variant="ghost"
+                          icon="check"
+                          aria-label={props.t("agentManager.apply.globalButton")}
+                          aria-busy={applyBusy()}
+                          onClick={props.onApply}
+                          disabled={!hasChanges() || applyBusy() || props.reviewScope() !== "branch"}
+                        />
                         <Show when={applyBusy()}>
                           <Spinner class="am-apply-spinner" />
                         </Show>
-                        {props.t("agentManager.apply.globalButton")}
-                      </Button>
+                      </span>
                     </Tooltip>
                   </>
                 </Show>
@@ -178,14 +185,18 @@ export const TabBar: Component<TabBarProps> = (props) => (
                     const configured = props.runConfigured
                     const title = () => (configured() ? (active() ? "Stop" : "Run") : "Configure run script")
                     return (
-                      <span
-                        class={`am-split-button am-run-group ${active() ? "am-run-active" : ""} ${!configured() ? "am-run-unconfigured" : ""}`}
-                      >
-                        <TooltipKeybind title={title()} keybind={props.bindings().runScript ?? ""} placement="bottom">
-                          <Button
+                      <span class={`am-split-button ${active() ? "am-run-active" : ""}`}>
+                        <TooltipKeybind
+                          title={title()}
+                          keybind={props.bindings().runScript ?? ""}
+                          placement="bottom"
+                          openDelay={0}
+                        >
+                          <IconButton
                             size="small"
                             variant="ghost"
                             icon={active() ? "stop" : "play"}
+                            aria-label={title()}
                             disabled={rs()?.state === "stopping"}
                             onClick={props.track(
                               "run_script",
@@ -195,14 +206,17 @@ export const TabBar: Component<TabBarProps> = (props) => (
                                 action: active() ? "stop" : configured() ? "run" : "configure",
                               }),
                             )}
-                          >
-                            {active() ? "Stop" : "Run"}
-                          </Button>
+                          />
                         </TooltipKeybind>
                         <DropdownMenu gutter={4} placement="bottom-end">
-                          <DropdownMenu.Trigger class="am-split-arrow" aria-label={props.t("agentManager.run.options")}>
-                            <Icon name="chevron-down" size="small" />
-                          </DropdownMenu.Trigger>
+                          <Tooltip value={props.t("agentManager.run.options")} placement="bottom" openDelay={0}>
+                            <DropdownMenu.Trigger
+                              class="am-split-arrow"
+                              aria-label={props.t("agentManager.run.options")}
+                            >
+                              <Icon name="chevron-down" size="small" />
+                            </DropdownMenu.Trigger>
+                          </Tooltip>
                           <DropdownMenu.Portal>
                             <DropdownMenu.Content class="am-split-menu">
                               <DropdownMenu.Item
@@ -220,12 +234,12 @@ export const TabBar: Component<TabBarProps> = (props) => (
                 </Show>
                 <Show when={props.prStatus()}>
                   {(pr) => (
-                    <Tooltip value={`PR #${pr().number}`} placement="bottom">
+                    <Tooltip value={`PR #${pr().number}`} placement="bottom" openDelay={0}>
                       <IconButton
                         icon="pull-request"
                         size="small"
                         variant="ghost"
-                        label={`PR #${pr().number}`}
+                        aria-label={`PR #${pr().number}`}
                         class={props.prOpen() ? "am-tab-diff-btn-active" : ""}
                         onClick={props.onTogglePR}
                       />
@@ -233,24 +247,24 @@ export const TabBar: Component<TabBarProps> = (props) => (
                   )}
                 </Show>
                 <Show when={props.documentsAvailable()}>
-                  <Tooltip value={props.t("agentManager.documents.toggle")} placement="bottom">
+                  <Tooltip value={props.t("agentManager.documents.toggle")} placement="bottom" openDelay={0}>
                     <IconButton
                       icon="book-open-check"
                       size="small"
                       variant="ghost"
-                      label={props.t("agentManager.documents.toggle")}
+                      aria-label={props.t("agentManager.documents.toggle")}
                       class={props.documentsOpen() ? "am-tab-diff-btn-active" : ""}
                       onClick={props.onToggleDocuments}
                     />
                   </Tooltip>
                 </Show>
                 <Show when={props.subagentsAvailable()}>
-                  <Tooltip value="Subagents" placement="bottom">
+                  <Tooltip value="Subagents" placement="bottom" openDelay={0}>
                     <IconButton
                       icon="task"
                       size="small"
                       variant="ghost"
-                      label="Subagents"
+                      aria-label="Subagents"
                       class={props.subagentsOpen() ? "am-tab-diff-btn-active" : ""}
                       onClick={props.onToggleSubagents}
                     />
@@ -260,11 +274,12 @@ export const TabBar: Component<TabBarProps> = (props) => (
                   title={props.t("agentManager.diff.toggle")}
                   keybind={props.bindings().toggleDiff ?? ""}
                   placement="bottom"
+                  openDelay={0}
                 >
                   <button
                     class={`am-diff-toggle-btn ${props.diffOpen() && !props.reviewActive() ? "am-tab-diff-btn-active" : ""} ${hasChanges() ? "am-diff-toggle-has-changes" : ""}`}
                     onClick={props.onToggleDiff}
-                    title={props.t("agentManager.diff.toggle")}
+                    aria-label={props.t("agentManager.diff.toggle")}
                   >
                     <Icon name="layers" size="small" />
                     <Show when={hasChanges()}>
@@ -279,7 +294,7 @@ export const TabBar: Component<TabBarProps> = (props) => (
                   </button>
                 </TooltipKeybind>
                 <Show when={props.browserAutomation()}>
-                  <Tooltip value={props.t("agentManager.browser.title")} placement="bottom">
+                  <Tooltip value={props.t("agentManager.browser.title")} placement="bottom" openDelay={0}>
                     <IconButton
                       icon="globe"
                       size="small"
@@ -294,12 +309,12 @@ export const TabBar: Component<TabBarProps> = (props) => (
             )
           })()}
           <Show when={props.selection() !== null}>
-            <Tooltip value={props.t("command.review.toggle")} placement="bottom">
+            <Tooltip value={props.t("command.review.toggle")} placement="bottom" openDelay={0}>
               <IconButton
                 icon="expand"
                 size="small"
                 variant="ghost"
-                label={props.t("command.review.toggle")}
+                aria-label={props.t("command.review.toggle")}
                 class={props.reviewActive() ? "am-tab-diff-btn-active" : ""}
                 onClick={props.onToggleReview}
               />

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -904,21 +904,6 @@ html[data-theme="kilo-vscode"]
   }
 }
 
-/* Toolbar Run button group — split layout comes from .am-split-button.
-   The label button tightens its right edge so the chevron sits as close
-   to the label as it does to the icon in the other split buttons. */
-.am-run-group [data-component="button"][data-size="small"] {
-  padding-right: 2px;
-}
-
-/* Unconfigured — muted until hover */
-.am-run-unconfigured {
-  opacity: 0.5;
-}
-.am-run-unconfigured:hover {
-  opacity: 0.85;
-}
-
 /* Green accent when running — uses VS Code's standard green token */
 .am-run-active,
 .am-run-active [data-component="icon"] {
@@ -1643,13 +1628,22 @@ body.am-wt-dragging-active * {
   border-left: 1px solid var(--border-weak-base);
 }
 
-/* One control height for the row: text buttons (Run, Apply, Open) match
-   the 20px icon buttons so hover fills align across every combination
-   of visible actions. */
-.am-tab-actions [data-component="button"][data-size="small"] {
-  height: 20px;
-  min-height: 20px;
+.am-tab-apply {
+  display: flex;
+  position: relative;
 }
+
+.am-tab-apply [aria-busy="true"] [data-component="icon"] {
+  visibility: hidden;
+}
+
+.am-tab-apply .am-apply-spinner {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  pointer-events: none;
+}
+
 .am-sidebar-search-popover[data-component="popover-content"] {
   max-height: min(480px, calc(100vh - 64px));
 }

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/TerminalDestinationButton.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/TerminalDestinationButton.tsx
@@ -12,7 +12,7 @@ import { Show } from "solid-js"
 import { DropdownMenu } from "@kilocode/kilo-ui/dropdown-menu"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import { IconButton } from "@kilocode/kilo-ui/icon-button"
-import { TooltipKeybind } from "@kilocode/kilo-ui/tooltip"
+import { Tooltip, TooltipKeybind } from "@kilocode/kilo-ui/tooltip"
 import { useLanguage } from "../../src/context/language"
 import type { TerminalDestination } from "../../src/types/messages/agent-manager"
 
@@ -39,20 +39,22 @@ export const TerminalDestinationButton: Component<Props> = (props) => {
   )
   return (
     <div class="am-split-button">
-      <TooltipKeybind title={t("agentManager.tab.terminal")} keybind={props.keybind()} placement="bottom">
+      <TooltipKeybind title={t("agentManager.tab.terminal")} keybind={props.keybind()} placement="bottom" openDelay={0}>
         <IconButton
           icon="console"
           size="small"
           variant="ghost"
-          label={t("agentManager.tab.openTerminal")}
+          aria-label={t("agentManager.tab.openTerminal")}
           class={props.active() ? "am-tab-diff-btn-active" : ""}
           onClick={props.onOpen}
         />
       </TooltipKeybind>
       <DropdownMenu gutter={4} placement="bottom-end">
-        <DropdownMenu.Trigger class="am-split-arrow" aria-label={t("agentManager.terminal.destination")}>
-          <Icon name="chevron-down" size="small" />
-        </DropdownMenu.Trigger>
+        <Tooltip value={t("agentManager.terminal.destination")} placement="bottom" openDelay={0}>
+          <DropdownMenu.Trigger class="am-split-arrow" aria-label={t("agentManager.terminal.destination")}>
+            <Icon name="chevron-down" size="small" />
+          </DropdownMenu.Trigger>
+        </Tooltip>
         <DropdownMenu.Portal>
           <DropdownMenu.Content class="am-split-menu">
             {item("vscode", t("agentManager.terminal.openInVscode"))}

--- a/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
@@ -1382,15 +1382,26 @@ export const TabBarSingleTab: Story = {
 
 const MockFullContextActions = () => (
   <div class="am-tab-actions">
-    <span class="am-split-button am-run-group">
+    <TooltipKeybind title="Open this worktree in VS Code" keybind="" placement="bottom">
+      <IconButton icon="folder" size="small" variant="ghost" aria-label="Open this worktree in VS Code" />
+    </TooltipKeybind>
+    <TooltipKeybind title="Apply selected worktree changes to local branch" keybind="" placement="bottom">
+      <IconButton
+        icon="check"
+        size="small"
+        variant="ghost"
+        aria-label="Apply selected worktree changes to local branch"
+      />
+    </TooltipKeybind>
+    <span class="am-split-button">
       <TooltipKeybind title="Run" keybind="⌘R" placement="bottom">
-        <Button size="small" variant="ghost" icon="play">
-          Run
-        </Button>
+        <IconButton size="small" variant="ghost" icon="play" aria-label="Run" />
       </TooltipKeybind>
-      <button class="am-split-arrow" aria-label="Run options">
-        <Icon name="chevron-down" size="small" />
-      </button>
+      <TooltipKeybind title="Run options" keybind="" placement="bottom">
+        <button class="am-split-arrow" aria-label="Run options">
+          <Icon name="chevron-down" size="small" />
+        </button>
+      </TooltipKeybind>
     </span>
     <TooltipKeybind title="Pull request" keybind="" placement="bottom">
       <IconButton icon="pull-request" size="small" variant="ghost" label="Pull request" />


### PR DESCRIPTION
## What Problem This Solves

Open, Apply, and Run used text buttons beside compact icon controls in Agent Manager. The mixed widths made the action row uneven, and delayed tooltips slowed discovery of icon actions.

## Why This Change Was Made

Use the existing icon-button component and shared spacing rather than a separate toolbar style. Keep descriptive tooltips, accessible button names, Run shortcuts, and the existing action handlers. Set the toolbar action tooltip delay to zero, including both dropdown arrows.

## User Impact

Open, Apply, and Run now match neighboring icon actions. Apply retains its disabled conditions and centered loading indicator. Run still switches to Stop while active, and its configuration menu remains available. Tooltips appear immediately on hover.

## Evidence

- Extension build, host/webview typecheck, and lint pass.
- Full extension unit suite: 4,840 passed, 1 skipped, 0 failed.
- Knip, i18n usage, toolbar architecture, and Kilo change-marker checks pass.
- Inspected the icon layout at 1x and 2x in light, dark, and both high-contrast themes.
- Verified Run and terminal dropdown interactions in isolated VS Code.

The screenshots render the real toolbar before (`86c1928c4a`) and after (`294219be7d`) with identical sample worktree state, the Dark Modern theme, and a 1000px viewport at 2x scale. These are controlled component captures, not live backend sessions.

### Before

<img width="1000" alt="Before: Open, Apply, and Run text buttons beside toolbar icons" src="https://marius-kilocode.github.io/pr-assets/20260904-toolbar-before-120658.png" />

### After

<img width="1000" alt="After: Open, Apply, and Run use consistent icon buttons" src="https://marius-kilocode.github.io/pr-assets/20260904-toolbar-after-120658.png" />

### Immediate hover tooltip

<img width="1000" alt="Apply icon showing its descriptive hover tooltip" src="https://marius-kilocode.github.io/pr-assets/20260904-toolbar-after-tooltip-120658.png" />
