### PR TITLE
fix(vscode): remove stale worktrees after PTY cleanup failure

### DIFF
--- a/.changeset/quiet-worktrees-clean.md
+++ b/.changeset/quiet-worktrees-clean.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Allow stale Agent Manager worktrees to be removed when terminal cleanup fails for their missing folders.

--- a/packages/kilo-vscode/src/agent-manager/provider-lifecycle.ts
+++ b/packages/kilo-vscode/src/agent-manager/provider-lifecycle.ts
@@ -250,7 +250,6 @@ export async function removeStaleLifecycleWorktree(
     releasePtyCleanup()
   } catch (error) {
     host.log(`Failed to remove stale worktree PTYs: ${error}`)
-    return null
   }
   host.forgetName(worktreeId)
   const orphaned = state.removeWorktree(worktreeId)

--- a/packages/kilo-vscode/tests/unit/agent-manager-provider-lifecycle.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-provider-lifecycle.test.ts
@@ -4,7 +4,11 @@ import * as os from "node:os"
 import * as path from "node:path"
 import type { KiloClient, SessionStatus } from "@kilocode/sdk/v2/client"
 import { ProjectContext } from "../../src/agent-manager/project/context"
-import { deleteLifecycleWorktree, type LifecycleHost } from "../../src/agent-manager/provider-lifecycle"
+import {
+  deleteLifecycleWorktree,
+  removeStaleLifecycleWorktree,
+  type LifecycleHost,
+} from "../../src/agent-manager/provider-lifecycle"
 import { WorktreeStateManager } from "../../src/agent-manager/WorktreeStateManager"
 
 describe("Agent Manager worktree deletion lifecycle", () => {
@@ -191,6 +195,22 @@ describe("Agent Manager worktree deletion lifecycle", () => {
       expect(state.getWorktrees()).toHaveLength(1)
     },
   )
+
+  it("removes stale state when PTY cleanup fails", async () => {
+    const id = state.getWorktrees().at(0)!.id
+    const session = state.addSession("session", id)
+    ctx.stale.add(id)
+    host.acquirePtyCleanup = mock(async () => {
+      throw new Error("backend offline")
+    })
+
+    await removeStaleLifecycleWorktree(ctx, host, id)
+
+    expect(state.getWorktrees()).toHaveLength(0)
+    expect(state.getSessions()).toHaveLength(0)
+    expect(ctx.stale.has(id)).toBeFalse()
+    expect(calls).toEqual(["run:remove", "run:clear", "name", "diff", `clear:${session.id}`, "push"])
+  })
 
   it("preserves state and releases deletion progress when the directory remains locked", async () => {
     const id = state.getWorktrees().at(0)!.id


### PR DESCRIPTION
## Summary

Allow Agent Manager to remove an already-stale worktree record even when PTY cleanup cannot contact the backend for its missing directory. Real worktree deletion remains fail-closed.

Fixes #13826

## Why

`removeStaleLifecycleWorktree` currently returns when `acquirePtyCleanup` rejects. A deleted directory can make the directory-scoped PTY request fail, so the later `state.removeWorktree` call is never reached and the stale card persists indefinitely.

PTY cleanup is best-effort in this state-only removal path: the checkout is already gone. The existing destructive deletion path still aborts on the same failure.

## Testing

- Regression test fails before the fix with one stale worktree remaining, then passes with the fix
- `bun test tests/unit/agent-manager-provider-lifecycle.test.ts` (15 passed)
- `bun test tests/unit/pty-cleanup.test.ts tests/unit/agent-manager-arch.test.ts` (82 passed)
- `bun run test:unit` (4,981 passed, 1 skipped)
- `bun run typecheck`
- `bun run lint`
- `bun run knip`
- `bun run check-kilocode-change`
- Pre-push monorepo typecheck (29 packages passed)

`bun run compile` was also attempted, but local CLI binary preparation requires Zig to compile the Linux Bubblewrap helper. Package typecheck, lint, focused tests, the full extension unit suite, and the pre-push monorepo typecheck completed successfully instead.