### PR TITLE
fix(vscode): keep deleted diff line numbers neutral

### DIFF
--- a/packages/kilo-ui/src/pierre/index.ts
+++ b/packages/kilo-ui/src/pierre/index.ts
@@ -36,6 +36,9 @@ const css = `
   --diffs-computed-diff-line-bg: var(--surface-diff-delete-base, var(--diffs-bg-deletion));
   --diffs-computed-selected-line-bg: var(--surface-diff-delete-base, var(--diffs-bg-deletion));
 }
+[data-diff] [data-column-number][data-line-type='change-deletion'] {
+  color: inherit;
+}
 [data-diff][data-background] [data-column-number][data-line-type='change-deletion'] {
   --diffs-computed-diff-line-bg: var(--surface-diff-delete-weaker, var(--diffs-bg-deletion-number));
   --diffs-computed-selected-line-bg: var(--surface-diff-delete-weaker, var(--diffs-bg-deletion-number));

--- a/packages/kilo-ui/tests/diff-indicators.spec.ts
+++ b/packages/kilo-ui/tests/diff-indicators.spec.ts
@@ -29,6 +29,13 @@ for (const scheme of ["light", "dark"]) {
         expect(bar.height).toBeGreaterThan(0)
         expect(bar.content).toBe('""')
         if (type === "deletion") expect(bar.base).not.toBe(scheme === "dark" ? "#ff6762" : "#ff2e3f")
+        if (type === "deletion") {
+          const context = page.locator("[data-column-number][data-line-type='context']").first()
+          await expect(context).toBeVisible()
+          expect(await gutter.evaluate((element) => getComputedStyle(element).color)).toBe(
+            await context.evaluate((element) => getComputedStyle(element).color),
+          )
+        }
       }
     })
   }


### PR DESCRIPTION
## What Problem This Solves
Deleted lines in Pierre diffs color gutter line numbers red, making the line numbers look like changed content.

## Why This Change Was Made
Pierre assigns the deletion foreground to changed line-number cells. The diff now inherits the normal gutter color for those cells while keeping deleted-line backgrounds and indicators unchanged.

## User Impact
Deleted code remains visibly highlighted, but its line numbers no longer use the deletion color.

## Evidence
Before:

<img width="700" alt="Deleted diff with red line numbers" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260907-deleted-line-numbers-before.png" />

After:

<img width="700" alt="Deleted diff with neutral line numbers" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260907-deleted-line-numbers-after.png" />

## Validation
- `bun test src/pierre/index.test.ts`
- `bun run test:visual -- tests/diff-indicators.spec.ts`
- `bunx prettier --check src/pierre/index.ts tests/diff-indicators.spec.ts`
- `git diff --check`