### PR TITLE
fix(agent-manager): restore worktree removal with cmd-w

### DIFF
--- a/.changeset/fix-agent-manager-cmd-w.md
+++ b/.changeset/fix-agent-manager-cmd-w.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix Agent Manager worktree deletion after closing all tabs.

--- a/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-arch.test.ts
@@ -467,6 +467,19 @@ describe("Agent Manager Worktree Actions", () => {
     expect(action).not.toContain('msg.action === "newMainTerminal"')
   })
 
+  it("keeps Cmd+W terminal handling before the empty-worktree fallback", () => {
+    const source = fs.readFileSync(TSX_FILE, "utf-8")
+    const start = source.indexOf("const closeActiveTab = () =>")
+    const end = source.indexOf("// Close the currently selected worktree", start)
+    const action = source.slice(start, end)
+
+    expect(start).toBeGreaterThanOrEqual(0)
+    expect(end).toBeGreaterThan(start)
+    expect(action).toContain("termHandlers.closeFocused()")
+    expect(action).toContain("termHandlers.closeActive()")
+    expect(action).toContain("if (tabs.length === 0)")
+  })
+
   it("forwards the quick-worktree command to immediate creation", () => {
     const source = fs.readFileSync(path.join(ROOT, "src/extension.ts"), "utf-8")
     const start = source.indexOf('vscode.commands.registerCommand("kilo-code.new.agentManager.quickWorktree"')

--- a/packages/kilo-vscode/tests/unit/agent-manager-terminal-state.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-terminal-state.test.ts
@@ -465,6 +465,24 @@ describe("Agent Manager terminal state", () => {
     })
   })
 
+  it("does not close an active terminal from another context", () => {
+    createRoot((dispose) => {
+      const item = scene("wt-2")
+      item.state.add("wt-1", { id: "terminal:one", title: "Terminal 1", wsUrl: "ws://one", font, placement: "tab" })
+      item.state.setActiveId("terminal:one")
+
+      expect(item.handlers.closeActive()).toBe(false)
+      expect(item.state.forSelection("wt-1").map((term) => term.id)).toEqual(["terminal:one"])
+      expect(item.posted).toEqual([])
+
+      item.setSelection("wt-1")
+      expect(item.handlers.closeActive()).toBe(true)
+      expect(item.state.forSelection("wt-1")).toEqual([])
+      expect(item.posted).toEqual([{ type: "agentManager.terminal.close", terminalId: "terminal:one" }])
+      dispose()
+    })
+  })
+
   it("moves activation to the last remaining side terminal on close", () => {
     createRoot((dispose) => {
       const item = scene()

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/state.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/state.ts
@@ -873,7 +873,9 @@ export function createTerminalHandlers(deps: TerminalHandlerDeps) {
 
   const closeActive = () => {
     const id = deps.state.activeId()
-    if (!id) return false
+    // The active id is shared across contexts; only close a terminal owned by
+    // the currently selected worktree so Cmd+W can reach its fallback.
+    if (!id || !deps.state.current().some((term) => term.id === id)) return false
     closeTerminal(id)
     return true
   }


### PR DESCRIPTION
## What Problem This Solves

`Cmd+W` could be consumed by a terminal belonging to another Agent Manager context, so an empty worktree could not reach its deletion fallback.

## Why This Change Was Made

Scope active-terminal closure to the currently selected context. Terminals in the selected worktree still close before worktree deletion.

## User Impact

After all tabs in a worktree are closed, `Cmd+W` reaches the existing delete confirmation flow without affecting terminals in another worktree.

## Evidence

- `bun test tests/unit/agent-manager-arch.test.ts tests/unit/agent-manager-terminal-state.test.ts`
- `bun run lint`
- `bun run compile`
- Isolated VS Code self-test in a disposable Git repository: real `Cmd+W` armed confirmation, a second press removed the disposable worktree, and `git worktree list` confirmed only `main` remained.