### PR TITLE
fix(jetbrains): stop auto-expanding worktree session list on new/forked sessions

### DIFF
--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeSessionEditorManager.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeSessionEditorManager.kt
@@ -250,8 +250,8 @@ open class WorktreeSessionEditorManager(
      * Copies [id]'s history into a new session in this worktree and opens it.
      *
      * Nothing here touches the session list's visibility: the forked row goes into the same list
-     * model every other creation path writes to, and [WorktreeSessionEditorPanel] applies its own
-     * promotion rule from there.
+     * model every other creation path writes to, and [WorktreeSessionEditorPanel] never changes
+     * visibility on its own -- it stays exactly as the user last left it (or hidden, if never chosen).
      */
     @RequiresEdt
     override fun forkSession(id: String, messageId: String?, surface: String) {

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeSessionEditorPanel.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeSessionEditorPanel.kt
@@ -166,8 +166,8 @@ class WorktreeSessionEditorPanel @RequiresEdt constructor(
         toolbar.component.isOpaque = false
         syncToolbar()
         list.installPopup(group)
-        // The list starts detached: a worktree opens with its sessions hidden until a stored choice or
-        // a second session says otherwise.
+        // The list starts detached: a worktree opens with its sessions hidden until a stored choice
+        // says otherwise (see restore()). Session count never forces it open on its own.
         splitter.secondComponent = manager.component
         addToTop(top())
         addToCenter(splitter)
@@ -376,7 +376,9 @@ class WorktreeSessionEditorPanel @RequiresEdt constructor(
 
     /**
      * Applies the stored visibility once the backend answers. A click that landed first already
-     * decided, so a late answer must not overwrite it.
+     * decided, so a late answer must not overwrite it. No stored value (`null`) leaves the list
+     * exactly as it started -- hidden -- and writes nothing; only an explicit [flip] ever persists
+     * a choice.
      */
     @RequiresEdt
     private fun restore(value: Boolean?) {
@@ -384,19 +386,6 @@ class WorktreeSessionEditorPanel @RequiresEdt constructor(
         ready = true
         pref = value
         value?.let(::syncExpanded)
-        resolve()
-    }
-
-    /**
-     * Shows the list the first time this worktree holds more than one session. Only that promotion is
-     * persisted, so a worktree the user never touched keeps writing nothing while it has one session.
-     */
-    @RequiresEdt
-    private fun resolve() {
-        if (!ready || pref != null || count() < AUTO) return
-        syncExpanded(true)
-        pref = true
-        save(true)
     }
 
     @RequiresEdt
@@ -569,7 +558,6 @@ class WorktreeSessionEditorPanel @RequiresEdt constructor(
         // the list hold that key until a refresh brings it in.
         val shown = if (pending) SessionHost.NEW else key
         list.update(rows, shown?.let { ActiveListSelection.Key(it) } ?: ActiveListSelection.Preserve)
-        resolve()
         syncToggle()
     }
 
@@ -711,9 +699,6 @@ class WorktreeSessionEditorPanel @RequiresEdt constructor(
     private companion object {
         private val LOG = KiloLog.create(WorktreeSessionEditorPanel::class.java)
         private val TERMINAL_DIR = Key.create<String>("kilo.worktree.terminal.dir")
-
-        /** Sessions a worktree must hold before the list shows itself without being asked. */
-        private const val AUTO = 2
 
         /** Classic UI leaves the toolbar inset key unset; matches the platform's own fallback. */
         private const val STRIP_PAD = 2

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeSessionListController.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeSessionListController.kt
@@ -92,8 +92,8 @@ class WorktreeSessionListController(
      * Forks [id] into this list's directory, optionally truncating at [messageId].
      *
      * The forked session is inserted at the head the same way [create] does. That optimistic insert
-     * is what lets the panel's own promotion rule react right away instead of waiting for the CLI's
-     * `session.created` to arrive through [COALESCE_MS]; the later reload is idempotent.
+     * is what lets the panel's row list and toggle badge react right away instead of waiting for the
+     * CLI's `session.created` to arrive through [COALESCE_MS]; the later reload is idempotent.
      *
      * Unlike the neighbours here this reports no telemetry of its own: fork is reachable from three
      * different surfaces, so the event belongs where the surface and the outcome are both known

--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeSessionEditorPanelTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeSessionEditorPanelTest.kt
@@ -261,7 +261,7 @@ class WorktreeSessionEditorPanelTest : BasePlatformTestCase() {
         }
     }
 
-    fun `test a second session shows the list once and stores that choice`() {
+    fun `test a second session never forces the list open or writes a choice`() {
         val view = view()
         rpc.listed += session("ses_1", 1.0)
         rpc.listed += session("ses_2", 2.0)
@@ -269,15 +269,16 @@ class WorktreeSessionEditorPanelTest : BasePlatformTestCase() {
         flush()
 
         edt {
-            assertNotNull(UIUtil.findComponentOfType(view, OnePixelSplitter::class.java)!!.firstComponent)
-            assertEquals(listOf(true), saves)
+            assertNull(UIUtil.findComponentOfType(view, OnePixelSplitter::class.java)!!.firstComponent)
+            assertTrue(saves.isEmpty())
         }
 
         rpc.listed += session("ses_3", 3.0)
         edt { controller.reload() }
         flush()
 
-        assertEquals(listOf(true), saves)
+        edt { assertNull(UIUtil.findComponentOfType(view, OnePixelSplitter::class.java)!!.firstComponent) }
+        assertTrue(saves.isEmpty())
     }
 
     fun `test a stored hidden list survives extra sessions`() {
@@ -325,7 +326,7 @@ class WorktreeSessionEditorPanelTest : BasePlatformTestCase() {
         }
     }
 
-    fun `test an empty stored answer promotes a worktree that already holds two sessions`() {
+    fun `test an empty stored answer leaves a worktree with two sessions hidden`() {
         var answer: ((Boolean?) -> Unit)? = null
         val view = view(load = { done -> answer = done })
         rpc.listed += session("ses_1", 1.0)
@@ -336,8 +337,8 @@ class WorktreeSessionEditorPanelTest : BasePlatformTestCase() {
         edt { answer!!(null) }
 
         edt {
-            assertNotNull(UIUtil.findComponentOfType(view, OnePixelSplitter::class.java)!!.firstComponent)
-            assertEquals(listOf(true), saves)
+            assertNull(UIUtil.findComponentOfType(view, OnePixelSplitter::class.java)!!.firstComponent)
+            assertTrue(saves.isEmpty())
         }
     }
 
@@ -737,7 +738,7 @@ class WorktreeSessionEditorPanelTest : BasePlatformTestCase() {
         assertTrue(manager.forks.isEmpty())
     }
 
-    fun `test forking a lone session promotes the list through the shared rule`() {
+    fun `test forking a lone session keeps the list hidden with no stored choice`() {
         val view = view()
         val session = session("ses_1", nowSeconds())
         rpc.listed += session
@@ -751,11 +752,11 @@ class WorktreeSessionEditorPanelTest : BasePlatformTestCase() {
         edt { view.forkRow(session) }
         flush()
 
-        // The fork adds a row to the same list model every other creation path writes to, so the
-        // panel's own second-session promotion is what opens the list -- no fork-specific rule.
+        // The fork adds a row to the same list model every other creation path writes to, but the
+        // panel never changes visibility on its own -- it stays hidden and nothing is persisted.
         edt {
-            assertNotNull(UIUtil.findComponentOfType(view, OnePixelSplitter::class.java)!!.firstComponent)
-            assertEquals(listOf(true), saves)
+            assertNull(UIUtil.findComponentOfType(view, OnePixelSplitter::class.java)!!.firstComponent)
+            assertTrue(saves.isEmpty())
         }
     }
 
@@ -929,7 +930,15 @@ class WorktreeSessionEditorPanelTest : BasePlatformTestCase() {
     fun `test multi select rename resets to first visible selected session`() {
         val edits = mutableListOf<String>()
         val view = edt {
-            WorktreeSessionEditorPanel(testRootDisposable, manager, controller, workspace, edit = { _, opts, _ -> edits += opts.value })
+            WorktreeSessionEditorPanel(
+                testRootDisposable,
+                manager,
+                controller,
+                workspace,
+                edit = { _, opts, _ -> edits += opts.value },
+                load = { done -> done(true) },
+                save = {},
+            )
         }
         rpc.listed += session("ses_1", 1.0)
         rpc.listed += session("ses_2", 2.0)
@@ -1227,8 +1236,8 @@ class WorktreeSessionEditorPanelTest : BasePlatformTestCase() {
         val focuses = mutableListOf<Boolean>()
         val deleted = mutableListOf<String>()
         val renamed = mutableListOf<Pair<String, String>>()
-        // Records the call and then runs the real fork, so the list model and the panel's promotion
-        // rule are exercised end to end rather than stubbed out.
+        // Records the call and then runs the real fork, so the list model and the panel's row/badge
+        // sync are exercised end to end rather than stubbed out.
         val forks = mutableListOf<Triple<String, String?, String>>()
         // Real editors resolve this once in start() from git; panel tests set it directly so
         // canMove()/moveRow() can be exercised without touching KiloWorktreeService.


### PR DESCRIPTION
## Issue

Fixes #

## Context

In the JetBrains plugin's worktree editor, starting a new session or continuing (forking) a session into a second session used to auto-expand the hidden session list and persist that as the user's stored visibility choice. Users who never explicitly opened the list would suddenly see it pop open, and that "shown" choice was then written to disk.

## Implementation

`WorktreeSessionEditorPanel` tracked visibility as a nullable `Boolean` (`null` = undefined/never chosen). A `resolve()` step ran after every list sync and after the stored value loaded: if the preference was still `null` and the worktree held 2+ sessions, it flipped the splitter open and saved `true`.

Removed `resolve()` and its call sites in `restore()` and `sync()`, along with the now-unused `AUTO` threshold constant. Visibility now only ever changes from an explicit user click (`flip()`) or from a previously stored value loading in (`restore()` applying a non-null stored value). A worktree with no stored preference stays collapsed regardless of session count, and nothing gets auto-persisted.

Updated stale doc comments in `WorktreeSessionEditorManager.kt` and `WorktreeSessionListController.kt` that described the removed promotion rule.

## Screenshots / Video

N/A — behavior-only change to a collapse/expand default; no new visuals.

## How to Test

### Manual/local verification

- Ran `./gradlew :frontend:test --tests "ai.kilocode.client.agentManager.worktree.*"` — all 202 tests across the package pass, 0 failures.
- Ran `./gradlew typecheck` from `packages/kilo-jetbrains/` — successful.

### Reviewer test steps

1. Open a worktree editor tab with a single session and no stored session-list preference.
2. Click "New session" (or fork/"continue" an existing session) so the worktree now holds 2+ sessions.
3. Confirm the session list stays collapsed and the toggle keeps its "Show sessions" tooltip — it no longer pops open automatically.
4. Click the toggle manually to show the list, then repeat step 2 — confirm the list stays open (an explicit choice still sticks).

### Blocked checks and substitute verification

-

## Checklist

- [x] Issue linked above, or exception explained — no tracked issue; reported directly by a user.
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes — not applicable; `@kilocode/kilo-jetbrains` is released via its own version-pin process, not changesets.
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch
