### PR TITLE
fix(cli): show GPT-6 Astra for ChatGPT OAuth

### DIFF
--- a/.changeset/show-astra-oauth.md
+++ b/.changeset/show-astra-oauth.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Show GPT-6 Astra when OpenAI is connected with ChatGPT OAuth.

--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -402,7 +402,7 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
               if (ALLOWED_MODELS.has(model.api.id)) return true
               if (DISALLOWED_MODELS.has(model.api.id)) return false // kilocode_change
               if (model.api.id === "gpt-5.6") return false
-              const match = model.api.id.match(/^gpt-(\d+\.\d+)/)
+              const match = model.api.id.match(/^gpt-(\d+(?:\.\d+)?)/)
               return match ? parseFloat(match[1]) > 5.4 : false
             })
             .map(([modelID, model]) => [

--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -402,8 +402,11 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
               if (ALLOWED_MODELS.has(model.api.id)) return true
               if (DISALLOWED_MODELS.has(model.api.id)) return false // kilocode_change
               if (model.api.id === "gpt-5.6") return false
-              const match = model.api.id.match(/^gpt-(\d+(?:\.\d+)?)/)
-              return match ? parseFloat(match[1]) > 5.4 : false
+              const match = model.api.id.match(/^gpt-(\d+)(?:\.(\d+))?/)
+              if (!match) return false
+              const major = Number(match[1])
+              const minor = Number(match[2] ?? 0)
+              return major > 5 || (major === 5 && minor > 4)
             })
             .map(([modelID, model]) => [
               modelID,

--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -402,11 +402,13 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
               if (ALLOWED_MODELS.has(model.api.id)) return true
               if (DISALLOWED_MODELS.has(model.api.id)) return false // kilocode_change
               if (model.api.id === "gpt-5.6") return false
+              // kilocode_change start - allow integer GPT major versions until the next upstream sync
               const match = model.api.id.match(/^gpt-(\d+)(?:\.(\d+))?/)
               if (!match) return false
               const major = Number(match[1])
               const minor = Number(match[2] ?? 0)
               return major > 5 || (major === 5 && minor > 4)
+              // kilocode_change end
             })
             .map(([modelID, model]) => [
               modelID,

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -266,6 +266,29 @@ describe("plugin.codex", () => {
     )
   })
 
+  test.each([
+    ["gpt-6-astra", true],
+    ["gpt-6", true],
+    ["gpt-6.0-astra", true],
+    ["gpt-7", true],
+    ["gpt-5", false],
+    ["gpt-4.1", false],
+    ["gpt-5.5-pro", false],
+    ["gpt-5.6", false],
+    ["not-a-gpt-model", false],
+  ])("filters OAuth model %s with integer or decimal versions", async (id, allowed) => {
+    const hooks = await CodexAuthPlugin({} as never)
+    const provider = {
+      models: {
+        [id]: { id, api: { id }, limit: {}, cost: {}, options: {} },
+      },
+    }
+
+    const models = await hooks.provider!.models!(provider as never, { auth: { type: "oauth" } } as never)
+
+    expect(Object.keys(models)).toEqual(allowed ? [id] : [])
+  })
+
   test("deduplicates concurrent Codex token refreshes", async () => {
     let auth = {
       type: "oauth" as const,

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -266,6 +266,7 @@ describe("plugin.codex", () => {
     )
   })
 
+  // kilocode_change start - cover integer GPT major versions until the next upstream sync
   test.each([
     ["gpt-6-astra", true],
     ["gpt-6", true],
@@ -300,6 +301,7 @@ describe("plugin.codex", () => {
 
     expect(Object.keys(models)).toEqual(allowed ? [id] : [])
   })
+  // kilocode_change end
 
   test("deduplicates concurrent Codex token refreshes", async () => {
     let auth = {

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -271,12 +271,24 @@ describe("plugin.codex", () => {
     ["gpt-6", true],
     ["gpt-6.0-astra", true],
     ["gpt-7", true],
+    ["gpt-10", true],
+    ["gpt-5.5-astra", true],
+    ["gpt-5.9", true],
+    ["gpt-5.10", true],
+    ["gpt-5.10-astra", true],
+    ["gpt-5.40", true],
     ["gpt-5", false],
+    ["gpt-5.4-astra", false],
+    ["gpt-5.04-astra", false],
     ["gpt-4.1", false],
+    ["gpt-4.99", false],
     ["gpt-5.5-pro", false],
     ["gpt-5.6", false],
+    ["gpt-6garbage", true],
+    ["gpt-6.", true],
+    ["gpt-6.1.2", true],
     ["not-a-gpt-model", false],
-  ])("filters OAuth model %s with integer or decimal versions", async (id, allowed) => {
+  ])("filters OAuth model %s by GPT major and minor versions", async (id, allowed) => {
     const hooks = await CodexAuthPlugin({} as never)
     const provider = {
       models: {


### PR DESCRIPTION
## Summary

Show `gpt-6-astra` in the direct OpenAI provider when authenticated through ChatGPT OAuth.

## Why

The OAuth model filter required a dotted GPT version, so the integer-major ID `gpt-6-astra` was removed even though it is supported. This imports the reviewed fixes from [OpenCode #47384](https://github.com/anomalyco/opencode/pull/47384) and [OpenCode #47385](https://github.com/anomalyco/opencode/pull/47385), with temporary Kilo annotations until the next upstream sync.

<img width="311" height="390" alt="image" src="https://github.com/user-attachments/assets/b06e449e-499c-4c2f-a182-be4fd2b35b44" />
