### PR TITLE
chore(vscode): allow intentional nullish comparisons

### DIFF
--- a/packages/kilo-vscode/eslint.config.mjs
+++ b/packages/kilo-vscode/eslint.config.mjs
@@ -26,7 +26,8 @@ export default [
       ],
 
       curly: "warn",
-      eqeqeq: "warn",
+      // Nullish checks intentionally cover both null and undefined.
+      eqeqeq: ["warn", "always", { null: "ignore" }],
       "no-throw-literal": "warn",
       "max-lines": ["error", 3000],
       complexity: ["error", 20],


### PR DESCRIPTION
## Summary
Allow intentional `== null` and `!= null` checks in the VS Code extension without `eqeqeq` warnings. Strict equality remains required for all other comparisons.

This is a follow-up to #13861 based on the review suggestion from @WebReflection.

Related to #13833.