### PR TITLE
fix(jetbrains): replace internal badge-icon APIs in worktree row icons

### DIFF
--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeIcons.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeIcons.kt
@@ -2,11 +2,10 @@ package ai.kilocode.client.agentManager.worktree
 
 import ai.kilocode.client.session.SessionActivityKind
 import ai.kilocode.client.session.SpinnerIcon
+import ai.kilocode.client.ui.LiveBadgeIcon
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.util.IconLoader
 import com.intellij.ui.AnimatedIcon
-import com.intellij.ui.BadgeDotProvider
-import com.intellij.ui.BadgeIcon
 import com.intellij.util.ui.JBUI
 import java.util.concurrent.ConcurrentHashMap
 import javax.swing.Icon
@@ -29,19 +28,12 @@ internal object WorktreeIcons {
     private val live = ConcurrentHashMap<Icon, Icon>()
 
     /**
-     * [base] wearing the New UI live-run badge: the platform success dot in the top-right corner,
-     * punched through the glyph so it reads over it. This is what `ExecutionUtil.withLiveIndicator`
-     * resolves to on New UI, and the same pairing the Run tool window stripe shows for a live process.
-     *
-     * The dot geometry is spelled out instead of taking [BadgeDotProvider]'s defaults. Those are
-     * fractions of a 20px stripe icon (dot 3.5/20, hole ring 1.5/20) that put the ring past the canvas
-     * edge, and `HoledIcon` sizes itself to the union of glyph and badge — so a 16px base reports ~18px
-     * and the row's icon column would widen for running rows alone. Keeping the platform's dot and ring
-     * size while pulling the center in by the ring width (x/y = 0.75/0.25 against a 0.25 hole radius)
-     * lands the ring flush with the top-right corner and the union back at the base's own 16px.
+     * [base] wearing the New UI live-run badge: a success dot in the top-right corner, punched
+     * through the glyph so it reads over it. See [LiveBadgeIcon] for why it is a Kilo-owned icon
+     * rather than the platform's own `BadgeIcon`/`BadgeDotProvider`.
      */
     fun live(base: Icon): Icon = live.computeIfAbsent(base) {
-        BadgeIcon(it, JBUI.CurrentTheme.IconBadge.SUCCESS, BadgeDotProvider(x = 0.75, y = 0.25, radius = 0.175, border = 0.075))
+        LiveBadgeIcon(it, JBUI.CurrentTheme.IconBadge.SUCCESS)
     }
 
     /** The row glyph for a worktree running a process with nothing else to say about it. */

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/LiveBadgeIcon.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/ui/LiveBadgeIcon.kt
@@ -1,0 +1,83 @@
+package ai.kilocode.client.ui
+
+import java.awt.Component
+import java.awt.Graphics
+import java.awt.Graphics2D
+import java.awt.Paint
+import java.awt.Rectangle
+import java.awt.RenderingHints
+import java.awt.geom.Ellipse2D
+import java.awt.geom.Path2D
+import javax.swing.Icon
+
+/**
+ * [icon] wearing a small colored dot in the top-right corner — the live-run pairing
+ * `ExecutionUtil.withLiveIndicator` and the Run tool window stripe show for a live process on New UI.
+ *
+ * Reimplemented instead of using `com.intellij.ui.BadgeIcon`/`BadgeDotProvider` because both (and
+ * their `HoledIcon` base) are `@ApiStatus.Internal` on the platform version this plugin targets —
+ * they were only promoted to stable in a later platform release.
+ *
+ * The platform's own default dot geometry is tuned for a 20px stripe icon (dot radius 3.5/20, border
+ * 1.5/20) and pushes the badge past a 16px base's edge; the platform's `HoledIcon` sizes itself to
+ * the union of glyph and badge, so a 16px base would report ~18px and widen a row's icon column for
+ * running rows alone. [X]/[Y] pull the badge center in by the border width so it lands flush with the
+ * top-right corner instead, and [getIconWidth]/[getIconHeight] report the base icon's own size rather
+ * than a union, so the badge never grows the icon.
+ */
+internal class LiveBadgeIcon(val icon: Icon, val paint: Paint) : Icon {
+    override fun getIconWidth(): Int = icon.iconWidth
+
+    override fun getIconHeight(): Int = icon.iconHeight
+
+    /**
+     * The badge's clip-out area, including its border margin, in a [size]x[size] canvas. This is the
+     * shape that has to stay inside the canvas for the badge to keep the base icon's own reported
+     * size — see the class doc for why the fractions are pulled in from the platform's own geometry.
+     */
+    fun holeBounds(size: Int): Ellipse2D = circle(size, HOLE_RADIUS)
+
+    override fun paintIcon(c: Component?, g: Graphics, x: Int, y: Int) {
+        val size = minOf(iconWidth, iconHeight)
+        val hole = holeBounds(size)
+
+        // The base glyph, clipped to exclude the badge (plus its border margin) entirely, so the
+        // glyph's own pixels never touch the badge color.
+        val base = g.create() as Graphics2D
+        try {
+            base.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+            base.translate(x, y)
+            val outside = Path2D.Double(Path2D.WIND_EVEN_ODD)
+            outside.append(base.clip ?: Rectangle(0, 0, iconWidth, iconHeight), false)
+            outside.append(hole, false)
+            base.clip = outside
+            icon.paintIcon(c, base, 0, 0)
+        } finally {
+            base.dispose()
+        }
+
+        // The badge dot itself, smaller than the hole so the border margin above shows through as a
+        // transparent ring separating it from the glyph.
+        val dot = g.create() as Graphics2D
+        try {
+            dot.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+            dot.translate(x, y)
+            dot.paint = paint
+            dot.fill(circle(size, DOT_RADIUS))
+        } finally {
+            dot.dispose()
+        }
+    }
+
+    private fun circle(size: Int, radius: Double): Ellipse2D {
+        val r = size * radius
+        return Ellipse2D.Double(size * X - r, size * Y - r, r * 2, r * 2)
+    }
+
+    private companion object {
+        const val X = 0.75
+        const val Y = 0.25
+        const val DOT_RADIUS = 0.175
+        const val HOLE_RADIUS = DOT_RADIUS + 0.075
+    }
+}

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/WorktreeIconsTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/WorktreeIconsTest.kt
@@ -3,15 +3,17 @@ package ai.kilocode.client.agentManager
 import ai.kilocode.client.agentManager.worktree.WorktreeIcons
 import ai.kilocode.client.session.SessionActivityKind
 import ai.kilocode.client.session.SpinnerIcon
+import ai.kilocode.client.ui.LiveBadgeIcon
 import ai.kilocode.client.ui.PrIcons
 import ai.kilocode.client.ui.UiStyle
 import com.intellij.icons.AllIcons
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.ui.AnimatedIcon
-import com.intellij.ui.BadgeIcon
 import com.intellij.ui.ColorUtil
 import com.intellij.util.ui.JBUI
 import java.awt.Color
+import java.awt.image.BufferedImage
+import javax.swing.Icon
 
 class WorktreeIconsTest : BasePlatformTestCase() {
     fun `test running session resolves to the animated spinner`() {
@@ -125,7 +127,7 @@ class WorktreeIconsTest : BasePlatformTestCase() {
             val plain = WorktreeIcons.forRow(busy = false, kind = kind)
             val badged = WorktreeIcons.forRow(busy = false, kind = kind, running = true)
             assertSame("$kind lost its glyph to the run indicator", WorktreeIcons.live(plain), badged)
-            assertSame("$kind should keep the same glyph underneath", plain, (badged as BadgeIcon).icon)
+            assertSame("$kind should keep the same glyph underneath", plain, (badged as LiveBadgeIcon).icon)
         }
     }
 
@@ -161,29 +163,71 @@ class WorktreeIconsTest : BasePlatformTestCase() {
     }
 
     /**
-     * The badge is a hole punched through the glyph, and HoledIcon sizes itself to the union of the two.
-     * Default dot fractions are tuned for a 20px stripe icon and overhang a 16px base, which would widen
-     * the row's icon column for running rows only, so the dot is pulled inside the canvas on purpose.
+     * The badge is a hole punched through the glyph, and [LiveBadgeIcon] reports the base icon's own
+     * size rather than a union with the hole. Default platform dot fractions are tuned for a 20px
+     * stripe icon and overhang a 16px base, which would widen the row's icon column for running rows
+     * only, so the dot is pulled inside the canvas on purpose.
      */
     fun `test the live-run indicator fits the row icon slot`() {
         assertEquals(WorktreeIcons.branch.iconWidth, WorktreeIcons.runIndicator.iconWidth)
         assertEquals(WorktreeIcons.branch.iconHeight, WorktreeIcons.runIndicator.iconHeight)
         // The badge must not silently swallow the glyph either: it wraps the platform run triangle.
-        assertSame(AllIcons.Toolwindows.ToolWindowRun, (WorktreeIcons.runIndicator as BadgeIcon).icon)
+        assertSame(AllIcons.Toolwindows.ToolWindowRun, (WorktreeIcons.runIndicator as LiveBadgeIcon).icon)
     }
 
     fun `test the live-run indicator wears the success badge in the top-right corner`() {
-        val badge = WorktreeIcons.runIndicator as BadgeIcon
+        val badge = WorktreeIcons.runIndicator as LiveBadgeIcon
         assertEquals(JBUI.CurrentTheme.IconBadge.SUCCESS, badge.paint)
 
-        // The hole is what HoledIcon unions into the icon size, so it is the shape that has to stay
-        // inside the canvas for the row's icon column to keep its width.
+        // The hole is what has to stay inside the canvas for the row's icon column to keep its width.
         val size = WorktreeIcons.branch.iconWidth
-        val hole = badge.provider.createShape(size, size, true)!!.bounds2D
+        val hole = badge.holeBounds(size).bounds2D
         assertTrue("badge overhangs the right edge: $hole in $size", hole.maxX <= size)
         assertTrue("badge overhangs the top edge: $hole", hole.minY >= 0)
         // Top-right, not centered or bottom-right like the pre-New UI indicator.
         assertTrue("badge is not in the right half: $hole", hole.centerX > size / 2)
         assertTrue("badge is not in the top half: $hole", hole.centerY < size / 2)
+    }
+
+    /**
+     * Platform icons resolve to a no-op `DummyIconImpl` under `BasePlatformTestCase`, so a real glyph
+     * (e.g. [AllIcons.Toolwindows.ToolWindowRun]) paints nothing here — this uses an opaque fake icon
+     * instead to check [LiveBadgeIcon]'s own painting deterministically.
+     */
+    private class FakeIcon(private val size: Int, private val color: Color) : Icon {
+        override fun getIconWidth() = size
+
+        override fun getIconHeight() = size
+
+        override fun paintIcon(c: java.awt.Component?, g: java.awt.Graphics, x: Int, y: Int) {
+            g.color = color
+            g.fillRect(x, y, size, size)
+        }
+    }
+
+    fun `test the live-run indicator paints the base glyph and a success dot`() {
+        val size = WorktreeIcons.branch.iconWidth
+        val glyphColor = Color.BLUE
+        val badge = LiveBadgeIcon(FakeIcon(size, glyphColor), JBUI.CurrentTheme.IconBadge.SUCCESS)
+        val image = BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB)
+        val g = image.createGraphics()
+        try {
+            badge.paintIcon(null, g, 0, 0)
+        } finally {
+            g.dispose()
+        }
+
+        // Outside the badge, the fake glyph's own color painted through untouched.
+        assertEquals(glyphColor.rgb and 0xFFFFFF, image.getRGB(0, 0) and 0xFFFFFF)
+
+        // The dot's own center pixel is opaque and carries the success color, not the glyph's — the
+        // exact hole/canvas geometry is covered separately in the corner-placement test above, since
+        // AWT's clip rasterization and `Ellipse2D.contains` sampling disagree at the boundary itself.
+        val successRgb = (badge.paint as Color).rgb
+        val centerX = (size * 0.75).toInt()
+        val centerY = (size * 0.25).toInt()
+        val centerRgb = image.getRGB(centerX, centerY)
+        assertEquals("badge center should be opaque", 0xFF, (centerRgb ushr 24) and 0xFF)
+        assertEquals(successRgb and 0xFFFFFF, centerRgb and 0xFFFFFF)
     }
 }


