### PR TITLE
fix(session): speed up cold session loading

### DIFF
--- a/.changeset/fast-cold-history.md
+++ b/.changeset/fast-cold-history.md
@@ -1,0 +1,6 @@
+---
+"kilo-code": patch
+"@kilocode/cli": patch
+---
+
+Load recent messages faster when opening large sessions, speed up token-usage totals across child sessions, and keep older history available on demand.

--- a/packages/core/schema.json
+++ b/packages/core/schema.json
@@ -2236,6 +2236,20 @@
         {
           "value": "session_id",
           "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": "json_valid(\"part\".\"data\") AND json_extract(\"part\".\"data\", '$.type') = 'step-finish'",
+      "origin": "manual",
+      "name": "part_session_step_finish_idx",
+      "entityType": "indexes",
+      "table": "part"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
         },
         {
           "value": "id",

--- a/packages/core/script/kilocode/migration.ts
+++ b/packages/core/script/kilocode/migration.ts
@@ -7,11 +7,11 @@ export function file(name: string, value: string) {
 }
 
 export function block(name: string | undefined, source: string, value: string) {
-  return (name !== undefined && board(name)) || /kilo_board(?:_message)?/.test(source)
+  return (name !== undefined && board(name)) || /kilo_board(?:_message)?|part_session_step_finish_idx/.test(source)
     ? `// kilocode_change start\n${value}\n// kilocode_change end`
     : value
 }
 
 export function line(name: string, value: string) {
-  return board(name) ? `${value} // kilocode_change` : value
+  return board(name) || name.endsWith("_kilocode_model_usage_index") ? `${value} // kilocode_change` : value
 }

--- a/packages/core/src/database/migration.gen.ts
+++ b/packages/core/src/database/migration.gen.ts
@@ -42,5 +42,6 @@ export const migrations = (
     import("./migration/20260622202450_simplify_session_input"),
     import("./migration/20260714141136_session-message-legacy-writer-compat"),
     import("./migration/20260828074139_kilocode_board"), // kilocode_change
+    import("./migration/20260907102000_kilocode_model_usage_index"), // kilocode_change
   ])
 ).map((module) => module.default) satisfies DatabaseMigration.Migration[]

--- a/packages/core/src/database/migration/20260907102000_kilocode_model_usage_index.ts
+++ b/packages/core/src/database/migration/20260907102000_kilocode_model_usage_index.ts
@@ -1,0 +1,13 @@
+import { Effect } from "effect"
+import type { DatabaseMigration } from "../migration"
+
+export default {
+  id: "20260907102000_kilocode_model_usage_index",
+  up(tx) {
+    return Effect.gen(function* () {
+      yield* tx.run(
+        `CREATE INDEX \`part_session_step_finish_idx\` ON \`part\` (\`session_id\`) WHERE json_valid("part"."data") AND json_extract("part"."data", '$.type') = 'step-finish';`,
+      )
+    })
+  },
+} satisfies DatabaseMigration.Migration

--- a/packages/core/src/database/schema.gen.ts
+++ b/packages/core/src/database/schema.gen.ts
@@ -284,6 +284,11 @@ export default {
       )
       yield* tx.run(`CREATE INDEX \`part_message_id_id_idx\` ON \`part\` (\`message_id\`,\`id\`);`)
       yield* tx.run(`CREATE INDEX \`part_session_idx\` ON \`part\` (\`session_id\`);`)
+      // kilocode_change start
+      yield* tx.run(
+        `CREATE INDEX \`part_session_step_finish_idx\` ON \`part\` (\`session_id\`) WHERE json_valid("part"."data") AND json_extract("part"."data", '$.type') = 'step-finish';`,
+      )
+      // kilocode_change end
       yield* tx.run(
         `CREATE INDEX \`recall_part_search_idx\` ON \`part\` (\`session_id\`,\`id\`,\`message_id\`,json_extract("data", '$.type'),CASE WHEN json_extract("data", '$.type') = 'text' THEN coalesce(json_extract("data", '$.text'), '') WHEN json_extract("data", '$.type') = 'file' THEN trim(coalesce(json_extract("data", '$.filename'), '') || ' ' || CASE WHEN coalesce(json_extract("data", '$.url'), '') NOT LIKE 'data:%' THEN coalesce(json_extract("data", '$.url'), '') ELSE '' END || ' ' || coalesce(json_extract("data", '$.source.path'), '') || ' ' || coalesce(json_extract("data", '$.source.name'), '') || ' ' || CASE WHEN coalesce(json_extract("data", '$.source.uri'), '') NOT LIKE 'data:%' THEN coalesce(json_extract("data", '$.source.uri'), '') ELSE '' END || ' ' || coalesce(json_extract("data", '$.source.clientName'), '')) ELSE coalesce(json_extract("data", '$.state.error'), '') END) WHERE json_valid("part"."data") AND ((json_extract("part"."data", '$.type') = 'text' AND coalesce(json_extract("part"."data", '$.synthetic'), 0) = 0 AND coalesce(json_extract("part"."data", '$.ignored'), 0) = 0) OR json_extract("part"."data", '$.type') = 'file' OR (json_extract("part"."data", '$.type') = 'tool' AND json_extract("part"."data", '$.state.status') = 'error'));`,
       )

--- a/packages/core/src/session/sql.ts
+++ b/packages/core/src/session/sql.ts
@@ -14,6 +14,7 @@ import { Timestamps } from "../database/schema.sql"
 import type { SystemContext } from "../system-context/index"
 import type { Revert } from "@opencode-ai/schema/revert"
 import { RecallPartIndex } from "../kilocode/session/recall-part-index" // kilocode_change
+import { sql } from "drizzle-orm" // kilocode_change
 
 type SessionMessageData = Omit<(typeof SessionMessage.Message)["Encoded"], "type" | "id">
 type V1MessageData = Omit<SessionV1.Info, "id" | "sessionID">
@@ -97,6 +98,11 @@ export const PartTable = sqliteTable(
   (table) => [
     index("part_message_id_id_idx").on(table.message_id, table.id),
     index("part_session_idx").on(table.session_id),
+    // kilocode_change start
+    index("part_session_step_finish_idx")
+      .on(table.session_id)
+      .where(sql`json_valid(${table.data}) AND json_extract(${table.data}, '$.type') = 'step-finish'`),
+    // kilocode_change end
     RecallPartIndex.make(table), // kilocode_change
   ],
 )

--- a/packages/core/test/kilocode/board/migration.test.ts
+++ b/packages/core/test/kilocode/board/migration.test.ts
@@ -35,7 +35,7 @@ describe("board migration", () => {
         expect(yield* db.all(sql`PRAGMA foreign_key_list('kilo_board')`)).toMatchObject([
           { table: "session", on_delete: "CASCADE" },
         ])
-        expect(migrations.at(-1)?.id).toContain("kilocode_board")
+        expect(migrations.find((migration) => migration.id.includes("kilocode_board"))?.id).toContain("kilocode_board")
       }),
     )
   })

--- a/packages/core/test/kilocode/model-usage-index.test.ts
+++ b/packages/core/test/kilocode/model-usage-index.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test"
+import { SqliteClient } from "@effect/sql-sqlite-bun"
+import { EffectDrizzleSqlite } from "@opencode-ai/effect-drizzle-sqlite"
+import { DatabaseMigration } from "@opencode-ai/core/database/migration"
+import { migrations } from "@opencode-ai/core/database/migration.gen"
+import migration from "@opencode-ai/core/database/migration/20260907102000_kilocode_model_usage_index"
+import { sql } from "drizzle-orm"
+import { Effect } from "effect"
+
+test("creates the step-finish index on fresh and upgraded databases and uses it for family usage", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const db = yield* EffectDrizzleSqlite.makeWithDefaults()
+      yield* DatabaseMigration.apply(db)
+      const definition = sql`SELECT sql FROM sqlite_master WHERE name = 'part_session_step_finish_idx'`
+      const fresh = yield* db.get(definition)
+      expect(fresh).toBeDefined()
+      expect(migrations).toContain(migration)
+
+      // Recreate the pre-migration state, including parts that must be indexed on upgrade.
+      yield* db.run(sql`DROP INDEX part_session_step_finish_idx`)
+      yield* db.run(sql`DELETE FROM migration WHERE id = ${migration.id}`)
+      yield* db.run(
+        sql`INSERT INTO project (id, worktree, time_created, time_updated, sandboxes) VALUES ('project', '/repo', 1, 1, '[]')`,
+      )
+      yield* db.run(
+        sql`INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated) VALUES ('root', 'project', 'root', '/repo', 'Root', '1', 1, 1)`,
+      )
+      yield* db.run(
+        sql`INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES ('message', 'root', 1, 1, '{"role":"assistant"}')`,
+      )
+      yield* db.run(
+        sql`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES ('step', 'message', 'root', 1, 1, '{"type":"step-finish","cost":0.25}'), ('tool', 'message', 'root', 1, 1, '{"type":"tool","cost":99}')`,
+      )
+      yield* db.run(
+        sql`INSERT INTO session (id, project_id, slug, directory, title, version, time_created, time_updated) VALUES ('unrelated', 'project', 'unrelated', '/repo', 'Unrelated', '1', 1, 1)`,
+      )
+      yield* db.run(
+        sql`INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES ('unrelated', 'unrelated', 1, 1, '{"role":"assistant"}')`,
+      )
+      yield* db.run(
+        sql`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES ('malformed', 'unrelated', 'unrelated', 1, 1, '{')`,
+      )
+      const query = sql`
+        SELECT sum(json_extract(part.data, '$.cost')) AS cost
+        FROM part
+        JOIN message ON message.id = part.message_id AND message.session_id = part.session_id
+        WHERE part.session_id IN (${"root"}, ${"child"})
+          AND json_valid(part.data)
+          AND json_extract(part.data, '$.type') = 'step-finish'
+          AND json_extract(message.data, '$.role') = 'assistant'`
+      const before = yield* db.get(query)
+      expect(before).toEqual({ cost: 0.25 })
+
+      yield* DatabaseMigration.apply(db)
+      yield* DatabaseMigration.apply(db)
+      expect(yield* db.get(sql`SELECT data FROM part WHERE id = 'malformed'`)).toEqual({ data: "{" })
+      expect(yield* db.get(definition)).toEqual(fresh)
+      expect(yield* db.get(query)).toEqual(before)
+      const plan = yield* db.all<{ detail: string }>(sql`EXPLAIN QUERY PLAN ${query}`)
+      expect(plan.some((row) => row.detail.includes("USING INDEX part_session_step_finish_idx"))).toBe(true)
+      expect(yield* db.get(sql`SELECT count(*) AS count FROM migration WHERE id = ${migration.id}`)).toEqual({
+        count: 1,
+      })
+    }).pipe(Effect.provide(SqliteClient.layer({ filename: ":memory:", disableWAL: true })), Effect.scoped),
+  )
+})

