### PR TITLE
docs(kilo-docs): add Standard Compute custom-provider setup

### DIFF
--- a/packages/kilo-docs/lib/nav/ai-providers.ts
+++ b/packages/kilo-docs/lib/nav/ai-providers.ts
@@ -30,6 +30,7 @@ export const AiProvidersNav: NavSection[] = [
       { href: "/ai-providers/openrouter", children: "OpenRouter" },
       { href: "/ai-providers/trustedrouter", children: "TrustedRouter" },
       { href: "/ai-providers/requesty", children: "Requesty" },
+      { href: "/ai-providers/standardcompute", children: "Standard Compute" },
       { href: "/ai-providers/daoxe", children: "DaoXE" },
       { href: "/ai-providers/unbound", children: "Unbound" },
       { href: "/ai-providers/zenmux", children: "ZenMux" },

--- a/packages/kilo-docs/pages/ai-providers/standardcompute.md
+++ b/packages/kilo-docs/pages/ai-providers/standardcompute.md
@@ -1,0 +1,63 @@
+---
+title: "Standard Compute"
+description: "Connect Standard Compute's routed model to Kilo Code using a custom provider."
+sidebar_label: Standard Compute
+---
+
+# Standard Compute
+
+Use [Standard Compute](https://standardcompute.com/) to keep working in Kilo Code while the service selects models and providers for your requests. The `standardcompute` model is a routing alias; it does not identify a single upstream model.
+
+## Connect in VS Code
+
+1. Get an API key from the [Standard Compute dashboard](https://standardcompute.com/dashboard).
+2. Open **Settings → Providers → Custom provider**.
+3. Enter these settings:
+
+| Setting | Value |
+|---|---|
+| Provider ID | `standardcompute` |
+| Display name | `Standard Compute` |
+| Provider API | `OpenAI Compatible` |
+| Base URL | `https://api.stdcmpt.com/v1` |
+| API key | Your Standard Compute API key |
+| Model ID | `standardcompute` |
+
+4. Submit the provider and select **Standard Compute** in the model picker.
+
+## Connect in the CLI
+
+Set `STANDARDCOMPUTE_API_KEY` in the shell where you run Kilo. Add this provider to `~/.config/kilo/kilo.json`; merge the entry into your existing `provider` object if you already have other providers configured.
+
+```json
+{
+  "provider": {
+    "standardcompute": {
+      "npm": "@ai-sdk/openai-compatible",
+      "env": ["STANDARDCOMPUTE_API_KEY"],
+      "models": {
+        "standardcompute": {
+          "name": "Standard Compute",
+          "limit": {
+            "context": 1000000,
+            "output": 4096
+          }
+        }
+      },
+      "options": {
+        "baseURL": "https://api.stdcmpt.com/v1"
+      }
+    }
+  }
+}
+```
+
+The context limit follows the provider's [models.dev entry](https://github.com/anomalyco/models.dev/blob/dev/providers/standardcompute/models/standardcompute.toml). This example uses a conservative 4,096-token output limit; adjust it to the limit available on your plan when you need longer responses.
+
+Select the model for a single command:
+
+```bash
+kilo run --model standardcompute/standardcompute "Explain the structure of this project."
+```
+
+For additional settings, see [OpenAI-compatible providers](/docs/ai-providers/openai-compatible). Standard Compute usage is billed by Standard Compute; see its [current plans](https://standardcompute.com/pricing).


### PR DESCRIPTION
## Issue

Closes #13844

## Context

Standard Compute uses one routing alias, so users need the actual endpoint and model ID when configuring Kilo's custom-provider connection. This adds a short provider guide with VS Code settings and a CLI example.

Disclosure: I run Standard Compute. The contribution was prepared with AI assistance.

## Implementation

Uses the existing OpenAI-compatible connection and environment-key configuration. The context metadata links to the provider's existing models.dev entry, and the example deliberately sets a smaller 4,096-token output limit. A single AI Gateways navigation entry makes the guide discoverable. Existing provider documentation and application behavior stay intact.

## Screenshots / Video

No application UI change. The new documentation route was checked in a local production build at `/docs/ai-providers/standardcompute`.

## How to Test

### Manual/local verification

Performed by the coding agent on macOS:

- Documentation test suite: **4 files, 22 tests passed**.
- Documentation production build: **226 pages generated successfully**, including the new provider guide; TypeScript and compilation passed.
- Markdoc validation and rendering passed. The embedded JSON parses, and endpoint, model alias, protocol package and environment-key fields match the existing custom-provider configuration.
- `git diff --check` passed.

### Reviewer test steps

1. Run the documentation site and open `/docs/ai-providers/standardcompute`.
2. Follow the new Standard Compute entry under AI Gateways.
3. Verify the VS Code settings table and CLI JSON/code blocks render.

### Blocked checks and substitute verification

The initial npm dependency installation failed in dependency resolution (`edgesOut`). Installing the documentation package dependencies in an isolated folder with Bun 1.3.14 and linking that folder locally allowed the package's real `test` and `build` scripts to pass. No dependency or lockfile changes are included.

This is documentation/configuration validation, not a live coding-quality benchmark. No extension or CLI application behavior changed.

## Checklist

- [x] Issue linked above
- [x] Tests/verification described
- [x] No application visual changes; documentation preview described
- [x] Changeset considered: documentation-only addition
- [x] AI-assisted diff reviewed against the existing configuration and documentation conventions

## Get in Touch

Please reply on this PR for configuration questions or requested changes.
