### PR TITLE
fix: run the documented permission.ask plugin hook

### DIFF
--- a/.changeset/permission-ask-hook.md
+++ b/.changeset/permission-ask-hook.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Run the documented `permission.ask` plugin hook. It was declared in the plugin API and described in the docs, but never invoked, so plugins registering it were silently ignored. A hook can now allow, ask or deny, and explain a denial — but it cannot cancel a prompt Kilo requires a human to answer.

--- a/packages/core/src/v1/permission.ts
+++ b/packages/core/src/v1/permission.ts
@@ -20,8 +20,14 @@ export class CorrectedError extends Schema.TaggedErrorClass<CorrectedError>()("P
 
 export class DeniedError extends Schema.TaggedErrorClass<DeniedError>()("PermissionDeniedError", {
   ruleset: Schema.Any,
+  // kilocode_change start: set when the denial did not come from a rule the user wrote
+  // — a plugin's `permission.ask` hook, for instance. Without it the model is told the
+  // user authored a rule that does not exist.
+  reason: Schema.optional(Schema.String),
+  // kilocode_change end
 }) {
   override get message() {
+    if (this.reason) return this.reason // kilocode_change
     return `The user has specified a rule which prevents you from using this specific tool call. Here are some of the relevant rules ${JSON.stringify(this.ruleset)}`
   }
 }

--- a/packages/opencode/src/kilocode/permission/agent-manager.ts
+++ b/packages/opencode/src/kilocode/permission/agent-manager.ts
@@ -1,13 +1,15 @@
-import { type Rule } from "./rule"
+import { type HardenedRule, type Rule } from "./rule"
 
 export namespace AgentManagerPermission {
   /**
    * Prompting, stopping, moving, or answering a pending question on an existing Agent Manager session has an
    * external side effect. Broad approvals for legacy session creation must not silently grant it.
    */
-  export function harden(permission: string, pattern: string, rule: Rule): Rule {
-    if (permission !== "agent_manager" || !["prompt", "stop", "move", "answer"].includes(pattern) || rule.action !== "allow") return rule
+  export function harden(permission: string, pattern: string, rule: Rule): HardenedRule {
+    if (permission !== "agent_manager" || !["prompt", "stop", "move", "answer"].includes(pattern)) return rule
     if (rule.permission === "agent_manager" && rule.pattern === pattern) return rule
-    return { permission, pattern, action: "ask" }
+    if (rule.action === "ask") return { ...rule, hardened: true }
+    if (rule.action !== "allow") return rule
+    return { permission, pattern, action: "ask", hardened: true }
   }
 }

--- a/packages/opencode/src/kilocode/permission/provenance.ts
+++ b/packages/opencode/src/kilocode/permission/provenance.ts
@@ -10,7 +10,7 @@ import type { Permission } from "@/permission"
  */
 export namespace PermissionProvenance {
   /** Where the deciding rule came from. */
-  export type Source = "agent" | "global" | "project" | "yolo" | "session" | "manual" | "default"
+  export type Source = "agent" | "global" | "project" | "yolo" | "session" | "manual" | "default" | "plugin"
 
   /** A rule optionally carrying its origin. `source` is runtime-only, never persisted. */
   export type SourcedRule = Permission.Rule & { source?: Source }
@@ -152,7 +152,12 @@ export namespace PermissionProvenance {
     patterns: readonly string[]
     agent: string
     origins: Origins
+    /** Set when a `permission.ask` plugin hook denied the call rather than a rule. */
+    pluginReason?: string
   }): Approval {
+    // A plugin's veto matches no rule the user wrote; naming one would send them
+    // looking through their config for something that is not there.
+    if (input.pluginReason) return { source: "plugin" }
     const candidate = input.ruleset as Partial<Permission.Rule> | undefined
     const rule =
       candidate?.action === "deny" && typeof candidate.pattern === "string"

--- a/packages/opencode/src/kilocode/permission/provenance.ts
+++ b/packages/opencode/src/kilocode/permission/provenance.ts
@@ -155,9 +155,14 @@ export namespace PermissionProvenance {
     /** Set when a `permission.ask` plugin hook denied the call rather than a rule. */
     pluginReason?: string
   }): Approval {
-    // A plugin's veto matches no rule the user wrote; naming one would send them
-    // looking through their config for something that is not there.
-    if (input.pluginReason) return { source: "plugin" }
+    // A plugin's veto matches no rule the user wrote, and `source` says so. The
+    // synthesized rule is still needed: callers read the decision off `rule.action`,
+    // and omitting it renders a refusal as an auto-approval.
+    if (input.pluginReason)
+      return {
+        source: "plugin",
+        rule: { permission: input.permission, pattern: input.patterns[0] ?? "*", action: "deny" },
+      }
     const candidate = input.ruleset as Partial<Permission.Rule> | undefined
     const rule =
       candidate?.action === "deny" && typeof candidate.pattern === "string"

--- a/packages/opencode/src/kilocode/permission/read.ts
+++ b/packages/opencode/src/kilocode/permission/read.ts
@@ -1,5 +1,5 @@
 import { Wildcard } from "@/util/wildcard"
-import { PermissionRule, type Rule } from "@/kilocode/permission/rule"
+import { PermissionRule, type HardenedRule, type Rule } from "@/kilocode/permission/rule"
 
 function guard(pattern: string) {
   if (Wildcard.match(pattern, "*.env.example")) return
@@ -8,12 +8,14 @@ function guard(pattern: string) {
 }
 
 export namespace ReadPermission {
-  export function harden(permission: string, pattern: string, rule: Rule): Rule {
+  export function harden(permission: string, pattern: string, rule: Rule): HardenedRule {
     if (permission !== "read") return rule
-    if (rule.action !== "allow") return rule
     const match = guard(pattern)
     if (!match) return rule
+    // An ask on a secret file is one this service insists on, however it arose.
+    if (rule.action === "ask") return { ...rule, hardened: true }
+    if (rule.action !== "allow") return rule
     if (!PermissionRule.broad(rule)) return rule
-    return { permission, pattern: match, action: "ask" }
+    return { permission, pattern: match, action: "ask", hardened: true }
   }
 }

--- a/packages/opencode/src/kilocode/permission/rule.ts
+++ b/packages/opencode/src/kilocode/permission/rule.ts
@@ -6,7 +6,17 @@ export type Rule = {
 
 export type Ruleset = ReadonlyArray<Rule>
 
+/**
+ * A rule the service downgraded to "ask" by itself. Marked at runtime only, never
+ * persisted: a broad allow rule cannot relax it, and neither can a plugin.
+ */
+export type HardenedRule = Rule & { hardened?: true }
+
 export namespace PermissionRule {
+  export function hardened(rule: Rule) {
+    return (rule as HardenedRule).hardened === true
+  }
+
   export function broad(rule: Rule) {
     return rule.permission === "*" || rule.pattern === "*"
   }

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -372,6 +372,7 @@ export namespace KiloSessionPrompt {
     const outcome = yield* input.permission.ask({ ...input.request, ruleset, hardRuleset })
 
     if (outcome.manual) return { source: "manual" } satisfies PermissionProvenance.Approval
+    if (outcome.plugin) return { source: "plugin" } satisfies PermissionProvenance.Approval
     return PermissionProvenance.classify({ rule: outcome.rule, agent: agent.name, origins: input.origins })
   })
 

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -85,6 +85,8 @@ export type PermissionReviewer = (
   // an unrecognised value must not be able to read as a decision.
   output: { status: string; message?: string },
 ) => Effect.Effect<void>
+/** deny beats ask beats allow; anything else is not a decision at all. */
+const strictness = (status: string) => (status === "deny" ? 2 : status === "ask" ? 1 : status === "allow" ? 0 : -1) // kilocode_change
 // kilocode_change end
 
 export interface Interface {
@@ -301,9 +303,14 @@ const layer = Layer.effect(
             Cause.hasInterrupts(cause)
               ? Effect.failCause(cause)
               : Effect.gen(function* () {
-                  review.status = before
-                  review.message = undefined
-                  yield* Effect.logWarning("permission.ask hook failed; keeping the rule decision", {
+                  // Every hook shares one `review`, so a failure can follow a decision an
+                  // earlier hook already made. Discard what the failing hook left behind
+                  // only when keeping it would be more permissive than the rules were.
+                  if (strictness(review.status) <= strictness(before)) {
+                    review.status = before
+                    review.message = undefined
+                  }
+                  yield* Effect.logWarning("permission.ask hook failed; keeping the safer decision", {
                     cause: Cause.pretty(cause),
                     permission: request.permission,
                   })

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -4,7 +4,7 @@ import { ConfigPermissionV1 } from "@opencode-ai/core/v1/config/permission"
 import * as Config from "@/config/config" // kilocode_change
 import { InstanceState } from "@/effect/instance-state"
 import { Wildcard } from "@opencode-ai/core/util/wildcard"
-import { Deferred, Effect, Layer, Context } from "effect"
+import { Cause, Context, Deferred, Effect, Layer } from "effect"
 import os from "os"
 import z from "zod" // kilocode_change
 import { zod } from "@opencode-ai/core/effect-zod" // kilocode_change
@@ -18,6 +18,7 @@ import { KiloHeadless } from "@/kilocode/permission/headless"
 import { drainCovered } from "@/kilocode/permission/drain"
 import { ReadPermission } from "@/kilocode/permission/read"
 import { AgentManagerPermission } from "@/kilocode/permission/agent-manager" // kilocode_change
+import { PermissionRule } from "@/kilocode/permission/rule" // kilocode_change
 import { ExternalDirectoryPermission } from "@/kilocode/permission/external-directory"
 // kilocode_change end
 
@@ -69,13 +70,28 @@ export interface AskOutcome {
   manual: boolean
   /** The winning rule (carries an optional `source` marker set at ruleset-build time). */
   rule?: Rule
+  /** true when a `permission.ask` plugin hook, not a rule, settled this call. */
+  plugin?: boolean
 }
+// kilocode_change end
+
+// kilocode_change start: a reviewer sees the effective rule decision and may
+// replace it. This is the interception point the documented `permission.ask`
+// plugin hook needs — without it the hook is declared but never invoked.
+export type PermissionReviewer = (
+  input: Request,
+  // `status` is whatever the hook left behind, so it is typed as an unvalidated
+  // string rather than the union: plugins are external, untyped JavaScript, and
+  // an unrecognised value must not be able to read as a decision.
+  output: { status: string; message?: string },
+) => Effect.Effect<void>
 // kilocode_change end
 
 export interface Interface {
   readonly ask: (input: AskInput) => Effect.Effect<AskOutcome, Error> // kilocode_change - was Effect<void>; returns the decision
   readonly reply: (input: ReplyInput) => Effect.Effect<void, NotFoundError>
   readonly list: () => Effect.Effect<ReadonlyArray<Request>>
+  readonly setReviewer: (fn: PermissionReviewer) => Effect.Effect<void> // kilocode_change
   // kilocode_change start
   readonly saveAlwaysRules: (input: z.infer<typeof SaveAlwaysRulesInput>) => Effect.Effect<void, NotFoundError>
   readonly allowEverything: (input: z.infer<typeof AllowEverythingInput>) => Effect.Effect<void>
@@ -123,7 +139,13 @@ export function resolve(permission: string, pattern: string, ruleset: Ruleset, .
     pattern,
     ReadPermission.harden(permission, pattern, evalFn(permission, pattern, ruleset)),
   ) // kilocode_change
-  const saved = AgentManagerPermission.harden(permission, pattern, evalFn(permission, pattern, ...overrides)) // kilocode_change
+  // kilocode_change - harden the saved/session side too: a broad "always allow" must not
+  // silently grant a secret-file read any more than a broad config rule may
+  const saved = AgentManagerPermission.harden(
+    permission,
+    pattern,
+    ReadPermission.harden(permission, pattern, evalFn(permission, pattern, ...overrides)),
+  )
   if (base.action === "deny") return base
   if (saved.action === "deny") return saved
   if (base.action === "ask") {
@@ -160,6 +182,7 @@ const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const events = yield* EventV2Bridge.Service
+    let reviewer: PermissionReviewer | undefined // kilocode_change: registered once by the plugin layer
     const config = yield* Config.Service // kilocode_change
     const database = yield* Database.Service // kilocode_change
     const state = yield* InstanceState.make<State>(
@@ -193,6 +216,8 @@ const layer = Layer.effect(
       // kilocode_change end
       let needsAsk = false
       let approvedRule: Rule | undefined // kilocode_change - remember the rule that auto-approved
+      let decidedByPlugin = false // kilocode_change - a reviewer overrode what the rules decided
+      let forcedAsk = false // kilocode_change - this prompt is one a human must answer, whatever the rules say
 
       // kilocode_change start - protect config access while honoring explicit global skill trust
       const isProtected = ConfigProtection.isRequest(request)
@@ -229,6 +254,7 @@ const layer = Layer.effect(
         // kilocode_change start - skill shell forces a prompt instead of honoring an allow/auto-approve rule
         if (forceAsk) {
           needsAsk = true
+          forcedAsk = true
           continue
         }
         // kilocode_change end
@@ -239,9 +265,82 @@ const layer = Layer.effect(
         }
         // kilocode_change end
         needsAsk = true
+        // kilocode_change start - a prompt the service insists on: a protected config path, or
+        // an ask it hardened itself (reading a *.env file, an agent_manager side effect). No
+        // allow rule the user writes can relax these, so a permission.ask hook must not either.
+        if ((isProtected && !trusted) || PermissionRule.hardened(rule)) forcedAsk = true
+        // kilocode_change end
       }
 
-      if (!needsAsk) return { manual: false, rule: approvedRule } // kilocode_change - report auto-approval
+      const id = request.id ?? PermissionV1.ID.ascending() // kilocode_change - one id for the hook and the request
+
+      // kilocode_change start: the reviewer may replace the effective decision.
+      // It sees the id the real request will carry, and copies of the mutable
+      // fields: a hook must not be able to rewrite the request the user is about
+      // to be shown, nor the patterns an "always" answer persists.
+      if (reviewer) {
+        const review: { status: string; message?: string } = { status: needsAsk ? "ask" : "allow" }
+        const before = review.status
+        yield* reviewer(
+          {
+            id,
+            sessionID: request.sessionID,
+            permission: request.permission,
+            patterns: [...request.patterns],
+            metadata: { ...request.metadata },
+            always: [...request.always],
+            tool: request.tool,
+          },
+          review,
+        ).pipe(
+          // A hook that throws must not take the permission check down with it:
+          // `trigger` runs hooks through Effect.promise, so a rejection arrives as a
+          // defect. Treat it like a hook that answered nonsense — keep the rules'
+          // decision, discarding whatever the hook wrote before it failed.
+          Effect.catchCause((cause) =>
+            Cause.hasInterrupts(cause)
+              ? Effect.failCause(cause)
+              : Effect.gen(function* () {
+                  review.status = before
+                  review.message = undefined
+                  yield* Effect.logWarning("permission.ask hook failed; keeping the rule decision", {
+                    cause: Cause.pretty(cause),
+                    permission: request.permission,
+                  })
+                }),
+          ),
+        )
+        if (review.status === "deny") {
+          // No rule matched: inventing one here would send the user looking
+          // through their config for something that is not there. The reason
+          // carries the explanation instead.
+          return yield* new DeniedError({
+            ruleset: [],
+            reason: review.message ?? "A plugin denied this permission request.",
+          })
+        }
+        // A hook may make a decision stricter. It may not cancel a prompt Kilo forces
+        // regardless of the user's own allow rules — skill shells, sandbox escapes,
+        // config writes, *.env reads and agent_manager side effects.
+        if (review.status === "allow" && forcedAsk) {
+          yield* Effect.logWarning("permission.ask hook tried to auto-approve a forced prompt; keeping the prompt", {
+            permission: request.permission,
+          })
+        } else if (review.status === "ask" || review.status === "allow") {
+          decidedByPlugin = review.status !== (needsAsk ? "ask" : "allow")
+          needsAsk = review.status === "ask"
+        } else
+          // Any other value is a misbehaving hook, not a decision: keep what the
+          // rules decided rather than failing open to allow.
+          yield* Effect.logWarning("permission.ask hook returned an unknown status; keeping the rule decision", {
+            status: review.status,
+            permission: request.permission,
+          })
+      }
+      // kilocode_change end
+
+      // kilocode_change - report auto-approval, and never credit a rule for a decision a plugin made
+      if (!needsAsk) return decidedByPlugin ? { manual: false, plugin: true } : { manual: false, rule: approvedRule }
 
       // kilocode_change start - headless subagent asks fail instead of queuing for a reply that never comes (#11903)
       if (yield* KiloHeadless.denies(request.sessionID).pipe(Effect.provideService(Database.Service, database))) {
@@ -249,7 +348,6 @@ const layer = Layer.effect(
       }
       // kilocode_change end
 
-      const id = request.id ?? PermissionV1.ID.ascending()
       const info: PermissionV1.Request = {
         id,
         sessionID: request.sessionID,
@@ -463,7 +561,8 @@ const layer = Layer.effect(
     })
     // kilocode_change end
 
-    return Service.of({ ask, reply, list, saveAlwaysRules, allowEverything, pending }) // kilocode_change
+    const setReviewer = (fn: PermissionReviewer) => Effect.sync(() => { reviewer = fn }) // kilocode_change
+    return Service.of({ ask, reply, list, saveAlwaysRules, allowEverything, pending, setReviewer }) // kilocode_change
   }),
 )
 

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -34,6 +34,7 @@ import { registerAdapter } from "@/control-plane/adapters"
 import type { WorkspaceAdapter } from "@/control-plane/types"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { EventV2Bridge } from "@/event-v2-bridge"
+import { Permission } from "@/permission" // kilocode_change
 import { InstallationChannel } from "@opencode-ai/core/installation/version"
 
 type State = {
@@ -313,6 +314,19 @@ const layer = Layer.effect(
       yield* InstanceState.get(state)
     })
 
+    // kilocode_change start: invoke the documented `permission.ask` hook, which
+    // is otherwise declared in the plugin API and never triggered. The dependency
+    // points plugin -> permission on purpose: the reverse edge would drag plugin
+    // loading into every graph that builds Permission on its own, which several
+    // tests do. The reviewer runs inside the permission service's ask flow, which
+    // already carries the instance context, so the trigger runs directly — it
+    // mutates `output` in place and asVoid drops the return value.
+    const permission = yield* Permission.Service
+    yield* permission.setReviewer((input, output) =>
+      trigger("permission.ask", input, output).pipe(Effect.asVoid),
+    )
+    // kilocode_change end
+
     return Service.of({ trigger, list, init })
   }),
 )
@@ -320,7 +334,7 @@ const layer = Layer.effect(
 export const node = LayerNode.make({
   service: Service,
   layer: layer,
-  deps: [EventV2Bridge.node, Config.node, RuntimeFlags.node],
+  deps: [EventV2Bridge.node, Config.node, RuntimeFlags.node, Permission.node], // kilocode_change
 })
 
 export * as Plugin from "."

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -153,6 +153,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
                     patterns: req.patterns,
                     agent: input.agent.name,
                     origins: permissionOrigins,
+                    pluginReason: err.reason, // kilocode_change
                   }),
                   req.permission,
                   PermissionProvenance.filepathOf(req.metadata),

--- a/packages/opencode/test/kilocode/permission/deny-provenance.test.ts
+++ b/packages/opencode/test/kilocode/permission/deny-provenance.test.ts
@@ -5,6 +5,7 @@ import { Bus } from "../../../src/bus"
 import { Permission } from "../../../src/permission"
 import { PermissionProvenance } from "../../../src/kilocode/permission/provenance"
 import { SessionID } from "../../../src/session/schema"
+import { describeApproval } from "@tui/kilocode/tool-approval"
 import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
 import { provideTmpdirInstance } from "../../fixture/fixture"
 import { testEffect } from "../../lib/effect"
@@ -81,5 +82,45 @@ describe("Permission.ask denial provenance", () => {
     })
     expect(approval.rule?.action).toBe("deny")
     expect(approval.rule).toEqual({ permission: "bash", pattern: "rm -rf /", action: "deny" })
+  })
+
+  test("a plugin's veto names the plugin as its source and still carries a deny rule", () => {
+    const approval = PermissionProvenance.classifyDenial({
+      ruleset: [],
+      permission: "bash",
+      patterns: ["npm install"],
+      agent: "build",
+      origins: undefined,
+      pluginReason: "blocked by the org policy plugin",
+    })
+    expect(approval.source).toBe("plugin")
+    expect(approval.rule).toEqual({ permission: "bash", pattern: "npm install", action: "deny" })
+  })
+
+  test("a plugin's veto renders in the TUI as a denial, not as an auto-approval", () => {
+    // The consequence of the rule above being present. `describeApproval` reads the decision
+    // off `rule.action` alone, so a plugin approval carrying no rule renders a refusal with
+    // the same words as an approval.
+    const approval = PermissionProvenance.classifyDenial({
+      ruleset: [],
+      permission: "bash",
+      patterns: ["npm install"],
+      agent: "build",
+      origins: undefined,
+      pluginReason: "blocked by the org policy plugin",
+    })
+    expect(describeApproval({ approval })).toBe("denied by a plugin (matched bash `npm install`)")
+  })
+
+  test("without a plugin reason the denial is still attributed to the rule that matched", () => {
+    const approval = PermissionProvenance.classifyDenial({
+      ruleset: { permission: "bash", pattern: "npm *", action: "deny" as const },
+      permission: "bash",
+      patterns: ["npm install"],
+      agent: "build",
+      origins: undefined,
+    })
+    expect(approval.source).toBe("agent")
+    expect(approval.rule).toEqual({ permission: "bash", pattern: "npm *", action: "deny" })
   })
 })

--- a/packages/opencode/test/kilocode/permission/plugin-permission-ask.test.ts
+++ b/packages/opencode/test/kilocode/permission/plugin-permission-ask.test.ts
@@ -41,12 +41,15 @@ const it = testEffect(
  */
 const MARKER = "permission-ask-hook-ran"
 
-/** A plugin whose only hook is `permission.ask`, with `body` as its statements. */
-function hookPlugin(...body: string[]) {
+/**
+ * A plugin whose only hook is `permission.ask`, with `body` as its statements. `marker` is the
+ * file it writes on entry, so tests registering more than one plugin can tell them apart.
+ */
+function markedHookPlugin(marker: string, ...body: string[]) {
   return [
     "export default async ({ directory }) => ({",
     '  "permission.ask": async (input, output) => {',
-    `    await Bun.write(directory + "/${MARKER}", input.permission)`,
+    `    await Bun.write(directory + "/${marker}", input.permission)`,
     ...body,
     "  },",
     "})",
@@ -54,29 +57,37 @@ function hookPlugin(...body: string[]) {
   ].join("\n")
 }
 
-const hookRan = Effect.gen(function* () {
-  const test = yield* TestInstance
-  return yield* Effect.promise(() =>
-    Bun.file(path.join(test.directory, MARKER))
-      .text()
-      .catch(() => undefined),
-  )
-})
+function hookPlugin(...body: string[]) {
+  return markedHookPlugin(MARKER, ...body)
+}
 
-function withProject<A, E, R>(source: string, self: Effect.Effect<A, E, R>) {
+const markerRan = (marker: string) =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    return yield* Effect.promise(() =>
+      Bun.file(path.join(test.directory, marker))
+        .text()
+        .catch(() => undefined),
+    )
+  })
+
+const hookRan = markerRan(MARKER)
+
+/** Register `sources` as plugins, in order: `Plugin.trigger` runs the hooks in the order listed. */
+function withPlugins<A, E, R>(sources: readonly string[], self: Effect.Effect<A, E, R>) {
   return Effect.gen(function* () {
     const test = yield* TestInstance
-    const file = path.join(test.directory, "plugin.ts")
+    const files = sources.map((_, index) => path.join(test.directory, `plugin-${index}.ts`))
     yield* Effect.all(
       [
-        Effect.promise(() => Bun.write(file, source)),
+        ...files.map((file, index) => Effect.promise(() => Bun.write(file, sources[index]!))),
         Effect.promise(() =>
           Bun.write(
             path.join(test.directory, "opencode.json"),
             JSON.stringify(
               {
                 $schema: "https://app.kilo.ai/config.json",
-                plugin: [pathToFileURL(file).href],
+                plugin: files.map((file) => pathToFileURL(file).href),
               },
               null,
               2,
@@ -84,10 +95,14 @@ function withProject<A, E, R>(source: string, self: Effect.Effect<A, E, R>) {
           ),
         ),
       ],
-      { discard: true, concurrency: 2 },
+      { discard: true, concurrency: "unbounded" },
     )
     return yield* self
   })
+}
+
+function withProject<A, E, R>(source: string, self: Effect.Effect<A, E, R>) {
+  return withPlugins([source], self)
 }
 
 const ask = (input: Parameters<Permission.Interface["ask"]>[0]) =>
@@ -377,6 +392,52 @@ describe("permission.ask plugin hook", () => {
 
         yield* reply({ requestID: pending[0]!.id, reply: "once" })
         expect(yield* Fiber.join(asking)).toEqual({ manual: true })
+      }),
+    ),
+  )
+
+  // Every hook shares one mutable `output`, so the discard above has to be selective: a
+  // throw arriving after a well-behaved earlier hook denied must not restore the pre-hook
+  // status and hand the call back to the allow rule.
+  it.instance("a hook that throws does not resurrect a denial an earlier hook made", () =>
+    withPlugins(
+      [
+        markedHookPlugin(
+          "denier-ran",
+          '    output.status = "deny"',
+          '    output.message = "blocked by the org policy plugin"',
+        ),
+        markedHookPlugin("thrower-ran", '    throw new Error("hook exploded")'),
+      ],
+      Effect.gen(function* () {
+        const error = yield* fail(ask(request(allowBash)))
+        expect(error).toBeInstanceOf(Permission.DeniedError)
+        expect((error as Permission.DeniedError).reason).toBe("blocked by the org policy plugin")
+        expect(yield* markerRan("denier-ran")).toBe("bash")
+        expect(yield* markerRan("thrower-ran")).toBe("bash")
+        expect(yield* list()).toEqual([])
+      }),
+    ),
+  )
+
+  // The mirror: what an earlier hook left is only worth keeping when it is at least as strict
+  // as the rules were, so an allow written before a later hook throws is still thrown away.
+  it.instance("a hook that throws discards an allow an earlier hook made", () =>
+    withPlugins(
+      [
+        markedHookPlugin("allower-ran", '    output.status = "allow"'),
+        markedHookPlugin("thrower-ran", '    throw new Error("hook exploded")'),
+      ],
+      Effect.gen(function* () {
+        const asking = yield* ask(request([])).pipe(Effect.forkScoped)
+
+        const pending = yield* waitForPending(1)
+        expect(yield* markerRan("allower-ran")).toBe("bash")
+        expect(yield* markerRan("thrower-ran")).toBe("bash")
+
+        yield* reply({ requestID: pending[0]!.id, reply: "once" })
+        expect(yield* Fiber.join(asking)).toEqual({ manual: true })
+        expect(yield* list()).toEqual([])
       }),
     ),
   )

--- a/packages/opencode/test/kilocode/permission/plugin-permission-ask.test.ts
+++ b/packages/opencode/test/kilocode/permission/plugin-permission-ask.test.ts
@@ -1,0 +1,383 @@
+// kilocode_change - new file
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Npm } from "@opencode-ai/core/npm"
+import { describe, expect } from "bun:test"
+import { Cause, Effect, Exit, Fiber } from "effect"
+import path from "path"
+import { pathToFileURL } from "url"
+import { Account } from "../../../src/account/account"
+import { Auth } from "../../../src/auth"
+import { RuntimeFlags } from "../../../src/effect/runtime-flags"
+import { ConfigProtection } from "../../../src/kilocode/permission/config-paths"
+import { Permission } from "../../../src/permission"
+import { Plugin } from "../../../src/plugin"
+import { SessionID } from "../../../src/session/schema"
+import { TestInstance } from "../../fixture/fixture"
+import { AccountTest } from "../../fake/account"
+import { AuthTest } from "../../fake/auth"
+import { NpmTest } from "../../fake/npm"
+import { testEffect } from "../../lib/effect"
+
+// One compiled graph. The plugin layer registers its reviewer on the Permission
+// service it resolves while being built, so a separate AppNodeBuilder.build per
+// service would hand it a Permission instance these tests never ask, leaving the
+// hook invisible.
+const root = LayerNode.group([Plugin.node, Permission.node, CrossSpawnSpawner.node])
+const it = testEffect(
+  AppNodeBuilder.build(root, [
+    [Auth.node, AuthTest.empty],
+    [Account.node, AccountTest.empty],
+    [Npm.node, NpmTest.noop],
+    [RuntimeFlags.node, RuntimeFlags.layer({ disableDefaultPlugins: true })],
+  ]),
+)
+
+/**
+ * Written by every hook below. Asserting on it keeps the "unrecognised status"
+ * case honest: without it, a plugin that failed to load would leave behind
+ * exactly the pending prompt that test is looking for.
+ */
+const MARKER = "permission-ask-hook-ran"
+
+/** A plugin whose only hook is `permission.ask`, with `body` as its statements. */
+function hookPlugin(...body: string[]) {
+  return [
+    "export default async ({ directory }) => ({",
+    '  "permission.ask": async (input, output) => {',
+    `    await Bun.write(directory + "/${MARKER}", input.permission)`,
+    ...body,
+    "  },",
+    "})",
+    "",
+  ].join("\n")
+}
+
+const hookRan = Effect.gen(function* () {
+  const test = yield* TestInstance
+  return yield* Effect.promise(() =>
+    Bun.file(path.join(test.directory, MARKER))
+      .text()
+      .catch(() => undefined),
+  )
+})
+
+function withProject<A, E, R>(source: string, self: Effect.Effect<A, E, R>) {
+  return Effect.gen(function* () {
+    const test = yield* TestInstance
+    const file = path.join(test.directory, "plugin.ts")
+    yield* Effect.all(
+      [
+        Effect.promise(() => Bun.write(file, source)),
+        Effect.promise(() =>
+          Bun.write(
+            path.join(test.directory, "opencode.json"),
+            JSON.stringify(
+              {
+                $schema: "https://app.kilo.ai/config.json",
+                plugin: [pathToFileURL(file).href],
+              },
+              null,
+              2,
+            ),
+          ),
+        ),
+      ],
+      { discard: true, concurrency: 2 },
+    )
+    return yield* self
+  })
+}
+
+const ask = (input: Parameters<Permission.Interface["ask"]>[0]) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* permission.ask(input)
+  })
+
+const reply = (input: Parameters<Permission.Interface["reply"]>[0]) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* permission.reply(input)
+  })
+
+const list = () =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* permission.list()
+  })
+
+const waitForPending = (count: number) =>
+  Effect.gen(function* () {
+    while (true) {
+      const items = yield* list()
+      if (items.length === count) return items
+      yield* Effect.sleep("10 millis")
+    }
+  }).pipe(
+    Effect.timeoutOrElse({
+      duration: "5 seconds",
+      orElse: () => Effect.fail(new Error(`timed out waiting for ${count} pending permission request(s)`)),
+    }),
+  )
+
+const fail = <A, E, R>(self: Effect.Effect<A, E, R>) =>
+  Effect.gen(function* () {
+    const exit = yield* self.pipe(Effect.exit)
+    if (Exit.isFailure(exit)) return Cause.squash(exit.cause)
+    throw new Error("expected permission effect to fail")
+  })
+
+const request = (ruleset: Permission.Ruleset, overrides: Partial<Permission.AskInput> = {}) => ({
+  sessionID: SessionID.make("session_test"),
+  permission: "bash",
+  patterns: ["npm install"],
+  metadata: {},
+  always: [],
+  ruleset,
+  ...overrides,
+})
+
+const allowBash: Permission.Ruleset = [{ permission: "bash", pattern: "*", action: "allow" }]
+
+/**
+ * Deliberately broad. `ReadPermission.harden` *downgrades* a `*.env` read only
+ * when the winning rule is broad (`permission` or `pattern` is `*`); a narrower
+ * `read: *.env` allow is left alone. This ruleset exercises that downgrade — the
+ * unruled read below is hardened by the other branch, not by this one.
+ */
+const allowRead: Permission.Ruleset = [{ permission: "read", pattern: "*", action: "allow" }]
+
+describe("permission.ask plugin hook", () => {
+  it.instance("allow settles a request the rules wanted to ask about", () =>
+    withProject(
+      hookPlugin('    output.status = "allow"'),
+      Effect.gen(function* () {
+        const outcome = yield* ask(request([]))
+        expect(outcome).toEqual({ manual: false, plugin: true })
+        expect(yield* list()).toEqual([])
+      }),
+    ),
+  )
+
+  it.instance("ask overrides a rule that would have auto-approved", () =>
+    withProject(
+      hookPlugin('    output.status = "ask"'),
+      Effect.gen(function* () {
+        const asking = yield* ask(request(allowBash)).pipe(Effect.forkScoped)
+
+        const pending = yield* waitForPending(1)
+        expect(pending[0]!.permission).toBe("bash")
+        expect(pending[0]!.patterns).toEqual(["npm install"])
+
+        yield* reply({ requestID: pending[0]!.id, reply: "once" })
+        expect(yield* Fiber.join(asking)).toEqual({ manual: true })
+        expect(yield* list()).toEqual([])
+      }),
+    ),
+  )
+
+  it.instance("deny fails the request and reports the hook's message", () =>
+    withProject(
+      hookPlugin('    output.status = "deny"', '    output.message = "blocked by the org policy plugin"'),
+      Effect.gen(function* () {
+        const error = yield* fail(ask(request(allowBash)))
+        expect(error).toBeInstanceOf(Permission.DeniedError)
+        const denied = error as Permission.DeniedError
+        expect(denied.reason).toBe("blocked by the org policy plugin")
+        expect(denied.message).toBe("blocked by the org policy plugin")
+        expect(yield* list()).toEqual([])
+      }),
+    ),
+  )
+
+  it.instance("an unrecognised status keeps the rule decision instead of allowing", () =>
+    withProject(
+      hookPlugin('    output.status = "denied"'),
+      Effect.gen(function* () {
+        const asking = yield* ask(request([])).pipe(Effect.forkScoped)
+
+        const pending = yield* waitForPending(1)
+        expect(yield* hookRan).toBe("bash")
+
+        yield* reply({ requestID: pending[0]!.id, reply: "once" })
+        expect(yield* Fiber.join(asking)).toEqual({ manual: true })
+      }),
+    ),
+  )
+
+  // A hook may make a decision stricter. It may not cancel a prompt Kilo forces
+  // regardless of the user's own allow rules — the cases below.
+
+  it.instance("allow cannot cancel the prompt a skill shell forces", () =>
+    withProject(
+      hookPlugin('    output.status = "allow"'),
+      Effect.gen(function* () {
+        const asking = yield* ask(request(allowBash, { metadata: { skillShell: true } })).pipe(Effect.forkScoped)
+
+        const pending = yield* waitForPending(1)
+        expect(yield* hookRan).toBe("bash")
+
+        // A skill-shell prompt refuses machine approvals, so answer it the way a
+        // client with a human in front of it would.
+        yield* reply({ requestID: pending[0]!.id, reply: "once", interactive: true })
+        expect(yield* Fiber.join(asking)).toEqual({ manual: true })
+        expect(yield* list()).toEqual([])
+      }),
+    ),
+  )
+
+  it.instance("allow cannot cancel the prompt a sandbox escalation forces", () =>
+    withProject(
+      hookPlugin('    output.status = "allow"'),
+      Effect.gen(function* () {
+        const asking = yield* ask(request(allowBash, { metadata: { sandboxEscalation: true } })).pipe(Effect.forkScoped)
+
+        const pending = yield* waitForPending(1)
+        expect(yield* hookRan).toBe("bash")
+
+        yield* reply({ requestID: pending[0]!.id, reply: "once", interactive: true })
+        expect(yield* Fiber.join(asking)).toEqual({ manual: true })
+        expect(yield* list()).toEqual([])
+      }),
+    ),
+  )
+
+  it.instance("allow cannot cancel the prompt a hardened *.env read forces", () =>
+    withProject(
+      hookPlugin('    output.status = "allow"'),
+      Effect.gen(function* () {
+        const asking = yield* ask(request(allowRead, { permission: "read", patterns: ["project/.env"] })).pipe(
+          Effect.forkScoped,
+        )
+
+        const pending = yield* waitForPending(1)
+        expect(yield* hookRan).toBe("read")
+        expect(pending[0]!.patterns).toEqual(["project/.env"])
+
+        yield* reply({ requestID: pending[0]!.id, reply: "once" })
+        expect(yield* Fiber.join(asking)).toEqual({ manual: true })
+      }),
+    ),
+  )
+
+  // Same permission, same `*.env` pattern, same hook as above — only the broad
+  // allow rule is gone, so nothing had to be downgraded. `ReadPermission.harden`
+  // marks the default `{ action: "ask" }` hardened all the same: what the hook
+  // cannot relax is the file being a `.env`, not the shape of the rule that got
+  // there. A hook that could auto-approve this read would be reading secrets on
+  // an empty ruleset — the loosest configuration, not the strictest.
+  it.instance("allow cannot cancel the prompt an unruled *.env read forces", () =>
+    withProject(
+      hookPlugin('    output.status = "allow"'),
+      Effect.gen(function* () {
+        const asking = yield* ask(request([], { permission: "read", patterns: ["project/.env"] })).pipe(
+          Effect.forkScoped,
+        )
+
+        const pending = yield* waitForPending(1)
+        expect(yield* hookRan).toBe("read")
+        expect(pending[0]!.patterns).toEqual(["project/.env"])
+
+        yield* reply({ requestID: pending[0]!.id, reply: "once" })
+        expect(yield* Fiber.join(asking)).toEqual({ manual: true })
+        expect(yield* list()).toEqual([])
+      }),
+    ),
+  )
+
+  // A config write `ConfigProtection.isRequest` matches, with no allow rule to
+  // downgrade. The prompt is forced by the request being protected, not by a
+  // rule the service had to rewrite — the metadata the request carries is the
+  // proof it was recognised as one.
+  it.instance("allow cannot cancel the prompt a protected config edit forces", () =>
+    withProject(
+      hookPlugin('    output.status = "allow"'),
+      Effect.gen(function* () {
+        const asking = yield* ask(request([], { permission: "edit", patterns: [".kilo/config.json"] })).pipe(
+          Effect.forkScoped,
+        )
+
+        const pending = yield* waitForPending(1)
+        expect(yield* hookRan).toBe("edit")
+        expect(pending[0]!.patterns).toEqual([".kilo/config.json"])
+        expect(pending[0]!.metadata).toEqual({
+          [ConfigProtection.DISABLE_ALWAYS_KEY]: true,
+          [ConfigProtection.CONFIG_PROTECTED_KEY]: true,
+        })
+
+        yield* reply({ requestID: pending[0]!.id, reply: "once" })
+        expect(yield* Fiber.join(asking)).toEqual({ manual: true })
+        expect(yield* list()).toEqual([])
+      }),
+    ),
+  )
+
+  // Prompting an existing Agent Manager session has an external side effect, so
+  // `AgentManagerPermission.harden` hardens the ask whether it downgraded a
+  // broad allow or found no rule at all — as here.
+  it.instance("allow cannot cancel the prompt an agent_manager side effect forces", () =>
+    withProject(
+      hookPlugin('    output.status = "allow"'),
+      Effect.gen(function* () {
+        const asking = yield* ask(request([], { permission: "agent_manager", patterns: ["prompt"] })).pipe(
+          Effect.forkScoped,
+        )
+
+        const pending = yield* waitForPending(1)
+        expect(yield* hookRan).toBe("agent_manager")
+        expect(pending[0]!.patterns).toEqual(["prompt"])
+
+        yield* reply({ requestID: pending[0]!.id, reply: "once" })
+        expect(yield* Fiber.join(asking)).toEqual({ manual: true })
+        expect(yield* list()).toEqual([])
+      }),
+    ),
+  )
+
+  it.instance("a hook that throws leaves an auto-approving rule in charge", () =>
+    withProject(
+      hookPlugin('    throw new Error("hook exploded")'),
+      Effect.gen(function* () {
+        const outcome = yield* ask(request(allowBash))
+        expect(outcome).toEqual({ manual: false, rule: { permission: "bash", pattern: "*", action: "allow" } })
+        expect(yield* hookRan).toBe("bash")
+        expect(yield* list()).toEqual([])
+      }),
+    ),
+  )
+
+  it.instance("a hook that throws leaves a rule that wanted to ask in charge", () =>
+    withProject(
+      hookPlugin('    throw new Error("hook exploded")'),
+      Effect.gen(function* () {
+        const asking = yield* ask(request([])).pipe(Effect.forkScoped)
+
+        const pending = yield* waitForPending(1)
+        expect(yield* hookRan).toBe("bash")
+
+        yield* reply({ requestID: pending[0]!.id, reply: "once" })
+        expect(yield* Fiber.join(asking)).toEqual({ manual: true })
+      }),
+    ),
+  )
+
+  // The hook mutates the very object the service reads back, so an allow written
+  // on the way out has to be discarded along with the throw — otherwise a hook
+  // could auto-approve by deciding and then failing.
+  it.instance("an allow written before a hook throws is discarded, not honoured", () =>
+    withProject(
+      hookPlugin('    output.status = "allow"', '    throw new Error("hook exploded after deciding")'),
+      Effect.gen(function* () {
+        const asking = yield* ask(request([])).pipe(Effect.forkScoped)
+
+        const pending = yield* waitForPending(1)
+        expect(yield* hookRan).toBe("bash")
+
+        yield* reply({ requestID: pending[0]!.id, reply: "once" })
+        expect(yield* Fiber.join(asking)).toEqual({ manual: true })
+      }),
+    ),
+  )
+})

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -4,13 +4,12 @@ import type {
   Project,
   Model,
   Provider,
-  Permission,
   UserMessage,
   Message,
   Part,
   Config as SDKConfig,
 } from "@kilocode/sdk"
-import type { Provider as ProviderV2, Model as ModelV2, Auth } from "@kilocode/sdk/v2"
+import type { Provider as ProviderV2, Model as ModelV2, Auth, PermissionRequest } from "@kilocode/sdk/v2"
 
 import type { BunShell } from "./shell.js"
 import { type ToolDefinition } from "./tool.js"
@@ -258,7 +257,16 @@ export interface Hooks {
     input: { sessionID: string; agent: string; model: Model; provider: ProviderContext; message: UserMessage },
     output: { headers: Record<string, string> },
   ) => Promise<void>
-  "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void>
+  /**
+   * Fires while a permission is being decided, after the configured rules have
+   * been evaluated. `output.status` carries that decision and may be replaced;
+   * `output.message` explains a denial to the model. A rule that already denied
+   * the request settles it before this hook runs.
+   */
+  "permission.ask"?: (
+    input: PermissionRequest,
+    output: { status: "ask" | "deny" | "allow"; message?: string },
+  ) => Promise<void>
   "command.execute.before"?: (
     input: { command: string; sessionID: string; arguments: string },
     output: { parts: Part[] },

--- a/packages/tui/src/kilocode/tool-approval.tsx
+++ b/packages/tui/src/kilocode/tool-approval.tsx
@@ -8,7 +8,7 @@ export function stateMetadata(state: ToolState | undefined) {
   return state && "metadata" in state ? state.metadata : undefined
 }
 
-const SOURCES = ["agent", "global", "project", "yolo", "session", "manual", "default"] as const
+const SOURCES = ["agent", "global", "project", "yolo", "session", "manual", "default", "plugin"] as const
 
 /** Read the approval/denial provenance off a tool part's metadata, if present. */
 export function toolApprovalFrom(metadata: Record<string, unknown> | undefined) {
@@ -32,6 +32,8 @@ function sourceLabel(approval: PermissionProvenance.Approval): string | undefine
       return "by a session auto-approve rule"
     case "default":
       return "by default"
+    case "plugin":
+      return "by a plugin"
     default:
       return undefined
   }


### PR DESCRIPTION
## Issue

Fixes #13837

## Context

`packages/plugin/src/index.ts:261` declares a `permission.ask` hook, and
`packages/kilo-docs/pages/automate/extending/plugins.md:337` documents it as
"Auto-allow or auto-deny permission prompts". Nothing calls it — `trigger` has
seven call sites and this is not one of them — so a plugin that registers the
hook never runs, with no error and no warning.

I hit this building a plugin that asks an external policy service before each
tool call. Without the hook there is no interception point: denying means
throwing from `tool.execute.before`, allowing means auto-answering the event
after the prompt has already flashed, and permission requests that are not tool
calls (`external_directory`, sandbox escalation) never reach a plugin at all.

## Implementation

The permission service gains a reviewer; the plugin layer registers one that
runs the hook. `Permission.ask` calls it with the decision the rules produced,
and the hook may leave it, tighten it, or relax it.

Program flow in `ask`: hard-ruleset veto and rule denials still return first, so
a plugin cannot relax a configured deny. Then the pattern loop, which now also
records whether the resulting prompt was *forced* — `skillShell` /
`sandboxEscalation`, a protected config path, or an ask `ReadPermission.harden`
/ `AgentManagerPermission.harden` produced. Then the hook. A hook's `allow` is
refused when the prompt was forced, and logged.

Marking hardened asks needed a runtime-only flag on the rule; it lives beside
the existing `SourcedRule` idea in `packages/opencode/src/kilocode/permission/rule.ts`
and is never persisted.

Four correctness fixes came with the wiring, because the hook sits on the
permission path:

- The declared input type was the legacy SDK `Permission` shape, which shares
  three of nine fields with what is actually passed — a plugin written against
  the published type reads `undefined` for `type`, `pattern` and `title`. It now
  declares `PermissionRequest` from `@kilocode/sdk/v2`, the shape the service
  really hands over, and both `as any` casts are gone.
- The hook was handed the caller's own `patterns`/`metadata`/`always` arrays,
  the same objects the pending request uses — so a hook could rewrite the prompt
  the user was about to read, and the patterns `reply` persists for "always". It
  now gets copies.
- It was handed a freshly minted id that no later event or reply would use. It
  now sees the id the request will carry.
- Any status other than the three legal values read as auto-allow, and a hook
  that threw escaped `ask`'s declared error channel and killed the tool call.
  Both now keep the decision the rules made, and log.

One change reaches beyond the hook, and I would rather flag it than bury it.
`resolve()` wrapped only the config side in `ReadPermission.harden`, while the
sibling `AgentManagerPermission.harden` wrapped both. With `read` unconfigured
that made the hardened default ask carry `pattern: "*"`, so any broad saved
allow — including the one auto-approve mode installs — matched it and returned
an un-hardened allow, and a `*.env` read went through with no prompt at all.
The saved side is now hardened too, which makes the guarantee above real rather
than theoretical. It also means a broad "always allow" stops silently covering
secret-file reads. Happy to split this out if you would rather take it
separately.

Provenance: a plugin decision is no longer attributed to the user's config.
`DeniedError` gained an optional `reason` that its message prefers, the
synthesised deny rule is gone, and `PermissionProvenance` has a `plugin` source
rendered as "by a plugin".

Tradeoff worth naming: `setReviewer` widens the service Interface, which means a
missing registration is a compile error rather than a silent no-op. A
`Context.Reference` would avoid the Interface change, but it cannot be a node in
the layer graph, so nothing could require it and a forgotten binding would put
the hook back to being silently dead.

Not in scope: a rule that denies settles before the hook, so `permission.ask`
observes allow and ask only. Hooks have no timeout anywhere in this codebase —
`trigger` runs them all through `Effect.promise` — and this PR does not change
that for other hooks.

## Screenshots / Video

N/A — no visual change.

### Manual/local verification

New test file
`packages/opencode/test/kilocode/permission/plugin-permission-ask.test.ts`.
Each test loads a real plugin from disk and asserts the hook ran, so a plugin
that failed to load cannot pass by accident.

```
bun test test/kilocode/permission/plugin-permission-ask.test.ts
                                          →  13 pass, 0 fail, 41 expect() calls
bun run script/test-runner.ts permission plugin session
                                          →  185 files, 185 passed, 0 failed, 0 flaky
bun run --cwd packages/opencode typecheck →  clean
bun run script/check-opencode-annotations.ts --worktree
                                          →  all shared upstream changes annotated
```

Every command above was run locally with AI assistance rather than typed by
hand. I read the resulting diff myself and can explain every line of it.

The tests were checked for vacuity by reverting each production line they pin —
the `forcedAsk` clamp, the `hardened` marker, the status restore, the whole
`catchCause` wrapper — and confirming that only the intended tests failed, then
restoring the files and verifying by checksum.

### Reviewer test steps

1. `bun install`
2. Create `plugin.ts` in a scratch project:
   ```ts
   export default async () => ({
     "permission.ask": async (input, output) => {
       if (input.permission === "bash") output.status = "deny"
     },
   })
   ```
   and point `kilo.json` at it: `{ "plugin": ["file:///abs/path/plugin.ts"] }`
3. Ask the agent to run any shell command — it is refused, and the message is
   the plugin's, not an invented rule.
4. Change the hook to `output.status = "allow"` and ask the agent to edit
   `AGENTS.md`. You are still prompted: config writes are forced.
5. On `main`, step 3 does nothing at all — that is the bug.

### Blocked checks and substitute verification

None blocked. The Windows and macOS matrices in CI were not run locally.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.
