### PR TITLE
fix(cli): time out stalled glob searches

### DIFF
--- a/.changeset/bound-glob-searches.md
+++ b/.changeset/bound-glob-searches.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Stop glob searches after two minutes and terminate cancelled search processes.

--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -114,6 +114,7 @@ const layer = Layer.effect(
       readonly args: string[]
       readonly limit: number
       readonly signal?: AbortSignal
+      readonly timeout?: number // kilocode_change
       readonly parse: (line: string) => Effect.Effect<A | undefined, Error>
       readonly pattern?: string
       readonly onItem?: (item: A) => Effect.Effect<void>
@@ -128,50 +129,63 @@ const layer = Layer.effect(
             cwd: input.cwd,
             extendEnv: true,
             stdin: "ignore",
-            forceKillAfter: input.stop ? Duration.seconds(1) : undefined, // kilocode_change - bound grep interruption
+            forceKillAfter: input.stop || input.timeout != null ? Duration.seconds(1) : undefined, // kilocode_change - bound search interruption
           })
           const validated = input.validate ? SpawnValidation.attach(command, input.validate) : command
-          const spawned = input.stop ? SpawnExit.attach(validated) : validated // kilocode_change
+          const spawned = input.stop || input.timeout != null ? SpawnExit.attach(validated) : validated // kilocode_change
           const handle = yield* process.spawn(spawned)
-          // kilocode_change end
-          const stderrFiber = yield* collectStream(handle.stderr, ERROR_BYTES).pipe(
-            Effect.map((output) => output.buffer.toString("utf8")),
-            Effect.forkScoped,
-          )
-          let observed = 0
-          let stopped = false // kilocode_change
-          const take = input.stop // kilocode_change start
-            ? Stream.takeUntil<A>((row) => {
-                stopped = input.stop?.(row) ?? false
-                return stopped
-              })
-            : Stream.take(input.limit + 1) // kilocode_change end
-          const rows = yield* Stream.decodeText(handle.stdout).pipe(
-            Stream.splitLines,
-            Stream.filter((line) => line.length > 0),
-            Stream.mapEffect(input.parse),
-            Stream.filter((row): row is A => row !== undefined),
-            Stream.tap((row) => {
-              if (!input.onItem || observed++ >= input.limit) return Effect.void
-              return input.onItem(row)
-            }),
-            take, // kilocode_change
-            Stream.runCollect,
-            Effect.map((chunk) => [...chunk]),
-          )
-          if (stopped) return { items: rows, truncated: true, partial: false } // kilocode_change
-          const truncated = input.stop ? false : rows.length > input.limit // kilocode_change - custom stop owns truncation
-          if (truncated) return { items: rows.slice(0, input.limit), truncated, partial: false }
+          const search = Effect.gen(function* () {
+            // kilocode_change end
+            const stderrFiber = yield* collectStream(handle.stderr, ERROR_BYTES).pipe(
+              Effect.map((output) => output.buffer.toString("utf8")),
+              Effect.forkScoped,
+            )
+            let observed = 0
+            let stopped = false // kilocode_change
+            const take = input.stop // kilocode_change start
+              ? Stream.takeUntil<A>((row) => {
+                  stopped = input.stop?.(row) ?? false
+                  return stopped
+                })
+              : Stream.take(input.limit + 1) // kilocode_change end
+            const rows = yield* Stream.decodeText(handle.stdout).pipe(
+              Stream.splitLines,
+              Stream.filter((line) => line.length > 0),
+              Stream.mapEffect(input.parse),
+              Stream.filter((row): row is A => row !== undefined),
+              Stream.tap((row) => {
+                if (!input.onItem || observed++ >= input.limit) return Effect.void
+                return input.onItem(row)
+              }),
+              take, // kilocode_change
+              Stream.runCollect,
+              Effect.map((chunk) => [...chunk]),
+            )
+            if (stopped) return { items: rows, truncated: true, partial: false } // kilocode_change
+            const truncated = input.stop ? false : rows.length > input.limit // kilocode_change - custom stop owns truncation
+            if (truncated) return { items: rows.slice(0, input.limit), truncated, partial: false }
 
-          const code = yield* handle.exitCode
-          const stderr = yield* Fiber.join(stderrFiber)
-          if (input.pattern && code === 2 && isInvalidPattern(stderr)) {
-            return yield* new InvalidPatternError({ pattern: input.pattern, message: stderr.trim() })
-          }
-          if (code !== 0 && code !== 1 && code !== 2) {
-            return yield* failure(stderr.trim() || `ripgrep failed with code ${code}`)
-          }
-          return { items: code === 1 ? [] : rows, truncated: false, partial: code === 2 }
+            const code = yield* handle.exitCode
+            const stderr = yield* Fiber.join(stderrFiber)
+            if (input.pattern && code === 2 && isInvalidPattern(stderr)) {
+              return yield* new InvalidPatternError({ pattern: input.pattern, message: stderr.trim() })
+            }
+            if (code !== 0 && code !== 1 && code !== 2) {
+              return yield* failure(stderr.trim() || `ripgrep failed with code ${code}`)
+            }
+            return { items: code === 1 ? [] : rows, truncated: false, partial: code === 2 }
+            // kilocode_change start
+          })
+          return yield* input.timeout == null
+            ? search
+            : search.pipe(
+                Effect.timeoutOrElse({
+                  duration: input.timeout,
+                  orElse: () =>
+                    Effect.fail(failure("Glob search timed out after 2 minutes. Narrow the search path or pattern.")),
+                }),
+              )
+          // kilocode_change end
         }),
       )
       const abortable = input.signal ? program.pipe(Effect.raceFirst(waitForAbort(input.signal))) : program
