### PR TITLE
feat(cli): support stdin prompts for Cloud Agent commands

### DIFF
--- a/.changeset/polite-cloud-stdin.md
+++ b/.changeset/polite-cloud-stdin.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": minor
+---
+
+Add an explicit --prompt-stdin option to Cloud start and send commands.

--- a/packages/opencode/src/kilocode/cli/cmd/cloud-stdin.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/cloud-stdin.ts
@@ -28,7 +28,7 @@ export function cloudPromptOptions(yargs: Argv) {
     .check((args) => {
       const argv = typeof args.prompt === "string"
       const stdin = args.promptStdin === true
-      if (argv === stdin) throw new Error(promptSelection)
+      if (argv && stdin) throw new Error(promptSelection)
       return true
     })
 }

--- a/packages/opencode/src/kilocode/cli/cmd/cloud-stdin.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/cloud-stdin.ts
@@ -1,0 +1,92 @@
+import type { Argv } from "yargs"
+import { Effect } from "effect"
+import { PromptSchema } from "@/kilocode/cloud/contracts"
+import { CliError, fail } from "@/cli/effect-cmd"
+
+const maximumCharacters = 100_000
+const maximumBytes = maximumCharacters * 3
+const invalidPrompt = "Cloud Agent prompt is invalid"
+const promptSelection = "Provide exactly one of --prompt or --prompt-stdin"
+
+export interface CloudPromptArgs {
+  prompt?: string
+  promptStdin?: boolean
+}
+
+export function cloudPromptOptions(yargs: Argv) {
+  return yargs
+    .option("prompt", {
+      type: "string",
+      describe: "prompt for the Cloud Agent",
+    })
+    .option("prompt-stdin", {
+      type: "boolean",
+      default: false,
+      describe: "read the prompt from standard input",
+    })
+    .check((args) => {
+      const argv = typeof args.prompt === "string"
+      const stdin = args.promptStdin === true
+      if (argv === stdin) throw new Error(promptSelection)
+      return true
+    })
+}
+
+export const resolveCloudPrompt = Effect.fn("Cli.cloud.prompt")(function* (
+  args: CloudPromptArgs,
+  stream?: ReadableStream<Uint8Array>,
+) {
+  const argv = typeof args.prompt === "string"
+  const stdin = args.promptStdin === true
+  if (argv === stdin) return yield* fail(promptSelection)
+
+  const prompt = stdin
+    ? yield* Effect.tryPromise({
+        try: () => readCloudPromptStdin(stream),
+        catch: () => new CliError({ message: invalidPrompt }),
+      })
+    : args.prompt
+
+  if (!PromptSchema.safeParse(prompt).success) return yield* fail(invalidPrompt)
+  return prompt
+})
+
+export function withCloudPrompt<A, E, R>(
+  args: CloudPromptArgs,
+  admit: (prompt: string) => Effect.Effect<A, E, R>,
+  stream?: ReadableStream<Uint8Array>,
+) {
+  return Effect.flatMap(resolveCloudPrompt(args, stream), admit)
+}
+
+export async function readCloudPromptStdin(stream = Bun.stdin.stream()): Promise<string> {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder("utf-8", { fatal: true })
+  const parts: string[] = []
+  let bytes = 0
+  let characters = 0
+  let complete = false
+
+  try {
+    for (;;) {
+      const next = await reader.read()
+      if (next.done) {
+        complete = true
+        const text = decoder.decode()
+        if (text.length > maximumCharacters - characters) throw new Error(invalidPrompt)
+        return parts.join("") + text
+      }
+
+      bytes += next.value.byteLength
+      if (bytes > maximumBytes) throw new Error(invalidPrompt)
+
+      const text = decoder.decode(next.value, { stream: true })
+      if (text.length > maximumCharacters - characters) throw new Error(invalidPrompt)
+      characters += text.length
+      parts.push(text)
+    }
+  } finally {
+    if (!complete) await reader.cancel().catch(() => undefined)
+    reader.releaseLock()
+  }
+}

