### PR TITLE
fix(cli): prevent swarm agents from messaging themselves

### DIFF
--- a/.changeset/prevent-self-board-messages.md
+++ b/.changeset/prevent-self-board-messages.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Prevent swarm agents from sending shared board messages to themselves.

--- a/packages/opencode/src/kilocode/board/store.ts
+++ b/packages/opencode/src/kilocode/board/store.ts
@@ -190,6 +190,8 @@ export namespace BoardStore {
           Effect.gen(function* () {
             const current = yield* ensure(tx, input.sessionID)
             const target = yield* recipient(input.to, current.root, tx)
+            if (target !== ALL && target === input.sessionID)
+              return yield* fail("Board messages cannot be sent to yourself")
             const ids = target === ALL ? [input.sessionID] : [input.sessionID, target]
             const labels = yield* titles(tx, current.root, ids, true)
             const call = input.callID ?? ""

--- a/packages/opencode/test/kilocode/board-tools.test.ts
+++ b/packages/opencode/test/kilocode/board-tools.test.ts
@@ -235,15 +235,17 @@ describe("shared board tools", () => {
           expect(unknown.metadata.availability).toMatchObject({ total: 1, active: 0, inactive: 0, unknown: 1 })
           expect(JSON.parse(unknown.output).warning).toContain("Availability was unknown")
           expect(yield* observed).toBe("unknown")
-          const self = yield* send("main", "main")
-          expect(self.metadata.availability).toMatchObject({ total: 0, active: 0 })
-          expect(JSON.parse(self.output)).not.toHaveProperty("warning")
-          const own = yield* post.execute(
-            { to: child.id, type: "INFO", body: "Note to self" },
-            yield* context(child.id, MessageID.ascending()),
+          const self = yield* Effect.exit(send("main", "main"))
+          expect(self._tag).toBe("Failure")
+          if (Exit.isFailure(self)) expect(Cause.pretty(self.cause)).toContain("cannot be sent to yourself")
+          const own = yield* Effect.exit(
+            post.execute(
+              { to: child.id, type: "INFO", body: "Note to self" },
+              yield* context(child.id, MessageID.ascending()),
+            ),
           )
-          expect(own.metadata.availability.total).toBe(0)
-          expect(JSON.parse(own.output)).not.toHaveProperty("warning")
+          expect(own._tag).toBe("Failure")
+          if (Exit.isFailure(own)) expect(Cause.pretty(own.cause)).toContain("cannot be sent to yourself")
           yield* jobs.start({ id: child.id, type: "task", run: Effect.never })
           const running = yield* send(child.id, "running")
           expect(JSON.parse(running.output)).not.toHaveProperty("warning")

--- a/packages/opencode/test/kilocode/board/store.test.ts
+++ b/packages/opencode/test/kilocode/board/store.test.ts
@@ -88,6 +88,35 @@ describe("BoardStore", () => {
     expect(result.raw).toEqual({ objective: "Build the shared board", objective_message_id: "msg_objective" })
   })
 
+  test("rejects messages addressed to the sending session", async () => {
+    const result = await setup(() =>
+      Effect.gen(function* () {
+        const main = yield* Effect.exit(
+          BoardStore.post({
+            sessionID: id("root"),
+            messageID: "msg_self_main",
+            to: "main",
+            type: "INFO",
+            body: "Main cannot receive its own message",
+          }),
+        )
+        const child = yield* Effect.exit(
+          BoardStore.post({
+            sessionID: id("child"),
+            messageID: "msg_self_child",
+            to: id("child"),
+            type: "INFO",
+            body: "Child cannot receive its own message",
+          }),
+        )
+        return { main, child, messages: (yield* BoardStore.read({ sessionID: id("root") })).messages }
+      }),
+    )
+    expect(result.main._tag).toBe("Failure")
+    expect(result.child._tag).toBe("Failure")
+    expect(result.messages).toEqual([])
+  })
+
   test.each(["legacy", "sequenced", "unsequenced"] as const)(
     "rejects JavaScript whitespace before capturing a %s objective",
     async (source) => {


### PR DESCRIPTION
## What Problem This Solves
Shared board agents could post a message to their own session, despite the board guidance telling them to notify other participants.

## Why This Change Was Made
The board store resolved recipient aliases but did not compare the resolved recipient with the sending session. The store now rejects direct self-targeted messages after alias resolution.

## User Impact
Parent and child sessions cannot send direct messages to themselves. Parent-to-child, child-to-parent, sibling, and `ALL` broadcasts remain supported.

## Evidence
- Focused board tests pass: 27 tests.
- Live board integration tests pass: 6 tests.
- CLI typecheck passes.
- VS Code Agent Manager self-test displayed `Board messages cannot be sent to yourself` and completed the flow.