@@ -192,6 +206,7 @@ const layer = Layer.effect(
           cwd: input.cwd,
           limit: input.limit,
           signal: input.signal,
+          timeout: 2 * 60 * 1000, // kilocode_change
           validate: input.validate, // kilocode_change - preserve spawn-bound target validation
           args: [
             "--no-config",

--- a/packages/core/test/kilocode/ripgrep-settlement.test.ts
+++ b/packages/core/test/kilocode/ripgrep-settlement.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect } from "bun:test"
 import fs from "node:fs/promises"
 import path from "node:path"
-import { Effect, Fiber, Layer } from "effect"
+import { Cause, Deferred, Effect, Fiber, Layer } from "effect"
+import * as TestClock from "effect/testing/TestClock"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { RipgrepBinary } from "@opencode-ai/core/ripgrep/binary"
+import { RelativePath } from "@opencode-ai/core/schema"
 import { tmpdir } from "../fixture/tmpdir"
 import { it } from "../lib/effect"
 
@@ -72,15 +74,96 @@ const fixture = async (dir: string, source: string) => {
   return binary
 }
 
-const layer = (binary: string) =>
+const layer = (binary: string, filepath = Effect.succeed(binary)) =>
   LayerNode.compile(Ripgrep.node, [
-    [
-      RipgrepBinary.node,
-      Layer.succeed(RipgrepBinary.Service, RipgrepBinary.Service.of({ filepath: Effect.succeed(binary) })),
-    ],
+    [RipgrepBinary.node, Layer.succeed(RipgrepBinary.Service, RipgrepBinary.Service.of({ filepath }))],
   ] as const)
 
 describe("Kilo ripgrep settlement", () => {
+  it.effect(
+    "starts the glob deadline after cached binary initialization",
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          const binary = yield* Effect.promise(() => fixture(tmp.path, 'process.stdout.write("fixture.ts\\n")'))
+          const started = yield* Deferred.make<void>()
+          const release = yield* Deferred.make<void>()
+          const state = { initialized: 0 }
+          const filepath = yield* Effect.cached(
+            Effect.gen(function* () {
+              state.initialized++
+              yield* Deferred.succeed(started, undefined)
+              yield* Deferred.await(release)
+              return binary
+            }),
+          )
+
+          yield* Effect.gen(function* () {
+            const ripgrep = yield* Ripgrep.Service
+            const first = yield* ripgrep.glob({ cwd: tmp.path, pattern: "*.ts", limit: 100 }).pipe(Effect.forkScoped)
+            yield* Deferred.await(started)
+            yield* TestClock.adjust(120_001)
+            expect(first.pollUnsafe()).toBeUndefined()
+            yield* Deferred.succeed(release, undefined)
+
+            const result = yield* Fiber.join(first)
+            const retry = yield* ripgrep.glob({ cwd: tmp.path, pattern: "*.ts", limit: 100 })
+            expect(result.items.map((item) => item.path)).toEqual([RelativePath.make("fixture.ts")])
+            expect(retry.items).toEqual(result.items)
+            expect(state.initialized).toBe(1)
+          }).pipe(Effect.provide(layer(binary, filepath)))
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+    10_000,
+  )
+
+  it.effect(
+    "times out a glob after two minutes despite partial matches and continuous errors",
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          const ready = path.join(tmp.path, "ready.pid")
+          const source = `const { writeFileSync, writeSync } = require("node:fs")
+const error = "readdir: Invalid argument\\n".repeat(512)
+writeSync(1, "partial.ts\\n")
+writeSync(2, error)
+writeFileSync(${JSON.stringify(ready)}, String(process.pid))
+setInterval(() => writeSync(2, error), 10)
+setTimeout(() => process.exit(1), 30_000)
+`
+          const binary = yield* Effect.promise(() => fixture(tmp.path, source))
+          const fiber = yield* Ripgrep.Service.pipe(
+            Effect.flatMap((ripgrep) => ripgrep.glob({ cwd: tmp.path, pattern: "*.ts", limit: 100 })),
+            Effect.provide(layer(binary)),
+            Effect.exit,
+            Effect.forkScoped,
+          )
+          const pid = Number(yield* Effect.promise(() => read(ready)))
+
+          yield* TestClock.adjust(119_999)
+          expect(fiber.pollUnsafe()).toBeUndefined()
+          expect(alive(pid)).toBe(true)
+          yield* TestClock.adjust(1)
+          const exit = yield* Fiber.join(fiber)
+
+          if (exit._tag !== "Failure") throw new Error("Glob unexpectedly completed")
+          expect(Cause.prettyErrors(exit.cause).map((err) => err.message)).toContain(
+            "Glob search timed out after 2 minutes. Narrow the search path or pattern.",
+          )
+          expect(alive(pid)).toBe(false)
+        }),
+      (tmp) =>
+        Effect.promise(async () => {
+          await cleanup(path.join(tmp.path, "ready.pid"))
+          await tmp[Symbol.asyncDispose]()
+        }),
+    ),
+    10_000,
+  )
+
   it.live(
     "settles a bounded parameterized grep when inherited output stays open",
     Effect.acquireUseRelease(
@@ -167,8 +250,53 @@ writeSync(1, ${JSON.stringify(output)})
     10_000,
   )
 
+  for (const tool of ["glob", "grep"] as const) {
+    it.live(
+      `force kills a ${tool} that does not exit after cancellation`,
+      Effect.acquireUseRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) =>
+          Effect.gen(function* () {
+            const ready = path.join(tmp.path, "ready.pid")
+            const source = `const { writeFileSync } = require("node:fs")
+if (process.platform !== "win32") process.on("SIGTERM", () => {})
+writeFileSync(${JSON.stringify(ready)}, String(process.pid))
+setInterval(() => {}, 10_000)
+setTimeout(() => process.exit(1), 30_000)
+`
+            const binary = yield* Effect.promise(() => fixture(tmp.path, source))
+
+            const controller = new AbortController()
+            const fiber = yield* Ripgrep.Service.pipe(
+              Effect.flatMap((ripgrep) => {
+                const input = { cwd: tmp.path, pattern: "needle", limit: 1, signal: controller.signal }
+                return tool === "glob"
+                  ? ripgrep.glob(input).pipe(Effect.asVoid)
+                  : ripgrep.grep({ ...input, context: 1 }).pipe(Effect.asVoid)
+              }),
+              Effect.provide(layer(binary)),
+              Effect.exit,
+              Effect.forkScoped,
+            )
+            const pid = Number(yield* Effect.promise(() => read(ready)))
+            controller.abort()
+            const exit = yield* Fiber.join(fiber).pipe(Effect.timeout("5 seconds"))
+
+            expect(exit._tag).toBe("Failure")
+            expect(alive(pid)).toBe(false)
+          }),
+        (tmp) =>
+          Effect.promise(async () => {
+            await cleanup(path.join(tmp.path, "ready.pid"))
+            await tmp[Symbol.asyncDispose]()
+          }),
+      ),
+      10_000,
+    )
+  }
+
   it.live(
-    "force kills a bounded grep that does not exit after cancellation",
+    "force kills a glob when its fiber is interrupted",
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),
       (tmp) =>
