### PR TITLE
fix(jetbrains): make Agent Manager worktree deletion non-blocking and fault tolerant

### DIFF
--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/diff/GitComparison.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/diff/GitComparison.kt
@@ -1,8 +1,10 @@
 package ai.kilocode.backend.diff
 
 import ai.kilocode.backend.rpc.CmdOut
+import ai.kilocode.backend.rpc.badDir
 import ai.kilocode.backend.rpc.baseBranch
 import ai.kilocode.backend.rpc.parseWorktreeList
+import ai.kilocode.log.KiloLog
 import ai.kilocode.rpc.dto.DiffFileDto
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.CapturingProcessHandler
@@ -14,6 +16,8 @@ import java.nio.file.LinkOption
 import java.nio.file.Path
 import kotlin.io.path.fileSize
 import kotlin.io.path.inputStream
+
+private val LOG = KiloLog.create(GitComparison::class.java)
 
 internal class GitComparison private constructor(
     private val dir: Path,
@@ -39,6 +43,12 @@ internal class GitComparison private constructor(
             if (!Files.isDirectory(dir)) return null
             val inside = runGitCommand(dir, listOf("rev-parse", "--is-inside-work-tree"))
             if (inside.exit == 128 && inside.stderr.startsWith("fatal: not a git repository")) return null
+            // The directory can vanish between the isDirectory check above and this spawn (a
+            // concurrent worktree removal), which git or the process launcher reports in either of
+            // two message shapes — see badDir(). Treat that race as "no data" rather than a thrown
+            // failure: the caller isolates per-item failures anyway, but a race this narrow doesn't
+            // deserve a WARN-level stack trace every time it's hit.
+            if (badDir(inside.stderr)) return null
             if (inside.checked().trim() != "true") return null
             val head = revision(dir, "HEAD") ?: return null
             if (mode == Mode.Local) return GitComparison(dir, head, "", head, head, null)
@@ -141,12 +151,18 @@ internal class GitComparison private constructor(
     }
 }
 
-internal fun runGitCommand(dir: Path, args: List<String>): CmdOut {
+/** Default watchdog for a git command. Cheap queries only — a destructive delete needs its own, wider budget. */
+internal const val GIT_COMMAND_TIMEOUT_MS = 30_000
+
+internal fun runGitCommand(dir: Path, args: List<String>, timeoutMs: Int = GIT_COMMAND_TIMEOUT_MS): CmdOut {
     return try {
         val cmd = GeneralCommandLine(listOf("git") + args).withWorkDirectory(dir.toFile())
             .withCharset(StandardCharsets.UTF_8).withEnvironment("LC_ALL", "C")
-        val out = CapturingProcessHandler(cmd).runProcess(30_000)
-        CmdOut(if (out.isTimeout) -1 else out.exitCode, out.stdout, out.stderr)
+        val out = CapturingProcessHandler(cmd).runProcess(timeoutMs)
+        if (out.isTimeout) {
+            LOG.warn("git command timed out: dir=$dir args=${args.joinToString(" ")} ms=$timeoutMs")
+        }
+        CmdOut(if (out.isTimeout) -1 else out.exitCode, out.stdout, out.stderr, out.isTimeout)
     } catch (err: CancellationException) {
         throw err
     } catch (err: ProcessCanceledException) {

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImpl.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImpl.kt
@@ -639,10 +639,6 @@ class KiloWorktreeRpcApiImpl(
                 val temp = trash?.stage(targetPath)
                 if (temp != null) {
                     LOG.info("worktree remove staged: path=${target.path} temp=$temp ms=${System.currentTimeMillis() - start}")
-                    val prune = runGit(base, "worktree", "prune", "--expire", "now")
-                    if (!prune.ok) {
-                        LOG.warn("worktree remove prune after stage failed: path=${target.path} exit=${prune.exit} stderr=${snippet(prune.stderr)}")
-                    }
                     Triple("rename", CmdOut(0, "", ""), temp)
                 } else {
                     LOG.info(
@@ -664,6 +660,17 @@ class KiloWorktreeRpcApiImpl(
             )
             return RemoveWorktreeResultDto(error = reason(res, "git worktree remove failed"), locked = locked)
         }
+        // Every successful arm arrives here with no checkout at the registered path — renamed away,
+        // deleted by git, or already gone before this call started — so unregistering is always both
+        // safe and needed. It has to happen before `branch -D`: git refuses to delete a branch that a
+        // registered worktree still has checked out, so pruning afterwards would leave the branch
+        // behind (the `git` arm has already unregistered it, making this a no-op there). `--expire now`
+        // because the default grace period is three months, which for a checkout that is already gone
+        // would mean not pruning it at all. This also clears unrelated dangling entries.
+        val prune = runGit(base, "worktree", "prune", "--expire", "now")
+        if (!prune.ok) {
+            LOG.warn("worktree prune failed: path=${target.path} exit=${prune.exit} stderr=${snippet(prune.stderr)}")
+        }
         // The worktree is gone; a failed branch delete must not fail the removal, only warn.
         branch?.trim()?.takeIf { it.isNotEmpty() }?.let {
             val del = runGit(base, "branch", "-D", it)
@@ -673,8 +680,6 @@ class KiloWorktreeRpcApiImpl(
         LOG.info("worktree removed: path=${target.path} branch=${branch ?: "(none)"} mode=$mode ms=${System.currentTimeMillis() - start}")
         invalidate()
         removeWorktreeState(store, target.path)
-        val prune = runGit(base, "worktree", "prune")
-        if (!prune.ok) LOG.warn("worktree prune failed: exit=${prune.exit} stderr=${prune.stderr.trim()}")
         runCatching { service<KiloBackendAppService>().workspaces.remove(target.path) }
             .onFailure { err -> LOG.info("workspace cache eviction skipped: path=${target.path} message=${err.message}") }
         storage?.let { trash?.sweep(it) }

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImpl.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImpl.kt
@@ -2,8 +2,10 @@ package ai.kilocode.backend.rpc
 
 import ai.kilocode.backend.app.ForkHandoff
 import ai.kilocode.backend.app.KiloBackendAppService
+import ai.kilocode.backend.diff.GIT_COMMAND_TIMEOUT_MS
 import ai.kilocode.backend.diff.GitComparison
 import ai.kilocode.backend.diff.runGitCommand
+import ai.kilocode.backend.worktree.WorktreeTrash
 import ai.kilocode.log.KiloLog
 import ai.kilocode.rpc.KiloWorktreeRpcApi
 import ai.kilocode.rpc.parsePrUrl
@@ -35,6 +37,7 @@ import com.intellij.execution.configurations.GeneralCommandLine.ParentEnvironmen
 import com.intellij.execution.process.CapturingProcessHandler
 import com.intellij.ide.impl.OpenProjectTask
 import com.intellij.ide.impl.ProjectUtil
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
@@ -49,7 +52,9 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
@@ -69,7 +74,13 @@ import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.util.concurrent.ConcurrentHashMap
 
-class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
+class KiloWorktreeRpcApiImpl(
+    // Resolved once at construction, matching every other worktree-scoped service accessed through
+    // this class. Null exactly when there is no IntelliJ Application to resolve it from (a plain unit
+    // test, same as every `service<...>()` call this file already makes) — every caller below treats
+    // that as "nothing is ever being removed via the fast path", not as an error.
+    private val trash: WorktreeTrash? = defaultTrash(),
+) : KiloWorktreeRpcApi {
 
     companion object {
         internal val LOG = KiloLog.create(KiloWorktreeRpcApiImpl::class.java)
@@ -80,12 +91,30 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
         // short enough to notice the reset without waiting out a poll interval.
         private const val GH_LIMIT_TTL = 60_000L
         private const val PR_TTL = 90_000L
+        // The rename+prune path returns long before this ever matters; it only bounds the fallback
+        // `git worktree remove --force`, which recursively deletes the checkout synchronously and
+        // therefore needs far more headroom than the 30s default query timeout.
+        private const val REMOVE_TIMEOUT_MS = 600_000
+        // Above this, a caller waiting on the per-repo mutation lock is worth a log line — most waits
+        // are a few ms and would just be noise.
+        private const val LOCK_WAIT_LOG_THRESHOLD_MS = 200L
+
+        private fun defaultTrash(): WorktreeTrash? {
+            if (ApplicationManager.getApplication() == null) return null
+            return service<WorktreeTrash>()
+        }
     }
 
     private val prs = ConcurrentHashMap<String, Timed<WorktreePrListDto>>()
     private val branches = ConcurrentHashMap<String, Timed<BranchStatusDto>>()
     private val resolver = PrResolver(gh = ::runGh, git = ::runGit)
     private val ghLock = Any()
+    // Serializes the git-mutating operations (create/import/remove/rename/adopt/reorder/session-list)
+    // for one repository, keyed by its main worktree's real path, so concurrent calls cannot interleave
+    // `worktree list` / `remove` / `branch -D` / `worktree prune` or race the read-modify-write of
+    // `.kilo/jetbrains.json`. Read paths (list/stats/dirty/prStatus/branchStatus/ghStatus/sessionList)
+    // are deliberately never locked — they must not queue behind a slow mutation.
+    private val locks = ConcurrentHashMap<String, Mutex>()
     @Volatile
     private var ghProbe: Timed<GhAvailability>? = null
     @Volatile
@@ -95,11 +124,18 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
         val base = Path.of(directory).normalize()
         val res = runGit(base, "worktree", "list", "--porcelain")
         if (!res.ok) return@withContext WorktreeListDto()
-        val items = managedWorktrees(parseWorktreeList(res.stdout))
-        val alive = items.filter { it.main || Files.isDirectory(Path.of(it.path)) }
+        val all = parseWorktreeList(res.stdout)
+        val items = managedWorktrees(all)
+        val alive = live(items.filter { it.main || Files.isDirectory(Path.of(it.path)) })
         val store = worktreeNameStore(alive)
         val state = store?.let { syncWorktreeState(it, worktreePaths(alive), livePaths(alive)) } ?: WorktreeState()
         val named = overlayWorktreeNames(alive, state.names)
+        // Cheap and non-blocking: sweeps orphaned `.kilo-delete-*` directories left by an interrupted
+        // delete (this plugin's or the VS Code extension's) every time the list is polled, so they do
+        // not require a fresh remove() to be cleaned up.
+        all.firstOrNull { it.main }?.let {
+            trash?.sweep(Path.of(it.path).normalize().resolve(".kilo").resolve("worktrees").normalize())
+        }
         WorktreeListDto(orderWorktrees(named, state.worktreeOrder))
     }
 
@@ -165,7 +201,7 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
         val root = Path.of(directory).normalize()
         val items = sync(root) ?: return@withContext WorktreeStatsListDto()
         val fallback = baseBranch(items) ?: "HEAD"
-        WorktreeStatsListDto(parallel(items.filter { !it.main }) { item -> stats(item, fallback) })
+        WorktreeStatsListDto(parallel(items.filter { !it.main }) { item -> statsSafe(item, fallback) })
     }
 
     /**
@@ -177,7 +213,7 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
     override suspend fun dirty(directory: String): WorktreeDirtyListDto = withContext(Dispatchers.IO) {
         val root = Path.of(directory).normalize()
         val items = sync(root) ?: return@withContext WorktreeDirtyListDto()
-        WorktreeDirtyListDto(parallel(items) { item -> dirty(item) })
+        WorktreeDirtyListDto(parallel(items) { item -> dirtySafe(item) })
     }
 
     /**
@@ -199,7 +235,7 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
         val res = runGit(root, "worktree", "list", "--porcelain")
         if (!res.ok) return null
         val raw = parseWorktreeList(res.stdout)
-        val stale = staleWorktrees(raw)
+        val stale = staleWorktrees(raw, trash)
         val synced = if (stale.isEmpty()) managedWorktrees(raw) else {
             LOG.info("worktree sync pruning stale managed worktrees: ${stale.joinToString(", ") { it.path }}")
             val prune = runGit(root, "worktree", "prune", "-v")
@@ -209,7 +245,7 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
             if (!again.ok) return null
             managedWorktrees(parseWorktreeList(again.stdout))
         }
-        return synced.filter { Files.isDirectory(Path.of(it.path)) }
+        return live(synced.filter { Files.isDirectory(Path.of(it.path)) })
     }
 
     override suspend fun ghStatus(directory: String, github: Boolean, maxAge: Long?): GhAvailability = withContext(Dispatchers.IO) {
@@ -232,13 +268,19 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
         if (available != GhAvailability.OK) return@withContext WorktreePrListDto(available).also { prs[directory] = Timed(now, it) }
         // Sync the worktree list before the per-worktree lookups so a worktree that was added and
         // then deleted on disk is pruned instead of resolved from a directory that no longer exists.
+        // sync() (via live()) already drops anything mid-removal, so prTargets never fans `gh` out
+        // into a directory this process is in the middle of deleting.
         val all = sync(root) ?: return@withContext WorktreePrListDto().also { prs[directory] = Timed(now, it) }
         val items = prTargets(all)
         val base = baseBranch(all)
         var status = GhAvailability.OK
         val data = parallel(items) { item ->
             if (status != GhAvailability.OK) return@parallel null
-            val lookup = resolver.resolve(item.path, item.branch, base)
+            val lookup = runCatching { resolver.resolve(item.path, item.branch, base) }.getOrElse { err ->
+                if (err is CancellationException) throw err
+                LOG.warn("worktree poll failed: op=pr path=${item.path} message=${err.message}", err)
+                return@parallel null
+            }
             // The resolver only ever reports UNAUTH or OK; a missing gh/git binary is already
             // caught by the upfront ghAvailable() check before this loop runs.
             if (lookup.availability != GhAvailability.OK) status = lookup.availability
@@ -259,6 +301,12 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
         val root = Path.of(directory).normalize()
         if (!Files.isDirectory(root)) {
             LOG.info("branch status skipped, directory does not exist: $root")
+            return@withContext BranchStatusDto()
+        }
+        // Not cached — same rule as the missing-directory branch above, so a directory recreated at
+        // this path right after a delete finishes is not pinned to an empty answer.
+        if (trash?.doomed(directory) == true) {
+            LOG.info("worktree poll skipped: op=branch path=$root reason=deleting")
             return@withContext BranchStatusDto()
         }
         val branch = runGit(root, "branch", "--show-current").stdout.trim()
@@ -297,8 +345,12 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
             emit(MoveProgressDto(MoveStage.CAPTURING))
             val captured = withContext(Dispatchers.IO) { WorktreeTransfer.capture(base) }.also { snapshot = it }
             emit(MoveProgressDto(MoveStage.CREATING))
+            // Not wrapped together with the later rollback()/remove() call below: that call takes its
+            // own lock on this same repo, and Mutex is not reentrant, so nesting them would deadlock.
+            // Each mutation only needs to be atomic on its own; the two never need to be atomic
+            // together.
             val created = withContext(Dispatchers.IO) {
-                addWorktree(base, branch.trim(), existing = false, baseRef = captured.head)
+                lock(base, "move-create") { addWorktree(base, branch.trim(), existing = false, baseRef = captured.head) }
             }
             val worktree = created.worktree ?: run {
                 emit(MoveProgressDto(MoveStage.ERROR, error = created.error ?: "Failed to create worktree"))
@@ -340,7 +392,13 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
         }
     }
 
-    /** Drops a worktree created earlier in a failed move so a retry is not blocked by leftovers. */
+    /**
+     * Drops a worktree created earlier in a failed move so a retry is not blocked by leftovers.
+     * Deliberately calls the public [remove] rather than [removeManaged] directly: [remove] takes
+     * its own lock on this repo, which is safe here specifically because nothing on this call path
+     * is still holding it — the lock taken for the original `addWorktree` call in [moveToWorktree]
+     * was released as soon as that call returned.
+     */
     private suspend fun rollback(directory: String, worktree: WorktreeDto, branch: String, reason: String) {
         LOG.warn("worktree move: rolling back ${worktree.path} after $reason")
         runCatching { remove(directory, worktree.path, branch, force = true) }
@@ -381,43 +439,83 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
         branches.clear()
     }
 
+    /**
+     * Runs [block] while holding the mutation lock for the repository rooted at [base]'s main
+     * worktree. Every discrete git-mutating RPC (create/import/remove/rename/adopt/reorder/session
+     * list) goes through this; read paths never do.
+     *
+     * Deliberately not reentrant-safe: [Mutex] is not reentrant, and nothing here nests two locked
+     * calls within one call stack. [rollback] calls the public [remove] specifically *without* this
+     * wrapping — [remove] takes its own lock, and an outer lock held across that call would deadlock.
+     */
+    private suspend fun <T> lock(base: Path, op: String, block: suspend () -> T): T {
+        val key = mainWorktree(base).toString()
+        val mutex = locks.computeIfAbsent(key) { Mutex() }
+        if (mutex.isLocked) {
+            val start = System.currentTimeMillis()
+            return mutex.withLock {
+                val waited = System.currentTimeMillis() - start
+                if (waited >= LOCK_WAIT_LOG_THRESHOLD_MS) LOG.info("worktree lock waited: op=$op base=$base ms=$waited")
+                block()
+            }
+        }
+        return mutex.withLock { block() }
+    }
+
+    /**
+     * Drops any worktree currently being removed (see [WorktreeTrash]) so [stats], [dirty],
+     * [prStatus], and [list] never fan out into a directory that is disappearing underneath them.
+     * A no-op when [trash] is unavailable, which is also the state in which nothing is ever actually
+     * mid-removal via the fast path.
+     */
+    private fun live(items: List<WorktreeDto>): List<WorktreeDto> {
+        val t = trash ?: return items
+        val (deleting, kept) = items.partition { !it.main && t.doomed(it.path) }
+        if (deleting.isNotEmpty()) {
+            LOG.info("worktree poll excluded deleting worktrees: ${deleting.joinToString(", ") { it.path }}")
+        }
+        return kept
+    }
+
     override suspend fun create(directory: String, request: CreateWorktreeRequestDto): CreateWorktreeResultDto =
         withContext(Dispatchers.IO) {
             val base = Path.of(directory).normalize()
             val branch = request.branch.trim()
             if (branch.isEmpty()) return@withContext CreateWorktreeResultDto(error = "Branch name is required")
-            addWorktree(base, branch, request.existingBranch, request.baseBranch)
+            lock(base, "create") { addWorktree(base, branch, request.existingBranch, request.baseBranch) }
         }
 
     override suspend fun importPr(directory: String, url: String): CreateWorktreeResultDto =
         withContext(Dispatchers.IO) {
             val base = Path.of(directory).normalize()
             val ref = parsePrUrl(url) ?: return@withContext CreateWorktreeResultDto(error = "Enter a valid GitHub pull request URL")
-            when (ghAvailable(base)) {
-                GhAvailability.GIT_MISSING -> return@withContext CreateWorktreeResultDto(error = "Git is not installed")
-                GhAvailability.MISSING -> return@withContext CreateWorktreeResultDto(error = "GitHub CLI (gh) is not installed")
-                GhAvailability.UNAUTH -> return@withContext CreateWorktreeResultDto(error = "GitHub CLI (gh) is not authorized")
-                // Stated rather than attempted: the import runs several gh calls and the first would
-                // fail anyway, so say why instead of leaving a half-made worktree behind.
-                GhAvailability.RATE_LIMITED -> return@withContext CreateWorktreeResultDto(
-                    error = "GitHub is rate limiting this token. Try again later.",
-                )
-                GhAvailability.OK -> Unit
+            lock(base, "import") {
+                when (ghAvailable(base)) {
+                    GhAvailability.GIT_MISSING -> return@lock CreateWorktreeResultDto(error = "Git is not installed")
+                    GhAvailability.MISSING -> return@lock CreateWorktreeResultDto(error = "GitHub CLI (gh) is not installed")
+                    GhAvailability.UNAUTH -> return@lock CreateWorktreeResultDto(error = "GitHub CLI (gh) is not authorized")
+                    // Stated rather than attempted: the import runs several gh calls and the first would
+                    // fail anyway, so say why instead of leaving a half-made worktree behind.
+                    GhAvailability.RATE_LIMITED -> return@lock CreateWorktreeResultDto(
+                        error = "GitHub is rate limiting this token. Try again later.",
+                    )
+                    GhAvailability.OK -> Unit
+                }
+                val fields = "headRefName,title,isCrossRepository,headRepositoryOwner"
+                val view = runGh(base, "pr", "view", ref.number.toString(), "--repo", "${ref.owner}/${ref.repo}", "--json", fields)
+                if (!view.ok) {
+                    LOG.warn("pr import view failed: url=$url exit=${view.exit} stderr=${view.stderr.trim()}")
+                    return@lock CreateWorktreeResultDto(error = view.stderr.ifBlank { "gh pr view failed" })
+                }
+                val head = parsePrHead(view.stdout)
+                val branch = prBranchName(head, ref.number)
+                val failure = fetchPrBranch({ args -> runGit(base, args) }, ref.number, head, branch)
+                if (failure != null) {
+                    LOG.warn("pr import fetch failed: url=$url exit=${failure.exit} stderr=${failure.stderr.trim()}")
+                    return@lock CreateWorktreeResultDto(error = failure.stderr.ifBlank { "Failed to check out the pull request branch" })
+                }
+                addWorktree(base, branch, existing = true, baseRef = null)
             }
-            val fields = "headRefName,title,isCrossRepository,headRepositoryOwner"
-            val view = runGh(base, "pr", "view", ref.number.toString(), "--repo", "${ref.owner}/${ref.repo}", "--json", fields)
-            if (!view.ok) {
-                LOG.warn("pr import view failed: url=$url exit=${view.exit} stderr=${view.stderr.trim()}")
-                return@withContext CreateWorktreeResultDto(error = view.stderr.ifBlank { "gh pr view failed" })
-            }
-            val head = parsePrHead(view.stdout)
-            val branch = prBranchName(head, ref.number)
-            val failure = fetchPrBranch({ args -> runGit(base, args) }, ref.number, head, branch)
-            if (failure != null) {
-                LOG.warn("pr import fetch failed: url=$url exit=${failure.exit} stderr=${failure.stderr.trim()}")
-                return@withContext CreateWorktreeResultDto(error = failure.stderr.ifBlank { "Failed to check out the pull request branch" })
-            }
-            addWorktree(base, branch, existing = true, baseRef = null)
         }
 
     /** Runs `git worktree add` under `<base>/.kilo/worktrees/<slug>` and records list bookkeeping. */
@@ -461,88 +559,151 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
     override suspend fun remove(directory: String, path: String, branch: String?, force: Boolean): RemoveWorktreeResultDto =
         withContext(Dispatchers.IO) {
             val base = Path.of(directory).normalize()
+            val start = System.currentTimeMillis()
             LOG.info("worktree remove requested: path=$path branch=${branch ?: "(none)"} force=$force base=$base")
-            val list = runGit(base, "worktree", "list", "--porcelain")
-            if (!list.ok) return@withContext RemoveWorktreeResultDto(error = list.stderr.ifBlank { "git worktree list failed" })
-            val all = parseWorktreeList(list.stdout)
-            val items = managedWorktrees(all)
-            val main = all.firstOrNull { it.main }
-            val storage = main?.let { Path.of(it.path).normalize().resolve(".kilo").resolve("worktrees").normalize() }
-            val target = all.firstOrNull {
-                val item = Path.of(it.path).normalize()
-                !it.main && samePath(it.path, path) && item.parent == storage
+            lock(base, "remove") {
+                val list = runGit(base, "worktree", "list", "--porcelain")
+                if (!list.ok) {
+                    LOG.warn("worktree remove rejected: reason=list-failed path=$path exit=${list.exit} stderr=${snippet(list.stderr)}")
+                    return@lock RemoveWorktreeResultDto(error = list.stderr.ifBlank { "git worktree list failed" })
+                }
+                val all = parseWorktreeList(list.stdout)
+                val items = managedWorktrees(all)
+                val main = all.firstOrNull { it.main }
+                val storage = main?.let { Path.of(it.path).normalize().resolve(".kilo").resolve("worktrees").normalize() }
+                val target = all.firstOrNull {
+                    val item = Path.of(it.path).normalize()
+                    !it.main && samePath(it.path, path) && item.parent == storage
+                }
+                if (target == null) {
+                    LOG.warn("worktree remove rejected: reason=unmanaged path=$path")
+                    return@lock RemoveWorktreeResultDto(error = "Refusing to remove unmanaged worktree: $path")
+                }
+                // Compare canonical (symlink-resolved) paths: on macOS the temp/repo root is a symlink
+                // (/var -> /private/var), so a raw startsWith against normalized porcelain paths would miss
+                // a live child and let `git worktree remove --force` delete it recursively.
+                val root = realPath(path)
+                val nested = all.filter {
+                    !it.prunable && Files.isDirectory(Path.of(it.path)) && !samePath(it.path, path) && realPath(it.path).startsWith(root)
+                }
+                if (nested.isNotEmpty()) {
+                    val names = nested.joinToString("\n") { it.path }
+                    LOG.warn("worktree remove rejected: reason=nested path=$path blockers=${nested.joinToString(", ") { it.path }}")
+                    return@lock RemoveWorktreeResultDto(error = "Delete nested worktrees first:\n$names")
+                }
+                val store = worktreeNameStore(items) ?: base.resolve(".kilo").resolve(WORKTREE_NAMES_FILE)
+                trash?.mark(target.path)
+                try {
+                    removeManaged(base, target, branch, force, store, storage, start)
+                } finally {
+                    trash?.unmark(target.path)
+                }
             }
-                ?: return@withContext RemoveWorktreeResultDto(error = "Refusing to remove unmanaged worktree: $path")
-            // Compare canonical (symlink-resolved) paths: on macOS the temp/repo root is a symlink
-            // (/var -> /private/var), so a raw startsWith against normalized porcelain paths would miss
-            // a live child and let `git worktree remove --force` delete it recursively.
-            val root = realPath(path)
-            val nested = all.filter {
-                !it.prunable && Files.isDirectory(Path.of(it.path)) && !samePath(it.path, path) && realPath(it.path).startsWith(root)
-            }
-            if (nested.isNotEmpty()) {
-                val names = nested.joinToString("\n") { it.path }
-                return@withContext RemoveWorktreeResultDto(error = "Delete nested worktrees first:\n$names")
-            }
-            val store = worktreeNameStore(items) ?: base.resolve(".kilo").resolve(WORKTREE_NAMES_FILE)
-            // Force means the user accepted removing a locked worktree; unlock first so the plain
-            // remove succeeds. Unlock fails harmlessly when the tree isn't actually locked.
-            if (force) {
-                val unlock = runGit(base, "worktree", "unlock", target.path)
-                if (!unlock.ok) LOG.info("worktree unlock skipped: path=$path exit=${unlock.exit} stderr=${unlock.stderr.trim()}")
-            }
-            // Only skip git's own removal when the checkout directory is actually gone. Git also flags a
-            // worktree prunable when its admin metadata is stale while the files remain; those must still
-            // be deleted so a later create of the same slug is not blocked by leftovers.
-            val res = if (!Files.isDirectory(Path.of(target.path))) {
-                CmdOut(0, "", "")
-            } else {
-                runGit(base, "worktree", "remove", "--force", target.path)
-            }
-            if (!res.ok) {
-                val locked = res.stderr.contains("locked working tree", ignoreCase = true)
-                LOG.warn("worktree remove failed: path=$path locked=$locked exit=${res.exit} stderr=${res.stderr.trim()}")
-                return@withContext RemoveWorktreeResultDto(
-                    error = res.stderr.ifBlank { "git worktree remove failed" },
-                    locked = locked,
-                )
-            }
-            // The worktree is gone; a failed branch delete must not fail the removal, only warn.
-            branch?.trim()?.takeIf { it.isNotEmpty() }?.let {
-                val del = runGit(base, "branch", "-D", it)
-                if (!del.ok) LOG.warn("worktree branch delete failed: branch=$it exit=${del.exit} stderr=${del.stderr.trim()}")
-            }
-            LOG.info("worktree removed: path=$path branch=${branch ?: "(none)"}")
-            invalidate()
-            removeWorktreeState(store, target.path)
-            val prune = runGit(base, "worktree", "prune")
-            if (!prune.ok) LOG.warn("worktree prune failed: exit=${prune.exit} stderr=${prune.stderr.trim()}")
-            runCatching { service<KiloBackendAppService>().workspaces.remove(target.path) }
-                .onFailure { err -> LOG.info("workspace cache eviction skipped: path=${target.path} message=${err.message}") }
-            RemoveWorktreeResultDto(ok = true)
         }
+
+    /**
+     * Performs the actual removal of [target], once it has been validated as a managed, non-nested
+     * worktree and marked in [WorktreeTrash]. Prefers an atomic rename to a `.kilo-delete-*` sibling
+     * so the RPC never blocks on the recursive filesystem delete; falls back to a synchronous
+     * `git worktree remove --force` when [trash] is unavailable, the rename fails (e.g. cross-device),
+     * or the worktree is locked without [force] — a lock check has to go through git itself so
+     * `locked` is reported correctly, and a filesystem rename cannot see or honor a git lock at all.
+     */
+    private fun removeManaged(
+        base: Path,
+        target: WorktreeDto,
+        branch: String?,
+        force: Boolean,
+        store: Path,
+        storage: Path?,
+        start: Long,
+    ): RemoveWorktreeResultDto {
+        // Force means the user accepted removing a locked worktree; unlock first so the plain
+        // remove succeeds. Unlock fails harmlessly when the tree isn't actually locked.
+        if (force) {
+            val unlock = runGit(base, "worktree", "unlock", target.path)
+            if (!unlock.ok) LOG.info("worktree unlock skipped: path=${target.path} exit=${unlock.exit} stderr=${unlock.stderr.trim()}")
+        }
+        val targetPath = Path.of(target.path)
+        // Only skip git's own removal when the checkout directory is actually gone. Git also flags a
+        // worktree prunable when its admin metadata is stale while the files remain; those must still
+        // be deleted so a later create of the same slug is not blocked by leftovers.
+        val outcome: Triple<String, CmdOut, Path?> = when {
+            !Files.isDirectory(targetPath) -> Triple("prune-only", CmdOut(0, "", ""), null)
+            target.locked && !force -> {
+                val r = runGit(base, listOf("worktree", "remove", "--force", target.path), REMOVE_TIMEOUT_MS)
+                LOG.info("worktree remove git: path=${target.path} exit=${r.exit} ms=${System.currentTimeMillis() - start} timeout=${r.timeout}")
+                Triple("git", r, null)
+            }
+            else -> {
+                val temp = trash?.stage(targetPath)
+                if (temp != null) {
+                    LOG.info("worktree remove staged: path=${target.path} temp=$temp ms=${System.currentTimeMillis() - start}")
+                    val prune = runGit(base, "worktree", "prune", "--expire", "now")
+                    if (!prune.ok) {
+                        LOG.warn("worktree remove prune after stage failed: path=${target.path} exit=${prune.exit} stderr=${snippet(prune.stderr)}")
+                    }
+                    Triple("rename", CmdOut(0, "", ""), temp)
+                } else {
+                    LOG.info(
+                        "worktree remove fallback: path=${target.path} " +
+                            "reason=${if (trash == null) "trash-unavailable" else "rename-failed"}",
+                    )
+                    val r = runGit(base, listOf("worktree", "remove", "--force", target.path), REMOVE_TIMEOUT_MS)
+                    LOG.info("worktree remove git: path=${target.path} exit=${r.exit} ms=${System.currentTimeMillis() - start} timeout=${r.timeout}")
+                    Triple("git", r, null)
+                }
+            }
+        }
+        val (mode, res, staged) = outcome
+        if (!res.ok) {
+            val locked = res.stderr.contains("locked working tree", ignoreCase = true)
+            LOG.warn(
+                "worktree remove failed: path=${target.path} locked=$locked timeout=${res.timeout} " +
+                    "exit=${res.exit} stderr=${snippet(res.stderr)}",
+            )
+            return RemoveWorktreeResultDto(error = reason(res, "git worktree remove failed"), locked = locked)
+        }
+        // The worktree is gone; a failed branch delete must not fail the removal, only warn.
+        branch?.trim()?.takeIf { it.isNotEmpty() }?.let {
+            val del = runGit(base, "branch", "-D", it)
+            if (!del.ok) LOG.warn("worktree branch delete failed: branch=$it exit=${del.exit} stderr=${del.stderr.trim()}")
+        }
+        staged?.let { trash?.reap(it) }
+        LOG.info("worktree removed: path=${target.path} branch=${branch ?: "(none)"} mode=$mode ms=${System.currentTimeMillis() - start}")
+        invalidate()
+        removeWorktreeState(store, target.path)
+        val prune = runGit(base, "worktree", "prune")
+        if (!prune.ok) LOG.warn("worktree prune failed: exit=${prune.exit} stderr=${prune.stderr.trim()}")
+        runCatching { service<KiloBackendAppService>().workspaces.remove(target.path) }
+            .onFailure { err -> LOG.info("workspace cache eviction skipped: path=${target.path} message=${err.message}") }
+        storage?.let { trash?.sweep(it) }
+        return RemoveWorktreeResultDto(ok = true)
+    }
 
     override suspend fun rename(directory: String, path: String, name: String): RenameWorktreeResultDto =
         withContext(Dispatchers.IO) {
             val title = name.trim()
             if (title.isEmpty()) return@withContext RenameWorktreeResultDto(error = "Name is required")
             val base = Path.of(directory).normalize()
-            val res = runGit(base, "worktree", "list", "--porcelain")
-            if (!res.ok) return@withContext RenameWorktreeResultDto(error = res.stderr.ifBlank { "git worktree list failed" })
-            val items = managedWorktrees(parseWorktreeList(res.stdout))
-            val store = worktreeNameStore(items)
-                ?: return@withContext RenameWorktreeResultDto(error = "Main worktree not found")
-            val target = items.firstOrNull { samePath(it.path, path) && !it.main }
-                ?: return@withContext RenameWorktreeResultDto(error = "Worktree not found")
-            return@withContext try {
-                val state = readWorktreeState(store).reconcile(worktreePaths(items), livePaths(items))
-                val names = state.names.toMutableMap()
-                names[target.path] = title
-                writeWorktreeState(store, state.copy(names = names))
-                RenameWorktreeResultDto(worktree = target.copy(name = title))
-            } catch (e: Exception) {
-                LOG.warn("worktree rename failed: path=$path message=${e.message}", e)
-                RenameWorktreeResultDto(error = e.message ?: "worktree rename failed")
+            lock(base, "rename") {
+                val res = runGit(base, "worktree", "list", "--porcelain")
+                if (!res.ok) return@lock RenameWorktreeResultDto(error = res.stderr.ifBlank { "git worktree list failed" })
+                val items = managedWorktrees(parseWorktreeList(res.stdout))
+                val store = worktreeNameStore(items)
+                    ?: return@lock RenameWorktreeResultDto(error = "Main worktree not found")
+                val target = items.firstOrNull { samePath(it.path, path) && !it.main }
+                    ?: return@lock RenameWorktreeResultDto(error = "Worktree not found")
+                try {
+                    val state = readWorktreeState(store).reconcile(worktreePaths(items), livePaths(items))
+                    val names = state.names.toMutableMap()
+                    names[target.path] = title
+                    writeWorktreeState(store, state.copy(names = names))
+                    RenameWorktreeResultDto(worktree = target.copy(name = title))
+                } catch (e: Exception) {
+                    LOG.warn("worktree rename failed: path=$path message=${e.message}", e)
+                    RenameWorktreeResultDto(error = e.message ?: "worktree rename failed")
+                }
             }
         }
 
@@ -551,43 +712,47 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
             val title = name.trim()
             if (title.isEmpty()) return@withContext RenameWorktreeResultDto()
             val base = Path.of(directory).normalize()
-            val res = runGit(base, "worktree", "list", "--porcelain")
-            if (!res.ok) return@withContext RenameWorktreeResultDto(error = res.stderr.ifBlank { "git worktree list failed" })
-            val items = managedWorktrees(parseWorktreeList(res.stdout))
-            val store = worktreeNameStore(items)
-                ?: return@withContext RenameWorktreeResultDto(error = "Main worktree not found")
-            val target = items.firstOrNull { samePath(it.path, path) && !it.main }
-                ?: return@withContext RenameWorktreeResultDto(error = "Worktree not found")
-            return@withContext try {
-                val state = readWorktreeState(store).reconcile(worktreePaths(items), livePaths(items))
-                val names = state.names.toMutableMap()
-                // Only adopt while the worktree is still default. A recorded name means the user (or a
-                // prior adoption) already titled it, so leave it untouched and report a no-op.
-                if (!names[target.path].isNullOrBlank()) return@withContext RenameWorktreeResultDto()
-                names[target.path] = title
-                writeWorktreeState(store, state.copy(names = names))
-                LOG.info("worktree name adopted: path=$path name=$title")
-                RenameWorktreeResultDto(worktree = target.copy(name = title))
-            } catch (e: Exception) {
-                LOG.warn("worktree adopt failed: path=$path message=${e.message}", e)
-                RenameWorktreeResultDto(error = e.message ?: "worktree adopt failed")
+            lock(base, "adopt") {
+                val res = runGit(base, "worktree", "list", "--porcelain")
+                if (!res.ok) return@lock RenameWorktreeResultDto(error = res.stderr.ifBlank { "git worktree list failed" })
+                val items = managedWorktrees(parseWorktreeList(res.stdout))
+                val store = worktreeNameStore(items)
+                    ?: return@lock RenameWorktreeResultDto(error = "Main worktree not found")
+                val target = items.firstOrNull { samePath(it.path, path) && !it.main }
+                    ?: return@lock RenameWorktreeResultDto(error = "Worktree not found")
+                try {
+                    val state = readWorktreeState(store).reconcile(worktreePaths(items), livePaths(items))
+                    val names = state.names.toMutableMap()
+                    // Only adopt while the worktree is still default. A recorded name means the user (or a
+                    // prior adoption) already titled it, so leave it untouched and report a no-op.
+                    if (!names[target.path].isNullOrBlank()) return@lock RenameWorktreeResultDto()
+                    names[target.path] = title
+                    writeWorktreeState(store, state.copy(names = names))
+                    LOG.info("worktree name adopted: path=$path name=$title")
+                    RenameWorktreeResultDto(worktree = target.copy(name = title))
+                } catch (e: Exception) {
+                    LOG.warn("worktree adopt failed: path=$path message=${e.message}", e)
+                    RenameWorktreeResultDto(error = e.message ?: "worktree adopt failed")
+                }
             }
         }
 
     override suspend fun reorder(directory: String, paths: List<String>): Boolean =
         withContext(Dispatchers.IO) {
             val base = Path.of(directory).normalize()
-            val res = runGit(base, "worktree", "list", "--porcelain")
-            if (!res.ok) return@withContext false
-            val items = managedWorktrees(parseWorktreeList(res.stdout))
-            val store = worktreeNameStore(items) ?: return@withContext false
-            return@withContext try {
-                val state = readWorktreeState(store)
-                writeWorktreeState(store, state.copy(worktreeOrder = paths).reconcile(worktreePaths(items), livePaths(items)))
-                true
-            } catch (e: Exception) {
-                LOG.warn("worktree reorder failed: dir=$directory message=${e.message}", e)
-                false
+            lock(base, "reorder") {
+                val res = runGit(base, "worktree", "list", "--porcelain")
+                if (!res.ok) return@lock false
+                val items = managedWorktrees(parseWorktreeList(res.stdout))
+                val store = worktreeNameStore(items) ?: return@lock false
+                try {
+                    val state = readWorktreeState(store)
+                    writeWorktreeState(store, state.copy(worktreeOrder = paths).reconcile(worktreePaths(items), livePaths(items)))
+                    true
+                } catch (e: Exception) {
+                    LOG.warn("worktree reorder failed: dir=$directory message=${e.message}", e)
+                    false
+                }
             }
         }
 
@@ -605,18 +770,20 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
     override suspend fun setSessionList(directory: String, visible: Boolean): Boolean =
         withContext(Dispatchers.IO) {
             val base = Path.of(directory).normalize()
-            val res = runGit(base, "worktree", "list", "--porcelain")
-            if (!res.ok) return@withContext false
-            val items = managedWorktrees(parseWorktreeList(res.stdout))
-            val store = worktreeNameStore(items) ?: return@withContext false
-            val target = items.firstOrNull { samePath(it.path, directory) } ?: return@withContext false
-            return@withContext try {
-                val state = readWorktreeState(store).reconcile(worktreePaths(items), livePaths(items))
-                writeWorktreeState(store, state.copy(sessionList = state.sessionList + (target.path to visible)))
-                true
-            } catch (e: Exception) {
-                LOG.warn("worktree session list state failed: dir=$directory message=${e.message}", e)
-                false
+            lock(base, "session-list") {
+                val res = runGit(base, "worktree", "list", "--porcelain")
+                if (!res.ok) return@lock false
+                val items = managedWorktrees(parseWorktreeList(res.stdout))
+                val store = worktreeNameStore(items) ?: return@lock false
+                val target = items.firstOrNull { samePath(it.path, directory) } ?: return@lock false
+                try {
+                    val state = readWorktreeState(store).reconcile(worktreePaths(items), livePaths(items))
+                    writeWorktreeState(store, state.copy(sessionList = state.sessionList + (target.path to visible)))
+                    true
+                } catch (e: Exception) {
+                    LOG.warn("worktree session list state failed: dir=$directory message=${e.message}", e)
+                    false
+                }
             }
         }
 
@@ -624,7 +791,8 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
 
     private fun runGit(base: Path, vararg args: String): CmdOut = runGit(base, args.toList())
 
-    private fun runGit(base: Path, args: List<String>): CmdOut = runGitCommand(base, args)
+    private fun runGit(base: Path, args: List<String>, timeoutMs: Int = GIT_COMMAND_TIMEOUT_MS): CmdOut =
+        runGitCommand(base, args, timeoutMs)
 
     private fun runGh(base: Path, vararg args: String): CmdOut = runGh(base, args.toList())
 
@@ -634,7 +802,8 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
                 .withWorkDirectory(base.toFile())
                 .withParentEnvironmentType(ParentEnvironmentType.CONSOLE)
             val out = CapturingProcessHandler(cmd).runProcess(30_000)
-            CmdOut(if (out.isTimeout) -1 else out.exitCode, out.stdout, out.stderr)
+            if (out.isTimeout) LOG.warn("gh command timed out: dir=$base args=${args.joinToString(" ")} ms=30000")
+            CmdOut(if (out.isTimeout) -1 else out.exitCode, out.stdout, out.stderr, out.isTimeout)
         } catch (e: Exception) {
             CmdOut(-1, "", e.message ?: "gh failed")
         }
@@ -659,6 +828,24 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
         items.map { item -> async { sem.withPermit { block(item) } } }.map { it.await() }
     }
 
+    /**
+     * [stats] for one worktree, isolated so a directory that vanished between [sync]'s check and
+     * this call (deleted by another process, or mid the fallback `git worktree remove --force`
+     * still running in the background) cannot cancel every other worktree's result through
+     * [parallel]'s shared [coroutineScope]. See [badDir] for the two exception shapes this expects.
+     */
+    internal fun statsSafe(item: WorktreeDto, fallback: String): WorktreeStatsDto = runCatching {
+        stats(item, fallback)
+    }.getOrElse { err ->
+        if (err is CancellationException) throw err
+        if (badDir(err.message.orEmpty())) {
+            LOG.info("worktree poll skipped: op=stats path=${item.path} reason=gone")
+        } else {
+            LOG.warn("worktree poll failed: op=stats path=${item.path} message=${err.message}", err)
+        }
+        WorktreeStatsDto(item.path)
+    }
+
     private fun stats(item: WorktreeDto, fallback: String): WorktreeStatsDto {
         val dir = Path.of(item.path).normalize()
         val comparison = GitComparison.open(dir, GitComparison.Mode.Base, fallback) ?: return WorktreeStatsDto(item.path)
@@ -673,6 +860,19 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
             files = files.size,
             base = comparison.base,
         )
+    }
+
+    /** [dirty] for one worktree, isolated the same way [statsSafe] isolates [stats]. */
+    internal fun dirtySafe(item: WorktreeDto): WorktreeDirtyDto = runCatching {
+        dirty(item)
+    }.getOrElse { err ->
+        if (err is CancellationException) throw err
+        if (badDir(err.message.orEmpty())) {
+            LOG.info("worktree poll skipped: op=dirty path=${item.path} reason=gone")
+        } else {
+            LOG.warn("worktree poll failed: op=dirty path=${item.path} message=${err.message}", err)
+        }
+        WorktreeDirtyDto(item.path)
     }
 
     private fun dirty(item: WorktreeDto): WorktreeDirtyDto {
@@ -725,6 +925,14 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
             LOG.info("gh probe skipped reason=$reason dir=$root missing=true")
             return@synchronized GhAvailability.OK
         }
+        // The frontend GhStatusCoordinator only ever probes the main repo root (project.kiloRoot()),
+        // which is never doomed itself, so this only matters when the open project *is* a worktree
+        // being deleted from another window — but the RPC is directory-scoped, not project-scoped,
+        // so it must still be checked here rather than relying on that caller behavior.
+        if (trash?.doomed(root.toString()) == true) {
+            LOG.info("worktree poll skipped: op=gh path=$root reason=deleting")
+            return@synchronized GhAvailability.OK
+        }
         val now = System.currentTimeMillis()
         if (github) {
             ghCache?.takeIf { usable(it.time, now, ghTtl(it.value), maxAge) }?.let {
@@ -766,6 +974,16 @@ class KiloWorktreeRpcApiImpl : KiloWorktreeRpcApi {
         return text.trim().replace(Regex("\\s+"), " ").take(180)
     }
 
+    /**
+     * Human-readable failure reason for [res]. A timed-out process is reported as such — its stderr
+     * is whatever it managed to flush before being killed, usually blank — rather than falling
+     * through to [fallback] and reading as an unexplained failure.
+     */
+    internal fun reason(res: CmdOut, fallback: String): String {
+        if (res.timeout) return "timed out"
+        return res.stderr.ifBlank { fallback }
+    }
+
 }
 
 /**
@@ -779,10 +997,20 @@ internal fun usable(time: Long, now: Long, ttl: Long, maxAge: Long?): Boolean {
     return now - time < limit
 }
 
-/** True when a process failed because its working directory is gone, not because the tool is absent. */
+/**
+ * True when a command failed because its working directory disappeared out from under it, not
+ * because the tool is absent or broken. Covers two distinct message shapes for the same race: the
+ * platform's own process-spawn failure (`Cannot start a process, the working directory '...' does
+ * not exist`) when the directory is already gone before the process starts, and git's own
+ * `fatal: Unable to read current working directory: No such file or directory` when a worktree is
+ * renamed or deleted after the process starts but before it calls `getcwd()` — exactly the race a
+ * concurrent worktree removal (staged rename, or the synchronous fallback `git worktree remove`)
+ * can cause mid-poll.
+ */
 internal fun badDir(text: String): Boolean {
     val msg = text.lowercase()
-    return msg.contains("working directory") && (msg.contains("does not exist") || msg.contains("not a directory"))
+    if (msg.contains("working directory") && (msg.contains("does not exist") || msg.contains("not a directory"))) return true
+    return msg.contains("unable to read current working directory")
 }
 
 internal fun classifyGhError(text: String): GhAvailability {
@@ -1059,6 +1287,10 @@ internal fun managedWorktrees(items: List<WorktreeDto>): List<WorktreeDto> {
         if (item.main) return@filter true
         if (item.prunable) return@filter false
         val path = Path.of(item.path).normalize()
+        // A directory git still lists but whose name carries the delete-staging prefix is a
+        // `WorktreeTrash` sibling mid-reap, not a worktree: it must never be presented or acted on
+        // as one, however briefly git's own metadata still names it.
+        if (path.fileName?.toString()?.startsWith(WorktreeTrash.PREFIX) == true) return@filter false
         path.parent == storage
     }
 }
@@ -1067,13 +1299,18 @@ internal fun managedWorktrees(items: List<WorktreeDto>): List<WorktreeDto> {
  * Kilo-managed worktrees under `.kilo/worktrees/` whose checkout is gone. This is the only reason
  * [KiloWorktreeRpcApiImpl.sync] runs a prune, so a stale worktree the user keeps somewhere else is
  * never a reason for the plugin to touch git's administrative files on a polling loop.
+ *
+ * [trash] excludes a worktree already being removed through [WorktreeTrash]: it is about to become
+ * stale by design (the removal renamed its directory away and will prune it itself), and letting a
+ * concurrent poll's prune race that in-flight removal is pure risk for no benefit.
  */
-internal fun staleWorktrees(items: List<WorktreeDto>): List<WorktreeDto> {
+internal fun staleWorktrees(items: List<WorktreeDto>, trash: WorktreeTrash? = null): List<WorktreeDto> {
     val main = items.firstOrNull { it.main } ?: return emptyList()
     val storage = Path.of(main.path).normalize().resolve(".kilo").resolve("worktrees").normalize()
     return items.filter { item ->
         if (item.main) return@filter false
         if (Path.of(item.path).normalize().parent != storage) return@filter false
+        if (trash?.doomed(item.path) == true) return@filter false
         item.prunable || !Files.isDirectory(Path.of(item.path))
     }
 }

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/PrResolver.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/rpc/PrResolver.kt
@@ -11,7 +11,14 @@ import kotlinx.serialization.json.jsonPrimitive
 import java.nio.file.Path
 
 /** Result of running a `git`/`gh` command. */
-internal data class CmdOut(val exit: Int, val stdout: String, val stderr: String) {
+internal data class CmdOut(
+    val exit: Int,
+    val stdout: String,
+    val stderr: String,
+    /** True when the process was killed for exceeding its timeout, so [exit] `-1` reads as a real
+     * failure reason instead of an unexplained one. */
+    val timeout: Boolean = false,
+) {
     val ok get() = exit == 0
 }
 

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/worktree/WorktreeTrash.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/worktree/WorktreeTrash.kt
@@ -1,0 +1,155 @@
+package ai.kilocode.backend.worktree
+
+import ai.kilocode.log.KiloLog
+import com.intellij.openapi.components.Service
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import java.io.IOException
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Registry and background executor for worktree deletion, so a remove RPC never blocks on a
+ * recursive filesystem delete and no polling loop (`stats`, `dirty`, `prStatus`, `branchStatus`, the
+ * gh probe) spawns a process inside a directory that is disappearing underneath it.
+ *
+ * Deletion is rename-then-delete, mirroring the VS Code extension's `WorktreeManager`
+ * (`packages/kilo-vscode/src/agent-manager/WorktreeManager.ts`): the caller atomically renames the
+ * worktree to a `$PREFIX<uuid>` sibling — which is what makes it vanish from `git worktree list` and
+ * from disk-existence checks in a single filesystem operation — then this service deletes that
+ * sibling's contents on its own scope. Both clients share the same prefix, so either one sweeps
+ * orphans the other left behind (e.g. after a force-quit mid-delete).
+ */
+@Service(Service.Level.APP)
+class WorktreeTrash(private val cs: CoroutineScope) {
+    companion object {
+        /** Must match the VS Code extension's `TEMP_PREFIX` exactly so orphan sweeps are shared. */
+        const val PREFIX = ".kilo-delete-"
+        private val LOG = KiloLog.create(WorktreeTrash::class.java)
+    }
+
+    /** Paths currently being removed, keyed by their canonical (symlink-resolved) form. */
+    private val marked = ConcurrentHashMap.newKeySet<String>()
+    private val jobs = CopyOnWriteArrayList<Job>()
+
+    /** Marks [path] as being removed. Callers must pair this with [unmark] via `try`/`finally`. */
+    fun mark(path: String) {
+        marked.add(canonical(path))
+        LOG.info("worktree trash marked: path=$path inflight=${marked.size}")
+    }
+
+    fun unmark(path: String) {
+        marked.remove(canonical(path))
+        LOG.info("worktree trash unmarked: path=$path inflight=${marked.size}")
+    }
+
+    /**
+     * True when [path] is mid-removal (explicitly [mark]ed) or is itself a staged-for-delete
+     * directory (its name starts with [PREFIX]). The second case covers a worktree discovered by a
+     * concurrent `git worktree list` before this process ever called [mark], and any leftover from a
+     * previous run that has not been swept yet — both must be invisible to every poll just the same
+     * as an explicitly marked path.
+     */
+    fun doomed(path: String): Boolean {
+        val name = Path.of(path).normalize().fileName?.toString().orEmpty()
+        if (name.startsWith(PREFIX)) return true
+        return marked.contains(canonical(path))
+    }
+
+    /**
+     * Atomically renames [dir] to a `$PREFIX<uuid>` sibling so it disappears from git and from disk
+     * existence checks in one filesystem operation. Returns the new path, or null when the rename
+     * failed (e.g. cross-device) — the caller falls back to `git worktree remove --force` in that
+     * case, so throwing here would only complicate that fallback for no benefit.
+     */
+    fun stage(dir: Path): Path? {
+        val temp = dir.resolveSibling(PREFIX + UUID.randomUUID())
+        return try {
+            Files.move(dir, temp)
+            LOG.info("worktree trash staged: from=$dir to=$temp")
+            temp
+        } catch (e: Exception) {
+            LOG.warn("worktree trash stage failed: from=$dir message=${e.message}", e)
+            null
+        }
+    }
+
+    /** Deletes [temp] recursively on this service's own scope. Never throws into the caller. */
+    fun reap(temp: Path) {
+        jobs.add(cs.launch(Dispatchers.IO) { reapNow(temp) })
+    }
+
+    /**
+     * Reaps every `$PREFIX*` directory directly under [storage] — orphans left by an interrupted
+     * delete (this process's or the VS Code extension's), or a stage whose reap never ran because
+     * the IDE closed first. Safe to call from every `list`/`sync`: listing an ordinary directory is
+     * cheap and re-sweeping an already-reaped name is a no-op.
+     */
+    fun sweep(storage: Path) {
+        if (!Files.isDirectory(storage)) return
+        jobs.add(
+            cs.launch(Dispatchers.IO) {
+                val found = runCatching {
+                    Files.newDirectoryStream(storage).use { stream ->
+                        stream.filter { Files.isDirectory(it) && it.fileName.toString().startsWith(PREFIX) }
+                    }
+                }.getOrElse {
+                    LOG.warn("worktree trash sweep listing failed: storage=$storage message=${it.message}", it)
+                    emptyList()
+                }
+                LOG.info("worktree trash sweep: storage=$storage found=${found.size}")
+                found.forEach { reapNow(it) }
+            },
+        )
+    }
+
+    /** Awaits every reap/sweep started so far. Test-only: production code never blocks on this. */
+    internal suspend fun drain() {
+        val snapshot = jobs.toList()
+        snapshot.forEach { it.join() }
+        jobs.removeAll(snapshot)
+    }
+
+    private fun reapNow(temp: Path) {
+        val start = System.currentTimeMillis()
+        LOG.info("worktree trash reap start: temp=$temp")
+        try {
+            deleteRecursively(temp)
+            LOG.info("worktree trash reap done: temp=$temp ms=${System.currentTimeMillis() - start}")
+        } catch (e: Exception) {
+            LOG.warn("worktree trash reap failed: temp=$temp message=${e.message}", e)
+        }
+    }
+
+    private fun deleteRecursively(root: Path) {
+        if (!Files.exists(root)) return
+        Files.walkFileTree(
+            root,
+            object : SimpleFileVisitor<Path>() {
+                override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+                    Files.deleteIfExists(file)
+                    return FileVisitResult.CONTINUE
+                }
+
+                override fun postVisitDirectory(dir: Path, exc: IOException?): FileVisitResult {
+                    Files.deleteIfExists(dir)
+                    return FileVisitResult.CONTINUE
+                }
+            },
+        )
+    }
+
+    /** Same symlink-resolution rule as [ai.kilocode.backend.rpc.samePath]/`realPath`. */
+    private fun canonical(path: String): String {
+        val file = Path.of(path).normalize()
+        return (if (Files.exists(file)) runCatching { file.toRealPath() }.getOrDefault(file) else file).toString()
+    }
+}

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/worktree/WorktreeTrash.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/worktree/WorktreeTrash.kt
@@ -7,10 +7,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import java.io.IOException
+import java.nio.file.DirectoryNotEmptyException
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
+import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.nio.file.SimpleFileVisitor
+import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.BasicFileAttributes
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -36,18 +39,36 @@ class WorktreeTrash(private val cs: CoroutineScope) {
         private val LOG = KiloLog.create(WorktreeTrash::class.java)
     }
 
-    /** Paths currently being removed, keyed by their canonical (symlink-resolved) form. */
-    private val marked = ConcurrentHashMap.newKeySet<String>()
+    /**
+     * Paths currently being removed: a stable [key] (normalization only, so it does not depend on the
+     * directory still existing) mapped to every identity that path resolved to when [mark] ran. A
+     * removal renames the checkout away almost immediately, so anything derived from `toRealPath()`
+     * stops being reproducible partway through — hence recording the identities up front and keying
+     * the entry on something that cannot change.
+     */
+    private val marked = ConcurrentHashMap<String, Set<String>>()
+
+    /** Trees a reap is walking right now, so two walkers never race over the same files. */
+    private val reaping = ConcurrentHashMap.newKeySet<String>()
+
+    /** Storage directories a sweep is scanning right now, so repeated polls do not pile up. */
+    private val sweeping = ConcurrentHashMap.newKeySet<String>()
+
+    /**
+     * In-flight reaps and sweeps only — each job removes itself on completion, so this never grows
+     * with the number of deletions performed over an IDE session. Exists solely so [drain] can await
+     * them in tests.
+     */
     private val jobs = CopyOnWriteArrayList<Job>()
 
     /** Marks [path] as being removed. Callers must pair this with [unmark] via `try`/`finally`. */
     fun mark(path: String) {
-        marked.add(canonical(path))
+        marked[key(path)] = identities(path)
         LOG.info("worktree trash marked: path=$path inflight=${marked.size}")
     }
 
     fun unmark(path: String) {
-        marked.remove(canonical(path))
+        marked.remove(key(path))
         LOG.info("worktree trash unmarked: path=$path inflight=${marked.size}")
     }
 
@@ -57,23 +78,36 @@ class WorktreeTrash(private val cs: CoroutineScope) {
      * concurrent `git worktree list` before this process ever called [mark], and any leftover from a
      * previous run that has not been swept yet — both must be invisible to every poll just the same
      * as an explicitly marked path.
+     *
+     * Matching is by identity intersection rather than by key, so a caller that names the worktree
+     * through a symlink still matches an entry marked by its real path (and the reverse), whether or
+     * not the directory still exists to resolve.
      */
     fun doomed(path: String): Boolean {
         val name = Path.of(path).normalize().fileName?.toString().orEmpty()
         if (name.startsWith(PREFIX)) return true
-        return marked.contains(canonical(path))
+        if (marked.isEmpty()) return false
+        val ids = identities(path)
+        return marked.values.any { stored -> stored.any { it in ids } }
     }
 
     /**
      * Atomically renames [dir] to a `$PREFIX<uuid>` sibling so it disappears from git and from disk
      * existence checks in one filesystem operation. Returns the new path, or null when the rename
-     * failed (e.g. cross-device) — the caller falls back to `git worktree remove --force` in that
-     * case, so throwing here would only complicate that fallback for no benefit.
+     * failed — the caller falls back to `git worktree remove --force` in that case, so throwing here
+     * would only complicate that fallback for no benefit.
+     *
+     * [StandardCopyOption.ATOMIC_MOVE] is required, not merely preferred: a plain `Files.move` across
+     * filesystems silently degrades to copy-then-delete, which would block the caller for the length
+     * of a full tree copy (the exact stall this whole path exists to avoid) and leave the original in
+     * place next to a half-built sibling. Demanding atomicity turns that case into the
+     * `AtomicMoveNotSupportedException` this catch reports as "cannot stage", so the caller's
+     * synchronous fallback runs instead.
      */
     fun stage(dir: Path): Path? {
         val temp = dir.resolveSibling(PREFIX + UUID.randomUUID())
         return try {
-            Files.move(dir, temp)
+            Files.move(dir, temp, StandardCopyOption.ATOMIC_MOVE)
             LOG.info("worktree trash staged: from=$dir to=$temp")
             temp
         } catch (e: Exception) {
@@ -84,48 +118,80 @@ class WorktreeTrash(private val cs: CoroutineScope) {
 
     /** Deletes [temp] recursively on this service's own scope. Never throws into the caller. */
     fun reap(temp: Path) {
-        jobs.add(cs.launch(Dispatchers.IO) { reapNow(temp) })
+        track(cs.launch(Dispatchers.IO) { reapNow(temp) })
     }
 
     /**
      * Reaps every `$PREFIX*` directory directly under [storage] — orphans left by an interrupted
      * delete (this process's or the VS Code extension's), or a stage whose reap never ran because
      * the IDE closed first. Safe to call from every `list`/`sync`: listing an ordinary directory is
-     * cheap and re-sweeping an already-reaped name is a no-op.
+     * cheap, a scan already running for the same [storage] is skipped rather than duplicated, and a
+     * tree another reap is already walking is left to that walker.
      */
     fun sweep(storage: Path) {
         if (!Files.isDirectory(storage)) return
-        jobs.add(
+        val key = storage.normalize().toString()
+        if (!sweeping.add(key)) return
+        track(
             cs.launch(Dispatchers.IO) {
-                val found = runCatching {
-                    Files.newDirectoryStream(storage).use { stream ->
-                        stream.filter { Files.isDirectory(it) && it.fileName.toString().startsWith(PREFIX) }
+                try {
+                    val found = runCatching {
+                        Files.newDirectoryStream(storage).use { stream ->
+                            stream.filter { Files.isDirectory(it) && it.fileName.toString().startsWith(PREFIX) }
+                        }
+                    }.getOrElse {
+                        LOG.warn("worktree trash sweep listing failed: storage=$storage message=${it.message}", it)
+                        emptyList()
                     }
-                }.getOrElse {
-                    LOG.warn("worktree trash sweep listing failed: storage=$storage message=${it.message}", it)
-                    emptyList()
+                    LOG.info("worktree trash sweep: storage=$storage found=${found.size}")
+                    found.forEach { reapNow(it) }
+                } finally {
+                    sweeping.remove(key)
                 }
-                LOG.info("worktree trash sweep: storage=$storage found=${found.size}")
-                found.forEach { reapNow(it) }
             },
         )
     }
 
-    /** Awaits every reap/sweep started so far. Test-only: production code never blocks on this. */
+    /** Awaits every reap/sweep still running. Test-only: production code never blocks on this. */
     internal suspend fun drain() {
-        val snapshot = jobs.toList()
-        snapshot.forEach { it.join() }
-        jobs.removeAll(snapshot)
+        // Loops rather than joining a single snapshot so a job started by one already being awaited is
+        // still covered. Filtering on `isActive` is what makes this terminate: a job removes itself
+        // from `jobs` in a completion handler, and there is no ordering guarantee that the handler has
+        // run by the time `join` resumes, so an emptiness check alone could spin on completed jobs.
+        while (true) {
+            val active = jobs.toList().filter { it.isActive }
+            if (active.isEmpty()) return
+            active.forEach { it.join() }
+        }
+    }
+
+    /** Reaps/sweeps still tracked. Test-only: guards against [jobs] growing over a session. */
+    internal fun pending(): Int = jobs.size
+
+    private fun track(job: Job) {
+        jobs.add(job)
+        job.invokeOnCompletion { jobs.remove(job) }
     }
 
     private fun reapNow(temp: Path) {
+        val key = temp.normalize().toString()
+        // Another reap (or a sweep that listed the same orphan) already owns this tree. Two walkers
+        // over one tree only produce failures as each deletes files the other is about to visit.
+        if (!reaping.add(key)) {
+            LOG.info("worktree trash reap skipped: temp=$temp reason=in-progress")
+            return
+        }
         val start = System.currentTimeMillis()
         LOG.info("worktree trash reap start: temp=$temp")
         try {
             deleteRecursively(temp)
             LOG.info("worktree trash reap done: temp=$temp ms=${System.currentTimeMillis() - start}")
         } catch (e: Exception) {
+            // Left in place deliberately: the name keeps its delete prefix, so it stays invisible to
+            // every poll and the next sweep retries it.
             LOG.warn("worktree trash reap failed: temp=$temp message=${e.message}", e)
+        } finally {
+            reaping.remove(key)
         }
     }
 
@@ -139,17 +205,46 @@ class WorktreeTrash(private val cs: CoroutineScope) {
                     return FileVisitResult.CONTINUE
                 }
 
+                /**
+                 * The base implementation rethrows, which would abandon the rest of the tree over one
+                 * entry. A file that vanished on its own (an external process, or a `.kilo-delete-*`
+                 * tree the VS Code extension is reaping concurrently) is already the outcome this
+                 * walk wants, so carry on; anything else is genuinely unexpected and propagates.
+                 */
+                override fun visitFileFailed(file: Path, exc: IOException): FileVisitResult {
+                    if (exc is NoSuchFileException) return FileVisitResult.CONTINUE
+                    throw exc
+                }
+
                 override fun postVisitDirectory(dir: Path, exc: IOException?): FileVisitResult {
-                    Files.deleteIfExists(dir)
+                    try {
+                        Files.deleteIfExists(dir)
+                    } catch (e: DirectoryNotEmptyException) {
+                        // Something was written into the tree while it was being walked. Leaving the
+                        // prefixed root behind is safe (see reapNow) and the next sweep retries.
+                        LOG.info("worktree trash reap left a non-empty directory: dir=$dir message=${e.message}")
+                    }
                     return FileVisitResult.CONTINUE
                 }
             },
         )
     }
 
-    /** Same symlink-resolution rule as [ai.kilocode.backend.rpc.samePath]/`realPath`. */
-    private fun canonical(path: String): String {
+    /**
+     * Existence-independent handle for a path, so a [mark]/[unmark] pair always agrees on the entry
+     * to add and remove even though the directory disappears between the two calls.
+     */
+    private fun key(path: String): String = Path.of(path).normalize().toString()
+
+    /**
+     * Every string form [path] can legitimately be named by right now: its normalized form, plus its
+     * symlink-resolved form when the directory still exists (on macOS a temp/repo root under `/var`
+     * resolves to `/private/var`, and git reports whichever the worktree was registered with). Same
+     * resolution rule as [ai.kilocode.backend.rpc.samePath]/`realPath`.
+     */
+    private fun identities(path: String): Set<String> {
         val file = Path.of(path).normalize()
-        return (if (Files.exists(file)) runCatching { file.toRealPath() }.getOrDefault(file) else file).toString()
+        val real = if (Files.exists(file)) runCatching { file.toRealPath() }.getOrNull() else null
+        return setOfNotNull(file.toString(), real?.toString())
     }
 }

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImplTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImplTest.kt
@@ -1,5 +1,6 @@
 package ai.kilocode.backend.rpc
 
+import ai.kilocode.backend.worktree.WorktreeTrash
 import ai.kilocode.rpc.parsePrUrl
 import ai.kilocode.rpc.dto.CreateWorktreeRequestDto
 import ai.kilocode.rpc.dto.GhAvailability
@@ -10,12 +11,16 @@ import ai.kilocode.rpc.dto.GhMerge
 import ai.kilocode.rpc.dto.GhReview
 import ai.kilocode.rpc.dto.GhState
 import ai.kilocode.rpc.dto.MoveStage
+import ai.kilocode.rpc.dto.WorktreeDirtyDto
 import ai.kilocode.rpc.dto.WorktreeDto
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.CapturingProcessHandler
 import com.intellij.openapi.util.SystemInfo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
@@ -76,6 +81,13 @@ class KiloWorktreeRpcApiImplTest {
         // the comparison into "always fresh".
         assertFalse(usable(time = 0, now = 0, ttl = 90_000, maxAge = 0))
         assertFalse(usable(time = 0, now = 0, ttl = 90_000, maxAge = -1))
+    }
+
+    @Test
+    fun `reason reports a timeout instead of falling through to the fallback text`() {
+        assertEquals("timed out", api.reason(CmdOut(-1, "", "", timeout = true), "git worktree remove failed"))
+        assertEquals("boom", api.reason(CmdOut(1, "", "boom"), "git worktree remove failed"))
+        assertEquals("git worktree remove failed", api.reason(CmdOut(1, "", ""), "git worktree remove failed"))
     }
 
     @Test
@@ -186,6 +198,40 @@ class KiloWorktreeRpcApiImplTest {
     fun `badDir detects a missing working directory spawn failure`() {
         assertTrue(badDir("Cannot start a process, the working directory '/tmp/gone' does not exist"))
         assertFalse(badDir("Cannot run program \"git\": error=2, No such file or directory"))
+        // git's own message for the same race once the process has already started: the working
+        // directory disappeared before git called getcwd(), rather than before it was even spawned.
+        assertTrue(badDir("fatal: Unable to read current working directory: No such file or directory"))
+        assertFalse(badDir("fatal: index file corrupt"))
+        assertFalse(badDir("fatal: not a git repository (or any of the parent directories): .git"))
+    }
+
+    @Test
+    fun `staleWorktrees excludes a worktree already marked doomed in WorktreeTrash`() {
+        val trash = WorktreeTrash(CoroutineScope(Dispatchers.Default + SupervisorJob()))
+        val main = WorktreeDto("/repo", "repo", "main", "/repo", main = true)
+        val gone = WorktreeDto("/repo/.kilo/worktrees/gone", "gone", "feature/gone", "/repo/.kilo/worktrees/gone", prunable = true)
+
+        assertEquals(listOf(gone.path), staleWorktrees(listOf(main, gone), trash).map { it.path })
+
+        trash.mark(gone.path)
+        // A worktree WorktreeTrash already knows is being removed is about to become stale by
+        // design (the removal renamed its directory away and will prune it itself); a concurrent
+        // poll's own prune must not race that in-flight removal.
+        assertTrue(staleWorktrees(listOf(main, gone), trash).isEmpty())
+    }
+
+    @Test
+    fun `managedWorktrees excludes a directory staged for delete even while git still lists it`() {
+        val main = WorktreeDto("/repo", "repo", "main", "/repo", main = true)
+        val staged = WorktreeDto(
+            "/repo/.kilo/worktrees/${WorktreeTrash.PREFIX}abc",
+            "${WorktreeTrash.PREFIX}abc",
+            "feature/x",
+            "/repo/.kilo/worktrees/${WorktreeTrash.PREFIX}abc",
+        )
+        val real = WorktreeDto("/repo/.kilo/worktrees/feature-x", "feature-x", "feature/x", "/repo/.kilo/worktrees/feature-x")
+
+        assertEquals(listOf(real.path), managedWorktrees(listOf(main, staged, real)).filter { !it.main }.map { it.path })
     }
 
     @Test
@@ -918,6 +964,42 @@ class KiloWorktreeRpcApiImplTest {
 
         assertEquals(1, item.unpushed)
         assertEquals(0, item.files, "committed work is not uncommitted")
+    }
+
+    /**
+     * [dirty] and [statsSafe]/[dirtySafe] via [api.dirty] and [api.stats] share the exact same
+     * `runCatching` isolation wrapper (see [statsSafe]/[dirtySafe] in the implementation), so proving
+     * it here for [dirty] covers the mechanism for both. [stats]'s own git calls compare two fully
+     * resolved commits (`GitComparison`'s two-revision form), which is why the same index corruption
+     * cannot be reused to force a throw there: a tree-to-tree diff never reads the index at all,
+     * unlike [dirty]'s working-tree comparison used below.
+     */
+    @Test
+    fun `dirty reports a neutral entry for a worktree whose index is corrupted instead of failing the whole call`() = runBlocking {
+        initRepo()
+        val healthy = assertNotNull(api.create(repo.toString(), CreateWorktreeRequestDto("healthy")).worktree)
+        val broken = assertNotNull(api.create(repo.toString(), CreateWorktreeRequestDto("broken")).worktree)
+        Files.writeString(Path.of(healthy.path).resolve("tracked.txt"), "edit\n")
+        corruptIndex(Path.of(broken.path))
+
+        // GitComparison.open() succeeds for `broken` (HEAD resolves fine); the corrupted index only
+        // breaks the later `git diff`/`ls-files` calls inside files() -- exactly the "open succeeded,
+        // a later command threw" shape a real fault takes, as opposed to a directory that is simply
+        // gone (which open() already returns null for, no throw involved).
+        val dto = api.dirty(repo.toString())
+
+        val healthyItem = assertNotNull(dto.items.singleOrNull { it.path == healthy.path })
+        assertEquals(1, healthyItem.files, "a healthy sibling must still be reported correctly")
+        val brokenItem = assertNotNull(dto.items.singleOrNull { it.path == broken.path })
+        assertEquals(WorktreeDirtyDto(broken.path), brokenItem, "a broken worktree gets a neutral entry, not an exception")
+    }
+
+    /** Overwrites [dir]'s own worktree index with garbage so `git diff`/`ls-files` fail well after
+     * `rev-parse --is-inside-work-tree` and `rev-parse HEAD` (which don't read the index) already
+     * succeeded. */
+    private fun corruptIndex(dir: Path) {
+        val gitDir = Path.of(output(dir, "rev-parse", "--path-format=absolute", "--git-dir").trim())
+        Files.write(gitDir.resolve("index"), "not an index".toByteArray())
     }
 
     @Test

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImplTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImplTest.kt
@@ -17,7 +17,9 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.CapturingProcessHandler
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.util.SystemInfo
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -88,6 +90,17 @@ class KiloWorktreeRpcApiImplTest {
         assertEquals("timed out", api.reason(CmdOut(-1, "", "", timeout = true), "git worktree remove failed"))
         assertEquals("boom", api.reason(CmdOut(1, "", "boom"), "git worktree remove failed"))
         assertEquals("git worktree remove failed", api.reason(CmdOut(1, "", ""), "git worktree remove failed"))
+    }
+
+    @Test
+    fun `cancellation checks in the poll wrappers also cover ProcessCanceledException`() {
+        // statsSafe/dirtySafe/prStatus isolate per-worktree failures behind runCatching and rethrow
+        // only CancellationException. That is enough to honor IntelliJ's "never swallow a PCE" rule
+        // solely because PCE extends java.util.concurrent.CancellationException, which is also what
+        // kotlinx.coroutines.CancellationException aliases on the JVM. Locked down here so a platform
+        // change that decoupled the two would fail this test instead of silently turning a cancelled
+        // progress indicator into a fake empty poll result.
+        assertTrue(ProcessCanceledException() is CancellationException)
     }
 
     @Test

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImplTrashTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImplTrashTest.kt
@@ -76,7 +76,16 @@ class KiloWorktreeRpcApiImplTrashTest {
 
         assertTrue(result.ok, "remove should still succeed via the prune-only path: ${result.error}")
         val listed = output(repo, "worktree", "list", "--porcelain")
-        assertFalse(listed.contains(created.path))
+        assertFalse(listed.contains(created.path), "the worktree must be unregistered: $listed")
+        // This arm reports success without running any git removal of its own, so the shared prune has
+        // to unregister the worktree before `branch -D` runs: git refuses to delete a branch a
+        // registered worktree still has checked out, and the default prune expiry is three months, so
+        // a just-vanished checkout would not be pruned at all without `--expire now`.
+        assertEquals(
+            "",
+            output(repo, "for-each-ref", "--format=%(refname)", "refs/heads/feature/x"),
+            "the branch must be deleted on the prune-only path too",
+        )
     }
 
     @Test

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImplTrashTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/rpc/KiloWorktreeRpcApiImplTrashTest.kt
@@ -1,0 +1,184 @@
+package ai.kilocode.backend.rpc
+
+import ai.kilocode.backend.worktree.WorktreeTrash
+import ai.kilocode.rpc.dto.CreateWorktreeRequestDto
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.CapturingProcessHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Exercises [KiloWorktreeRpcApiImpl.remove] and the read paths with a real [WorktreeTrash] wired
+ * in, unlike [KiloWorktreeRpcApiImplTest] where every `api` runs with `trash = null` (there is no
+ * IntelliJ Application in that plain-unit-test environment, so the default constructor argument's
+ * `ApplicationManager.getApplication() == null` guard resolves to null there — see
+ * [KiloWorktreeRpcApiImpl]'s `defaultTrash()`). Constructing [WorktreeTrash] directly, the same way
+ * [WorktreeTrashTest] does, sidesteps that guard entirely.
+ */
+class KiloWorktreeRpcApiImplTrashTest {
+    private val repo: Path = Files.createTempDirectory("kilo-worktree-trash-rpc")
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    private val trash = WorktreeTrash(scope)
+    private val api = KiloWorktreeRpcApiImpl(trash)
+
+    @AfterTest
+    fun tearDown() {
+        scope.cancel()
+        delete(repo)
+    }
+
+    @Test
+    fun `remove stages the directory and prunes without waiting for the recursive delete`() = runBlocking {
+        initRepo()
+        val created = assertNotNull(api.create(repo.toString(), CreateWorktreeRequestDto("feature/x")).worktree)
+
+        val result = api.remove(repo.toString(), created.path, created.branch)
+
+        assertTrue(result.ok, "remove should report success: ${result.error}")
+        // The original path is gone immediately -- moved, not deleted synchronously.
+        assertFalse(Files.exists(Path.of(created.path)))
+        val listed = output(repo, "worktree", "list", "--porcelain")
+        assertFalse(listed.contains(created.path), "git must no longer track the removed worktree: $listed")
+        assertEquals(
+            "",
+            output(repo, "for-each-ref", "--format=%(refname)", "refs/heads/feature/x"),
+            "remove must delete the branch too",
+        )
+
+        trash.drain()
+        val storage = repo.resolve(".kilo").resolve("worktrees")
+        val orphans = Files.newDirectoryStream(storage).use { stream ->
+            stream.filter { it.fileName.toString().startsWith(WorktreeTrash.PREFIX) }.toList()
+        }
+        assertTrue(orphans.isEmpty(), "the staged directory must be fully reaped: $orphans")
+    }
+
+    @Test
+    fun `remove succeeds when the checkout was already deleted outside the IDE`() = runBlocking {
+        initRepo()
+        val created = assertNotNull(api.create(repo.toString(), CreateWorktreeRequestDto("feature/x")).worktree)
+        delete(Path.of(created.path))
+
+        val result = api.remove(repo.toString(), created.path, created.branch)
+
+        assertTrue(result.ok, "remove should still succeed via the prune-only path: ${result.error}")
+        val listed = output(repo, "worktree", "list", "--porcelain")
+        assertFalse(listed.contains(created.path))
+    }
+
+    @Test
+    fun `remove falls back to a synchronous git remove when locked without force, even with staging available`() = runBlocking {
+        initRepo()
+        val created = assertNotNull(api.create(repo.toString(), CreateWorktreeRequestDto("feature/x")).worktree)
+        git(repo, "worktree", "lock", "--reason", "held by test", created.path)
+
+        val blocked = api.remove(repo.toString(), created.path, created.branch, force = false)
+
+        assertFalse(blocked.ok)
+        assertTrue(blocked.locked, "blocked removal should report locked=true: ${blocked.error}")
+        // Not renamed away: a filesystem rename cannot see or honor git's lock, so staging must be
+        // skipped entirely rather than left half-done.
+        assertTrue(Files.exists(Path.of(created.path)), "locked worktree must survive a non-force remove")
+
+        val forced = api.remove(repo.toString(), created.path, created.branch, force = true)
+        assertTrue(forced.ok, "force remove should succeed: ${forced.error}")
+        assertFalse(Files.exists(Path.of(created.path)))
+    }
+
+    @Test
+    fun `stats and dirty skip a worktree that WorktreeTrash reports as doomed`() = runBlocking {
+        initRepo()
+        val kept = assertNotNull(api.create(repo.toString(), CreateWorktreeRequestDto("kept")).worktree)
+        val deleting = assertNotNull(api.create(repo.toString(), CreateWorktreeRequestDto("deleting")).worktree)
+
+        trash.mark(deleting.path)
+        val stats = api.stats(repo.toString())
+        val dirty = api.dirty(repo.toString())
+        assertTrue(stats.items.any { it.path == kept.path })
+        assertTrue(stats.items.none { it.path == deleting.path }, "a doomed worktree must not be polled by stats")
+        assertTrue(dirty.items.any { it.path == kept.path })
+        assertTrue(dirty.items.none { it.path == deleting.path }, "a doomed worktree must not be polled by dirty")
+
+        trash.unmark(deleting.path)
+        assertTrue(api.stats(repo.toString()).items.any { it.path == deleting.path }, "unmarking must restore polling")
+    }
+
+    @Test
+    fun `branchStatus skips a directory being deleted without caching the empty answer`() = runBlocking {
+        initRepo()
+        val worktree = assertNotNull(api.create(repo.toString(), CreateWorktreeRequestDto("feature/x")).worktree)
+        // Primes the real cache entry for this key.
+        assertEquals("feature/x", api.branchStatus(worktree.path).branch)
+
+        trash.mark(worktree.path)
+        // maxAge = 0 forces past any cached entry so this call actually reaches the doomed check.
+        assertEquals("", api.branchStatus(worktree.path, maxAge = 0).branch)
+        trash.unmark(worktree.path)
+
+        // If the doomed-skip path had wrongly written its empty answer into the cache, this default
+        // (TTL-based) lookup would still see it; it must instead find the real cached branch,
+        // meaning the skip path never touched the cache at all.
+        assertEquals("feature/x", api.branchStatus(worktree.path).branch)
+    }
+
+    @Test
+    fun `concurrent removes all succeed and leave consistent state`() = runBlocking {
+        initRepo()
+        val worktrees = (1..4).map { assertNotNull(api.create(repo.toString(), CreateWorktreeRequestDto("branch-$it")).worktree) }
+
+        val results = coroutineScope {
+            worktrees.map { async { api.remove(repo.toString(), it.path, it.branch) } }.map { it.await() }
+        }
+
+        results.forEachIndexed { i, result -> assertTrue(result.ok, "removal $i should succeed: ${result.error}") }
+        val listed = output(repo, "worktree", "list", "--porcelain")
+        worktrees.forEach { assertFalse(listed.contains(it.path), "git must no longer track ${it.path}: $listed") }
+        val state = readWorktreeState(repo.resolve(".kilo").resolve("jetbrains.json"))
+        worktrees.forEach { wt ->
+            assertTrue(wt.path !in state.worktreeOrder, "order must not reference removed worktree ${wt.path}")
+            assertTrue(wt.path !in state.names, "names must not reference removed worktree ${wt.path}")
+        }
+    }
+
+    private fun initRepo() {
+        git(repo, "init")
+        git(repo, "config", "user.email", "test@kilo.ai")
+        git(repo, "config", "user.name", "Kilo Test")
+        Files.writeString(repo.resolve("README.md"), "hello")
+        git(repo, "add", "README.md")
+        git(repo, "commit", "-m", "init")
+    }
+
+    private fun git(dir: Path, vararg args: String) {
+        val cmd = GeneralCommandLine(listOf("git") + args).withWorkDirectory(dir.toFile())
+        val out = CapturingProcessHandler(cmd).runProcess(30_000)
+        assertEquals(0, out.exitCode, "git ${args.joinToString(" ")} failed: ${out.stderr}")
+    }
+
+    private fun output(dir: Path, vararg args: String): String {
+        val cmd = GeneralCommandLine(listOf("git") + args).withWorkDirectory(dir.toFile())
+        val out = CapturingProcessHandler(cmd).runProcess(30_000)
+        assertEquals(0, out.exitCode, "git ${args.joinToString(" ")} failed: ${out.stderr}")
+        return out.stdout
+    }
+
+    private fun delete(dir: Path) {
+        if (!Files.exists(dir)) return
+        Files.walk(dir).use { paths ->
+            paths.sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+        }
+    }
+}

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/worktree/WorktreeTrashTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/worktree/WorktreeTrashTest.kt
@@ -50,6 +50,44 @@ class WorktreeTrashTest {
     }
 
     @Test
+    fun `unmark clears the entry even though the directory disappeared after mark`() {
+        // The real removal sequence: mark while the checkout exists, stage it away, then unmark in a
+        // finally block. Anything derived from toRealPath() is no longer reproducible by then, so an
+        // entry keyed on it would leak and keep the slug invisible to every poll until the IDE
+        // restarts — including for a worktree later recreated at the same path.
+        val dir = root.resolve("wt").also { Files.createDirectories(it) }
+        trash.mark(dir.toString())
+        assertNotNull(trash.stage(dir))
+        trash.unmark(dir.toString())
+
+        assertFalse(trash.doomed(dir.toString()), "unmark must clear the entry mark() created")
+        Files.createDirectories(dir)
+        assertFalse(trash.doomed(dir.toString()), "a worktree recreated at the path must not stay doomed")
+    }
+
+    @Test
+    fun `doomed still matches the forms captured at mark time once nothing resolves any more`() {
+        val real = root.resolve("real").also { Files.createDirectories(it) }
+        val link = root.resolve("link")
+        try {
+            Files.createSymbolicLink(link, real)
+        } catch (e: Exception) {
+            return // symlinks unsupported (e.g. some Windows CI configs without privilege) — skip
+        }
+        val resolved = link.toRealPath() // the identity mark() records, captured while still resolvable
+
+        trash.mark(link.toString())
+        delete(real)
+        Files.deleteIfExists(link)
+
+        // Recording both forms up front is what keeps this matching: a removal renames the checkout
+        // away immediately, and once nothing resolves, a query can only be compared against whatever
+        // was captured while it still did.
+        assertTrue(trash.doomed(link.toString()), "the name used to mark must keep matching")
+        assertTrue(trash.doomed(resolved.toString()), "the resolved form recorded at mark time must keep matching")
+    }
+
+    @Test
     fun `doomed is true for any path whose name carries the delete prefix`() {
         val staged = root.resolve("${WorktreeTrash.PREFIX}abc-123")
         assertTrue(trash.doomed(staged.toString()))
@@ -111,6 +149,38 @@ class WorktreeTrashTest {
     fun `sweep on a missing storage directory does not throw`() = runBlocking {
         trash.sweep(root.resolve("missing"))
         trash.drain()
+    }
+
+    @Test
+    fun `concurrent reaps and sweeps over the same tree still delete it without failing`() = runBlocking {
+        // sweep() runs on every list() poll while a reap of the same staged tree may already be in
+        // flight. Two walkers over one tree would otherwise abort each other as each deletes files the
+        // other is about to visit, leaving the tree behind.
+        val dir = root.resolve("${WorktreeTrash.PREFIX}contended")
+        repeat(40) { i ->
+            val nested = dir.resolve("nested-$i")
+            Files.createDirectories(nested)
+            repeat(10) { j -> Files.writeString(nested.resolve("file-$j.txt"), "x".repeat(64)) }
+        }
+
+        repeat(4) { trash.reap(dir) }
+        repeat(4) { trash.sweep(root) }
+        trash.drain()
+
+        assertFalse(Files.exists(dir), "the tree must be gone despite contending walkers")
+    }
+
+    @Test
+    fun `repeated sweeps and reaps do not accumulate jobs`() = runBlocking {
+        // jobs exists only so drain() can await in-flight work; if completed entries were never
+        // removed it would grow for the whole IDE session, since sweep() is called from every poll.
+        repeat(30) {
+            trash.sweep(root)
+            trash.reap(root.resolve("${WorktreeTrash.PREFIX}absent-$it"))
+        }
+        trash.drain()
+
+        assertEquals(0, trash.pending(), "every finished reap/sweep must drop out of the job list")
     }
 
     private fun delete(path: Path) {

--- a/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/worktree/WorktreeTrashTest.kt
+++ b/packages/kilo-jetbrains/backend/src/test/kotlin/ai/kilocode/backend/worktree/WorktreeTrashTest.kt
@@ -1,0 +1,122 @@
+package ai.kilocode.backend.worktree
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class WorktreeTrashTest {
+    private val root: Path = Files.createTempDirectory("kilo-worktree-trash")
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    private val trash = WorktreeTrash(scope)
+
+    @AfterTest
+    fun tearDown() {
+        scope.cancel()
+        delete(root)
+    }
+
+    @Test
+    fun `mark and unmark toggle doomed for the exact path`() {
+        val dir = root.resolve("wt").also { Files.createDirectories(it) }
+        assertFalse(trash.doomed(dir.toString()))
+        trash.mark(dir.toString())
+        assertTrue(trash.doomed(dir.toString()))
+        trash.unmark(dir.toString())
+        assertFalse(trash.doomed(dir.toString()))
+    }
+
+    @Test
+    fun `doomed matches a path resolved through a symlink the same as its real target`() {
+        val real = root.resolve("real").also { Files.createDirectories(it) }
+        val link = root.resolve("link")
+        try {
+            Files.createSymbolicLink(link, real)
+        } catch (e: Exception) {
+            return // symlinks unsupported (e.g. some Windows CI configs without privilege) — skip
+        }
+        trash.mark(link.toString())
+        assertTrue(trash.doomed(real.toString()))
+    }
+
+    @Test
+    fun `doomed is true for any path whose name carries the delete prefix`() {
+        val staged = root.resolve("${WorktreeTrash.PREFIX}abc-123")
+        assertTrue(trash.doomed(staged.toString()))
+    }
+
+    @Test
+    fun `stage renames the directory to a delete-prefixed sibling`() = runBlocking {
+        val dir = root.resolve("wt").also { Files.createDirectories(it) }
+        Files.writeString(dir.resolve("file.txt"), "content")
+
+        val temp = trash.stage(dir)
+
+        assertNotNull(temp)
+        assertFalse(Files.exists(dir))
+        assertTrue(Files.exists(temp))
+        assertTrue(temp.fileName.toString().startsWith(WorktreeTrash.PREFIX))
+        assertEquals("content", Files.readString(temp.resolve("file.txt")))
+    }
+
+    @Test
+    fun `stage returns null without throwing when the source does not exist`() = runBlocking {
+        val missing = root.resolve("missing")
+        assertNull(trash.stage(missing))
+    }
+
+    @Test
+    fun `reap deletes a populated tree`() = runBlocking {
+        val dir = root.resolve("${WorktreeTrash.PREFIX}reap-me")
+        Files.createDirectories(dir.resolve("nested"))
+        Files.writeString(dir.resolve("nested").resolve("file.txt"), "x")
+
+        trash.reap(dir)
+        trash.drain()
+
+        assertFalse(Files.exists(dir))
+    }
+
+    @Test
+    fun `reap of an already-gone directory is a no-op`() = runBlocking {
+        trash.reap(root.resolve("${WorktreeTrash.PREFIX}never-existed"))
+        trash.drain() // must not throw
+    }
+
+    @Test
+    fun `sweep reaps every delete-prefixed directory and ignores ordinary ones`() = runBlocking {
+        val orphanA = root.resolve("${WorktreeTrash.PREFIX}a").also { Files.createDirectories(it) }
+        val orphanB = root.resolve("${WorktreeTrash.PREFIX}b").also { Files.createDirectories(it) }
+        val kept = root.resolve("kept-worktree").also { Files.createDirectories(it) }
+
+        trash.sweep(root)
+        trash.drain()
+
+        assertFalse(Files.exists(orphanA))
+        assertFalse(Files.exists(orphanB))
+        assertTrue(Files.exists(kept))
+    }
+
+    @Test
+    fun `sweep on a missing storage directory does not throw`() = runBlocking {
+        trash.sweep(root.resolve("missing"))
+        trash.drain()
+    }
+
+    private fun delete(path: Path) {
+        if (!Files.exists(path)) return
+        Files.walk(path).use { stream ->
+            stream.sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+        }
+    }
+}

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/GhStatusCoordinator.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/GhStatusCoordinator.kt
@@ -23,6 +23,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
+/**
+ * [probe] always resolves its target directory from [target]'s [Project.kiloRoot], which is the
+ * project's main repository root, never a worktree — so this class does not need to know when a
+ * worktree is being deleted. The one case that still matters (the *open project itself* is a
+ * worktree that another window is deleting) is covered on the backend: `KiloWorktreeRpcApiImpl`'s
+ * `probeGh` checks `WorktreeTrash` before spawning `git`/`gh`, since the RPC is directory-scoped and
+ * cannot rely on this coordinator's behavior.
+ */
 @Service(Service.Level.APP)
 class GhStatusCoordinator(
     private val cs: CoroutineScope,

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeController.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeController.kt
@@ -4,6 +4,7 @@ import ai.kilocode.client.plugin.KiloBundle
 import ai.kilocode.client.telemetry.Telemetry
 import ai.kilocode.client.util.edt
 import ai.kilocode.client.session.SessionActivityKind
+import ai.kilocode.log.KiloLog
 import ai.kilocode.rpc.dto.CreateWorktreeRequestDto
 import ai.kilocode.rpc.dto.CreateWorktreeResultDto
 import ai.kilocode.rpc.dto.MoveStage
@@ -36,6 +37,10 @@ class WorktreeController(
     private val abort: suspend (String, String) -> Unit = { _, _ -> },
     private val telemetry: (String, Map<String, String>) -> Unit = { event, props -> Telemetry.send(event, props) },
 ) {
+    companion object {
+        private val LOG = KiloLog.create(WorktreeController::class.java)
+    }
+
     val model = CollectionListModel<WorktreeDto>()
     private val pending = LinkedHashMap<String, WorktreeDto>()
     private val tasks = LinkedHashMap<String, String>()
@@ -208,11 +213,14 @@ class WorktreeController(
         tasks[dto.id] = KiloBundle.message("common.deleting")
         edt { refresh(dto) }
         cs.launch {
+            val start = System.currentTimeMillis()
             // Stop anything the worktree run popup started here first, so git can remove the
             // directory without orphaning a process left running against a deleted working tree.
             service<KiloRunService>().release(directory, dto.path)
             val result = service.remove(directory, dto.path, dto.branch, force)
+            val ms = System.currentTimeMillis() - start
             if (result.ok) {
+                LOG.info("worktree delete: path=${dto.path} force=$force ok=true ms=$ms")
                 edt {
                     tasks.remove(dto.id)
                     val index = model.getElementIndex(dto)
@@ -226,6 +234,7 @@ class WorktreeController(
             }
             // Removal failed: git still tracks the worktree. Keep the row and reconcile with
             // ground truth so a stale optimistic delete can't make the entry reappear later.
+            LOG.warn("worktree delete: path=${dto.path} force=$force ok=false locked=${result.locked} ms=$ms error=${result.error}")
             edt {
                 tasks.remove(dto.id)
                 refresh(dto)

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeStatusService.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeStatusService.kt
@@ -283,7 +283,7 @@ class WorktreeStatusService internal constructor(
             val dir = project.kiloRoot() ?: return@launch
             runCatching { service<KiloWorktreeService>().stats(dir) }
                 .onSuccess { dto -> statsFlow.value = dto.items.associateBy { normalizeWorktreePath(it.path) } }
-                .onFailure { err -> LOG.warn("worktree stats refresh failed dir=$dir", err) }
+                .onFailure { err -> LOG.warn("worktree stats refresh failed dir=$dir (previous values kept)", err) }
         }
     }
 
@@ -295,7 +295,7 @@ class WorktreeStatusService internal constructor(
             val dir = project.kiloRoot() ?: return@launch
             runCatching { service<KiloWorktreeService>().dirty(dir) }
                 .onSuccess { dto -> dirtyFlow.value = dto.items.associateBy { normalizeWorktreePath(it.path) } }
-                .onFailure { err -> LOG.warn("worktree dirty refresh failed dir=$dir", err) }
+                .onFailure { err -> LOG.warn("worktree dirty refresh failed dir=$dir (previous values kept)", err) }
         }
     }
 


### PR DESCRIPTION
## Issue

<!-- Reference an existing issue with `Fixes #123`, `Closes #123`, or equivalent linked issue wording. -->

Fixes #

No tracked issue — found and fixed while diagnosing a user-reported JetBrains Agent Manager worktree deletion failure from local logs.

## Context

Deleting an Agent Manager worktree with a large `node_modules` blocked the `remove` RPC for 25–30s, because `git worktree remove --force` runs the recursive filesystem delete synchronously. While that delete was in flight, every other polling loop (`stats`, `dirty`, `prStatus`, `branchStatus`, the gh probe) kept spawning `git`/`gh` processes against the directory mid-delete, and one directory disappearing mid-command threw `IllegalStateException: ... Unable to read current working directory`, which cancelled every *other* worktree's result through the shared `parallel()` coroutine scope — so a single slow delete broke stats/dirty/PR badges for the whole Agent Manager list, which is what the user experienced as "deletion failed."

Six real deletions were traced end-to-end in the log: all of them eventually succeeded, but each blocked 18–31s and produced a wave of unrelated-looking crashes for the surviving worktrees during that window.

## Implementation

- **Non-blocking removal**: `remove()` now atomically renames the worktree to a `.kilo-delete-<uuid>` sibling (new `WorktreeTrash` service, matching the VS Code extension's `WorktreeManager` convention — same prefix, so either client sweeps the other's orphans), runs `git worktree prune --expire now`, deletes the branch, and returns success immediately. The actual recursive delete runs in the background on `WorktreeTrash`'s own coroutine scope. A worktree that is locked without `force` skips staging entirely and falls through to the existing synchronous `git worktree remove --force` — a filesystem rename can't see or honor a git lock, and renaming a directory git still considers locked would leave its metadata permanently stuck as prunable-but-locked.
- **Poll isolation**: every read path (`sync`/`list`/`stats`/`dirty`/`prStatus`/`branchStatus`/the gh probe) now checks `WorktreeTrash`'s doomed-path registry and skips a worktree that's mid-removal, without caching the empty answer.
- **Failure isolation**: `stats`/`dirty`'s per-item work is now wrapped so one worktree throwing (e.g. its directory vanishing mid-command) returns a neutral entry instead of cancelling every sibling result via `parallel()`'s shared `coroutineScope`. `badDir()` now also recognizes git's own `"Unable to read current working directory"` message (from the log) and classifies it as an expected race (INFO) rather than a real fault (WARN).
- **Honest timeouts**: `CmdOut` now carries a `timeout` flag, the fallback `git worktree remove --force` gets a 10-minute budget instead of the 30s default used for cheap queries, and a killed process reports "timed out" instead of a blank error.
- **Serialized mutations**: git-mutating RPCs (`create`/`import`/`remove`/`rename`/`adopt`/`reorder`/session-list) are now serialized per repository with a `Mutex`, so concurrent calls can't interleave `worktree list`/`remove`/`prune` or race the `.kilo/jetbrains.json` read-modify-write. Read paths stay unlocked. `moveToWorktree`'s rollback deliberately isn't nested under the same lock as its create, since `Mutex` isn't reentrant.
- **Logging**: every rejection/outcome in `remove()` now logs with elapsed time and the removal mode (`prune-only` / `rename` / `git` fallback), so a slow delete is distinguishable from a hung one.

## Screenshots / Video

N/A — backend/logging change, no UI change.

## How to Test

### Manual/local verification

- Ran `./gradlew test` for the whole `packages/kilo-jetbrains` plugin (backend, frontend, shared) — all green.
- Ran `./gradlew typecheck` for the plugin — passes.
- Traced the original bug report's `kilo.log`/`idea.log` excerpts against the new code paths to confirm the fix addresses the exact observed exceptions and blocking durations.

### Reviewer test steps

1. In a JetBrains Agent Manager session, create a worktree and run `bun install` (or similar) in it so it has a large `node_modules`.
2. Delete that worktree. The row should disappear in well under a second, and `kilo.log` should show `worktree removed: ... mode=rename ms=<small>`.
3. While the background delete finishes, confirm other worktrees' stats/dirty/PR badges keep updating with no `Git comparison failed` stack traces in the log.
4. Delete several worktrees back-to-back and confirm each completes without errors and `.kilo/worktrees/` ends up with no leftover `.kilo-delete-*` directories.

### Blocked checks and substitute verification

- Did not launch a full sandbox IDE (`runIdeSplitMode`) for this change; substituted with the Gradle unit/integration test suite (984 backend tests + frontend tests, all real `git` repos in temp directories, no mocks) covering the rename/prune fast path, the locked-without-force fallback, per-item failure isolation via a corrupted index, doomed-path skip behavior for stats/dirty/branchStatus, and four concurrent removes leaving consistent worktree-list/state-file output.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes — not applicable: `packages/kilo-jetbrains/` is not part of the bun changesets system (`.changeset/config.json`'s `fixed` group only covers `kilo-code`/`@kilocode/cli`); JetBrains has its own changelog process via the `release-jetbrains` release flow.
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch
