### PR TITLE
fix(vscode): keep Shift+Tab out of slash command selection

### DIFF
--- a/.changeset/fix-shift-tab-slash-selection.md
+++ b/.changeset/fix-shift-tab-slash-selection.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep Shift+Tab available for reasoning variant cycling while the slash command menu is open, without selecting a command or changing the draft.

--- a/packages/kilo-vscode/tests/unit/use-slash-command.test.ts
+++ b/packages/kilo-vscode/tests/unit/use-slash-command.test.ts
@@ -370,6 +370,48 @@ describe("useSlashCommand sandbox action", () => {
 })
 
 describe("slash command keyboard selection", () => {
+  it.each(["sandbox", "verify"])("leaves Shift+Tab unhandled with /%s selected", (name) => {
+    const draft = `/${name} keep this draft`
+    const state = { text: draft, prevented: 0, selected: 0, toggles: 0 }
+    const ctx = setup(() => state.toggles++)
+    const cursor = name.length + 1
+    const textarea = {
+      value: draft,
+      selectionStart: cursor,
+      setSelectionRange: (start: number) => (textarea.selectionStart = start),
+      focus: () => {},
+    } as unknown as HTMLTextAreaElement
+    const event = {
+      key: "Tab",
+      shiftKey: true,
+      isComposing: false,
+      preventDefault: () => state.prevented++,
+    } as unknown as KeyboardEvent
+
+    ctx.fire({
+      type: "commandsLoaded",
+      commands: [{ name: "verify", description: "Verify changes", hints: [] }],
+    })
+    ctx.slash.onInput(draft, cursor)
+    expect(ctx.slash.results()[0]?.name).toBe(name)
+
+    const handled = ctx.slash.onKeyDown(
+      event,
+      textarea,
+      (text) => (state.text = text),
+      () => state.selected++,
+    )
+
+    expect(handled).toBe(false)
+    expect(state).toEqual({ text: draft, prevented: 0, selected: 0, toggles: 0 })
+    expect(textarea.value).toBe(draft)
+    expect(textarea.selectionStart).toBe(cursor)
+    expect(ctx.slash.show()).toBe(true)
+    expect(ctx.slash.index()).toBe(0)
+    expect(ctx.sent).toEqual([{ type: "requestCommands" }])
+    ctx.dispose()
+  })
+
   it.each(["Enter", "Tab"] as const)("keeps %s selection aligned with the action-first menu", (key) => {
     const state = { text: "/refresh", prevented: 0 }
     const ctx = setup(() => {})

--- a/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useSlashCommand.ts
@@ -392,7 +392,7 @@ export function useSlashCommand(
       setIndex((i) => Math.max(i - 1, 0))
       return true
     }
-    if (e.key === "Enter" || e.key === "Tab") {
+    if (e.key === "Enter" || (e.key === "Tab" && !e.shiftKey)) {
       const cmd = filtered[index()]
       if (!cmd) return false
       e.preventDefault()


### PR DESCRIPTION
## What Problem This Solves

With the slash command menu open, Shift+Tab accepted the highlighted command before the prompt could cycle reasoning effort. For `/v`, this opened the variant picker instead of changing the variant and removed the command prefix from the draft.

## Why This Change Was Made

Exclude Shift+Tab from slash-menu selection so the existing variant shortcut can handle it. Keep ordinary Tab and Enter selection unchanged. The shared hook covers chat prompts and the New Worktree prompt without changing their shortcut or focus-navigation policies.

## User Impact

Cycle reasoning effort while a slash menu is open without selecting a command, changing the draft, or moving the caret. When cycling is disabled or unavailable, the menu no longer consumes backward focus navigation.

## Evidence

- Both new regression cases failed before the fix and passed afterward. They cover client actions and server commands, including draft, caret, menu state, and selection side effects.
- 60 focused tests passed. Extension typecheck, lint, build, formatting, Knip, and the Kilo marker guard passed.
- Tested in an isolated VS Code instance: Shift+Tab cycled effort for `/v` and `/v something` with the caret after `/v`, keeping the draft and caret unchanged. Plain Tab and Enter still opened the variant picker. The isolated instance was cleaned up.

<img width="574" alt="After Shift+Tab, the draft remains /v something and reasoning effort is Low" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260904-shift-tab-preserve-draft-quill-storm.png" />