@@ -178,23 +306,17 @@ writeSync(1, ${JSON.stringify(output)})
 if (process.platform !== "win32") process.on("SIGTERM", () => {})
 writeFileSync(${JSON.stringify(ready)}, String(process.pid))
 setInterval(() => {}, 10_000)
+setTimeout(() => process.exit(1), 30_000)
 `
           const binary = yield* Effect.promise(() => fixture(tmp.path, source))
-
-          const controller = new AbortController()
           const fiber = yield* Ripgrep.Service.pipe(
-            Effect.flatMap((ripgrep) =>
-              ripgrep.grep({ cwd: tmp.path, pattern: "needle", context: 1, limit: 1, signal: controller.signal }),
-            ),
+            Effect.flatMap((ripgrep) => ripgrep.glob({ cwd: tmp.path, pattern: "*.ts", limit: 100 })),
             Effect.provide(layer(binary)),
-            Effect.exit,
             Effect.forkScoped,
           )
           const pid = Number(yield* Effect.promise(() => read(ready)))
-          controller.abort()
-          const exit = yield* Fiber.join(fiber).pipe(Effect.timeout("5 seconds"))
 
-          expect(exit._tag).toBe("Failure")
+          yield* Fiber.interrupt(fiber).pipe(Effect.timeout("5 seconds"))
           expect(alive(pid)).toBe(false)
         }),
       (tmp) =>


### PR DESCRIPTION
## Issue

No separate issue; this was found while investigating a stalled evaluation.

## Context

The glob result-count cap does not limit runtime. A runaway `rg --files` traversal can therefore hold a tool call open for hours, even when it produces few matches.

## Implementation

Add a two-minute synchronous execution deadline to glob. Expiry returns an explicit timeout error asking for a narrower path or pattern, rather than treating incomplete work as an empty search. Timeout and cancellation use the existing direct-exit settlement and one-second force-kill escalation.

The deadline starts after binary initialization and spawn: Effect caches interrupted initialization, so timing out first-use setup can otherwise break subsequent searches. The cold-start regression protects that boundary. Glob matching rules, public tool arguments, async behavior, and `find` behavior are unchanged.

## Verification

Agent-executed verification:
- Focused core search/process regression suite and CLI glob integration tests.
- Full repository pre-push typechecks, including JetBrains.
- Changed-file lint, formatting, shared-change annotation, and architecture checks.

Reviewers can run `bun test ./test/kilocode/ripgrep-settlement.test.ts --timeout 30000` from `packages/core` to exercise the virtual-clock deadline and real-subprocess cleanup regressions. This is a non-visual change.