### PR TITLE
fix(vscode): trim Git command output

### DIFF
--- a/packages/kilo-vscode/src/agent-manager/project/paths.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/paths.ts
@@ -64,7 +64,7 @@ export async function resolveProjectRoot(
     Promise.resolve()
       .then(() => git(dir, args))
       .catch(() => undefined)
-  const revparse = async (arg: string) => (await run(["rev-parse", arg]))?.replace(/\r?\n$/, "")
+  const revparse = async (arg: string) => (await run(["rev-parse", arg]))?.trimEnd()
   // Older Git echoes unsupported rev-parse flags into stdout with exit code zero.
   // --show-toplevel is already absolute; never resolve an option line as a path.
   const top = await revparse("--show-toplevel")


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #13863. The Git project-root resolver removed the unsupported `--path-format` option, but its output cleanup still removed only the final newline. Git command output should be normalized with the standard trailing-whitespace operation.

## Why This Change Was Made

Use `trimEnd()` so CRLF output and any trailing command-output whitespace are removed consistently before path validation and canonicalization. This is a one-line review follow-up with no behavior change for normal paths.

## Evidence

- Focused project-path tests: 11 passed, 0 failed.
- Extension typecheck passed.
- Prettier check passed.

This PR is intentionally limited to the review correction from #13863.