### PR TITLE
fix: preserve OpenRouter reasoning-off variants for optional reasoning models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1232,10 +1232,10 @@ export function reasoningVariants(model: ModelsDev.Model, target: Provider.Model
   const toggle = options.some((option) => option.type === "toggle")
   const budget = options.find((option) => option.type === "budget_tokens")
   if (effort) {
-    return nonEmptyVariants({
+    return {
       ...(toggle ? reasoningToggle(target) : {}),
       ...effortVariants(target, effort.values),
-    })
+    }
   }
   if (!budget) return toggle ? nonEmptyVariants(reasoningToggle(target)) : undefined
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1229,10 +1229,14 @@ export function reasoningVariants(model: ModelsDev.Model, target: Provider.Model
   if (options.length === 0) return {}
 
   const effort = options.find((option) => option.type === "effort")
-  if (effort) return effortVariants(target, effort.values)
-
   const toggle = options.some((option) => option.type === "toggle")
   const budget = options.find((option) => option.type === "budget_tokens")
+  if (effort) {
+    return nonEmptyVariants({
+      ...(toggle ? reasoningToggle(target) : {}),
+      ...effortVariants(target, effort.values),
+    })
+  }
   if (!budget) return toggle ? nonEmptyVariants(reasoningToggle(target)) : undefined
 
   return nonEmptyVariants({
@@ -1275,16 +1279,23 @@ function nonEmptyVariants(variants: NonNullable<Provider.Model["variants"]>): Pr
 }
 
 function reasoningToggle(model: Provider.Model): NonNullable<Provider.Model["variants"]> {
+  if (model.api.npm === "@openrouter/ai-sdk-provider")
+    return {
+      none: { reasoning: { enabled: false } },
+    }
+
   if (model.api.npm === "@ai-sdk/alibaba")
     return {
       none: { enableThinking: false },
       high: { enableThinking: true },
     }
+
   if (model.api.npm === "@ai-sdk/cohere")
     return {
       none: { thinking: { type: "disabled" } },
       high: { thinking: { type: "enabled" } },
     }
+
   return {}
 }
 

--- a/packages/opencode/test/kilocode/provider-reasoning-options.test.ts
+++ b/packages/opencode/test/kilocode/provider-reasoning-options.test.ts
@@ -72,6 +72,24 @@ describe("ProviderTransform.reasoningVariants - models.dev reasoning_options", (
     expect(result?.max).toEqual({ reasoning: { effort: "max" } })
   })
 
+  test("toggle plus effort exposes an explicit reasoning-off variant on OpenRouter", () => {
+    const target = mockModel({
+      providerID: "openrouter",
+      api: { id: "deepseek/deepseek-v4-flash-0731", url: "https://openrouter.ai", npm: "@openrouter/ai-sdk-provider" },
+    })
+    const result = ProviderTransform.reasoningVariants(
+      raw([
+        { type: "toggle" },
+        { type: "effort", values: ["low", "high", "max"] },
+      ]),
+      target,
+    )
+    expect(Object.keys(result ?? {})).toEqual(["none", "low", "high", "max"])
+    expect(result?.none).toEqual({ reasoning: { enabled: false } })
+    expect(result?.low).toEqual({ reasoning: { effort: "low" } })
+    expect(result?.max).toEqual({ reasoning: { effort: "max" } })
+  })
+
   test("budget_tokens produces high/max budget variants on bedrock", () => {
     const target = mockModel({
       api: { id: "anthropic.claude-sonnet-4-5", url: "https://bedrock.amazonaws.com", npm: "@ai-sdk/amazon-bedrock" },


### PR DESCRIPTION
## Summary
- preserve the `toggle` reasoning option when an OpenRouter model also exposes effort levels
- add the OpenRouter `none` variant as `{ reasoning: { enabled: false } }`
- add a regression test for `deepseek/deepseek-v4-flash-0731`-style toggle + effort metadata

## Testing
- `bun test packages/opencode/test/kilocode/provider-reasoning-options.test.ts` — 16 passed
- `bun run typecheck` — 30/30 successful

Closes #13807