### PR TITLE
fix(vscode): retry marketplace publishing

### DIFF
--- a/packages/kilo-vscode/script/publish.ts
+++ b/packages/kilo-vscode/script/publish.ts
@@ -43,15 +43,22 @@ const flag = prerelease ? ["--pre-release"] : []
 for (const target of targets) {
   const vsixPath = join(outDir, `kilo-vscode-${target}.vsix`)
   console.log(`\n🚀 Publishing ${target} to VS Code Marketplace${prerelease ? " (pre-release)" : ""}...`)
-  await $`vsce publish ${flag} --packagePath ${vsixPath}`
+  await retry(() => $`vsce publish ${flag} --skip-duplicate --packagePath ${vsixPath}`, {
+    attempts: 3,
+    delay: 10_000,
+    label: `vsce publish ${target}`,
+  })
   console.log(`  ✅ Published ${target} to VS Code Marketplace`)
 
   console.log(`\n📤 Publishing ${target} to Open VSX${prerelease ? " (pre-release)" : ""}...`)
-  await retry(() => $`npx ovsx publish ${flag} --pat ${process.env.OPENVSX_TOKEN} --packagePath ${vsixPath}`, {
-    attempts: 3,
-    delay: 10_000,
-    label: `ovsx publish ${target}`,
-  })
+  await retry(
+    () => $`npx ovsx publish ${flag} --skip-duplicate --pat ${process.env.OPENVSX_TOKEN} --packagePath ${vsixPath}`,
+    {
+      attempts: 3,
+      delay: 10_000,
+      label: `ovsx publish ${target}`,
+    },
+  )
   console.log(`  ✅ Published ${target} to Open VSX`)
 }
 

--- a/packages/kilo-vscode/script/publish.ts
+++ b/packages/kilo-vscode/script/publish.ts
@@ -45,7 +45,7 @@ for (const target of targets) {
   console.log(`\n🚀 Publishing ${target} to VS Code Marketplace${prerelease ? " (pre-release)" : ""}...`)
   await retry(() => $`vsce publish ${flag} --skip-duplicate --packagePath ${vsixPath}`, {
     attempts: 3,
-    delay: 10_000,
+    delay: 30_000,
     label: `vsce publish ${target}`,
   })
   console.log(`  ✅ Published ${target} to VS Code Marketplace`)
@@ -55,7 +55,7 @@ for (const target of targets) {
     () => $`npx ovsx publish ${flag} --skip-duplicate --pat ${process.env.OPENVSX_TOKEN} --packagePath ${vsixPath}`,
     {
       attempts: 3,
-      delay: 10_000,
+      delay: 30_000,
       label: `ovsx publish ${target}`,
     },
   )
@@ -76,8 +76,9 @@ async function retry<T>(fn: () => Promise<T>, opts: { attempts: number; delay: n
       return await fn()
     } catch (err) {
       if (i === opts.attempts) throw err
-      console.warn(`  ⚠️  ${opts.label} failed (attempt ${i}/${opts.attempts}), retrying in ${opts.delay / 1000}s...`)
-      await new Promise((r) => setTimeout(r, opts.delay))
+      const delay = opts.delay * 2 ** (i - 1)
+      console.warn(`  ⚠️  ${opts.label} failed (attempt ${i}/${opts.attempts}), retrying in ${delay / 1000}s...`)
+      await new Promise((r) => setTimeout(r, delay))
     }
   }
   throw new Error("unreachable")

--- a/packages/kilo-vscode/tests/unit/publish.test.ts
+++ b/packages/kilo-vscode/tests/unit/publish.test.ts
@@ -34,5 +34,5 @@ test.each(["vsce publish", "npx ovsx publish"])("%s retries the same package and
       ?.asKind(SyntaxKind.NumericLiteral)
       ?.getLiteralValue()
   expect(value("attempts")).toBe(3)
-  expect(value("delay")).toBe(10_000)
+  expect(value("delay")).toBe(30_000)
 })

--- a/packages/kilo-vscode/tests/unit/publish.test.ts
+++ b/packages/kilo-vscode/tests/unit/publish.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { Project, SyntaxKind } from "ts-morph"
+
+const project = new Project({ useInMemoryFileSystem: true })
+const source = project.createSourceFile(
+  "publish.ts",
+  await Bun.file(`${import.meta.dir}/../../script/publish.ts`).text(),
+)
+
+test.each(["vsce publish", "npx ovsx publish"])("%s retries the same package and skips duplicates", (command) => {
+  const retry = source
+    .getDescendantsOfKind(SyntaxKind.CallExpression)
+    .find(
+      (call) => call.getExpression().getText() === "retry" && call.getArguments().at(0)?.getText().includes(command),
+    )
+  expect(retry).toBeDefined()
+
+  const shell = retry
+    ?.getArguments()
+    .at(0)
+    ?.asKind(SyntaxKind.ArrowFunction)
+    ?.getBody()
+    .asKind(SyntaxKind.TaggedTemplateExpression)
+  expect(shell?.getTag().getText()).toBe("$")
+  expect(shell?.getTemplate().getText()).toContain("${flag} --skip-duplicate")
+  expect(shell?.getTemplate().getText()).toContain("--packagePath ${vsixPath}")
+
+  const options = retry?.getArguments().at(1)?.asKind(SyntaxKind.ObjectLiteralExpression)
+  const value = (name: string) =>
+    options
+      ?.getProperty(name)
+      ?.asKind(SyntaxKind.PropertyAssignment)
+      ?.getInitializer()
+      ?.asKind(SyntaxKind.NumericLiteral)
+      ?.getLiteralValue()
+  expect(value("attempts")).toBe(3)
+  expect(value("delay")).toBe(10_000)
+})


### PR DESCRIPTION
## What Problem This Solves

Two consecutive releases stopped on VS Code Marketplace request timeouts. Some platforms were already published, while later platforms and the GitHub VSIX uploads were not reached.

## Why This Change Was Made

Use the existing retry helper for Marketplace publishing: three total attempts, waiting 30 seconds before the second attempt and 60 seconds before the third. Add `--skip-duplicate` to both VSCE and Open VSX so a retry can continue if an upload succeeded but its response was lost.

Each attempt reuses the original VSIX. VSCE 3.9.2 does not expose a publish timeout setting, so this change adds recovery rather than changing the GitHub job timeout.

## User Impact

A single transient publish failure no longer immediately stops the release. Duplicate checks remain independent for each marketplace and platform: skipping an existing Marketplace upload still proceeds to Open VSX. Persistent errors still fail after three attempts.

## Evidence

- [v7.5.12 failure](https://github.com/Kilo-Org/kilocode/actions/runs/33873085148/job/101027074228): Windows ARM64 Marketplace request timed out after about 181 seconds.
- [v7.5.13 failure](https://github.com/Kilo-Org/kilocode/actions/runs/33875981645/job/101035599197): Alpine ARM64 timed out while the larger Alpine x64 package published in about 15 seconds. Aggregate VSIX artifact size was only 0.0015% larger than the successful v7.5.11 release.
- Passed extension compilation, package lint and typechecks, direct script/test lint and typechecks, formatting, and two focused command-wiring regression tests.
- Six offline smoke scenarios exercised the actual publish script with substitute executables: stable and prerelease success, recovery on the third attempt for either marketplace, and stopping after three failures for either marketplace. No live publication was performed.

After merge, validate with a new patch release from main, checking all eight targets on both marketplaces and the GitHub VSIX assets. Rerunning an old failed job does not include this fix.