### PR TITLE
fix(tui): keep Home/End for text editing instead of list navigation

### DIFF
--- a/.changeset/home-end-prompt-navigation.md
+++ b/.changeset/home-end-prompt-navigation.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix Home and End keys in the CLI so they move the text cursor in the prompt and in panel filter inputs instead of being captured for message or list navigation.

--- a/packages/opencode/src/cli/cmd/run/footer.command.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.command.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @opentui/solid */
 import { TextAttributes, type InputRenderable, type KeyEvent } from "@opentui/core"
-import { useKeyboard, type JSX } from "@opentui/solid"
+import { useKeyboard, useRenderer, type JSX } from "@opentui/solid" // kilocode_change
 import fuzzysort from "fuzzysort"
 import { createEffect, createMemo, createSignal, type Accessor } from "solid-js"
 import { RunFooterMenu, createFooterMenuState, type RunFooterMenuItem } from "./footer.menu"
@@ -138,6 +138,7 @@ function handleKey(input: {
   setQuery: (value: string) => void
   select: () => void
   close: () => void
+  focused: () => boolean // kilocode_change
 }) {
   const name = input.event.name.toLowerCase()
   const ctrl = input.event.ctrl && !input.event.meta && !input.event.shift && !input.event.super
@@ -147,6 +148,16 @@ function handleKey(input: {
     input.close()
     return
   }
+
+  // kilocode_change start - keep Home/End text editing while the filter field
+  // holds text; they only jump the list while the filter is empty or unfocused
+  if (name === "home" || name === "end") {
+    const field = input.field()
+    if (field && !field.isDestroyed && field.plainText.length > 0 && input.focused()) {
+      return
+    }
+  }
+  // kilocode_change end
 
   // kilocode_change start - treat ctrl+p as the up binding
   if (up(input.event)) {
@@ -360,6 +371,7 @@ export function RunCommandMenuBody(props: {
   onExit: () => void
 }) {
   let field: InputRenderable | undefined
+  const renderer = useRenderer() // kilocode_change
   const [query, setQuery] = createSignal("")
   const skills = createMemo(() => (props.commands() ?? []).filter((item) => item.source === "skill"))
   const activeSubagentCount = createMemo(() => props.subagents().filter((item) => item.status === "running").length)
@@ -544,7 +556,7 @@ export function RunCommandMenuBody(props: {
       return
     }
 
-    handleKey({ event, menu, field: () => field, setQuery, select, close: props.onClose })
+    handleKey({ event, menu, field: () => field, setQuery, select, close: props.onClose, focused: () => renderer.currentFocusedEditor === field }) // kilocode_change
   })
 
   return (
@@ -591,6 +603,7 @@ export function RunSubagentSelectBody(props: {
   onRows?: (rows: number) => void
 }) {
   let field: InputRenderable | undefined
+  const renderer = useRenderer() // kilocode_change
   const [query, setQuery] = createSignal("")
   const entries = createMemo<SubagentEntry[]>(() =>
     props.tabs().map((item) => {
@@ -650,7 +663,7 @@ export function RunSubagentSelectBody(props: {
     }
     // kilocode_change end
 
-    handleKey({ event, menu, field: () => field, setQuery, select, close: props.onClose })
+    handleKey({ event, menu, field: () => field, setQuery, select, close: props.onClose, focused: () => renderer.currentFocusedEditor === field }) // kilocode_change
   })
 
   return (
@@ -695,6 +708,7 @@ export function RunQueuedPromptSelectBody(props: {
   onRows?: (rows: number) => void
 }) {
   let field: InputRenderable | undefined
+  const renderer = useRenderer() // kilocode_change
   const [query, setQuery] = createSignal("")
   const entries = createMemo<QueuedEntry[]>(() =>
     props.prompts().map((prompt) => ({
@@ -747,6 +761,7 @@ export function RunQueuedPromptSelectBody(props: {
         if (item) props.onEdit(item.prompt)
       },
       close: props.onClose,
+      focused: () => renderer.currentFocusedEditor === field, // kilocode_change
     })
   })
 
@@ -790,6 +805,7 @@ export function RunSkillSelectBody(props: {
   onSelect: (name: string) => void
 }) {
   let field: InputRenderable | undefined
+  const renderer = useRenderer() // kilocode_change
   const [query, setQuery] = createSignal("")
   const entries = createMemo<SkillEntry[]>(() =>
     (props.commands() ?? [])
@@ -824,7 +840,7 @@ export function RunSkillSelectBody(props: {
       return
     }
 
-    handleKey({ event, menu, field: () => field, setQuery, select, close: props.onClose })
+    handleKey({ event, menu, field: () => field, setQuery, select, close: props.onClose, focused: () => renderer.currentFocusedEditor === field }) // kilocode_change
   })
 
   return (
@@ -868,6 +884,7 @@ export function RunVariantSelectBody(props: {
   onSelect: (variant: string | undefined) => void
 }) {
   let field: InputRenderable | undefined
+  const renderer = useRenderer() // kilocode_change
   const [query, setQuery] = createSignal("")
   const entries = createMemo<VariantEntry[]>(() => [
     {
@@ -922,7 +939,7 @@ export function RunVariantSelectBody(props: {
       return
     }
 
-    handleKey({ event, menu, field: () => field, setQuery, select, close: props.onClose })
+    handleKey({ event, menu, field: () => field, setQuery, select, close: props.onClose, focused: () => renderer.currentFocusedEditor === field }) // kilocode_change
   })
 
   return (
@@ -966,6 +983,7 @@ export function RunModelSelectBody(props: {
   onSelect: (model: NonNullable<RunInput["model"]>) => void
 }) {
   let field: InputRenderable | undefined
+  const renderer = useRenderer() // kilocode_change
   const [query, setQuery] = createSignal("")
   const entries = createMemo<ModelEntry[]>(() =>
     (props.providers() ?? [])
@@ -1043,7 +1061,7 @@ export function RunModelSelectBody(props: {
       return
     }
 
-    handleKey({ event, menu, field: () => field, setQuery, select, close: props.onClose })
+    handleKey({ event, menu, field: () => field, setQuery, select, close: props.onClose, focused: () => renderer.currentFocusedEditor === field }) // kilocode_change
   })
 
   return (

--- a/packages/opencode/test/cli/run/footer.command.test.tsx
+++ b/packages/opencode/test/cli/run/footer.command.test.tsx
@@ -1,0 +1,126 @@
+// kilocode_change - new file
+/** @jsxImportSource @opentui/solid */
+import { expect, test } from "bun:test"
+import { BoxRenderable, InputRenderable } from "@opentui/core"
+import { extend, testRender, useRenderer } from "@opentui/solid"
+import { createSignal, type Signal } from "solid-js"
+import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
+import { OpencodeKeymapProvider, registerOpencodeKeymap } from "@opencode-ai/tui/keymap"
+import { RunCommandMenuBody } from "@/cli/cmd/run/footer.command"
+import { RUN_THEME_FALLBACK, type RunFooterTheme } from "@/cli/cmd/run/theme"
+import type { RunCommand } from "@/cli/cmd/run/types"
+import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
+
+extend({ spinner: BoxRenderable })
+
+const tuiConfig = createTuiResolvedConfig()
+
+function cmd(name: string): RunCommand {
+  return { name, description: name, source: "command", template: "", hints: [] }
+}
+
+async function mountMenu(input: {
+  onCommand?: (name: string) => void
+  onEditor?: () => void
+  onExit?: () => void
+}) {
+  let offKeymap: (() => void) | undefined
+  let field: InputRenderable | undefined
+  const theme: Signal<RunFooterTheme> = createSignal(RUN_THEME_FALLBACK.footer)
+  const commandEvents: string[] = []
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    offKeymap = registerOpencodeKeymap(keymap, renderer, tuiConfig)
+    const [commands] = createSignal<RunCommand[]>([cmd("practice"), cmd("prep"), cmd("lint"), cmd("build")])
+
+    return (
+      <OpencodeKeymapProvider keymap={keymap}>
+        <RunCommandMenuBody
+          theme={theme[0]}
+          commands={commands}
+          subagents={() => []}
+          queued={() => []}
+          variants={() => []}
+          variantCycle=""
+          onClose={() => {}}
+          onModel={() => {}}
+          onEditor={input.onEditor ?? (() => commandEvents.push("editor"))}
+          onSkill={() => {}}
+          onSubagent={() => {}}
+          onQueued={() => {}}
+          onVariant={() => {}}
+          onVariantCycle={() => {}}
+          onCommand={(name) => {
+            commandEvents.push(name)
+            input.onCommand?.(name)
+          }}
+          onNew={() => {}}
+          onExit={input.onExit ?? (() => commandEvents.push("exit"))}
+        />
+      </OpencodeKeymapProvider>
+    )
+  }
+
+  const app = await testRender(() => <Harness />, { width: 80, height: 14, kittyKeyboard: true })
+
+  return {
+    app,
+    get field() {
+      return app.renderer.currentFocusedEditor as InputRenderable
+    },
+    commandEvents,
+    cleanup() {
+      app.renderer.currentFocusedRenderable?.blur()
+      app.renderer.currentFocusedEditor?.blur()
+      offKeymap?.()
+      app.renderer.destroy()
+    },
+  }
+}
+
+test("home/end move the cursor while the run panel filter holds text", async () => {
+  const menu = await mountMenu({})
+  try {
+    const field = menu.field
+    expect(menu.app.renderer.currentFocusedEditor instanceof InputRenderable).toBe(true)
+    expect(field.plainText).toBe("")
+
+    await menu.app.mockInput.typeText("li", 0)
+    expect(field.plainText).toBe("li")
+
+    menu.app.mockInput.pressKey("END")
+    expect(field.cursorOffset).toBe(2)
+
+    menu.app.mockInput.pressKey("HOME")
+    expect(field.cursorOffset).toBe(0)
+  } finally {
+    menu.cleanup()
+  }
+})
+
+test("home/end still jump the run panel list while the filter is empty", async () => {
+  const onEditor: string[] = []
+  const onExit: string[] = []
+  const menu = await mountMenu({
+    onEditor: () => onEditor.push("ed"),
+    onExit: () => onExit.push("ex"),
+  })
+  try {
+    const field = menu.field
+    expect(field.plainText).toBe("")
+
+    // END jumps to the last entry (Exit); Enter picks it.
+    menu.app.mockInput.pressKey("END")
+    menu.app.mockInput.pressEnter()
+    expect(onExit).toEqual(["ex"])
+
+    // HOME jumps back to the first entry (Open editor); Enter picks it.
+    menu.app.mockInput.pressKey("HOME")
+    menu.app.mockInput.pressEnter()
+    expect(onEditor).toEqual(["ed"])
+  } finally {
+    menu.cleanup()
+  }
+})

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -129,7 +129,7 @@ function goUpsellKeys(action: RetryAction) {
   }
 }
 
-const sessionBindingCommands = [
+export const sessionBindingCommands = [ // kilocode_change
   "session.share",
   "session.rename",
   "session.timeline",
@@ -145,8 +145,7 @@ const sessionBindingCommands = [
   "session.toggle.actions",
   "session.toggle.scrollbar",
   "session.toggle.generic_tool_output",
-  "session.first",
-  "session.last",
+  // kilocode_change - session.first/last stay gated to the unfocused layer so home/end are not stolen from a focused prompt textarea
   "session.messages_last_user",
   "session.message.next",
   "session.message.previous",
@@ -172,7 +171,7 @@ const sessionGlobalBindingCommands = [
   "session.half.page.down",
 ] as const
 
-const sessionGlobalUnfocusedBindingCommands = ["session.first", "session.last"] as const
+export const sessionGlobalUnfocusedBindingCommands = ["session.first", "session.last"] as const // kilocode_change
 
 const context = createContext<{
   width: number

--- a/packages/tui/test/prompt-home-end.test.tsx
+++ b/packages/tui/test/prompt-home-end.test.tsx
@@ -1,0 +1,142 @@
+// kilocode_change - new file
+/** @jsxImportSource @opentui/solid */
+import { TextareaRenderable } from "@opentui/core"
+import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
+import { testRender, useRenderer } from "@opentui/solid"
+import { expect, test } from "bun:test"
+import { onCleanup } from "solid-js"
+import { createTuiResolvedConfig } from "./fixture/tui-runtime"
+import {
+  KILO_BASE_MODE,
+  OpencodeKeymapProvider,
+  registerOpencodeKeymap,
+  useBindings,
+} from "../src/keymap"
+import { sessionBindingCommands, sessionGlobalUnfocusedBindingCommands } from "../src/routes/session"
+
+async function wait(fn: () => boolean, timeout = 5000) {
+  const start = Date.now()
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
+    await Bun.sleep(10)
+  }
+}
+
+function mount(input: {
+  extraBaseBindings?: ReturnType<ReturnType<typeof createTuiResolvedConfig>["keybinds"]["gather"]>
+  firsts: number[]
+  lasts?: number[]
+}) {
+  let area: TextareaRenderable | undefined
+  let offKeymap: (() => void) | undefined
+
+  function Layers() {
+    const renderer = useRenderer()
+    const config = createTuiResolvedConfig()
+    useBindings(() => ({
+      commands: [
+        { name: "session.first", title: "First message", run: () => void input.firsts.push(1) },
+        { name: "session.last", title: "Last message", run: () => void input.lasts?.push(1) },
+      ],
+    }))
+    useBindings(() => ({
+      mode: KILO_BASE_MODE,
+      bindings: config.keybinds.gather("session", sessionBindingCommands),
+    }))
+    if (input.extraBaseBindings) {
+      useBindings(() => ({
+        mode: KILO_BASE_MODE,
+        bindings: input.extraBaseBindings,
+      }))
+    }
+    useBindings(() => ({
+      enabled: () => renderer.currentFocusedEditor === null,
+      bindings: config.keybinds.gather("session.global.unfocused", sessionGlobalUnfocusedBindingCommands),
+    }))
+    return null
+  }
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const config = createTuiResolvedConfig()
+    offKeymap = registerOpencodeKeymap(keymap, renderer, config)
+
+    return (
+      <OpencodeKeymapProvider keymap={keymap}>
+        <Layers />
+        <textarea
+          width={60}
+          ref={(r: TextareaRenderable) => {
+            area = r
+            queueMicrotask(() => r.focus())
+          }}
+        />
+      </OpencodeKeymapProvider>
+    )
+  }
+
+  return testRender(() => <Harness />, { width: 80, height: 10, kittyKeyboard: true }).then((app) => ({
+    app,
+    get area() {
+      return area
+    },
+    cleanup() {
+      app.renderer.currentFocusedRenderable?.blur()
+      app.renderer.currentFocusedEditor?.blur()
+      offKeymap?.()
+      app.renderer.destroy()
+    },
+  }))
+}
+
+test("home/end move the prompt cursor while session first/last stay gated to unfocused", async () => {
+  const firsts: number[] = []
+  const lasts: number[] = []
+  const mountResult = await mount({ firsts, lasts })
+
+  try {
+    await wait(() => mountResult.app.renderer.currentFocusedEditor instanceof TextareaRenderable)
+    const editor = mountResult.area!
+    await mountResult.app.mockInput.typeText("hello world", 0)
+    expect(editor.plainText).toBe("hello world")
+    expect(editor.cursorOffset).toBe(11)
+
+    mountResult.app.mockInput.pressKey("HOME")
+    expect(editor.cursorOffset).toBe(0)
+    expect(firsts).toEqual([])
+
+    mountResult.app.mockInput.pressKey("END")
+    expect(editor.cursorOffset).toBe(11)
+    expect(lasts).toEqual([])
+
+    // Unfocus: home/end navigate to first/last message again.
+    editor.blur()
+    mountResult.app.mockInput.pressKey("HOME")
+    mountResult.app.mockInput.pressKey("END")
+    expect(firsts).toEqual([1])
+    expect(lasts).toEqual([1])
+  } finally {
+    mountResult.cleanup()
+  }
+})
+
+test("home/end bound in the always-on session layer are stolen from the prompt", async () => {
+  const config = createTuiResolvedConfig()
+  const extraBaseBindings = config.keybinds.gather("session", ["session.first"])
+  const firsts: number[] = []
+  const mountResult = await mount({ firsts, extraBaseBindings })
+
+  try {
+    await wait(() => mountResult.app.renderer.currentFocusedEditor instanceof TextareaRenderable)
+    const editor = mountResult.area!
+    await mountResult.app.mockInput.typeText("hello world", 0)
+    expect(editor.cursorOffset).toBe(11)
+
+    mountResult.app.mockInput.pressKey("HOME")
+    expect(firsts).toEqual([1])
+    expect(editor.cursorOffset).toBe(11)
+  } finally {
+    mountResult.cleanup()
+  }
+})


### PR DESCRIPTION
Fixes #13717 and completes the same class of bug addressed by #13722 for the dialog filter inputs.

## Problem

Home and End did not move the text cursor in the CLI prompt. The legacy session route bound `session.first`/`session.last` to `home`/`end` in the always-on base key layer, so the focused prompt textarea never received the keys (arrow keys still worked). The same class of bug affected the direct-mode panel filter inputs (command, model, skill, variant, subagent, queued): Home/End jumped the item list even while typing in the filter.

## Change

- `packages/tui/src/routes/session/index.tsx`: remove `session.first`/`session.last` from the always-on session binding layer. They stay registered in the existing unfocused-gated layer, so Home/End still jump to the first/last message when no editor is focused, and the prompt textarea gets them while typing.
- `packages/opencode/src/cli/cmd/run/footer.command.tsx`: in the run-mode selection panels, treat Home/End as list jumps only while the filter field is empty or unfocused; while the filter holds text, the focused input moves the cursor.

## Verification

- New test `packages/tui/test/prompt-home-end.test.tsx`: with the fixed layer wiring, Home/End move the cursor in a focused textarea and still fire `session.first`/`session.last` once it is blurred; also reproduces the pre-fix theft.
- New test `packages/opencode/test/cli/run/footer.command.test.tsx`: Home/End move the cursor while the run panel filter holds text, and still jump the list while it is empty.
- `packages/tui` full test suite: pass (238 pass / 0 fail). `packages/opencode` run suite passes except pre-existing sandbox-environment subprocess failures (no network/model).
- Typecheck passes for both `packages/tui` and `packages/opencode`.
- `bun run script/check-opencode-annotations.ts --worktree` passes.