### PR TITLE
fix(vscode): stop hidden polling and reuse diff file counts

### DIFF
--- a/.changeset/quiet-hidden-diff-polling.md
+++ b/.changeset/quiet-hidden-diff-polling.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Pause Changes, Review, and chat badge polling while their panels are hidden, and reuse unchanged file counts to reduce CPU use in large repositories.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -478,6 +478,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private followupListeners: Array<(session: Session, directory: string) => void> = []
   private statsPoller: GitStatsPoller | null = null
   private statsGitOps: GitOps | null = null
+  private statsVisible = true
   private cachedStats: unknown = null
   private cachedGitRepo = false
   private cachedGitDirectory: string | undefined
@@ -778,16 +779,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.visibilityDisposable?.dispose()
     this.visibilityDisposable = webviewView.onDidChangeVisibility(() => {
       this.setSidebarVisible(webviewView.visible)
-      if (this.statsPoller) {
-        this.statsPoller.setEnabled(webviewView.visible)
-        this.statsPoller.setVisible(webviewView.visible)
-      }
       this.focusSession(webviewView.visible ? this.contextSessionID : undefined)
     })
     this.initializeConnection()
   }
 
   private setSidebarVisible(visible: boolean): void {
+    this.setStatsVisible(visible)
     this.setStreamVisibility(visible)
     vscode.commands.executeCommand("setContext", "kilo-code.new.sidebarVisible", visible)
     if (!visible && this.opts.focusContext) {
@@ -811,12 +809,14 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.setupWebviewMessageHandler(panel.webview)
     this.viewStateDisposable?.dispose()
     this.viewStateDisposable = this.visibleTaskStreams.bindPanel(panel, () => {
+      this.setStatsVisible(panel.visible)
       this.setStreamVisibility(panel.active && panel.visible)
       if (this.opts.disableViewedRegistration) return
       const id = this.contextSessionID
       this.streams.focus(panel.visible ? id : undefined)
       this.connectionService.registerVisible(this.instanceId, panel.visible && id ? [id] : [])
     })
+    this.setStatsVisible(panel.visible)
     this.setStreamVisibility(panel.active && panel.visible)
     this.initializeConnection()
   }
@@ -5485,6 +5485,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   }
 
   // ── Worktree stats polling (sidebar diff badge) ──────────────────
+  private setStatsVisible(visible: boolean): void {
+    this.statsVisible = visible
+    this.statsPoller?.setEnabled(visible)
+    this.statsPoller?.setVisible(visible)
+  }
+
   private startStatsPolling(): void {
     if (this.opts.disableStatsPolling) return
     this.statsPoller?.stop()
@@ -5509,8 +5515,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       log: () => {},
       hiddenIntervalMs: 60000,
     })
