### PR TITLE
fix(opencode): show OpenRouter BYOK upstream inference cost

### DIFF
--- a/packages/opencode/src/kilocode/session/index.ts
+++ b/packages/opencode/src/kilocode/session/index.ts
@@ -183,7 +183,8 @@ export namespace KiloSession {
    *
    * Supports the following internal transports:
    *   1. OpenRouter chat completions  -> `metadata.openrouter.usage.cost`
-   *                                      (`costDetails.upstreamInferenceCost` for Kilo)
+   *                                      (`costDetails.upstreamInferenceCost` for Kilo
+   *                                      and for BYOK-routed requests)
    *   2. Anthropic Messages or OpenAI Responses via OpenRouter
    *                                   -> `usage.providerMetadata.aiSdk.cost_details`
    *   3. Anthropic Messages or OpenAI Responses via Vercel AI Gateway
@@ -192,6 +193,12 @@ export namespace KiloSession {
    * Kilo does not charge end users a per-request fee, so for the Kilo provider the
    * top-level `cost` field (the gateway/marketplace fee) would understate the user's
    * actual upstream spend. Always prefer the upstream/market cost when present.
+   *
+   * For OpenRouter BYOK routing, `cost` is what OpenRouter charged the account ($0,
+   * or only its routing fee) while the real spend is the upstream inference cost
+   * charged to the user's own provider key. A non-BYOK response always bills the
+   * account at least the upstream cost, so preferring upstream only when it exceeds
+   * the billed amount never changes non-BYOK sessions.
    *
    * Returns `undefined` when no provider cost is available, so the caller
    * should fall back to the standard token-based calculation.
@@ -221,8 +228,13 @@ export namespace KiloSession {
       const regular = num(orUsage.cost)
       // Kilo doesn't charge a fee on top of the upstream inference cost, so for Kilo
       // prefer the upstream cost (the user's true spend). For the OpenRouter provider
-      // itself, the regular `cost` field is what the user is billed.
-      const cost = isKilo && upstream !== undefined ? upstream : regular
+      // itself, the regular `cost` field is what the user is billed — except when the
+      // request routes through a BYOK provider key: then OpenRouter bills the account
+      // $0 (or only its routing fee) and the true spend is the upstream inference cost
+      // charged to the user's own key. A non-BYOK response always bills at least the
+      // upstream cost, so preferring upstream only when it exceeds the billed amount
+      // never changes non-BYOK sessions.
+      const cost = upstream !== undefined && (isKilo || upstream > (regular ?? -Infinity)) ? upstream : regular
       if (cost !== undefined) return cost
     }
 

--- a/packages/opencode/test/kilocode/provider-cost.test.ts
+++ b/packages/opencode/test/kilocode/provider-cost.test.ts
@@ -9,10 +9,11 @@ function createModel(opts: {
   input?: number
   cost?: Provider.Model["cost"]
   npm?: string
+  providerID?: string
 }): Provider.Model {
   return {
     id: "test-model",
-    providerID: "test",
+    providerID: opts.providerID ?? "test",
     name: "Test",
     limit: {
       context: opts.context,
@@ -120,6 +121,108 @@ describe("KiloSession.providerCost — Vercel AI Gateway", () => {
     })
 
     expect(result.cost).toBe(fallback)
+  })
+})
+
+describe("KiloSession.providerCost — OpenRouter chat completions", () => {
+  const openrouterModel = () =>
+    createModel({
+      context: 100_000,
+      output: 32_000,
+      npm: "@openrouter/ai-sdk-provider",
+      providerID: "openrouter",
+    })
+
+  test("uses upstream_inference_cost when OpenRouter reports $0 for BYOK routing", () => {
+    const result = SessionNs.getUsage({
+      model: openrouterModel(),
+      usage: baseUsage,
+      metadata: {
+        openrouter: {
+          usage: {
+            // Raw OpenRouter payload for a BYOK key: { cost: 0, is_byok: true,
+            // cost_details: { upstream_inference_cost: 0.00000445 } }. The AI SDK
+            // normalizes cost_details -> costDetails. `cost` is what OpenRouter
+            // charged the account ($0 by definition for BYOK); the real spend is
+            // the upstream inference cost on the user's own provider key.
+            cost: 0,
+            costDetails: { upstreamInferenceCost: 0.00000445 },
+          },
+        },
+      },
+    })
+
+    expect(result.cost).toBe(0.00000445)
+  })
+
+  test("uses upstream_inference_cost when OpenRouter bills only its BYOK routing fee", () => {
+    const result = SessionNs.getUsage({
+      model: openrouterModel(),
+      usage: baseUsage,
+      metadata: {
+        openrouter: {
+          usage: {
+            // Observed BYOK shape in kilo-gateway fixtures: `cost` is OpenRouter's
+            // routing fee, a fraction of the upstream spend on the user's own key.
+            cost: 0.0032093125,
+            costDetails: { upstreamInferenceCost: 0.06418625 },
+          },
+        },
+      },
+    })
+
+    expect(result.cost).toBe(0.06418625)
+  })
+
+  test("keeps usage.cost for a non-BYOK OpenRouter response", () => {
+    const result = SessionNs.getUsage({
+      model: openrouterModel(),
+      usage: baseUsage,
+      metadata: {
+        openrouter: {
+          usage: {
+            // Non-BYOK: `cost` is the full account charge (upstream + fee), the
+            // value surfaced today. It must not change.
+            cost: 0.0123,
+            costDetails: { upstreamInferenceCost: 0.0117 },
+          },
+        },
+      },
+    })
+
+    expect(result.cost).toBe(0.0123)
+  })
+
+  test("keeps usage.cost when no cost_details are reported", () => {
+    const result = SessionNs.getUsage({
+      model: openrouterModel(),
+      usage: baseUsage,
+      metadata: {
+        openrouter: {
+          usage: { cost: 0.0123 },
+        },
+      },
+    })
+
+    expect(result.cost).toBe(0.0123)
+  })
+
+  test("prefers upstream_inference_cost for the Kilo provider", () => {
+    const result = SessionNs.getUsage({
+      model: model(),
+      provider: kilo,
+      usage: baseUsage,
+      metadata: {
+        openrouter: {
+          usage: {
+            cost: 0.5,
+            costDetails: { upstreamInferenceCost: 0.879694 },
+          },
+        },
+      },
+    })
+
+    expect(result.cost).toBe(0.879694)
   })
 })
 


### PR DESCRIPTION
> **Not verified.** kwf reopened this section on 2026-09-07: verification restarted (phase pr)
> The proof below came from an earlier round and can be stale. Do not review until this note is gone.

> **kwf trial run.** This PR came from a workflow trial request, not from a tracked work item. Review it as you would any other PR; the label `kwf-trial` marks where it came from.

## Request

> Surface: the VS Code extension (Kilo-Org/kilocode issue 13829).
> 
> OpenRouter BYOK sessions always show $0, because providerCost reads `usage.cost` and ignores `usage.cost_details.upstream_inference_cost`.
> 
> OpenRouter returns, for every response it routes through a BYOK provider key:
> 
>     "usage": { "cost": 0, "is_byok": true,
>                "cost_details": { "upstream_inference_cost": 0.00000445 } }
> 
> `cost` is what OpenRouter charged the account, which is 0 by definition for BYOK routing. The real spend is `cost_details.upstream_inference_cost`. Reported on 7.5.14 and 7.5.15 with `openrouter/z-ai/glm-5.3-flash`.
> 
> Expected: a BYOK session shows the upstream inference cost, and a non-BYOK session keeps showing `usage.cost` exactly as it does today.
> 
> Rule: reproduce first. If it does not reproduce on main, answer no_change with the evidence.

## Changelog for users

- OpenRouter sessions routed through a BYOK provider key now show the upstream inference cost (`cost_details.upstream_inference_cost`) instead of $0 or only OpenRouter's routing fee.
- Non-BYOK OpenRouter sessions keep showing `usage.cost` exactly as before.

## Changelog for maintainers

- The `providerCost` OpenRouter branch now returns the upstream cost when it is present and either the provider is Kilo or the upstream cost exceeds the billed `usage.cost`. Look there first.
- The change relies on the invariant that a non-BYOK `usage.cost` is always at least the upstream inference cost (upstream plus OpenRouter's fee), so the shown value is unchanged for non-BYOK responses. Confirm this against the usage-accounting doc cited in the code comment.
- New edge behavior: when `usage.cost` is missing but `costDetails.upstreamInferenceCost` is present, the function now returns the upstream figure; main previously fell through to the token-based fallback. Confirm this is acceptable for your metadata shapes.
- Tests in `provider-cost.test.ts` cover BYOK $0 cost, BYOK routing-fee-only cost, non-BYOK, missing `cost_details`, and the Kilo provider preference.
- No changeset file is part of the diff; add one if this user-visible fix must ship in release notes.

## E2E proof