--- a/packages/opencode/src/kilocode/cli/cmd/cloud-stdin.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/cloud-stdin.ts
@@ -7,6 +7,7 @@ const maximumCharacters = 100_000
 const maximumBytes = maximumCharacters * 3
 const invalidPrompt = "Cloud Agent prompt is invalid"
 const promptSelection = "Provide exactly one of --prompt or --prompt-stdin"
+type PromptStream = ReadableStream<Uint8Array<ArrayBufferLike>>
 
 export interface CloudPromptArgs {
   prompt?: string
@@ -34,7 +35,7 @@ export function cloudPromptOptions(yargs: Argv) {
 
 export const resolveCloudPrompt = Effect.fn("Cli.cloud.prompt")(function* (
   args: CloudPromptArgs,
-  stream?: ReadableStream<Uint8Array>,
+  stream?: PromptStream,
 ) {
   const argv = typeof args.prompt === "string"
   const stdin = args.promptStdin === true
@@ -47,19 +48,19 @@ export const resolveCloudPrompt = Effect.fn("Cli.cloud.prompt")(function* (
       })
     : args.prompt
 
-  if (!PromptSchema.safeParse(prompt).success) return yield* fail(invalidPrompt)
+  if (typeof prompt !== "string" || !PromptSchema.safeParse(prompt).success) return yield* fail(invalidPrompt)
   return prompt
 })
 
 export function withCloudPrompt<A, E, R>(
   args: CloudPromptArgs,
   admit: (prompt: string) => Effect.Effect<A, E, R>,
-  stream?: ReadableStream<Uint8Array>,
+  stream?: PromptStream,
 ) {
   return Effect.flatMap(resolveCloudPrompt(args, stream), admit)
 }
 
-export async function readCloudPromptStdin(stream = Bun.stdin.stream()): Promise<string> {
+export async function readCloudPromptStdin(stream: PromptStream = Bun.stdin.stream()): Promise<string> {
   const reader = stream.getReader()
   const decoder = new TextDecoder("utf-8", { fatal: true })
   const parts: string[] = []

--- a/packages/opencode/src/kilocode/cli/cmd/cloud.ts
+++ b/packages/opencode/src/kilocode/cli/cmd/cloud.ts
@@ -2,6 +2,7 @@ import type { Argv } from "yargs"
 import { Effect } from "effect"
 import { cmd } from "@/cli/cmd/cmd"
 import { effectCmd } from "@/cli/effect-cmd"
+import { cloudPromptOptions, withCloudPrompt } from "./cloud-stdin"
 
 // Keep the top-level import graph light: this module is registered eagerly at CLI
 // startup, so the cloud implementation is imported inside handlers (same deferral
@@ -12,12 +13,7 @@ export const CloudStartCommand = effectCmd({
   command: "start",
   describe: "start a Cloud Agent task",
   builder: (yargs) =>
-    yargs
-      .option("prompt", {
-        type: "string",
-        demandOption: true,
-        describe: "prompt for the Cloud Agent",
-      })
+    cloudPromptOptions(yargs)
       .option("repo", {
         type: "string",
         describe: "repository shorthand or URL",
@@ -48,17 +44,21 @@ export const CloudStartCommand = effectCmd({
         describe: "connect to the WebSocket stream and print events as JSONL",
       }),
   handler: Effect.fn("Cli.cloud.start")(function* (args) {
-    const CloudCommands = yield* cloud
-    yield* CloudCommands.start({
-      prompt: args.prompt,
-      ...(args.repo === undefined ? {} : { repo: args.repo }),
-      ...(args.repoType === undefined ? {} : { repoType: args.repoType }),
-      ...(args.branch === undefined ? {} : { branch: args.branch }),
-      ...(args.model === undefined ? {} : { model: args.model }),
-      ...(args.mode === undefined ? {} : { mode: args.mode }),
-      ...(args.orgId === undefined ? {} : { orgID: args.orgId }),
-      ...(args.stream === undefined ? {} : { stream: args.stream }),
-    })
+    yield* withCloudPrompt(args, (prompt) =>
+      Effect.gen(function* () {
+        const CloudCommands = yield* cloud
+        yield* CloudCommands.start({
+          prompt,
+          ...(args.repo === undefined ? {} : { repo: args.repo }),
+          ...(args.repoType === undefined ? {} : { repoType: args.repoType }),
+          ...(args.branch === undefined ? {} : { branch: args.branch }),
+          ...(args.model === undefined ? {} : { model: args.model }),
+          ...(args.mode === undefined ? {} : { mode: args.mode }),
+          ...(args.orgId === undefined ? {} : { orgID: args.orgId }),
+          ...(args.stream === undefined ? {} : { stream: args.stream }),
+        })
+      }),
+    )
   }),
 })
 
@@ -67,20 +67,19 @@ export const CloudSendCommand = effectCmd({
   describe: "send a follow-up prompt to a Cloud Agent task",
   instance: false,
   builder: (yargs) =>
-    yargs
+    cloudPromptOptions(yargs)
       .option("session-id", {
         type: "string",
         demandOption: true,
         describe: "Cloud Agent session ID",
-      })
-      .option("prompt", {
-        type: "string",
-        demandOption: true,
-        describe: "follow-up prompt for the Cloud Agent",
       }),
   handler: Effect.fn("Cli.cloud.send")(function* (args) {
-    const CloudCommands = yield* cloud
-    yield* CloudCommands.send({ sessionID: args.sessionId, prompt: args.prompt })
+    yield* withCloudPrompt(args, (prompt) =>
+      Effect.gen(function* () {
+        const CloudCommands = yield* cloud
+        yield* CloudCommands.send({ sessionID: args.sessionId, prompt })
+      }),
+    )
   }),
 })
 

--- a/packages/opencode/test/kilocode/cli/cloud-stdin.test.ts
+++ b/packages/opencode/test/kilocode/cli/cloud-stdin.test.ts
@@ -7,7 +7,7 @@ import { readCloudPromptStdin, resolveCloudPrompt, withCloudPrompt } from "../..
 const encoder = new TextEncoder()
 
 function stream(parts: string[]) {
-  return new ReadableStream<Uint8Array>({
+  return new ReadableStream<Uint8Array<ArrayBufferLike>>({
     start(controller) {
       for (const part of parts) controller.enqueue(encoder.encode(part))
       controller.close()
@@ -15,32 +15,50 @@ function stream(parts: string[]) {
   })
 }
 
-async function parse(command: typeof CloudStartCommand | typeof CloudSendCommand, argv: string[]) {
-  return await command.builder!(yargs([]).exitProcess(false)).parseAsync(argv)
+function startBuilder() {
+  if (!CloudStartCommand.builder) throw new Error("Cloud start command requires a builder")
+  if (typeof CloudStartCommand.builder !== "function") throw new Error("Cloud start command requires a function builder")
+  return CloudStartCommand.builder
+}
+
+function sendBuilder() {
+  if (!CloudSendCommand.builder) throw new Error("Cloud send command requires a builder")
+  if (typeof CloudSendCommand.builder !== "function") throw new Error("Cloud send command requires a function builder")
+  return CloudSendCommand.builder
+}
+
+async function parseStart(argv: string[]) {
+  const parser = await startBuilder()(yargs([]).exitProcess(false))
+  return await parser.parseAsync(argv)
+}
+
+async function parseSend(argv: string[]) {
+  const parser = await sendBuilder()(yargs([]).exitProcess(false))
+  return await parser.parseAsync(argv)
 }
 
 describe("Cloud prompt stdin", () => {
   test("preserves argv prompts for start and send", async () => {
-    const start = await parse(CloudStartCommand, ["--prompt", "start from argv"])
-    const send = await parse(CloudSendCommand, ["--session-id", "ses_123", "--prompt", "send from argv"])
+    const start = await parseStart(["--prompt", "start from argv"])
+    const send = await parseSend(["--session-id", "ses_123", "--prompt", "send from argv"])
 
     expect(await Effect.runPromise(resolveCloudPrompt(start))).toBe("start from argv")
     expect(await Effect.runPromise(resolveCloudPrompt(send))).toBe("send from argv")
   })
 
   test("accepts stdin prompts for start and send", async () => {
-    const start = await parse(CloudStartCommand, ["--prompt-stdin"])
-    const send = await parse(CloudSendCommand, ["--session-id", "ses_123", "--prompt-stdin"])
+    const start = await parseStart(["--prompt-stdin"])
+    const send = await parseSend(["--session-id", "ses_123", "--prompt-stdin"])
 
     expect(await Effect.runPromise(resolveCloudPrompt(start, stream(["start from stdin"])))).toBe("start from stdin")
     expect(await Effect.runPromise(resolveCloudPrompt(send, stream(["send from stdin"])))).toBe("send from stdin")
   })
 
   test("rejects conflicting and missing prompt selectors", async () => {
-    await expect(parse(CloudStartCommand, ["--prompt", "argv", "--prompt-stdin"])).rejects.toThrow(
+    await expect(parseStart(["--prompt", "argv", "--prompt-stdin"])).rejects.toThrow(
       "Provide exactly one of --prompt or --prompt-stdin",
     )
-    await expect(parse(CloudStartCommand, [])).rejects.toThrow("Provide exactly one of --prompt or --prompt-stdin")
+    await expect(parseStart([])).rejects.toThrow("Provide exactly one of --prompt or --prompt-stdin")
   })
 
   test("rejects empty and oversized stdin before admission", async () => {
@@ -67,7 +85,7 @@ describe("Cloud prompt stdin", () => {
   test("preserves Unicode split across byte chunks", async () => {
     const value = "before \uD83D\uDE80 after"
     const bytes = encoder.encode(value)
-    const input = new ReadableStream<Uint8Array>({
+    const input = new ReadableStream<Uint8Array<ArrayBufferLike>>({
       start(controller) {
         controller.enqueue(bytes.slice(0, 8))
         controller.enqueue(bytes.slice(8, 10))

--- a/packages/opencode/test/kilocode/cli/cloud-stdin.test.ts
+++ b/packages/opencode/test/kilocode/cli/cloud-stdin.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import yargs from "yargs"
+import { CloudSendCommand, CloudStartCommand } from "../../../src/kilocode/cli/cmd/cloud"
+import { readCloudPromptStdin, resolveCloudPrompt, withCloudPrompt } from "../../../src/kilocode/cli/cmd/cloud-stdin"
+
+const encoder = new TextEncoder()
+
+function stream(parts: string[]) {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const part of parts) controller.enqueue(encoder.encode(part))
+      controller.close()
+    },
+  })
+}
+
+async function parse(command: typeof CloudStartCommand | typeof CloudSendCommand, argv: string[]) {
+  return await command.builder!(yargs([]).exitProcess(false)).parseAsync(argv)
+}
+
+describe("Cloud prompt stdin", () => {
+  test("preserves argv prompts for start and send", async () => {
+    const start = await parse(CloudStartCommand, ["--prompt", "start from argv"])
+    const send = await parse(CloudSendCommand, ["--session-id", "ses_123", "--prompt", "send from argv"])
+
+    expect(await Effect.runPromise(resolveCloudPrompt(start))).toBe("start from argv")
+    expect(await Effect.runPromise(resolveCloudPrompt(send))).toBe("send from argv")
+  })
+
+  test("accepts stdin prompts for start and send", async () => {
+    const start = await parse(CloudStartCommand, ["--prompt-stdin"])
+    const send = await parse(CloudSendCommand, ["--session-id", "ses_123", "--prompt-stdin"])
+
+    expect(await Effect.runPromise(resolveCloudPrompt(start, stream(["start from stdin"])))).toBe("start from stdin")
+    expect(await Effect.runPromise(resolveCloudPrompt(send, stream(["send from stdin"])))).toBe("send from stdin")
+  })
+
+  test("rejects conflicting and missing prompt selectors", async () => {
+    await expect(parse(CloudStartCommand, ["--prompt", "argv", "--prompt-stdin"])).rejects.toThrow(
+      "Provide exactly one of --prompt or --prompt-stdin",
+    )
+    await expect(parse(CloudStartCommand, [])).rejects.toThrow("Provide exactly one of --prompt or --prompt-stdin")
+  })
+
+  test("rejects empty and oversized stdin before admission", async () => {
+    let calls = 0
+    const admit = () => {
+      calls += 1
+      return Effect.void
+    }
+
+    await expect(Effect.runPromise(withCloudPrompt({ promptStdin: true }, admit, stream([])))).rejects.toMatchObject({
+      message: "Cloud Agent prompt is invalid",
+    })
+    await expect(
+      Effect.runPromise(withCloudPrompt({ promptStdin: true }, admit, stream(["x".repeat(100_001)]))),
+    ).rejects.toMatchObject({ message: "Cloud Agent prompt is invalid" })
+    expect(calls).toBe(0)
+  })
+
+  test("accepts the exact prompt boundary", async () => {
+    const prompt = "x".repeat(100_000)
+    expect(await readCloudPromptStdin(stream([prompt]))).toBe(prompt)
+  })
+
+  test("preserves Unicode split across byte chunks", async () => {
+    const value = "before \uD83D\uDE80 after"
+    const bytes = encoder.encode(value)
+    const input = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes.slice(0, 8))
+        controller.enqueue(bytes.slice(8, 10))
+        controller.enqueue(bytes.slice(10))
+        controller.close()
+      },
+    })
+
+    expect(await readCloudPromptStdin(input)).toBe(value)
+  })
+})

--- a/packages/opencode/test/kilocode/cli/cloud-stdin.test.ts
+++ b/packages/opencode/test/kilocode/cli/cloud-stdin.test.ts
@@ -58,7 +58,9 @@ describe("Cloud prompt stdin", () => {
     await expect(parseStart(["--prompt", "argv", "--prompt-stdin"])).rejects.toThrow(
       "Provide exactly one of --prompt or --prompt-stdin",
     )
-    await expect(parseStart([])).rejects.toThrow("Provide exactly one of --prompt or --prompt-stdin")
+    await expect(Effect.runPromise(resolveCloudPrompt({}))).rejects.toMatchObject({
+      message: "Provide exactly one of --prompt or --prompt-stdin",
+    })
   })
 
   test("rejects empty and oversized stdin before admission", async () => {

--- a/packages/opencode/test/kilocode/help.test.ts
+++ b/packages/opencode/test/kilocode/help.test.ts
@@ -170,6 +170,12 @@ describe("kilo cloud help", () => {
     const names = [...help.matchAll(/^\s*kilo cloud ([a-z][a-z-]*)\b/gm)].map((match) => match[1])
     expect([...new Set(names)].sort()).toEqual(["result", "send", "start", "status"])
   })
+
+  test("documents start prompt stdin", async () => {
+    const output = await generateHelp({ command: "cloud", format: "md", commands })
+    expect(output).toContain("kilo cloud start")
+    expect(output).toContain("--prompt-stdin")
+  })
 })
 
 describe("edge cases", () => {


### PR DESCRIPTION
## Summary

- Add an explicit `--prompt-stdin` option to `cloud start` and `cloud send`.
- Require exactly one prompt source and validate streamed UTF-8 input before submission.
- Add coverage for argument parsing, size limits, empty input, and split Unicode chunks.

## Testing

- `bun test ./test/kilocode/cli/cloud-stdin.test.ts`
- `bun run typecheck`
- Full pre-push typecheck hook passed with authenticated release metadata access.