-    this.statsPoller.setEnabled(true)
-    this.statsPoller.setVisible(true)
+    this.setStatsVisible(this.statsVisible)
   }
 
   /**
@@ -5526,7 +5531,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     this.streams.focus(undefined)
     this.connectionService.unregisterVisible(this.instanceId)
     this.connectionService.unregisterAttached(this.instanceId)
-    this.statsPoller?.stop()
+    this.setStatsVisible(false)
     this.statsGitOps?.dispose()
     this.unsubscribeEvent?.()
     this.unsubscribeState?.()

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -393,10 +393,12 @@ export class AgentManagerProvider implements Disposable {
     this.panel = ctx
     this.browserLifecycle.replay()
 
-    for (const poller of [this.statsPoller, this.projectPollers, this.diffs]) void poller.setVisible(ctx.visible)
+    for (const poller of [this.statsPoller, this.projectPollers]) poller.setVisible(ctx.visible)
+    this.diffs.setVisible(ctx.visible).catch((err) => this.log("Failed to update diff visibility:", err))
     this.onVisibilityChange?.(ctx.visible)
     ctx.onDidChangeVisibility((visible) => {
-      for (const poller of [this.statsPoller, this.projectPollers, this.diffs]) void poller.setVisible(visible)
+      for (const poller of [this.statsPoller, this.projectPollers]) poller.setVisible(visible)
+      this.diffs.setVisible(visible).catch((err) => this.log("Failed to update diff visibility:", err))
       this.visiblePresence.flush()
     })
 

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -393,12 +393,10 @@ export class AgentManagerProvider implements Disposable {
     this.panel = ctx
     this.browserLifecycle.replay()
 
-    this.statsPoller.setVisible(ctx.visible)
-    this.projectPollers.setVisible(ctx.visible)
+    for (const poller of [this.statsPoller, this.projectPollers, this.diffs]) void poller.setVisible(ctx.visible)
     this.onVisibilityChange?.(ctx.visible)
     ctx.onDidChangeVisibility((visible) => {
-      this.statsPoller.setVisible(visible)
-      this.projectPollers.setVisible(visible)
+      for (const poller of [this.statsPoller, this.projectPollers, this.diffs]) void poller.setVisible(visible)
       this.visiblePresence.flush()
     })
 

--- a/packages/kilo-vscode/src/agent-manager/git-stats-snapshot.ts
+++ b/packages/kilo-vscode/src/agent-manager/git-stats-snapshot.ts
@@ -2,7 +2,7 @@ import { createHash } from "crypto"
 import type { BigIntStats } from "fs"
 import * as fs from "fs/promises"
 import { LRUCache } from "lru-cache"
-import { binaryFile } from "../diff/shared/binary"
+import { probe } from "../diff/shared/binary"
 import { resolveInside } from "../diff/shared/path"
 import { serialize } from "../util/serialize"
 import type { GitOps } from "./GitOps"
@@ -175,9 +175,12 @@ export async function measure(file: string, classify = true): Promise<Measuremen
     if (hit?.stamp === key) return hit
 
     const value = await (async () => {
-      const binary = stat.isFile() && (await binaryFile(file))
+      const binary = stat.isFile() ? await probe(file) : false
+      if (binary === undefined) return undefined
       if (binary || stat.size > MAX_BYTES) return { binary, count: 0 }
-      const content = stat.isSymbolicLink() ? await fs.readlink(file) : await fs.readFile(file, "utf8")
+      const current = await fs.lstat(file, { bigint: true })
+      if (stamp(current) !== key) return undefined
+      const content = current.isSymbolicLink() ? await fs.readlink(file) : await fs.readFile(file, "utf8")
       const count = !content ? 0 : content.endsWith("\n") ? content.split("\n").length - 1 : content.split("\n").length
       return { binary, count }
     })().catch(() => undefined)

--- a/packages/kilo-vscode/src/agent-manager/git-stats-snapshot.ts
+++ b/packages/kilo-vscode/src/agent-manager/git-stats-snapshot.ts
@@ -8,9 +8,12 @@ import { serialize } from "../util/serialize"
 import type { GitOps } from "./GitOps"
 import { Semaphore } from "./semaphore"
 
+type Measurement = { stamp: string; count: number; binary: boolean }
+
 const MAX_BYTES = 1_000_000n
 const reads = new Semaphore(16)
-const cache = new LRUCache<string, { stamp: string; count: number }>({ max: 10_000 })
+const cache = new LRUCache<string, Measurement>({ max: 10_000 })
+let misses = 0
 
 export interface DiffStats {
   files: number
@@ -158,30 +161,42 @@ function numstat(raw: Buffer): DiffStats {
   return result
 }
 
-export async function lines(file: string): Promise<number> {
+export async function measure(file: string, classify = true): Promise<Measurement | undefined> {
   return reads.run(async () => {
     const stat = await fs.lstat(file, { bigint: true }).catch(() => undefined)
     if (!stat) {
       cache.delete(file)
-      return 0
+      return undefined
     }
-    if (stat.size === 0n || stat.size > MAX_BYTES) return 0
+    if (!classify && (stat.size === 0n || stat.size > MAX_BYTES)) return { stamp: "", count: 0, binary: false }
     const key = stamp(stat)
+    if (stat.size === 0n) return { stamp: key, count: 0, binary: false }
     const hit = cache.get(file)
-    if (hit?.stamp === key) return hit.count
+    if (hit?.stamp === key) return hit
 
-    const count = await (async () => {
-      if (await binaryFile(file)) return 0
+    const value = await (async () => {
+      const binary = stat.isFile() && (await binaryFile(file))
+      if (binary || stat.size > MAX_BYTES) return { binary, count: 0 }
       const content = stat.isSymbolicLink() ? await fs.readlink(file) : await fs.readFile(file, "utf8")
-      if (!content) return 0
-      return content.endsWith("\n") ? content.split("\n").length - 1 : content.split("\n").length
+      const count = !content ? 0 : content.endsWith("\n") ? content.split("\n").length - 1 : content.split("\n").length
+      return { binary, count }
     })().catch(() => undefined)
-    if (count === undefined) return 0
+    if (!value) return { stamp: key, count: 0, binary: false }
 
+    const result = { stamp: key, ...value }
     const current = await fs.lstat(file, { bigint: true }).catch(() => undefined)
-    if (current && stamp(current) === key) cache.set(file, { stamp: key, count })
-    return count
+    if (!current || stamp(current) !== key) return result
+    if (!cache.has(file) && cache.size === cache.max) {
+      misses = (misses + 1) % 16
+      if (misses !== 0) return result
+    }
+    cache.set(file, result)
+    return result
   })
+}
+
+export async function lines(file: string): Promise<number> {
+  return (await measure(file, false))?.count ?? 0
 }
 
 export function refOID(refs: RefSnapshot | undefined, ref: string): string | undefined {

--- a/packages/kilo-vscode/src/agent-manager/local-diff.ts
+++ b/packages/kilo-vscode/src/agent-manager/local-diff.ts
@@ -1,8 +1,8 @@
 import * as fs from "fs/promises"
-import { binaryFile } from "../diff/shared/binary"
 import { imageMime, loadImage, readImageFile } from "../diff/shared/image"
 import { resolveInside } from "../diff/shared/path"
 import type { GitOps } from "./GitOps"
+import { measure } from "./git-stats-snapshot"
 import { check, collect, fileSize, MAX_DETAIL_BYTES, readAfter, summarize, type Meta } from "./local-diff-batch"
 import { createDiffCache } from "./local-diff-cache"
 import type { WorktreeDiffEntry } from "./types"
@@ -10,10 +10,6 @@ import type { WorktreeDiffEntry } from "./types"
 type Status = Meta["status"]
 
 type Log = (...args: unknown[]) => void
-
-/** Cap untracked file reads so line-counting a multi-megabyte log file does
- *  not stall the poll. Matches `GitOps.workingTreeStats()`. */
-const MAX_UNTRACKED_BYTES = 1_000_000
 
 /** Cap per-side reads in the detail view. Opening very large tracked files
  *  used to spike `kilo serve`; now that the detail path runs in the
@@ -170,18 +166,6 @@ async function sizes(git: GitOps, dir: string, anc: string, meta: Meta, signal?:
   ])
 }
 
-async function lineCount(file: string): Promise<number> {
-  const stat = await fs.lstat(file).catch(() => undefined)
-  if (!stat || stat.size === 0) return 0
-  if (stat.size > MAX_UNTRACKED_BYTES) return 0
-  const content = stat.isSymbolicLink()
-    ? await fs.readlink(file).catch(() => "")
-    : await fs.readFile(file, "utf-8").catch(() => "")
-  if (!content) return 0
-  if (content.endsWith("\n")) return content.split("\n").length - 1
-  return content.split("\n").length
-}
-
 function statusFromCode(code: string): Status {
   if (code === "A") return "added"
   if (code === "D") return "deleted"
@@ -252,18 +236,17 @@ async function list(git: GitOps, dir: string, anc: string, log?: Log): Promise<M
       paths.slice(index, index + MAX_SUMMARY_FILES).map(async (file): Promise<Meta | undefined> => {
         const full = resolveInside(dir, file)
         if (!full) return undefined
-        const exists = await fs.lstat(full).catch(() => undefined)
-        if (!exists) return undefined
-        const binary = await binaryFile(full)
+        const value = await measure(full)
+        if (!value) return undefined
         return {
           file,
-          additions: binary ? 0 : await lineCount(full),
+          additions: value.count,
           deletions: 0,
           status: "added",
           tracked: false,
           generatedLike: generatedLike(file),
-          binary,
-          stamp: await statStamp(dir, file),
+          binary: value.binary,
+          stamp: value.stamp,
         }
       }),
     )
@@ -321,18 +304,17 @@ async function detailMeta(
     })
     check(signal)
     if (untracked.code !== 0 || !untracked.stdout.split("\n").includes(file)) return undefined
-    const exists = await fs.lstat(full).catch(() => undefined)
-    if (!exists) return undefined
-    const binary = await binaryFile(full)
+    const value = await measure(full)
+    if (!value) return undefined
     return {
       file,
-      additions: binary ? 0 : await lineCount(full),
+      additions: value.count,
       deletions: 0,
       status: "added",
       tracked: false,
       generatedLike: generatedLike(file),
-      binary,
-      stamp: await statStamp(dir, file),
+      binary: value.binary,
+      stamp: value.stamp,
     }
   }
 

--- a/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
@@ -248,6 +248,10 @@ export class WorktreeDiffController {
     void this.activate(id, true, true)
   }
 
+  public setVisible(visible: boolean): Promise<void> {
+    return this.controller.setVisible(visible)
+  }
+
   public stop(): void {
     this.generation++
     this.controller.stop()

--- a/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-diff-controller.ts
@@ -248,8 +248,8 @@ export class WorktreeDiffController {
     void this.activate(id, true, true)
   }
 
-  public setVisible(visible: boolean): Promise<void> {
-    return this.controller.setVisible(visible)
+  public async setVisible(visible: boolean): Promise<void> {
+    await this.controller.setVisible(visible)
   }
 
   public stop(): void {

--- a/packages/kilo-vscode/src/diff/DiffViewerProvider.ts
+++ b/packages/kilo-vscode/src/diff/DiffViewerProvider.ts
@@ -137,6 +137,7 @@ export class DiffViewerProvider implements vscode.Disposable {
       (ctx) => this.catalog.listAvailable(ctx),
       (msg) => void panel.webview.postMessage(msg),
     )
+    void this.controller.setVisible(panel.visible)
     if (this.ctx) this.controller.setContext(this.ctx)
 
     this.fontConfigDisposable?.dispose()
@@ -144,6 +145,7 @@ export class DiffViewerProvider implements vscode.Disposable {
 
     this.panelDisposables.push(
       panel.webview.onDidReceiveMessage((msg) => this.onMessage(msg as Record<string, unknown>)),
+      panel.onDidChangeViewState(() => void this.controller?.setVisible(panel.visible)),
       panel.onDidDispose(() => this.onPanelDisposed()),
     )
   }

--- a/packages/kilo-vscode/src/diff/DiffViewerProvider.ts
+++ b/packages/kilo-vscode/src/diff/DiffViewerProvider.ts
@@ -137,7 +137,7 @@ export class DiffViewerProvider implements vscode.Disposable {
       (ctx) => this.catalog.listAvailable(ctx),
       (msg) => void panel.webview.postMessage(msg),
     )
-    void this.controller.setVisible(panel.visible)
+    this.controller.setVisible(panel.visible).catch((err) => this.log("Failed to update diff visibility:", err))
     if (this.ctx) this.controller.setContext(this.ctx)
 
     this.fontConfigDisposable?.dispose()
@@ -145,7 +145,9 @@ export class DiffViewerProvider implements vscode.Disposable {
 
     this.panelDisposables.push(
       panel.webview.onDidReceiveMessage((msg) => this.onMessage(msg as Record<string, unknown>)),
-      panel.onDidChangeViewState(() => void this.controller?.setVisible(panel.visible)),
+      panel.onDidChangeViewState(() =>
+        this.controller?.setVisible(panel.visible).catch((err) => this.log("Failed to update diff visibility:", err)),
+      ),
       panel.onDidDispose(() => this.onPanelDisposed()),
     )
   }

--- a/packages/kilo-vscode/src/diff/SourceController.ts
+++ b/packages/kilo-vscode/src/diff/SourceController.ts
@@ -67,6 +67,8 @@ export class SourceController {
   private interval: ReturnType<typeof setInterval> | undefined
   private lastHash: string | undefined
   private epoch = 0
+  private visible = true
+  private options: ActivateOptions = {}
   private readonly fetches = new Map<DiffSource, Promise<boolean>>()
 
   constructor(
@@ -86,6 +88,16 @@ export class SourceController {
 
   get isPolling(): boolean {
     return this.interval !== undefined
+  }
+
+  async setVisible(visible: boolean): Promise<void> {
+    if (this.visible === visible) return
+    this.visible = visible
+    if (!visible) {
+      this.stopPolling()
+      return
+    }
+    await this.resume()
   }
 
   /** Dispose the active source and bump the epoch so in-flight fetches are dropped. */
