### PR TITLE
fix(vscode): keep indexing status in sync

### DIFF
--- a/.changeset/fix-indexing-status-consent.md
+++ b/.changeset/fix-indexing-status-consent.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep codebase indexing status current and support workspace paths with non-ASCII characters.

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -472,6 +472,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   private indexingProjectId: string | undefined
   private indexingSettingsRequest = 0
   private indexingStatusRequest = 0
+  private indexingTarget?: { source: string; directory: string; projectId?: string }
   private slimEditMetadata = true
 
   private pendingFollowup: Followup | null = null
@@ -1800,6 +1801,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         (payload, directory) => {
           const event = unwrapSyncEvent(payload)
           if (!event) return false
+          if (event.type === "indexing.status" && directory) {
+            return sameDirectory(directory, this.indexingScope.directory)
+          }
           if (
             directory &&
             directory !== "global" &&
@@ -1857,6 +1861,8 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         this.postConnectionState(error)
 
         if (state === "connected") {
+          const target = this.indexingScope
+          void this.fetchAndSendIndexingStatus(target.directory, target.projectId)
           this.flushPendingKiloModel()
           // Fire config warnings independently so a failure in the
           // sequential await chain doesn't prevent warnings from being shown
@@ -2907,6 +2913,13 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     }
   }
 
+  private get indexingScope() {
+    const source = this.getWorkspaceDirectory(this.currentSession?.id)
+    const target = this.indexingTarget
+    if (target && (target.source === source || sameDirectory(target.source, source))) return target
+    return { source, directory: source, projectId: undefined }
+  }
+
   private async fetchAndSendIndexingStatus(directory?: string, projectId?: string): Promise<void> {
     if (!this.client || !this.extensionContext) {
       if (this.cachedIndexingStatusMessage) {
@@ -2917,15 +2930,20 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
     const config = this.connectionService.getServerConfig()
     if (!config) return
-    const request = ++this.indexingStatusRequest
+    const source = this.getWorkspaceDirectory(this.currentSession?.id)
+    const dir = directory ?? source
+    if (!dir) return
+    const target = { source, directory: dir, projectId }
+    this.indexingTarget = target
 
     try {
-      const dir = directory ?? this.getWorkspaceDirectory(this.currentSession?.id)
-      if (!dir) return
       const store = indexingConsentStore(this.extensionContext)
       const project = await store.project(dir)
+      if (target !== this.indexingScope) return
+      target.directory = project.root
+      const request = ++this.indexingStatusRequest
       const status = await this.syncIndexingConsent(project.root, store.enabled(project.id), config)
-      if (request !== this.indexingStatusRequest) return
+      if (request !== this.indexingStatusRequest || target !== this.indexingScope) return
       const message = {
         type: "indexingStatusLoaded",
         status,
@@ -3807,9 +3825,20 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     await this.sendIndexingSettings(project.id)
     const config = this.connectionService.getServerConfig()
     if (!config) return
+    const target = {
+      source: this.getWorkspaceDirectory(this.currentSession?.id),
+      directory: project.root,
+      projectId: project.id,
+    }
+    this.indexingTarget = target
     const request = ++this.indexingStatusRequest
     const status = await this.syncIndexingConsent(project.root, enabled, config)
-    if (request !== this.indexingStatusRequest || this.indexingProjectId !== project.id) return
+    if (
+      request !== this.indexingStatusRequest ||
+      target !== this.indexingScope ||
+      this.indexingProjectId !== project.id
+    )
+      return
     const message = { type: "indexingStatusLoaded", status, projectId: project.id }
     this.cachedIndexingStatusMessage = message
     this.postMessage(message)
@@ -3826,7 +3855,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       headers: {
         Authorization: `Basic ${auth}`,
         "Content-Type": "application/json",
-        "x-kilo-directory": dir,
+        "x-kilo-directory": encodeURIComponent(dir),
       },
       body: JSON.stringify({ enabled }),
     })
@@ -4753,6 +4782,20 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
    * Filters events by project ID and tracked session IDs so each webview only sees its own sessions.
    */
   private handleEvent(event: ProviderEvent, directory?: string): void {
+    if (event.type === "indexing.status") {
+      const target = this.indexingScope
+      if (directory && !sameDirectory(directory, target.directory)) return
+      this.indexingStatusRequest++
+      const message = {
+        type: "indexingStatusLoaded",
+        status: event.properties.status,
+        projectId: target.projectId,
+      }
+      this.cachedIndexingStatusMessage = message
+      this.postMessage(message)
+      return
+    }
+
     if (event.type === "kilo-sessions.remote-status-changed") {
       this.remoteService?.updateFromEvent({ enabled: event.properties.enabled, connected: event.properties.connected })
       return
@@ -4859,13 +4902,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     // message.part.* events are always session-scoped; drop if session unknown.
     if (!sessionID && isSessionScopedPartEvent(event.type)) return
     if (this.postModelUsageChanged(event, sessionID)) return
-    if (
-      event.type !== "indexing.status" &&
-      event.type !== "session.deleted" &&
-      sessionID &&
-      !this.trackedSessionIds.has(sessionID)
-    )
-      return
+    if (event.type !== "session.deleted" && sessionID && !this.trackedSessionIds.has(sessionID)) return
 
     if (event.type === "message.part.updated") this.refreshGitStatusFromPart(event, sessionID)
 
@@ -4978,10 +5015,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       )
     }
 
-    if (event.type === "indexing.status" && directory) {
-      if (!sameDirectory(directory, this.getWorkspaceDirectory(this.currentSession?.id))) return
-    }
-
     const msg = isLegacySyncEvent(event)
       ? this.mapSyncEventToWebviewMessage(event)
       : mapSSEEventToWebviewMessage(event, sessionID)
@@ -4995,9 +5028,6 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
       if (!sameDirectory(next.directory, this.getWorkspaceDirectory(next.sessionID))) return
       this.postMessage({ ...next, revision: ++this.sandboxRevision })
       return
-    }
-    if (next.type === "indexingStatusLoaded") {
-      this.cachedIndexingStatusMessage = next
     }
     this.streams.flush(sessionID)
     this.postMessage(next)

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -3825,6 +3825,10 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     await this.sendIndexingSettings(project.id)
     const config = this.connectionService.getServerConfig()
     if (!config) return
+    if (this.indexingProjectId !== project.id) {
+      await this.syncIndexingConsent(project.root, enabled, config)
+      return
+    }
     const target = {
       source: this.getWorkspaceDirectory(this.currentSession?.id),
       directory: project.root,
@@ -3834,7 +3838,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     const request = ++this.indexingStatusRequest
     const status = await this.syncIndexingConsent(project.root, enabled, config)
     if (
-      request !== this.indexingStatusRequest ||
+      (enabled && request !== this.indexingStatusRequest) ||
       target !== this.indexingScope ||
       this.indexingProjectId !== project.id
     )

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -1862,7 +1862,7 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
 
         if (state === "connected") {
           const target = this.indexingScope
-          void this.fetchAndSendIndexingStatus(target.directory, target.projectId)
+          this.fetchAndSendIndexingStatus(target.directory, target.projectId)
           this.flushPendingKiloModel()
           // Fire config warnings independently so a failure in the
           // sequential await chain doesn't prevent warnings from being shown

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -930,7 +930,9 @@ describe("KiloProvider — pending session refresh on reconnect", () => {
     // Find the onStateChange callback that handles "connected"
     const connectedIdx = provider.indexOf('state === "connected"')
     expect(connectedIdx, '"connected" state handler must exist').toBeGreaterThan(-1)
-    const snippet = provider.slice(connectedIdx, connectedIdx + 800)
+    const end = provider.indexOf("this.unsubscribeNotificationDismiss", connectedIdx)
+    expect(end, "notification subscription must follow connection handler").toBeGreaterThan(connectedIdx)
+    const snippet = provider.slice(connectedIdx, end)
     expect(snippet, "must call flushPendingSessionRefresh from connected handler").toContain(
       'this.flushPendingSessionRefresh("sse-connected")',
     )

--- a/packages/kilo-vscode/tests/unit/kilo-provider-indexing-refresh.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-indexing-refresh.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import type { Config } from "@kilocode/sdk/v2/client"
-import { indexingConsentStore } from "../../src/indexing-consent"
+import { indexingConsentStore, type IndexingProject } from "../../src/indexing-consent"
 import { fetchSnapshot } from "../../src/kilo-provider/config-snapshot"
 
 // vscode mock is provided by the shared preload (tests/setup/vscode-mock.ts)
@@ -26,6 +26,8 @@ type Internals = {
   fetchAndSendCommands: () => Promise<void>
   fetchAndSendNotifications: () => Promise<void>
   fetchAndSendIndexingStatus: (directory?: string, projectId?: string) => Promise<void>
+  sendIndexingSettings: (projectId?: string) => Promise<IndexingProject | undefined>
+  setIndexingConsent: (projectId: string, enabled: boolean) => Promise<void>
   initializeConnection: () => Promise<void>
   connectionGeneration: number
   configBindings: {
@@ -127,7 +129,8 @@ const complete = {
 
 function indexing(dir = "/repo", root = dir) {
   const context = { globalState: { get: () => undefined, update: async () => {} } }
-  indexingConsentStore(context as never).project = async () => ({ id: "prj-test", root, label: "Project" })
+  const store = indexingConsentStore(context as never)
+  store.project = async () => ({ id: "prj-test", root, label: "Project" })
   const client = {
     kilo: { profile: async () => ({ data: null }) },
     config: { warnings: async () => ({ data: [] }) },
@@ -145,7 +148,7 @@ function indexing(dir = "/repo", root = dir) {
   provider.postMessage = (message) => void messages.push(message as Record<string, unknown>)
   provider.setSessionDirectory("ses_indexing", dir)
   internal.currentSession = { id: "ses_indexing" }
-  return { internal, client, service, messages }
+  return { internal, client, service, messages, store }
 }
 
 describe("KiloProvider indexing refresh", () => {
@@ -398,6 +401,92 @@ describe("KiloProvider indexing refresh", () => {
     } finally {
       response.resolve(Response.json(initial))
       await request
+      globalThis.fetch = original
+    }
+  })
+
+  it("keeps the Disabled consent response when progress arrives during the request", async () => {
+    const fixture = indexing()
+    const project = await fixture.store.project("/repo")
+    fixture.store.list = async () => [project]
+    const disabled = { ...initial, state: "Disabled", message: "Indexing consent is required." }
+    const called = Promise.withResolvers<RequestInit | undefined>()
+    const response = Promise.withResolvers<Response>()
+    const original = globalThis.fetch
+    globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
+      called.resolve(init)
+      return response.promise
+    }) as typeof fetch
+
+    const request = fixture.internal.setIndexingConsent(project.id, false)
+    try {
+      const init = await called.promise
+      expect(JSON.parse(String(init?.body))).toEqual({ enabled: false })
+      fixture.internal.handleEvent({ type: "indexing.status", properties: { status: initial } }, project.root)
+      response.resolve(Response.json(disabled))
+      await request
+
+      expect(fixture.messages.filter((message) => message.type === "indexingStatusLoaded")).toEqual([
+        expect.objectContaining({ status: initial, projectId: project.id }),
+        expect.objectContaining({ status: disabled, projectId: project.id }),
+      ])
+    } finally {
+      response.resolve(Response.json(disabled))
+      await request
+      globalThis.fetch = original
+    }
+  })
+
+  it("applies a delayed consent save without replacing or invalidating the selected project status", async () => {
+    const fixture = indexing()
+    const project = await fixture.store.project("/repo")
+    const prior = { id: "prj-other", root: "/other-repo", label: "Other" }
+    const projects = [prior, project]
+    const waiting = Promise.withResolvers<void>()
+    const listing = Promise.withResolvers<IndexingProject[]>()
+    let lists = 0
+    fixture.store.list = async () => {
+      if (++lists !== 2) return projects
+      waiting.resolve()
+      return listing.promise
+    }
+    const called = Promise.withResolvers<void>()
+    const response = Promise.withResolvers<Response>()
+    const calls: Array<{ directory: string; enabled: boolean }> = []
+    const original = globalThis.fetch
+    globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
+      const directory = decodeURIComponent(new Headers(init?.headers).get("x-kilo-directory") ?? "")
+      calls.push({ directory, enabled: JSON.parse(String(init?.body)).enabled })
+      if (directory === prior.root) return Promise.resolve(Response.json(initial))
+      called.resolve()
+      return response.promise
+    }) as typeof fetch
+
+    const saving = fixture.internal.setIndexingConsent(prior.id, true)
+    let request: Promise<void> | undefined
+    try {
+      await waiting.promise
+      await fixture.internal.sendIndexingSettings(project.id)
+      request = fixture.internal.fetchAndSendIndexingStatus(project.root, project.id)
+      await called.promise
+      listing.resolve(projects)
+      await saving
+      expect(calls).toEqual([
+        { directory: project.root, enabled: false },
+        { directory: prior.root, enabled: true },
+      ])
+      response.resolve(Response.json(initial))
+      await request
+      fixture.internal.handleEvent({ type: "indexing.status", properties: { status: complete } }, project.root)
+
+      expect(fixture.messages.filter((message) => message.type === "indexingStatusLoaded")).toEqual([
+        expect.objectContaining({ status: initial, projectId: project.id }),
+        expect.objectContaining({ status: complete, projectId: project.id }),
+      ])
+    } finally {
+      listing.resolve(projects)
+      response.resolve(Response.json(initial))
+      await Promise.all([saving, request])
       globalThis.fetch = original
     }
   })

--- a/packages/kilo-vscode/tests/unit/kilo-provider-indexing-refresh.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-indexing-refresh.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test"
 import type { Config } from "@kilocode/sdk/v2/client"
+import { indexingConsentStore } from "../../src/indexing-consent"
 import { fetchSnapshot } from "../../src/kilo-provider/config-snapshot"
 
 // vscode mock is provided by the shared preload (tests/setup/vscode-mock.ts)
@@ -24,7 +25,8 @@ type Internals = {
   fetchAndSendSkills: () => Promise<void>
   fetchAndSendCommands: () => Promise<void>
   fetchAndSendNotifications: () => Promise<void>
-  fetchAndSendIndexingStatus: () => Promise<void>
+  fetchAndSendIndexingStatus: (directory?: string, projectId?: string) => Promise<void>
+  initializeConnection: () => Promise<void>
   connectionGeneration: number
   configBindings: {
     create: (input: unknown) => { id: string }
@@ -105,6 +107,45 @@ function createConnection() {
       getClient: () => client,
     },
   }
+}
+
+const initial = {
+  state: "In Progress",
+  message: "Indexing is initializing.",
+  processedFiles: 0,
+  totalFiles: 0,
+  percent: 0,
+}
+
+const complete = {
+  state: "Complete",
+  message: "Index up-to-date.",
+  processedFiles: 100,
+  totalFiles: 100,
+  percent: 100,
+}
+
+function indexing(dir = "/repo", root = dir) {
+  const context = { globalState: { get: () => undefined, update: async () => {} } }
+  indexingConsentStore(context as never).project = async () => ({ id: "prj-test", root, label: "Project" })
+  const client = {
+    kilo: { profile: async () => ({ data: null }) },
+    config: { warnings: async () => ({ data: [] }) },
+  }
+  const service = {
+    getClient: () => client,
+    getServerConfig: () => ({ baseUrl: "http://127.0.0.1:9999", password: "secret" }),
+    getServerInfo: () => null,
+    getConnectionError: () => null,
+    resolveEventSessionId: () => undefined,
+  }
+  const provider = new KiloProvider({} as never, service as never, context as never)
+  const internal = provider as unknown as Internals
+  const messages: Array<Record<string, unknown>> = []
+  provider.postMessage = (message) => void messages.push(message as Record<string, unknown>)
+  provider.setSessionDirectory("ses_indexing", dir)
+  internal.currentSession = { id: "ses_indexing" }
+  return { internal, client, service, messages }
 }
 
 describe("KiloProvider indexing refresh", () => {
@@ -307,58 +348,119 @@ describe("KiloProvider indexing refresh", () => {
     })
   })
 
-  it("fetchAndSendIndexingStatus writes project consent through the dedicated endpoint", async () => {
-    const worktree = "/repo/.kilo/.kilocode/worktrees/feature"
-    const calls: { input: RequestInfo | URL; init?: RequestInit }[] = []
-    const original = globalThis.fetch
+  it.each(["/repo/.kilo/.kilocode/worktrees/feature", "/home/user/桌面/project", "/repo/100%/%2F/project"])(
+    "fetchAndSendIndexingStatus writes consent with an encoded directory header: %s",
+    async (dir) => {
+      const calls: { input: RequestInfo | URL; init?: RequestInit }[] = []
+      const original = globalThis.fetch
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls.push({ input, init })
+        return Response.json(initial)
+      }) as typeof fetch
 
-    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-      calls.push({ input, init })
-      return new Response(
-        JSON.stringify({
-          state: "Disabled",
-          message: "Indexing is disabled in worktree sessions.",
-          processedFiles: 0,
-          totalFiles: 0,
-          percent: 0,
-        }),
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        },
-      )
+      try {
+        await indexing(dir).internal.fetchAndSendIndexingStatus()
+
+        expect(calls).toHaveLength(1)
+        const call = calls.at(0)
+        const headers = new Headers(call?.init?.headers)
+        const auth = Buffer.from("kilo:secret").toString("base64")
+        expect(headers.get("Authorization")).toBe(`Basic ${auth}`)
+        expect(headers.get("x-kilo-directory")).toBe(encodeURIComponent(dir))
+        expect(decodeURIComponent(headers.get("x-kilo-directory") ?? "")).toBe(dir)
+        expect(call?.init?.method).toBe("PUT")
+        expect(String(call?.input)).toBe("http://127.0.0.1:9999/indexing/consent")
+        expect(JSON.parse(String(call?.init?.body))).toEqual({ enabled: false })
+      } finally {
+        globalThis.fetch = original
+      }
+    },
+  )
+
+  it("keeps newer indexing.status when an older HTTP status response arrives", async () => {
+    const fixture = indexing()
+    const called = Promise.withResolvers<void>()
+    const response = Promise.withResolvers<Response>()
+    const original = globalThis.fetch
+    globalThis.fetch = (() => {
+      called.resolve()
+      return response.promise
     }) as typeof fetch
 
+    const request = fixture.internal.fetchAndSendIndexingStatus()
     try {
-      const provider = new KiloProvider(
-        {} as never,
-        {
-          getClient: () => ({}) as never,
-          getServerConfig: () => ({ baseUrl: "http://127.0.0.1:9999", password: "secret" }),
-        } as never,
-        {
-          globalState: {
-            get: () => undefined,
-            update: async () => {},
-          },
-        } as never,
-      )
-      const internal = provider as unknown as Internals
-      provider.setSessionDirectory("ses_worktree", worktree)
-      internal.currentSession = { id: "ses_worktree" }
+      await called.promise
+      fixture.internal.handleEvent({ type: "indexing.status", properties: { status: complete } }, "/repo")
+      response.resolve(Response.json(initial))
+      await request
 
-      await internal.fetchAndSendIndexingStatus()
+      expect(fixture.messages).toEqual([expect.objectContaining({ type: "indexingStatusLoaded", status: complete })])
+    } finally {
+      response.resolve(Response.json(initial))
+      await request
+      globalThis.fetch = original
+    }
+  })
 
-      expect(calls.length).toBe(1)
-      const headers = new Headers(calls[0]?.init?.headers)
-      const auth = Buffer.from("kilo:secret").toString("base64")
-      expect(headers.get("Authorization")).toBe(`Basic ${auth}`)
-      expect(headers.get("x-kilo-directory")).toBe(worktree)
-      expect(calls[0]?.init?.method).toBe("PUT")
-      expect(String(calls[0]?.input)).toBe("http://127.0.0.1:9999/indexing/consent")
-      expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({ enabled: false })
+  it("accepts the resolved project root and rejects unrelated indexing.status events from a repo subfolder", async () => {
+    const fixture = indexing("/repo/subfolder", "/repo")
+    const original = globalThis.fetch
+    globalThis.fetch = (async () => Response.json(initial)) as typeof fetch
+
+    try {
+      await fixture.internal.fetchAndSendIndexingStatus(undefined, "prj-test")
+      const event = { type: "indexing.status", properties: { status: complete } }
+      fixture.internal.handleEvent(event, "/other-repo")
+      expect(fixture.messages).toHaveLength(1)
+
+      fixture.internal.handleEvent(event, "/repo")
+      expect(fixture.messages).toEqual([
+        expect.objectContaining({ type: "indexingStatusLoaded", status: initial, projectId: "prj-test" }),
+        expect.objectContaining({ type: "indexingStatusLoaded", status: complete, projectId: "prj-test" }),
+      ])
     } finally {
       globalThis.fetch = original
+    }
+  })
+
+  it("refreshes indexing on SSE reconnect without waiting for profile", async () => {
+    const fixture = indexing()
+    const callback = Promise.withResolvers<(state: Internals["connectionState"]) => Promise<void>>()
+    const subscribe = () => () => {}
+    Object.assign(fixture.service, {
+      connect: async () => {},
+      getClient: () => null,
+      getConnectionState: () => "disconnected",
+      onEventFiltered: subscribe,
+      onStateChange: (listener: (state: Internals["connectionState"]) => Promise<void>) => {
+        callback.resolve(listener)
+        return () => {}
+      },
+      onNotificationDismissed: subscribe,
+      onLanguageChanged: subscribe,
+      onProfileChanged: subscribe,
+      onFavoritesChanged: subscribe,
+      onModelSelectorExpandedChanged: subscribe,
+      onClearPendingPrompts: subscribe,
+      registerDirectoryProvider: subscribe,
+    })
+    await fixture.internal.initializeConnection()
+    expect(fixture.internal.connectionState).toBe("disconnected")
+
+    const profile = Promise.withResolvers<{ data: null }>()
+    const calls: string[] = []
+    fixture.service.getClient = () => fixture.client
+    fixture.client.kilo.profile = () => profile.promise
+    fixture.internal.fetchAndSendIndexingStatus = async () => {
+      calls.push("indexing")
+    }
+
+    const syncing = (await callback.promise)("connected")
+    try {
+      expect(calls).toEqual(["indexing"])
+    } finally {
+      profile.resolve({ data: null })
+      await syncing
     }
   })
 


### PR DESCRIPTION
## What Problem This Solves

Codebase indexing can remain on an old "Indexing is initializing" status after the worker has finished. A delayed consent HTTP response can overwrite a newer completion event, status events can be discarded when a repository subfolder differs from the resolved indexing root, and reconnecting does not refresh the status.

Directories containing characters outside the HTTP header ByteString range also prevent the consent request from being sent at all. Closes #13769.

## Why This Change Was Made

Keep HTTP responses and live status events tied to the same indexing target. Newer events invalidate pending status snapshots, superseded targets cannot overwrite the current view, and project-scoped events retain their project ID. Explicit consent revocation keeps its authoritative Disabled response even if old progress arrives in flight. A delayed save for another project still applies consent without replacing the selected status target. Refresh indexing on reconnect without waiting for the profile request. Encode the directory header using the same convention as the SDK.

The patch is limited to extension consent and status handling. It does not change embedding requests, indexing concurrency, file discovery, or diagnostic logging, and does not claim to fix every backend indexing stall.

## User Impact

Indexing can be enabled from Unicode-named paths. Repository subfolders receive completion updates for their resolved project root, and a late response no longer puts a completed index back into an initializing state.

## Evidence

- 135 focused indexing, consent, session-refresh, routing, and architecture tests pass, including Unicode/percent encoding, delayed HTTP versus live completion, project-root filtering, reconnect-before-profile, consent revocation during progress, and delayed saves after switching projects. The architecture guard checks the complete connection callback rather than an arbitrary character window.
- Extension typecheck, lint, build, unused-export guard, marker guard, formatting, and diff checks pass. The complete local unit suite exceeded its 120-second command limit; it was not counted as a pass.
- Self-tested the built extension in isolated VS Code on macOS, opening a subfolder of a Unicode-named Git repository. A localhost embedding fixture and LanceDB processed the files and reached `IDX Complete`. The completed state also appeared after reloading VS Code. After the consent-race fixes, disabling showed `IDX Disabled` and re-enabling returned to `IDX Complete`. The isolated instances were cleaned up afterward. The original reporter's Windows environment was not available.

<img width="700" alt="Indexing enabled with IDX Complete and File watcher started. Index up-to-date." src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260904-indexing-status-complete-spark-college.png" />

<img width="700" alt="Indexing disabled with the matching IDX Disabled status." src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260904-indexing-status-disabled-spark-college.png" />