--- a/packages/kilo-ui/src/hooks/create-auto-scroll.test.tsx
+++ b/packages/kilo-ui/src/hooks/create-auto-scroll.test.tsx
@@ -515,6 +515,38 @@ describe("createAutoScroll non-scrollable layouts", () => {
     ctx.dispose()
   })
 
+  test("skips mutation geometry reads after settling expires but still follows content resize", async () => {
+    const ctx = setup()
+    overflow(ctx)
+
+    try {
+      ctx.el.scrollHeight = 1080
+      ctx.mutate()
+      expect(ctx.el.scrollTop).toBe(1080)
+
+      await Bun.sleep(350)
+      ctx.el.scrollTop = 880
+      const height = mock(() => 1200)
+      const viewport = mock(() => 200)
+      Object.defineProperties(ctx.el, {
+        scrollHeight: { get: height },
+        clientHeight: { get: viewport },
+      })
+
+      ctx.mutate()
+
+      expect(height).not.toHaveBeenCalled()
+      expect(viewport).not.toHaveBeenCalled()
+      expect(ctx.el.scrollTop).toBe(880)
+      expect(ctx.scroll.userScrolled()).toBe(false)
+
+      ctx.resize(0)
+      expect(ctx.el.scrollTop).toBe(1200)
+    } finally {
+      ctx.dispose()
+    }
+  })
+
   test("ignores content mutations while the user reads earlier output", () => {
     const ctx = setup({ working: true })
     ctx.el.scrollHeight = 1000
@@ -529,8 +561,9 @@ describe("createAutoScroll non-scrollable layouts", () => {
     ctx.dispose()
   })
 
-  test("leaves an idle transcript where a layout clamp put it", () => {
+  test("leaves an idle transcript where a layout clamp put it", async () => {
     const ctx = setup()
+    await Bun.sleep(350)
     ctx.el.scrollHeight = 1000
     ctx.el.clientHeight = 200
     ctx.el.scrollTop = 800

--- a/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
+++ b/packages/kilo-ui/src/hooks/create-auto-scroll.tsx
@@ -159,7 +159,7 @@ export function createAutoScroll(options: AutoScrollOptions) {
   // waiting for it lets the browser paint one frame with the new content hanging
   // below the viewport, which reads as the transcript twitching as it streams.
   const onContentMutate = () => {
-    if (!scroll) return
+    if (!scroll || !active()) return
     if (store.userScrolled || userActivity.isRecent()) return
     if (!canScroll(scroll)) return
 

--- a/packages/kilo-vscode/src/KiloProvider.ts
+++ b/packages/kilo-vscode/src/KiloProvider.ts
@@ -2029,13 +2029,17 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
   }
 
   /** Non-blocking: refresh session metadata + status for the webview after switching. */
-  private refreshSessionDetails(sessionID: string, dir: string, signal?: AbortSignal): void {
+  private async refreshSessionDetails(
+    sessionID: string,
+    dir: string,
+    signal?: AbortSignal,
+  ): Promise<Session | undefined> {
     if (!this.client) return
     void this.refreshGitStatus(this.sessionGitDirectories.get(sessionID) ?? dir, sessionID)
     const revision = this.revisions.get(sessionID)
     const refresh = (this.refreshes.get(sessionID) ?? 0) + 1
     this.refreshes.set(sessionID, refresh)
-    this.client.session
+    const details = this.client.session
       .get({ sessionID, directory: dir })
       .then((r) => {
         if (!r.data || signal?.aborted || this.contextSessionID !== sessionID) return
@@ -2050,10 +2054,15 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         this.setCurrentSession(r.data)
         this.contextSessionID = r.data.id
         this.postMessage({ type: "sessionUpdated", session: this.sessionToWebview(r.data) })
+        return r.data
       })
-      .catch((e: unknown) => console.warn("[Kilo New] KiloProvider: getSession failed (non-critical):", e))
+      .catch((e: unknown) => {
+        console.warn("[Kilo New] KiloProvider: getSession failed (non-critical):", e)
+        return undefined
+      })
     this.postMessage({ type: "workspaceDirectoryChanged", directory: this.getWorkspaceDirectory(sessionID) })
     this.sync(sessionID, dir, signal, refresh)
+    return details
   }
 
   private sync(sessionID: string, dir: string, signal?: AbortSignal, refresh?: number): void {
@@ -2132,8 +2141,9 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
     if (abort) {
       this.loadMessagesAbort?.abort()
       this.loadMessagesAbort = abort
-      this.refreshSessionDetails(sessionID, dir, abort.signal)
     }
+    const revision = this.revisions.get(sessionID)
+    const details = abort ? this.refreshSessionDetails(sessionID, dir, abort.signal) : undefined
     const since = mode === "reconcile" ? Date.now() : undefined
     try {
       const page = await fetchMessagePage(this.client, {
@@ -2142,6 +2152,12 @@ export class KiloProvider implements vscode.WebviewViewProvider, TelemetryProper
         limit: options.limit ?? MESSAGE_PAGE_LIMIT,
         before: options.before,
         signal: abort?.signal,
+        tail:
+          details &&
+          (async () => {
+            const session = await details
+            return !!session && !session.revert && this.revisions.get(sessionID) === revision
+          }),
       })
       if (abort?.signal.aborted) return
       // Drop results for a session deleted mid-fetch. Prepend/reconcile have

--- a/packages/kilo-vscode/src/kilo-provider/message-page.ts
+++ b/packages/kilo-vscode/src/kilo-provider/message-page.ts
@@ -24,6 +24,7 @@ export async function fetchMessagePage(
     limit: number
     before?: string
     signal?: AbortSignal
+    tail?: boolean | (() => Promise<boolean>)
   },
 ) {
   // limit: 0 is the server contract for "return every message".
@@ -49,6 +50,22 @@ export async function fetchMessagePage(
   }
 
   const fill = async (page: Awaited<ReturnType<typeof read>>, depth = 0): Promise<Awaited<ReturnType<typeof read>>> => {
+    if (input.tail && !full && !input.before) {
+      for (let index = page.items.length - 1; index > 0; index--) {
+        const first = page.items.at(index)
+        if (first?.info.role !== "user") continue
+        const items = page.items.slice(index)
+        const parents = new Set(items.filter((item) => item.info.role === "user").map((item) => item.info.id))
+        const replies = items.map((item) => item.info).filter((info) => info.role === "assistant")
+        // Show the newest complete turn first. Queued prompts and compaction
+        // replies must still retain every reply's actual parent.
+        if (!replies.length || !replies.every((info) => parents.has(info.parentID))) continue
+        if ((await (typeof input.tail === "function" ? input.tail() : input.tail)) && !input.signal?.aborted) {
+          return { items, cursor: synthesizeCursor(first) }
+        }
+        break
+      }
+    }
     if (page.items[0]?.info.role !== "assistant") return page
     if (depth >= FILL_LIMIT) return page
     if (!page.cursor || input.signal?.aborted) return page

--- a/packages/kilo-vscode/tests/fixtures/session-provider-activity.tsx
+++ b/packages/kilo-vscode/tests/fixtures/session-provider-activity.tsx
@@ -1384,6 +1384,74 @@ try {
     sent.some((item) => (item as { type?: string }).type === "sendMessage"),
     true,
   )
+  // A trimmed cold page must not reduce older-history page size or lose messages.
+  await emit({ type: "sessionsLoaded", sessions: [...unwrap(value.sessions()), info("pagination")] })
+  value.selectSession("pagination")
+  assert.equal(value.loading(), true)
+  assert.deepEqual(
+    sent.findLast((item) => item.type === "loadMessages"),
+    {
+      type: "loadMessages",
+      sessionID: "pagination",
+      mode: "replace",
+      limit: 80,
+    },
+  )
+  const history = Array.from({ length: 100 }, (_, index) => {
+    const id = `history-${String(index).padStart(3, "0")}`
+    return {
+      id,
+      sessionID: "pagination",
+      role: "user",
+      createdAt: new Date(index).toISOString(),
+      parts: [{ id: `${id}-text`, messageID: id, sessionID: "pagination", type: "text", text: id }],
+    }
+  })
+  await emit({
+    type: "messagesLoaded",
+    sessionID: "pagination",
+    mode: "replace",
+    messages: history.slice(80),
+    cursor: "older",
+    hasMore: true,
+  })
+  assert.equal(value.loading(), false)
+  assert.equal(value.messages().length, 20)
+  assert.equal(value.loadOlderMessages(), true)
+  assert.equal(value.loadOlderMessages(), false)
+  assert.deepEqual(
+    sent.findLast((item) => item.type === "loadMessages"),
+    {
+      type: "loadMessages",
+      sessionID: "pagination",
+      mode: "prepend",
+      before: "older",
+      limit: 80,
+    },
+  )
+  await emit({
+    type: "messagesLoaded",
+    sessionID: "pagination",
+    mode: "prepend",
+    messages: history.slice(0, 80),
+    hasMore: false,
+  })
+  assert.deepEqual(
+    value.messages().map((item) => item.id),
+    history.map((item) => item.id),
+  )
+  for (const item of history) assert.equal(value.getParts(item.id).at(0)?.id, `${item.id}-text`)
+  assert.equal(value.loadOlderMessages(), false)
+  value.selectSession("pagination")
+  assert.equal(value.loading(), false)
+  assert.deepEqual(
+    sent.findLast((item) => item.type === "loadMessages"),
+    {
+      type: "loadMessages",
+      sessionID: "pagination",
+      mode: "focus",
+    },
+  )
   assert.deepEqual(failures, [])
 } finally {
   const before = state("background")

--- a/packages/kilo-vscode/tests/unit/kilo-provider-load-messages.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-provider-load-messages.test.ts
@@ -26,12 +26,13 @@ function defer<T>(): Deferred<T> {
   return { promise, resolve, reject }
 }
 
-function mkMessage(id: string, role: "user" | "assistant", time = 0) {
+function mkMessage(id: string, role: "user" | "assistant", time = 0, parentID?: string) {
   return {
     info: {
       id,
       sessionID: "s1",
       role,
+      parentID,
       time: { created: time },
     },
     parts: [],
@@ -236,6 +237,7 @@ function createConnection(client: ReturnType<typeof createClient> | null) {
 
 type ProviderInternals = {
   connectionState: State
+  loadMessagesAbort: AbortController | null
   webview: { postMessage: (message: unknown) => Promise<unknown> } | null
   currentSession: { id: string; directory?: string; cost?: number; revert?: { messageID: string } } | null
   contextSessionID: string | undefined
@@ -268,7 +270,10 @@ type ProviderInternals = {
   handleSetSandboxDefault: (enabled: boolean, requestID: string, directory?: string) => Promise<void>
   handleToggleSandbox: (input: { sessionID: string; requestID: string }) => Promise<void>
   refreshGitStatus: (directory?: string, sessionID?: string) => Promise<void>
-  handleLoadMessages: (sid: string, opts?: { mode?: string; before?: string; limit?: number }) => Promise<void>
+  handleLoadMessages: (
+    sid: string,
+    opts?: { mode?: string; before?: string; limit?: number; focus?: boolean },
+  ) => Promise<void>
   handleSyncSession: (sid: string, parent?: string) => Promise<void>
   releaseChildSession: (sid: string) => void
   handleDeleteSession: (sid: string) => Promise<void>
@@ -1270,6 +1275,115 @@ describe("KiloProvider.handleDeleteMessage", () => {
     })
     expect(sent).toContainEqual({ type: "deleteMessageResult", ...ids, success: false })
     error.mockRestore()
+  })
+})
+
+describe("KiloProvider.handleLoadMessages / cold tail", () => {
+  const items = [
+    mkMessage("m2", "assistant", 20, "m1"),
+    mkMessage("m3", "user", 30),
+    mkMessage("m4", "assistant", 40, "m3"),
+  ]
+
+  it.each([false, true, "error"] as const)(
+    "waits for authoritative metadata (%s) without delaying messages",
+    async (revert) => {
+      const details = Promise.withResolvers<{ data: unknown }>()
+      const requested = Promise.withResolvers<void>()
+      let gets = 0
+      const client = createClient({
+        sessionGet: () => {
+          gets++
+          return details.promise
+        },
+      })
+      client.session.messages = async (params) => {
+        client.calls.push(params)
+        requested.resolve()
+        return params.before
+          ? mkResult([mkMessage("m1", "user", 10)])
+          : { ...mkResult(items), response: { headers: new Headers({ "X-Next-Cursor": "older" }) } }
+      }
+      const { provider, internal, sent } = makeProvider(client)
+      internal.currentSession = mkSession()
+      const load = internal.handleLoadMessages("s1")
+      await requested.promise
+      expect(gets).toBe(1)
+      expect(client.calls).toHaveLength(1)
+      expect(sent.some((msg) => (msg as { type: string }).type === "messagesLoaded")).toBe(false)
+      if (revert === "error") details.reject(new Error("metadata unavailable"))
+      else details.resolve({ data: mkSession(revert ? { messageID: "m3" } : undefined) })
+      await load
+      const loaded = sent.find((msg) => (msg as { type: string }).type === "messagesLoaded") as {
+        messages: { id: string }[]
+      }
+      expect(loaded.messages.map((msg) => msg.id)).toEqual(revert ? ["m1", "m2", "m3", "m4"] : ["m3", "m4"])
+      expect(client.calls).toHaveLength(revert ? 2 : 1)
+      expect(gets).toBe(1)
+      expect(sent.some((msg) => (msg as { type: string }).type === "error")).toBe(false)
+      provider.dispose()
+    },
+  )
+
+  it("disables trimming for non-focused loads without fetching metadata", async () => {
+    let gets = 0
+    const client = createClient({
+      sessionGet: async () => {
+        gets++
+        return { data: mkSession() }
+      },
+    })
+    client.session.messages = async (params) =>
+      params.before
+        ? mkResult([mkMessage("m1", "user", 10)])
+        : { ...mkResult(items), response: { headers: new Headers({ "X-Next-Cursor": "older" }) } }
+    const { provider, internal, sent } = makeProvider(client)
+    await internal.handleLoadMessages("s1", { focus: false })
+    const loaded = sent.find((msg) => (msg as { type: string }).type === "messagesLoaded") as {
+      messages: { id: string }[]
+    }
+    expect(loaded.messages.map((msg) => msg.id)).toEqual(["m1", "m2", "m3", "m4"])
+    expect(gets).toBe(0)
+    provider.dispose()
+  })
+
+  it("does not trim after metadata is superseded while messages are pending", async () => {
+    const pending = Promise.withResolvers<ReturnType<typeof mkResult>>()
+    const client = createClient({ sessionData: mkSession() })
+    client.session.messages = async (params) =>
+      params.before ? mkResult([mkMessage("m1", "user", 10)]) : pending.promise
+    const { provider, internal, sent } = makeProvider(client)
+    const load = internal.handleLoadMessages("s1")
+    await Promise.resolve()
+    await Promise.resolve()
+    internal.revisions.set("s1", { id: "newer", seq: 1 })
+    pending.resolve({ ...mkResult(items), response: { headers: new Headers({ "X-Next-Cursor": "older" }) } })
+    await load
+    const loaded = sent.find((msg) => (msg as { type: string }).type === "messagesLoaded") as {
+      messages: { id: string }[]
+    }
+    expect(loaded.messages.map((msg) => msg.id)).toEqual(["m1", "m2", "m3", "m4"])
+    provider.dispose()
+  })
+
+  it("drops a cancelled load waiting for metadata without backfilling", async () => {
+    const details = Promise.withResolvers<{ data: unknown }>()
+    const requested = Promise.withResolvers<void>()
+    const client = createClient({ sessionGet: () => details.promise })
+    client.session.messages = async (params) => {
+      client.calls.push(params)
+      requested.resolve()
+      return { ...mkResult(items), response: { headers: new Headers({ "X-Next-Cursor": "older" }) } }
+    }
+    const { provider, internal, sent } = makeProvider(client)
+    const load = internal.handleLoadMessages("s1")
+    await requested.promise
+    internal.loadMessagesAbort?.abort()
+    details.resolve({ data: mkSession() })
+    await load
+    expect(client.calls).toHaveLength(1)
+    expect(sent.some((msg) => (msg as { type: string }).type === "messagesLoaded")).toBe(false)
+    provider.dispose()
   })
 })
 

--- a/packages/kilo-vscode/tests/unit/message-page.test.ts
+++ b/packages/kilo-vscode/tests/unit/message-page.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from "bun:test"
 import { fetchMessagePage } from "../../src/kilo-provider/message-page"
 
-type Message = { info: { id: string; role: "user" | "assistant"; time: { created: number } }; parts: unknown[] }
+type Message = {
+  info: { id: string; role: "user" | "assistant"; parentID?: string; summary?: boolean; time: { created: number } }
+  parts: unknown[]
+}
 
-function message(id: string, role: "user" | "assistant", time: number): Message {
-  return { info: { id, role, time: { created: time } }, parts: [] }
+function message(id: string, role: "user" | "assistant", time: number, parentID?: string): Message {
+  return { info: { id, role, parentID, time: { created: time } }, parts: [] }
 }
 
 function mockClient(pages: { items: Message[]; cursor?: string }[]) {
@@ -32,6 +35,138 @@ function mockClient(pages: { items: Message[]; cursor?: string }[]) {
 }
 
 describe("fetchMessagePage / cursor fallback", () => {
+  it("shows only the latest complete turn and keeps every earlier turn pageable", async () => {
+    const items = [
+      message("m1", "user", 10),
+      message("m2", "assistant", 20, "m1"),
+      message("m3", "user", 30),
+      message("m4", "assistant", 40, "m3"),
+      message("m5", "user", 50),
+    ]
+    const calls: string[] = []
+    const client = {
+      session: {
+        messages: async (params: { before?: string }) => {
+          const cursor = params.before ? JSON.parse(Buffer.from(params.before, "base64url").toString()) : undefined
+          calls.push(cursor?.id ?? "tail")
+          return {
+            data: items.filter((item) => !cursor || item.info.time.created < cursor.time),
+            response: new Response(),
+          }
+        },
+      },
+    }
+    const page = await fetchMessagePage(client as never, {
+      sessionID: "s1",
+      workspaceDir: "/repo",
+      limit: 80,
+      tail: true,
+    })
+    expect(page.items.map((item) => item.info.id)).toEqual(["m3", "m4", "m5"])
+    const older = await fetchMessagePage(client as never, {
+      sessionID: "s1",
+      workspaceDir: "/repo",
+      limit: 80,
+      before: page.cursor,
+    })
+    expect([...older.items, ...page.items]).toEqual(items)
+    expect(calls).toEqual(["tail", "m3"])
+  })
+
+  it("returns complete recent turns without waiting for older pages on a cold load", async () => {
+    const { client, calls } = mockClient([
+      {
+        items: [message("m2", "assistant", 30, "m1"), message("m3", "user", 30), message("m4", "assistant", 30, "m3")],
+        cursor: "c1",
+      },
+      { items: [message("m1", "user", 10), message("m2", "assistant", 30, "m1")] },
+    ])
+    const page = await fetchMessagePage(client as never, {
+      sessionID: "s1",
+      workspaceDir: "/repo",
+      limit: 3,
+      tail: true,
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(page.items.map((item) => item.info.id)).toEqual(["m3", "m4"])
+    expect(JSON.parse(Buffer.from(page.cursor!, "base64url").toString())).toEqual({ id: "m3", time: 30 })
+
+    const older = await fetchMessagePage(client as never, {
+      sessionID: "s1",
+      workspaceDir: "/repo",
+      limit: 3,
+      before: page.cursor,
+    })
+    expect([...older.items, ...page.items].map((item) => item.info.id)).toEqual(["m1", "m2", "m3", "m4"])
+    expect(calls.at(1)?.before).toBe(page.cursor)
+  })
+
+  it("does not trim replies interleaved with queued prompts whose parent is missing", async () => {
+    const { client, calls } = mockClient([
+      {
+        items: [message("m2", "assistant", 20, "m1"), message("m3", "user", 30), message("m4", "assistant", 40, "m1")],
+        cursor: "c1",
+      },
+      { items: [message("m1", "user", 10)] },
+    ])
+    const page = await fetchMessagePage(client as never, {
+      sessionID: "s1",
+      workspaceDir: "/repo",
+      limit: 3,
+      tail: true,
+    })
+    expect(calls).toHaveLength(2)
+    expect(page.items.map((item) => item.info.id)).toEqual(["m1", "m2", "m3", "m4"])
+  })
+
+  it("retains a compaction summary together with its compaction parent", async () => {
+    const parent = message("m3", "user", 30)
+    parent.parts = [{ type: "compaction", auto: true }]
+    const summary = message("m4", "assistant", 40, "m3")
+    summary.info.summary = true
+    const { client, calls } = mockClient([
+      { items: [message("m2", "assistant", 20, "m1"), parent, summary], cursor: "c1" },
+    ])
+    const page = await fetchMessagePage(client as never, {
+      sessionID: "s1",
+      workspaceDir: "/repo",
+      limit: 3,
+      tail: true,
+    })
+    expect(calls).toHaveLength(1)
+    expect(page.items).toEqual([parent, summary])
+  })
+
+  it("still fills a cold page containing only a partial turn and queued prompts", async () => {
+    const { client, calls } = mockClient([
+      { items: [message("m2", "assistant", 20), message("m3", "user", 30)], cursor: "c1" },
+      { items: [message("m1", "user", 10)] },
+    ])
+    const page = await fetchMessagePage(client as never, {
+      sessionID: "s1",
+      workspaceDir: "/repo",
+      limit: 2,
+      tail: true,
+    })
+    expect(calls).toHaveLength(2)
+    expect(page.items.map((item) => item.info.id)).toEqual(["m1", "m2", "m3"])
+    expect(page.cursor).toBeUndefined()
+  })
+
+  it("does not trim full-history exports even when tail is requested", async () => {
+    const items = [message("m1", "assistant", 10), message("m2", "user", 20), message("m3", "assistant", 30)]
+    const { client } = mockClient([{ items }])
+    const page = await fetchMessagePage(client as never, {
+      sessionID: "s1",
+      workspaceDir: "/repo",
+      limit: 0,
+      tail: true,
+    })
+    expect(page.items).toEqual(items)
+    expect(page.cursor).toBeUndefined()
+  })
+
   it("returns server cursor when X-Next-Cursor header is present", async () => {
     const { client } = mockClient([
       {

--- a/packages/opencode/src/kilocode/session/model-usage.ts
+++ b/packages/opencode/src/kilocode/session/model-usage.ts
@@ -83,6 +83,7 @@ export namespace ModelUsage {
         sessionIDs.map((id) => sql`${id}`),
         sql`,`,
       )})
+        AND json_valid(part.data)
         AND json_extract(part.data, '$.type') = 'step-finish'
         AND json_extract(message.data, '$.role') = 'assistant'
     )

--- a/packages/opencode/test/kilocode/session-model-usage.test.ts
+++ b/packages/opencode/test/kilocode/session-model-usage.test.ts
@@ -13,7 +13,7 @@ import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Database } from "@opencode-ai/core/database/database"
-import { eq } from "drizzle-orm"
+import { eq, sql } from "drizzle-orm"
 import { TestInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
@@ -158,6 +158,66 @@ describe("session model usage", () => {
   it.instance("returns undefined for a missing session", () =>
     Effect.gen(function* () {
       expect(yield* ModelUsage.get(SessionID.make("ses_missing"))).toBeUndefined()
+    }),
+  )
+
+  it.instance("keeps usage correct when step-finish parts are inserted, updated, and deleted", () =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const root = yield* sessions.create({ title: "usage updates" })
+      const model = ref("test", "model")
+      const message = yield* seed(root.id, model)
+      const empty = yield* ModelUsage.get(root.id)
+      const { db } = yield* Database.Service
+      yield* db.run(sql`
+        INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+        VALUES (${PartID.ascending()}, ${message.id}, ${root.id}, 1, 1, '{')`)
+      const part = {
+        id: PartID.ascending(),
+        messageID: message.id,
+        sessionID: root.id,
+        type: "step-finish",
+        reason: "stop",
+        cost: 0.25,
+        tokens: { input: 10, output: 2, reasoning: 1, cache: { read: 4, write: 3 } },
+      } satisfies MessageV2.StepFinishPart
+      yield* sessions.updatePart(part)
+      yield* sessions.updatePart({
+        id: PartID.ascending(),
+        messageID: message.id,
+        sessionID: root.id,
+        type: "text",
+        text: "Non-step output must not contribute to usage",
+      })
+      const usage = { steps: 1, cost: part.cost, tokens: part.tokens }
+      expect(yield* ModelUsage.get(root.id)).toEqual({
+        sessionIDs: [root.id],
+        totals: usage,
+        models: [{ ...model, ...usage }],
+      })
+
+      const updated = { ...part, cost: 0.5, tokens: { ...part.tokens, input: 20 } }
+      yield* sessions.updatePart(updated)
+      const totals = { steps: 1, cost: updated.cost, tokens: updated.tokens }
+      expect(yield* ModelUsage.get(root.id)).toEqual({
+        sessionIDs: [root.id],
+        totals,
+        models: [{ ...model, ...totals }],
+      })
+
+      // Changing the discriminator must remove and restore partial-index membership.
+      yield* sessions.updatePart({
+        id: part.id,
+        messageID: message.id,
+        sessionID: root.id,
+        type: "text",
+        text: "Replaced step",
+      })
+      expect(yield* ModelUsage.get(root.id)).toEqual(empty)
+      yield* sessions.updatePart(updated)
+      expect((yield* ModelUsage.get(root.id))?.totals).toEqual(totals)
+      yield* sessions.removePart({ sessionID: root.id, messageID: message.id, partID: part.id })
+      expect(yield* ModelUsage.get(root.id)).toEqual(empty)
     }),
   )
 })


### PR DESCRIPTION
## What Problem This Solves
Opening sessions with large parent and child histories can show `Loading messages` for several hundred milliseconds. The token usage calculation scanned all parts across the session family before the transcript became ready.

## Why This Change Was Made
Add a partial SQLite index for `step-finish` parts, which are the only parts used by model usage totals. Keep initial transcript loading bounded to the newest complete turn and preserve older history through existing pagination. Skip inactive auto-scroll geometry reads.

The migration includes a `json_valid` guard so malformed legacy part data cannot prevent database startup.

## User Impact
The reported `Inline remote PR comments in diff view` session has 1,693 parent messages and 49 child sessions. It now opens substantially faster without changing displayed token totals or history behavior.

## Performance Results
All values are milliseconds from selecting the session to the transcript readiness marker. Each row uses three fresh isolated VS Code runs with the same fixture and build.

| Scenario | Before runs | Before median | After runs | After median | Improvement |
|---|---:|---:|---:|---:|---:|
| Large session, 2,987 messages | 341.6, 293.2, 307.8 | 307.8 | 214.0, 191.3, 190.7 | 191.3 | 116.5 ms, 37.8% |
| Medium session, 494 messages | 581.4, 244.7, 236.2 | 244.7 | 175.6, 152.4, 162.7 | 162.7 | 82.0 ms, 33.5% |
| Reported session, full family, baseline A | 543.2, 580.9, 598.1 | 580.9 | 236.9, 427.9, 238.0 | 238.0 | 342.9 ms, 59.0% |
| Reported session, full family, control B | 703.5, 621.2, 836.3 | 703.5 | 236.9, 427.9, 238.0 | 238.0 | 465.5 ms, 66.2% |

The full-family baselines show cold-start variance. The conservative comparison is `580.9 ms` to `238.0 ms`, a `59.0%` reduction.

## Fixture Sizes

| Dataset | Sessions | Messages | Parts | Stored part JSON |
|---|---:|---:|---:|---:|
| Reported parent session | 1 | 1,693 | 9,026 | 47,336,777 bytes |
| Reported parent plus children | 50 | 3,574 | 23,004 | 137,275,673 bytes |
| Large benchmark parent | 1 | 2,987 | 11,653 | 67,676,891 bytes |
| Medium benchmark parent | 1 | 494 | 2,112 | 46,806,256 bytes |

The initial reported-session view contains 13 messages, 47 parts, and 72,684 bytes. The existing history loader still exposes all 1,693 parent messages.

## Model Usage Query
Six runs were measured before and after the partial index on the full reported session family.

| Run | Before | After |
|---|---:|---:|
| 1 | 158.078 ms | 20.602 ms |
| 2 | 127.599 ms | 18.929 ms |
| 3 | 146.501 ms | 18.002 ms |
| 4 | 117.679 ms | 19.540 ms |
| 5 | 165.910 ms | 21.773 ms |
| 6 | 119.775 ms | 23.319 ms |
| Minimum | 117.679 ms | 18.002 ms |
| Maximum | 165.910 ms | 23.319 ms |
| Median | 137.050 ms | 20.071 ms |

The median query reduction is `116.979 ms`, or `85.4%`. Usage totals were identical before and after indexing. The one-time index build took `152.512 ms` on the disposable 137 MB fixture.

## Validation
- 18 core migration and index tests passed.
- 5 CLI model-usage tests passed.
- 141 extension pagination, loading, streaming, and cancellation tests passed.
- 39 auto-scroll tests passed.
- Extension build, typechecks, lint, schema generation, migration consistency, annotation checks, source links, and visual regression passed.
- CI unit matrix passed on Linux, macOS, and Windows.
- Kilo Code Review reported `No Issues Found`.
- Review threads: 0 unresolved, 0 total.

The change does not add a new endpoint, persistent cache, worker, or background prefetch.