@@ -108,8 +120,8 @@ export class SourceController {
     const ctx = this.ctx
     if (!ctx) return
     this.stop()
-    const epoch = this.epoch
     this.activeId = id
+    this.options = opts
 
     const source = this.build(id, ctx)
     this.active = source
@@ -117,12 +129,7 @@ export class SourceController {
     this.send(this.messages.available?.(this.listAvailable(ctx), id))
     this.send(this.messages.capabilities?.(source.descriptor.capabilities))
 
-    if (opts.fetch === false) return
-
-    const keepPolling = await this.fetch(source, epoch, true)
-    // Prevents the polling interval from starting after teardown or swap.
-    if (this.epoch !== epoch || this.activeId !== id) return
-    if (opts.poll !== false && keepPolling) this.startPolling(source, epoch)
+    await this.resume()
   }
 
   /**
@@ -246,6 +253,15 @@ export class SourceController {
     this.post(msg)
   }
 
+  private async resume(): Promise<void> {
+    const source = this.active
+    const epoch = this.epoch
+    if (!source || !this.visible || this.options.fetch === false) return
+    const keep = await this.fetch(source, epoch, true)
+    if (this.epoch !== epoch || this.active !== source || !this.visible) return
+    if (this.options.poll !== false && keep) this.startPolling(source, epoch)
+  }
+
   private startPolling(source: DiffSource, epoch: number): void {
     this.stopPolling()
     let busy = false
@@ -268,6 +284,7 @@ export class SourceController {
   }
 
   private fetch(source: DiffSource, epoch: number, initial: boolean, force = false): Promise<boolean> {
+    if (!this.visible) return Promise.resolve(false)
     const current = this.fetches.get(source)
     if (current && !force) return current
     if (current) {

--- a/packages/kilo-vscode/src/diff/shared/binary.ts
+++ b/packages/kilo-vscode/src/diff/shared/binary.ts
@@ -14,16 +14,21 @@ function binary(bytes: Uint8Array): boolean {
 }
 
 export async function binaryFile(file: string): Promise<boolean> {
+  return (await probe(file)) ?? false
+}
+
+export async function probe(file: string): Promise<boolean | undefined> {
   const stat = await fs.lstat(file).catch(() => undefined)
-  if (!stat?.isFile()) return false
+  if (!stat) return undefined
+  if (!stat.isFile()) return false
 
   const handle = await fs.open(file, "r").catch(() => undefined)
-  if (!handle) return false
+  if (!handle) return undefined
   const sample = Buffer.alloc(SAMPLE_BYTES)
   const read = await handle
     .read(sample, 0, sample.length, 0)
     .catch(() => undefined)
     .finally(() => handle.close())
-  if (!read) return false
+  if (!read) return undefined
   return binary(sample.subarray(0, read.bytesRead))
 }

--- a/packages/kilo-vscode/tests/unit/git-stats-snapshot.test.ts
+++ b/packages/kilo-vscode/tests/unit/git-stats-snapshot.test.ts
@@ -3,7 +3,7 @@ import * as fs from "fs/promises"
 import * as os from "os"
 import * as path from "path"
 import { GitOps, type ExecBufferResult } from "../../src/agent-manager/GitOps"
-import { GitStatsSnapshot, refOID } from "../../src/agent-manager/git-stats-snapshot"
+import { GitStatsSnapshot, lines, refOID } from "../../src/agent-manager/git-stats-snapshot"
 import { diffSummary } from "../../src/agent-manager/local-diff"
 
 function run(dir: string, args: string[]): string {
@@ -138,6 +138,31 @@ describe("GitStatsSnapshot", () => {
     })
   })
 
+  it("does not cache metadata when a file changes during its read", async () => {
+    await repo(async (dir, base) => {
+      const snapshots = new GitStatsSnapshot(new GitOps({ log: () => undefined }))
+      const file = path.join(dir, "changing.txt")
+      await fs.writeFile(file, "one\ntwo\n")
+      const read = fs.readFile
+      const probe = spyOn(fs, "readFile").mockImplementationOnce(async (...args) => {
+        const value = await read(...args)
+        await fs.writeFile(file, "replacement\n")
+        return value
+      })
+      try {
+        expect((await snapshots.diff(dir, base, ["changing.txt"])).additions).toBe(2)
+        expect((await snapshots.diff(dir, base, ["changing.txt"])).additions).toBe(1)
+        expect(probe).toHaveBeenCalledTimes(2)
+        expect((await snapshots.diff(dir, base, ["changing.txt"])).additions).toBe(1)
+        expect(probe).toHaveBeenCalledTimes(2)
+        await fs.unlink(file)
+        expect(await lines(file)).toBe(0)
+      } finally {
+        probe.mockRestore()
+      }
+    })
+  })
+
   it("skips extra metadata reads for empty and oversized files", async () => {
     await repo(async (dir, base) => {
       const snapshots = new GitStatsSnapshot(new GitOps({ log: () => undefined }))
@@ -188,6 +213,53 @@ describe("GitStatsSnapshot", () => {
       }
     })
   })
+
+  it("resists scans over cache capacity and admits files from a new root", async () => {
+    const paths: string[] = []
+    const files = Array.from({ length: 11_000 }, (_, index) => `${index}.txt`)
+    const read = spyOn(fs, "readFile")
+    const scan = async (dir: string, base: string) => {
+      const snapshots = new GitStatsSnapshot(new GitOps({ log: () => undefined }))
+      paths.push(...files.map((file) => path.join(dir, file)))
+      for (let index = 0; index < files.length; index += 64) {
+        await Promise.all(
+          files.slice(index, index + 64).map((file) => fs.writeFile(path.join(dir, file), "one\ntwo\n")),
+        )
+      }
+      const counts: number[] = []
+      for (let pass = 0; pass < 3; pass++) {
+        read.mockClear()
+        expect(await snapshots.diff(dir, base, files)).toEqual({
+          files: files.length,
+          additions: files.length * 2,
+          deletions: 0,
+        })
+        counts.push(read.mock.calls.length)
+      }
+      return counts
+    }
+    try {
+      await repo(async (dir, base) => {
+        const counts = await scan(dir, base)
+        expect(counts.at(0)).toBe(files.length)
+        for (const count of counts.slice(1)) {
+          expect(count).toBeGreaterThanOrEqual(files.length - 10_000)
+          expect(count).toBeLessThan(files.length / 2)
+        }
+      })
+      await repo(async (dir, base) => {
+        const counts = await scan(dir, base)
+        expect(counts.at(0)).toBe(files.length)
+        expect(counts.at(1)!).toBeLessThan(counts.at(0)!)
+        expect(counts.at(2)!).toBeLessThan(counts.at(1)!)
+      })
+    } finally {
+      read.mockRestore()
+      for (let index = 0; index < paths.length; index += 64) {
+        await Promise.all(paths.slice(index, index + 64).map((file) => lines(file)))
+      }
+    }
+  }, 60_000)
 
   it("reads ref OIDs and upstreams", async () => {
     await repo(async (dir) => {

--- a/packages/kilo-vscode/tests/unit/kilo-provider-acknowledgement.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-acknowledgement.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from "bun:test"
 import type { EventSessionTurnClose, Session } from "@kilocode/sdk/v2/client"
 import { KiloProvider } from "../../src/KiloProvider"
+import type { GitOps } from "../../src/agent-manager/GitOps"
+import type { GitStatsPoller } from "../../src/agent-manager/GitStatsPoller"
 import { KiloConnectionService } from "../../src/services/cli-backend/connection-service"
 import type { SSEPayload } from "../../src/services/cli-backend/sdk-sse-adapter"
 
@@ -25,10 +27,20 @@ function completion(id = "evt-001"): EventSessionTurnClose {
   return { id, type: "session.turn.close", properties: { sessionID: "s1", parentID: "parent", reason: "completed" } }
 }
 
-function attach(connection: KiloConnectionService, blocked = true) {
-  const provider = new KiloProvider({} as never, connection)
+function attach(
+  connection: KiloConnectionService,
+  blocked = true,
+  opts: ConstructorParameters<typeof KiloProvider>[3] = {},
+) {
+  const provider = new KiloProvider({} as never, connection, undefined, opts)
   resources.push(provider)
-  const internal = provider as unknown as { initConnectionPromise: Promise<void> }
+  const internal = provider as unknown as {
+    initConnectionPromise: Promise<void>
+    _getHtmlForWebview: () => string
+    startStatsPolling: () => void
+    statsPoller: GitStatsPoller | null
+    statsGitOps: GitOps | null
+  }
   internal.initConnectionPromise = Promise.resolve()
   const pending = Promise.withResolvers<(message: Record<string, unknown>) => Promise<void>>()
   const sent: unknown[] = []
@@ -46,7 +58,7 @@ function attach(connection: KiloConnectionService, blocked = true) {
       return blocked ? null : message
     },
   })
-  return { provider, webview, sent, intercepts, receive: pending.promise }
+  return { provider, internal, webview, sent, intercepts, receive: pending.promise }
 }
 
 describe("session acknowledgement host routing", () => {
@@ -240,5 +252,118 @@ describe("webview activation host routing", () => {
     change()
     expect(editor.sent.at(-1)).toEqual({ type: "webviewActiveChanged", active: false })
     expect([...presence.visible.values()].flatMap((ids) => [...ids])).toEqual([])
+  })
+})
+
+describe("webview stats visibility", () => {
+  function surface(kind: "sidebar" | "panel", visible: boolean) {
+    const editor = attach(create())
+    editor.internal._getHtmlForWebview = () => ""
+    const listeners = new Set<() => void>()
+    const subscribe = (listener: () => void) => {
+      listeners.add(listener)
+      return { dispose: () => listeners.delete(listener) }
+    }
+    const view = {
+      webview: editor.webview,
+      active: false,
+      visible,
+      onDidChangeViewState: subscribe,
+      onDidChangeVisibility: subscribe,
+    }
+    const resolve = () => {
+      if (kind === "sidebar") {
+        editor.provider.resolveWebviewView(view as never, {} as never, {} as never)
+        return
+      }
+      editor.provider.resolveWebviewPanel(view as never)
+    }
+    resolve()
+    return {
+      ...editor,
+      view,
+      listeners,
+      resolve,
+      change: (visible: boolean) => {
+        view.visible = visible
+        for (const listener of listeners) listener()
+      },
+    }
+  }
+
+  it.each(["sidebar", "panel"] as const)("keeps initially hidden %s stats disabled", (kind) => {
+    const editor = surface(kind, false)
+    editor.internal.startStatsPolling()
+
+    expect(editor.internal.statsPoller).toMatchObject({ active: false, visible: false, timer: undefined })
+
+    editor.change(true)
+    expect(editor.internal.statsPoller).toMatchObject({ active: true, visible: true })
+  })
+
+  it.each(["sidebar", "panel"] as const)("pauses and resumes %s stats without replacing the poller", (kind) => {
+    const editor = surface(kind, true)
+    editor.internal.startStatsPolling()
+    const poller = editor.internal.statsPoller
+
+    expect(poller).toMatchObject({ active: true, visible: true })
+    editor.change(false)
+    expect(poller).toMatchObject({ active: false, visible: false, timer: undefined })
+    editor.change(true)
+    expect(editor.internal.statsPoller).toBe(poller)
+    expect(poller).toMatchObject({ active: true, visible: true })
+  })
+
+  it.each(["sidebar", "panel"] as const)("keeps replacement %s stats paused while hidden", (kind) => {
+    const editor = surface(kind, true)
+    editor.change(false)
+    editor.internal.startStatsPolling()
+    const poller = editor.internal.statsPoller
+    const git = editor.internal.statsGitOps
+    editor.internal.startStatsPolling()
+
+    expect(editor.internal.statsPoller).not.toBe(poller)
+    expect(git?.disposed).toBe(true)
+    expect(editor.internal.statsPoller).toMatchObject({ active: false, visible: false, timer: undefined })
+  })
+
+  it.each(["sidebar", "panel"] as const)("applies current %s visibility when resolving again", (kind) => {
+    const editor = surface(kind, true)
+    editor.internal.startStatsPolling()
+    editor.view.visible = false
+    editor.resolve()
+
+    expect(editor.listeners.size).toBe(1)
+    expect(editor.internal.statsPoller).toMatchObject({ active: false, visible: false, timer: undefined })
+  })
+
+  it.each(["sidebar", "panel"] as const)("disposes %s stats and visibility listeners", (kind) => {
+    const editor = surface(kind, true)
+    editor.internal.startStatsPolling()
+    editor.provider.dispose()
+    editor.change(false)
+    editor.change(true)
+
+    expect(editor.listeners.size).toBe(0)
+    expect(editor.internal.statsPoller).toMatchObject({ active: false, timer: undefined })
+    expect(editor.internal.statsGitOps?.disposed).toBe(true)
+  })
+
+  it("preserves stats polling for custom embedded webviews", () => {
+    const editor = attach(create())
+    editor.internal.startStatsPolling()
+    editor.provider.setStreamVisibility(false)
+
+    expect(editor.internal.statsPoller).toMatchObject({ active: true, visible: true })
+  })
+
+  it("keeps Agent Manager embedded stats disabled across activation changes", () => {
+    const editor = attach(create(), true, { disableStatsPolling: true, disableViewedRegistration: true })
+    for (const active of [false, true, false, true]) {
+      editor.provider.setStreamVisibility(active)
+      editor.internal.startStatsPolling()
+      expect(editor.internal.statsPoller).toBeNull()
+      expect(editor.internal.statsGitOps).toBeNull()
+    }
   })
 })

--- a/packages/kilo-vscode/tests/unit/local-diff.test.ts
+++ b/packages/kilo-vscode/tests/unit/local-diff.test.ts
@@ -421,6 +421,53 @@ describe("createLocalDiff summary cache", () => {
     })
   })
 
+  it("retries binary classification after a failed sample instead of caching it", async () => {
+    await withRepo(async (dir, base) => {
+      await fs.writeFile(path.join(dir, "binary.bin"), Buffer.alloc(1_000_001))
+      const local = createLocalDiff(git())
+      const probe = spyOn(fs, "open").mockRejectedValueOnce(new Error("temporary sample failure"))
+      try {
+        expect((await local.summary(dir, base)).at(0)).toMatchObject({ additions: 0, summarized: true })
+        expect(probe).toHaveBeenCalledTimes(1)
+        const recovered = await local.summary(dir, base)
+        expect(recovered.at(0)).toMatchObject({ additions: 0, summarized: false })
+        expect(probe).toHaveBeenCalledTimes(2)
+        expect(await local.summary(dir, base)).toEqual(recovered)
+        expect(probe).toHaveBeenCalledTimes(2)
+      } finally {
+        probe.mockRestore()
+      }
+    })
+  })
+
+  it("skips full reads when a file grows past the cutoff during its binary probe", async () => {
+    await withRepo(async (dir, base) => {
+      const file = path.join(dir, "growing.txt")
+      await fs.writeFile(file, "small\n")
+      const local = createLocalDiff(git())
+      const open = fs.open
+      const probe = spyOn(fs, "open").mockImplementationOnce(async (...args) => {
+        const handle = await open(...args)
+        const close = handle.close.bind(handle)
+        handle.close = async () => {
+          await close()
+          await fs.writeFile(file, Buffer.alloc(1_000_001, 0x61))
+        }
+        return handle
+      })
+      const read = spyOn(fs, "readFile")
+      try {
+        expect((await local.summary(dir, base)).at(0)).toMatchObject({ additions: 0, summarized: true })
+        expect(read).not.toHaveBeenCalled()
+        expect((await local.summary(dir, base)).at(0)).toMatchObject({ additions: 0, summarized: true })
+        expect(read).not.toHaveBeenCalled()
+      } finally {
+        probe.mockRestore()
+        read.mockRestore()
+      }
+    })
+  })
+
   it("refreshes changed, deleted, and replaced files without rereading stable siblings", async () => {
     await withRepo(async (dir, base) => {
       const file = path.join(dir, "changing.txt")

--- a/packages/kilo-vscode/tests/unit/local-diff.test.ts
+++ b/packages/kilo-vscode/tests/unit/local-diff.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "bun:test"
+import { describe, it, expect, spyOn } from "bun:test"
 import * as fs from "fs/promises"
 import * as os from "os"
 import * as path from "path"
@@ -11,6 +11,7 @@ import {
   MAX_DETAIL_BYTES,
 } from "../../src/agent-manager/local-diff"
 import { GitOps, type ExecBufferResult, type ExecResult } from "../../src/agent-manager/GitOps"
+import { GitStatsSnapshot } from "../../src/agent-manager/git-stats-snapshot"
 import { WorktreeDiffReverter } from "../../src/diff/shared/reverter"
 import { resolveLocalDiffTarget } from "../../src/diff/shared/target"
 
@@ -371,6 +372,137 @@ describe("diffSummary", () => {
       const src = result.find((e) => e.file === "src.ts")
       expect(dist?.generatedLike).toBe(true)
       expect(src?.generatedLike).toBe(false)
+    })
+  })
+})
+
+describe("createLocalDiff summary cache", () => {
+  it("reuses counts and binary probes across summaries and badges", async () => {
+    await withRepo(async (dir, base) => {
+      await fs.writeFile(path.join(dir, "text.txt"), "one\ntwo\n")
+      await fs.writeFile(path.join(dir, "binary.bin"), Buffer.from([0, 1, 2, 3]))
+      const ops = git()
+      const local = createLocalDiff(ops)
+      const snapshots = new GitStatsSnapshot(ops)
+      const read = spyOn(fs, "readFile")
+      const probe = spyOn(fs, "open")
+      try {
+        const first = await local.summary(dir, base)
+        expect(first.map((entry) => [entry.file, entry.additions, entry.summarized])).toEqual([
+          ["binary.bin", 0, false],
+          ["text.txt", 2, true],
+        ])
+        expect(read).toHaveBeenCalledTimes(1)
+        expect(probe).toHaveBeenCalledTimes(2)
+        read.mockClear()
+        probe.mockClear()
+
+        expect(await local.summary(dir, base)).toEqual(first)
+        expect(await createLocalDiff(ops).summary(dir, base)).toEqual(first)
+        expect(await snapshots.diff(dir, base, ["binary.bin", "text.txt"])).toEqual({
+          files: 2,
+          additions: 2,
+          deletions: 0,
+        })
+        expect(read).not.toHaveBeenCalled()
+        expect(probe).not.toHaveBeenCalled()
+
+        await fs.writeFile(path.join(dir, "text.txt"), "three\nfour\nfive\n")
+        expect((await snapshots.diff(dir, base, ["binary.bin", "text.txt"])).additions).toBe(3)
+        read.mockClear()
+        probe.mockClear()
+        expect((await local.summary(dir, base)).find((entry) => entry.file === "text.txt")?.additions).toBe(3)
+        expect(read).not.toHaveBeenCalled()
+        expect(probe).not.toHaveBeenCalled()
+      } finally {
+        read.mockRestore()
+        probe.mockRestore()
+      }
+    })
+  })
+
+  it("refreshes changed, deleted, and replaced files without rereading stable siblings", async () => {
+    await withRepo(async (dir, base) => {
+      const file = path.join(dir, "changing.txt")
+      const time = new Date(1_000_000_000_000)
+      await fs.writeFile(file, "one\ntwo\n")
+      await fs.utimes(file, time, time)
+      await fs.writeFile(path.join(dir, "stable.txt"), "stable\n")
+      const local = createLocalDiff(git())
+      const first = await local.summary(dir, base)
+      const read = spyOn(fs, "readFile")
+      const probe = spyOn(fs, "open")
+      try {
+        await fs.writeFile(file, Buffer.from([0, 1, 2, 3, 4, 5, 6, 7]))
+        await fs.utimes(file, time, time)
+        const changed = await local.summary(dir, base)
+        expect(changed.find((entry) => entry.file === "changing.txt")).toMatchObject({
+          additions: 0,
+          summarized: false,
+        })
+        expect(changed.at(0)?.stamp).not.toBe(first.at(0)?.stamp)
+        expect(changed.at(1)).toEqual(first.at(1))
+        expect(read).not.toHaveBeenCalled()
+        expect(probe).toHaveBeenCalledTimes(1)
+        probe.mockClear()
+
+        await fs.unlink(file)
+        expect(await local.summary(dir, base)).toEqual([first.at(1)!])
+        expect(read).not.toHaveBeenCalled()
+        expect(probe).not.toHaveBeenCalled()
+
+        await fs.writeFile(file, "new\ntext")
+        await fs.utimes(file, time, time)
+        const replaced = await local.summary(dir, base)
+        expect(replaced.at(0)).toMatchObject({ file: "changing.txt", additions: 2, summarized: true })
+        expect(replaced.at(0)?.stamp).not.toBe(changed.at(0)?.stamp)
+        expect(replaced.at(1)).toEqual(first.at(1))
+        expect(read).toHaveBeenCalledTimes(1)
+        expect(read.mock.calls.at(0)?.at(0)).toBe(file)
+        expect(probe).toHaveBeenCalledTimes(1)
+        read.mockClear()
+        probe.mockClear()
+        expect(await local.summary(dir, base)).toEqual(replaced)
+        expect(read).not.toHaveBeenCalled()
+        expect(probe).not.toHaveBeenCalled()
+      } finally {
+        read.mockRestore()
+        probe.mockRestore()
+      }
+    })
+  })
+
+  it("preserves empty, oversized, binary, and symlink summaries", async () => {
+    await withRepo(async (dir, base) => {
+      await fs.writeFile(path.join(dir, "empty.txt"), "")
+      await fs.writeFile(path.join(dir, "large.txt"), Buffer.alloc(1_000_001, 0x61))
+      await fs.writeFile(path.join(dir, "large.bin"), Buffer.alloc(1_000_001))
+      await fs.writeFile(path.join(dir, "text.bin"), "one\r\ntwo")
+      await fs.symlink("large.bin", path.join(dir, "link.txt"))
+      await fs.symlink("missing", path.join(dir, "broken.txt"))
+      const local = createLocalDiff(git())
+      const first = await local.summary(dir, base)
+      expect(first.map((entry) => [entry.file, entry.additions, entry.summarized])).toEqual([
+        ["broken.txt", 1, true],
+        ["empty.txt", 0, true],
+        ["large.bin", 0, false],
+        ["large.txt", 0, true],
+        ["link.txt", 1, true],
+        ["text.bin", 2, true],
+      ])
+      const read = spyOn(fs, "readFile")
+      const probe = spyOn(fs, "open")
+      const link = spyOn(fs, "readlink")
+      try {
+        expect(await local.summary(dir, base)).toEqual(first)
+        expect(read).not.toHaveBeenCalled()
+        expect(probe).not.toHaveBeenCalled()
+        expect(link).not.toHaveBeenCalled()
+      } finally {
+        read.mockRestore()
+        probe.mockRestore()
+        link.mockRestore()
+      }
     })
   })
 })

--- a/packages/kilo-vscode/tests/unit/source-controller.test.ts
+++ b/packages/kilo-vscode/tests/unit/source-controller.test.ts
@@ -183,6 +183,107 @@ describe("SourceController.activate", () => {
   })
 })
 
+describe("SourceController.setVisible", () => {
+  it("defers hidden activation and refreshes when shown without rebuilding", async () => {
+    let fetches = 0
+    let disposed = 0
+    const source: DiffSource = {
+      descriptor: WORKSPACE_DESC,
+      async fetch() {
+        fetches++
+        return { diffs: [] }
+      },
+      dispose() {
+        disposed++
+      },
+    }
+    const { controller } = make({ workspace: source })
+    controller.setContext({ workspaceRoot: "/repo" })
+    try {
+      await controller.setVisible(false)
+      await controller.activate("workspace")
+      await controller.refresh()
+      expect(fetches).toBe(0)
+      expect(controller.isPolling).toBe(false)
+      expect(controller.currentId).toBe("workspace")
+
+      await controller.setVisible(true)
+      await controller.setVisible(true)
+      expect(fetches).toBe(1)
+      expect(controller.isPolling).toBe(true)
+
+      await controller.setVisible(false)
+      await controller.refresh()
+      expect(controller.isPolling).toBe(false)
+      expect(fetches).toBe(1)
+      await controller.setVisible(true)
+      expect(fetches).toBe(2)
+      expect(disposed).toBe(0)
+    } finally {
+      controller.stop()
+    }
+  })
+
+  it("does not restart polling when an in-flight fetch finishes hidden", async () => {
+    const gate = Promise.withResolvers<void>()
+    let fetches = 0
+    const { controller } = make({
+      workspace: {
+        descriptor: WORKSPACE_DESC,
+        async fetch() {
+          fetches++
+          await gate.promise
+          return { diffs: [] }
+        },
+      },
+    })
+    controller.setContext({ workspaceRoot: "/repo" })
+    try {
+      const activation = controller.activate("workspace")
+      await controller.setVisible(false)
+      gate.resolve()
+      await activation
+      expect(controller.isPolling).toBe(false)
+      expect(fetches).toBe(1)
+      await controller.setVisible(true)
+      expect(fetches).toBe(2)
+      expect(controller.isPolling).toBe(true)
+    } finally {
+      gate.resolve()
+      controller.stop()
+    }
+  })
+
+  it.each([{ poll: false }, { fetch: false }])("preserves activation options %j when shown", async (options) => {
+    let fetches = 0
+    const { controller } = make({
+      workspace: {
+        descriptor: WORKSPACE_DESC,
+        async fetch() {
+          fetches++
+          return { diffs: [] }
+        },
+      },
+    })
+    controller.setContext({ workspaceRoot: "/repo" })
+    try {
+      await controller.setVisible(false)
+      await controller.activate("workspace", options)
+      await controller.setVisible(true)
+      expect(fetches).toBe("fetch" in options ? 0 : 1)
+      expect(controller.isPolling).toBe(false)
+      await controller.setVisible(false)
+      controller.stop()
+      await controller.setVisible(true)
+      expect(controller.currentId).toBeUndefined()
+      expect(controller.isPolling).toBe(false)
+      expect(fetches).toBe("fetch" in options ? 0 : 1)
+    } finally {
+      controller.stop()
+    }
+  })
+})
+
 describe("SourceController.stop", () => {
   it("disposes the active source", async () => {
     let disposed = 0

--- a/packages/kilo-vscode/tests/unit/worktree-diff-controller.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-diff-controller.test.ts
@@ -73,6 +73,35 @@ function byType(items: unknown[], type: string) {
   })
 }
 
+describe("WorktreeDiffController.setVisible", () => {
+  it("defers hidden watches and resumes the latest base when shown", async () => {
+    let fetches = 0
+    const { controller, builds } = make({
+      fetch: async () => {
+        fetches++
+      },
+    })
+    try {
+      await controller.setVisible(false)
+      controller.start("w1#branch")
+      await waitFor(() => builds.length === 1)
+      expect(fetches).toBe(0)
+      await controller.setBase("w1#branch", "feature-x")
+      expect(fetches).toBe(0)
+      await controller.setVisible(true)
+      expect(fetches).toBe(1)
+      expect(builds.at(-1)?.ctx.baseBranch).toBe("feature-x")
+      await controller.setVisible(false)
+      await controller.request("w1#branch")
+      expect(fetches).toBe(1)
+      await controller.setVisible(true)
+      expect(fetches).toBe(2)
+    } finally {
+      controller.stop()
+    }
+  })
+})
+
 describe("WorktreeDiffController.setBase", () => {
   it("rebuilds the active source against the overridden base branch", async () => {
     const { controller, builds } = make()


### PR DESCRIPTION
## What Problem This Solves

Changes/Review still reread every eligible untracked text file on each 2.5-second summary poll, including while the panel was hidden. Standalone Kilo editor tabs also kept separate 5-second stats pollers active when hidden. The badge cache added in #13728 did not cover the review-summary path, and sequential scans above its 10,000-entry capacity could evict and reread the entire working set on every pass.

Fixes #13720.

## Why This Change Was Made

Pause diff and standalone-chat stats polling while the owning view is hidden, including initial hidden activation. Preserve the selected diff source and activation options, then refresh when the view becomes visible. An already-running scan can finish, but it cannot restart the hidden polling timer.

Share metadata-keyed line counts and binary classification between review summaries, individual untracked-file metadata, and badges. Keep the existing 16-operation read limit, 10,000-entry cache limit, and 1,000,000-byte line-count cutoff. Once the cache is full, admit one new path per 16 misses instead of allowing a sequential scan to replace every cached entry. Changed resident entries are still updated immediately; totals are not truncated. Failed binary probes are not cached, and metadata is rechecked after probing so a file that grows beyond the cutoff is not fully read.

## User Impact

Visible diffs and badges continue to update. Changes made while a view is hidden appear when it is reopened. Diff totals and text, binary, empty-file, oversized-file, and symlink handling are covered by regression tests.

This reduces repeated file work, not all repository activity: Git status and metadata scans remain. Over-capacity working sets still require some reads. New repositories warm more slowly when the shared cache is already full. No new setting or feature removal is involved.

## Evidence

### Exact Node summary measurements

macOS arm64, Node v25.2.1. Two separate Node bundles used the same `createLocalDiff(...).summary()` workload: the baseline source from `86c1928c4a` and the final patch at `5134625384`. The paired run was repeated after the binary-probe recovery and metadata revalidation corrections. Each disposable Git repository contained 512 unchanged untracked text files, each 163,840 bytes and 8,192 lines: **83,886,080 bytes (80 MiB)** total. Each pass returned **512 files and 4,194,304 added lines** in both versions.

CPU is Node process user + system CPU time, not wall time or whole-VS-Code CPU utilization. Times below are the recorded values rounded to milliseconds. Full-file reads count `fs.readFile` calls; Git work and binary-probe reads are separate.

| Pass | Before full-file reads | After full-file reads | Before CPU (ms) | After CPU (ms) | Before elapsed (ms) | After elapsed (ms) | Before max event-loop delay (ms) | After max event-loop delay (ms) |
|---|---|---|---|---|---|---|---|---|
| Cold | 512 | 512 | 259 | 290 | 172 | 190 | 12 | 12 |
| Warm 1 | 512 | 0 | 205 | 17 | 170 | 41 | 12 | 10 |
| Warm 2 | 512 | 0 | 189 | 14 | 163 | 40 | 13 | 10 |
| Warm 3 | 512 | 0 | 213 | 15 | 169 | 41 | 14 | 10 |

- Median warm CPU: **205 ms to 15 ms**, a **190 ms reduction (92.68%)**.
- Median warm elapsed time: **169 ms to 41 ms**, a **128 ms reduction (75.74%)**.
- Cold-pass trade-off in this run: CPU increased **259 ms to 290 ms** and elapsed time increased **172 ms to 190 ms**. Cold reads now include the metadata safety recheck; warm cache hits avoid it.
- Warm full-file reads: **512 to 0**, removing **80 MiB** of full-file reads per scan. Cold reads remain necessary.
- Event-loop delay was sampled at 10 ms resolution. These are short synthetic samples, not a claim that the original 55-worktree environment or its sustained 100% CPU was reproduced.

### Exact cache-capacity measurements

Real 8 KiB text files, three consecutive scans, with unchanged totals:

| Working set | Before reads per pass | After reads per pass |
|---|---|---|
| 9,000 files | 9,000 / 0 / 0 | 9,000 / 0 / 0 |
| 11,000 files | 11,000 / 11,000 / 11,000 | 11,000 / 1,065 / 1,065 |

For the 11,000-file case, warm scans perform **9,935 fewer full-file reads (90.32%)**, reducing full-file bytes read from **90,112,000 to 8,724,480** per scan. These read counts were reverified after the final probe-safety corrections. Switching to a different 11,000-file root with an already-full cache produced **11,000 / 10,312 / 9,668** reads in the patched version, showing the slower but progressive warm-up trade-off.

### Functional verification

- Final extension unit suite: **4,866 passed, 1 skipped, 0 failed**, across 383 files, both locally and in CI. Local duration: **137.66 s**; CI test duration: **42.01 s**.
- Final corrections: compile (host/webview typechecks, lint, and bundles), **77 focused file/cache tests**, and the two independently reproduced probe/growth regressions passed. Knip, formatting, and the Kilo change-marker guard passed.
- All applicable CI checks passed at commit `5134625384`. Automated review reported no issues; there are no unresolved review threads. The two independent local review findings were fixed and retested before enabling auto-merge.
- Isolated VS Code: Agent Manager review and standalone Changes both showed edits made while hidden after reopening. Native chat hide/show retained its input view. Before/after renderer traces were captured for the same review-to-file transition; these renderer traces are not used as extension-host CPU measurements.

The screenshot shows an untracked file refreshed to two lines after editing it while review was hidden. It contains only disposable fixture data.

<img width="650" alt="Review refreshes an untracked file to two added lines after an edit made while the panel was hidden" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260904-watcher-cpu-hidden-review-refresh-1309.png" />
