### PR TITLE
fix(vscode): use theme colors for diff deletion indicators

### DIFF
--- a/.changeset/solid-deletion-bars.md
+++ b/.changeset/solid-deletion-bars.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Use the diff theme color for deleted-line indicators, including when line numbers are hidden.

--- a/packages/kilo-ui/src/pierre/index.ts
+++ b/packages/kilo-ui/src/pierre/index.ts
@@ -21,6 +21,9 @@ export const LINE_DIFF_TYPE = "word-alt" as const
 // Pierre 1.1 treats its changed-line override properties as tint targets. Apply
 // Kilo semantic surfaces at the computed row level so host diff colors stay final.
 const css = `
+[data-indicators='bars'] [data-column-number][data-line-type='change-deletion'] {
+  --diffs-deletion-base: var(--surface-diff-delete-strong, #ff6762);
+}
 [data-diff][data-background] [data-line][data-line-type='change-addition'] {
   --diffs-computed-diff-line-bg: var(--surface-diff-add-base, var(--diffs-bg-addition));
   --diffs-computed-selected-line-bg: var(--surface-diff-add-base, var(--diffs-bg-addition));

--- a/packages/kilo-ui/tests/diff-indicators.spec.ts
+++ b/packages/kilo-ui/tests/diff-indicators.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test"
+
+for (const scheme of ["light", "dark"]) {
+  for (const width of [420, 1000]) {
+    test(`diff bars in ${scheme} theme at ${width}px`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 720 })
+      await page.goto(`/iframe.html?id=components-diff--default&viewMode=story&globals=colorScheme:${scheme}`)
+
+      const diff = page.locator("[data-diff]").first()
+      await expect(diff).toBeVisible()
+      if (width < 640) await expect(diff).toHaveAttribute("data-disable-line-numbers", "")
+      if (width > 640) await expect(diff).not.toHaveAttribute("data-disable-line-numbers", "")
+
+      for (const type of ["deletion", "addition"]) {
+        const gutter = page.locator(`[data-column-number][data-line-type='change-${type}']`).first()
+        await expect(gutter).toBeVisible()
+        const bar = await gutter.evaluate((element) => {
+          const style = getComputedStyle(element, "::before")
+          return {
+            width: parseFloat(style.width),
+            opacity: style.opacity,
+            height: parseFloat(style.height),
+            content: style.content,
+            base: getComputedStyle(element).getPropertyValue("--diffs-deletion-base").trim(),
+          }
+        })
+        expect(bar.width).toBe(4)
+        expect(bar.opacity).toBe("1")
+        expect(bar.height).toBeGreaterThan(0)
+        expect(bar.content).toBe('""')
+        if (type === "deletion") expect(bar.base).not.toBe(scheme === "dark" ? "#ff6762" : "#ff2e3f")
+      }
+    })
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Deleted lines in narrow diff views can lose their visible line-number cue, making them hard to distinguish from unchanged content. Bright default deletion indicators also do not match the surrounding diff surfaces.

## Why This Change Was Made

Pierre already owns indicator layout, width, pattern, and responsive visibility. The Kilo Pierre wrapper now overrides only the deletion indicator color with the existing diff theme token, leaving Pierre's rendering behavior unchanged.

## User Impact

Deleted-line indicators remain visible when line numbers are hidden and use a muted theme-aligned color.

<img width="1000" alt="Diff viewer with a muted deletion indicator beside removed lines" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260907-diff-viewer-deletion-indicator.png" />

Fixes #13846

## Evidence

- Focused Playwright coverage passes for light and dark themes at 420px and 1000px.
- `bun run compile` passes in `packages/kilo-vscode/`.
- Prettier and `git diff --check` pass.
