### PR TITLE
fix(vscode): harden Git worktree path resolution

### DIFF
--- a/.changeset/fix-indexing-git-path.md
+++ b/.changeset/fix-indexing-git-path.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Prevent invalid Git output from becoming the indexing directory when resolving worktree projects with older Git versions.

--- a/packages/kilo-vscode/src/agent-manager/project/paths.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/paths.ts
@@ -64,17 +64,22 @@ export async function resolveProjectRoot(
     Promise.resolve()
       .then(() => git(dir, args))
       .catch(() => undefined)
-  const revparse = (args: string[]) => run(["rev-parse", ...args])
-  const top = await revparse(["--path-format=absolute", "--show-toplevel"])
-  if (!top) return undefined
-  const root = canonicalizePath(top.trim())
-  const [gitdir, common] = await Promise.all([
-    revparse(["--path-format=absolute", "--git-dir"]),
-    revparse(["--path-format=absolute", "--git-common-dir"]),
-  ])
-  if (!gitdir || !common) return root
-  if (samePath(canonicalizePath(gitdir.trim()), canonicalizePath(common.trim()))) return root
+  const revparse = async (arg: string) => (await run(["rev-parse", arg]))?.replace(/\r?\n$/, "")
+  // Older Git echoes unsupported rev-parse flags into stdout with exit code zero.
+  // --show-toplevel is already absolute; never resolve an option line as a path.
+  const top = await revparse("--show-toplevel")
+  if (!top || !path.isAbsolute(top)) return undefined
+  const root = canonicalizePath(top)
+  const [gitdir, common] = await Promise.all([revparse("--git-dir"), revparse("--git-common-dir")])
+  if (!gitdir || !common || gitdir.startsWith("--") || common.startsWith("--")) return root
+  // Git metadata paths can be relative to the command's cwd, not the extension host's cwd.
+  if (samePath(canonicalizePath(path.resolve(dir, gitdir)), canonicalizePath(path.resolve(dir, common)))) {
+    return root
+  }
   const listing = await run(["worktree", "list", "--porcelain", "-z"])
-  const first = listing?.split("\0").find((field) => field.startsWith("worktree "))
-  return first ? canonicalizePath(first.slice("worktree ".length)) : root
+  const plain = listing ?? (await run(["worktree", "list", "--porcelain"]))
+  const fields = plain?.includes("\0") ? plain.split("\0") : plain?.split(/\r?\n/)
+  const first = fields?.find((field) => field.startsWith("worktree "))
+  const primary = first?.slice("worktree ".length)
+  return primary && path.isAbsolute(primary) ? canonicalizePath(primary) : root
 }

--- a/packages/kilo-vscode/tests/unit/agent-project-paths.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-project-paths.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test"
 import * as fs from "fs"
 import * as os from "os"
 import * as path from "path"
