### PR TITLE
fix(vscode): keep prompt undo and redo inside the webview

### DIFF
--- a/.changeset/chat-input-undo.md
+++ b/.changeset/chat-input-undo.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep chat input undo and redo from changing files open in Markdown custom editors.

--- a/packages/kilo-vscode/tests/prompt-undo.spec.ts
+++ b/packages/kilo-vscode/tests/prompt-undo.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test, type Page } from "@playwright/test"
+
+const GLOBALS = "colorScheme:dark;theme:kilo-vscode;vscodeTheme:dark-modern"
+
+async function open(page: Page) {
+  await page.goto(`/iframe.html?id=prompt-input--default-420&viewMode=story&globals=${GLOBALS}`, { waitUntil: "load" })
+  const input = page.locator("textarea.prompt-input")
+  await expect(input).toBeVisible()
+  await page.evaluate(() => window.postMessage({ type: "connectionState", state: "connected" }, window.origin))
+  await expect(input).toBeEnabled()
+  return input
+}
+
+async function observe(page: Page, block = false) {
+  const trace = await page.evaluateHandle((block) => {
+    const events: KeyboardEvent[] = []
+    const forwarded: KeyboardEvent[] = []
+    window.addEventListener("keydown", (event) => {
+      if (event.key.length !== 1) return
+      forwarded.push(event)
+      if (block) event.preventDefault()
+    })
+    window.addEventListener(
+      "keydown",
+      (event) => {
+        if (event.key.length === 1) events.push(event)
+      },
+      true,
+    )
+    return { events, forwarded }
+  }, block)
+  return () =>
+    trace.evaluate((state) => ({
+      prevented: state.events.splice(0).map((event) => event.defaultPrevented),
+      forwarded: state.forwarded.splice(0).map((event) => event.key),
+    }))
+}
+
+test("native undo and redo stay local despite host key forwarding", async ({ page }) => {
+  const input = await open(page)
+  await input.pressSequentially("Draft text")
+  await expect(input).toHaveValue("Draft text")
+  const read = await observe(page, true)
+
+  await input.press("ControlOrMeta+z")
+  await expect(input).toHaveValue("")
+  expect(await read()).toEqual({ prevented: [false], forwarded: [] })
+
+  await input.press("ControlOrMeta+Shift+Z")
+  await expect(input).toHaveValue("Draft text")
+  expect(await read()).toEqual({ prevented: [false], forwarded: [] })
+})
+
+test("only supported history chords stop propagation without cancelling text defaults", async ({ page }) => {
+  const input = await open(page)
+  await input.pressSequentially("Draft text")
+  const read = await observe(page)
+
+  for (const modifier of ["Control", "Meta"]) {
+    for (const chord of ["z", "Shift+Z", "y"]) {
+      await input.press(`${modifier}+${chord}`)
+      expect(await read(), `${modifier}+${chord}`).toEqual({ prevented: [false], forwarded: [] })
+    }
+    for (const chord of ["c", "x", "v", "Alt+z", "Alt+Shift+Z", "Alt+y", "Shift+Y"]) {
+      await input.dispatchEvent("keydown", {
+        key: chord.split("+").at(-1),
+        ctrlKey: modifier === "Control",
+        metaKey: modifier === "Meta",
+        altKey: chord.includes("Alt"),
+        shiftKey: chord.includes("Shift"),
+      })
+      expect(await read(), `${modifier}+${chord}`).toEqual({
+        prevented: [false],
+        forwarded: [chord.split("+").at(-1)],
+      })
+    }
+  }
+})
+
+test("enhanced prompt undo restores the original without reaching the host", async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(window, "acquireVsCodeApi", {
+      value: () => ({
+        getState: () => undefined,
+        setState: () => undefined,
+        postMessage: (message: { type: string; requestId?: string }) => {
+          if (message.type !== "enhancePrompt") return
+          window.postMessage(
+            { type: "enhancePromptResult", requestId: message.requestId, text: "Enhanced draft" },
+            window.origin,
+          )
+        },
+      }),
+    })
+  })
+  const input = await open(page)
+  await input.pressSequentially("Original draft")
+  await page.getByRole("button", { name: "Enhance prompt", exact: true }).click()
+  await expect(input).toHaveValue("Enhanced draft")
+  const read = await observe(page, true)
+
+  await input.press("ControlOrMeta+z")
+  await expect(input).toHaveValue("Original draft")
+  expect(await read()).toEqual({ prevented: [true], forwarded: [] })
+})

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -1647,6 +1647,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             onInput={handleInput}
             onKeyDown={(e) => {
               if (speechDown(e)) return
+              const key = e.key.toLowerCase()
+              if ((e.ctrlKey || e.metaKey) && !e.altKey && (key === "z" || (key === "y" && !e.shiftKey))) {
+                e.stopPropagation()
+              }
               handleKeyDown(e)
             }}
             onKeyUp={(e) => {


### PR DESCRIPTION
## What Problem This Solves

Undo and redo in the focused chat input can change the underlying Markdown file when a Markdown custom editor is active instead of changing the draft.

Closes #13724.

## Why This Change Was Made

VS Code forwards webview undo/redo shortcuts to the host, where custom-editor command handling can take priority over the focused webview. Stop those keyboard events at the prompt textarea without preventing native text undo/redo. Keep the existing enhanced-prompt undo and speech shortcut handling.

## User Impact

Undo/redo stays in the focused prompt with Markdown Preview or Markdown Editor open. This adds no features, settings, or global keybindings. Clipboard shortcuts, Alt-modified combinations, and Shift+Y retain their existing routing. Custom VS Code commands assigned to the intercepted undo/redo combinations no longer receive those events while the prompt has focus.

## Evidence

- Extension build, host/webview type checks, lint, formatting, Knip, and the Kilo change-marker guard passed.
- 75 nearby prompt/history/mention tests passed. Type checks, lint, and these tests also passed after rebasing onto main.
- Three Chromium regression tests passed against a fresh Storybook build: native undo/redo despite host forwarding, shortcut boundaries, and enhanced-prompt undo.
- Real isolated macOS VS Code checks passed with plain text, Markdown Preview, and Markdown Editor active, including unlocked Markdown editing. Prompt undo/redo worked while the document remained unchanged. The isolated instance was cleaned up.
- Windows-specific verification remains outstanding. Check Ctrl+Z and Ctrl+Y with each Markdown custom editor active; only the focused prompt should change.