### PR DESCRIPTION
## Summary

`verifyPlugin` failed the `7.1.6-rc.1` publish run ([run](https://github.com/Kilo-Org/kilocode/actions/runs/34006382783)) with:

```
Verification failed with [INTERNAL_API_USAGES] problems.
```

All 5 usages came from `WorktreeIcons.live()` (introduced in #13712): `com.intellij.ui.BadgeIcon`, `BadgeDotProvider`, and `BadgeShapeProvider` are `@ApiStatus.Internal` on the platform version this plugin targets (`IU-261`) — they were only promoted to stable in a later platform release (confirmed against `$INTELLIJ_REPO`, commit `99a9aeacba02` "Promote BadgeIcon to stable").

Nothing was published; the run failed before the Marketplace/GitHub Release steps.

## Why not just use the public `withIconBadge`/`withLiveIndicator`?

Both delegate to the same internal `BadgeIcon(icon, color)` with the platform's *default* dot geometry, which is tuned for a 20px stripe icon. On a 16px base the hole overhangs the edge, and `HoledIcon` reports the icon's size as the union of glyph + hole — so a 16px base would report ~18px and widen the worktree row's icon column for running rows only. That's exactly what the existing custom geometry (`x=0.75, y=0.25, radius=0.175, border=0.075`) was written to avoid, and what two existing tests assert against.

## Fix

Added `LiveBadgeIcon` (`ui/LiveBadgeIcon.kt`) — a Kilo-owned `Icon` following the same house pattern as `DotIcon`/`ActivityIcon`/`FilledBadgeIcon`: plain `javax.swing.Icon`, antialiased `Graphics2D` painting, geometry as fractions of the base icon's own size. Reproduces the previous pixels exactly (same fractions, same clip-then-fill approach used by the platform's `HoledIcon`/`BadgeIcon`), with zero internal API usage.

`WorktreeIcons.live()` now returns `LiveBadgeIcon` instead of the platform's `BadgeIcon`. Tests updated to target the new type, plus one new paint test verifying the badge actually renders the base glyph and a success-colored, opaque dot (using a synthetic base icon, since real platform icons resolve to a no-op `DummyIconImpl` under `BasePlatformTestCase`).

## Verification

From `packages/kilo-jetbrains/`:
- `./gradlew typecheck` — pass
- `./gradlew test` — pass (all suites, including 21/21 in `WorktreeIconsTest`)
- `./gradlew verifyPlugin` — **the check that failed publish**: `INTERNAL_API_USAGES` dropped from 5 to **0**; result is now `Compatible`.