+import { simpleGit } from "simple-git"
 import {
   canonicalizePath,
   findTrackedBranch,
@@ -79,13 +80,92 @@ describe("project-paths", () => {
 
   it("resolveProjectRoot maps a linked worktree to the primary checkout", async () => {
     const calls = new Map([
-      ["rev-parse --path-format=absolute --show-toplevel", "/repo/worktree"],
-      ["rev-parse --path-format=absolute --git-dir", "/repo/.git/worktrees/feature"],
-      ["rev-parse --path-format=absolute --git-common-dir", "/repo/.git"],
+      ["rev-parse --show-toplevel", "/repo/worktree"],
+      ["rev-parse --git-dir", "/repo/.git/worktrees/feature"],
+      ["rev-parse --git-common-dir", "/repo/.git"],
       ["worktree list --porcelain -z", "worktree /repo\0HEAD abc\0\0worktree /repo/worktree\0HEAD def\0"],
     ])
     const root = await resolveProjectRoot("/repo/worktree", async (_cwd, args) => calls.get(args.join(" ")) ?? "")
 
     expect(root).toBe(canonicalizePath("/repo"))
+  })
+
+  it("rejects option-contaminated top-level output instead of using the process cwd", async () => {
+    const root = await resolveProjectRoot(os.tmpdir(), async () => `--path-format=absolute\n${os.tmpdir()}\n`)
+    expect(root).toBeUndefined()
+  })
+
+  it("resolves relative metadata paths against the Git cwd", async () => {
+    const dir = path.join(os.tmpdir(), "pp-relative", "server")
+    const root = path.dirname(dir)
+    const calls = new Map([
+      ["rev-parse --show-toplevel", `${root}\n`],
+      ["rev-parse --git-dir", "../.git\n"],
+      ["rev-parse --git-common-dir", `${path.join(root, ".git")}\n`],
+    ])
+    const commands: string[] = []
+    const result = await resolveProjectRoot(dir, async (_cwd, args) => {
+      commands.push(args.join(" "))
+      return calls.get(args.join(" ")) ?? ""
+    })
+    expect(result).toBe(canonicalizePath(root))
+    expect(commands).toEqual([...calls.keys()])
+  })
+
+  it.each([undefined, "worktree --path-format=absolute\ninvalid\0"])(
+    "falls back to the valid checkout when worktree listing is unavailable or malformed (%s)",
+    async (listing) => {
+      const dir = path.join(os.tmpdir(), "pp-linked")
+      const calls = new Map([
+        ["rev-parse --show-toplevel", `${dir}\n`],
+        ["rev-parse --git-dir", path.join(os.tmpdir(), "repo", ".git", "worktrees", "linked")],
+        ["rev-parse --git-common-dir", path.join(os.tmpdir(), "repo", ".git")],
+        ["worktree list --porcelain -z", listing],
+      ])
+      const root = await resolveProjectRoot(dir, async (_cwd, args) => {
+        const output = calls.get(args.join(" "))
+        if (output == null) throw new Error("unsupported option")
+        return output
+      })
+      expect(root).toBe(canonicalizePath(dir))
+    },
+  )
+
+  it("resolves real Unicode checkout and linked-worktree subfolders without newer Git flags", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pp-git-"))
+    const root = path.join(dir, "\u76ee\u5f55 primary")
+    const linked = path.join(dir, "\u76ee\u5f55 linked")
+    fs.mkdirSync(root)
+    try {
+      const git = simpleGit(root)
+      await git.init()
+      await git.raw([
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "--allow-empty",
+        "-m",
+        "init",
+      ])
+      await git.raw(["worktree", "add", "-b", "linked", linked])
+      for (const checkout of [root, linked]) {
+        const subdir = path.join(checkout, "server")
+        fs.mkdirSync(subdir)
+        const result = await resolveProjectRoot(subdir, (cwd, args) => {
+          expect(args.some((arg) => arg.startsWith("--path-format"))).toBe(false)
+          return simpleGit(cwd).raw(args)
+        })
+        expect(result).toBe(canonicalizePath(root))
+      }
+      const fallback = await resolveProjectRoot(path.join(linked, "server"), (cwd, args) => {
+        if (args.includes("-z")) throw new Error("unsupported option: -z")
+        return simpleGit(cwd).raw(args)
+      })
+      expect(fallback).toBe(canonicalizePath(root))
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## What Problem This Solves

Related to #13843. On Windows, the extension project-root resolver can accept malformed `git rev-parse` output as a directory. With older Git, the unsupported `--path-format=absolute` option can be echoed into stdout. If linked-worktree discovery then fails, that malformed value can be sent as the indexing directory and later fail in the CLI during `realpath`.

## Why This Change Was Made

The resolver does not need `--path-format=absolute`: `--show-toplevel` is already absolute, and Git metadata paths can be resolved relative to the Git command directory. The resolver now removes the unnecessary option, rejects option-contaminated top-level output, validates worktree paths, and retries `git worktree list --porcelain` when the NUL-delimited `-z` form is unavailable. This keeps older Git linked worktrees mapped to the primary checkout instead of accepting a malformed path or losing shared baseline routing.

## User Impact

Windows users opening subfolders of linked worktrees should no longer send an invalid VS Code-prefixed path to indexing when Git does not support the newer options. Valid Unicode and space-containing worktree paths remain supported.

This addresses the confirmed malformed-path mechanism from #13843. The reporter's exact native Windows Git version and character-level path corruption were not available for reproduction, so the PR does not claim to prove every symptom in that report.

## Evidence

- Full VS Code unit suite: 4,985 passed, 1 skipped, 0 failed.
- Focused project-path and indexing tests: 118 passed, 0 failed.
- Extension typecheck passed.
- Extension lint, formatting, Knip, and `kilocode_change` checks passed.
- Regression tests cover option-contaminated output, relative Git metadata paths, unavailable or malformed worktree listing, Unicode checkout paths, linked-worktree subfolders, and fallback to the plain porcelain listing.
- Isolated VS Code smoke test on macOS resolved a Unicode linked-worktree subfolder to the primary checkout without an initialization error.

### Manual Test

On Windows, use Git with a linked worktree under a non-ASCII path, open a nested subfolder in VS Code, open Kilo Settings > Indexing, and enable indexing. The project should resolve to a valid checkout path and should not show an `ENOENT realpath` initialization error.