### PR TITLE
fix(vscode): restore /update-from-base requests

### DIFF
--- a/.changeset/fix-base-update-transport.md
+++ b/.changeset/fix-base-update-transport.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix `/update-from-base` silently failing when sending the selected model.

--- a/packages/kilo-vscode/tests/fixtures/session-provider-activity.tsx
+++ b/packages/kilo-vscode/tests/fixtures/session-provider-activity.tsx
@@ -9,7 +9,7 @@ Object.defineProperty(window.document, "hasFocus", { value: () => focused.value 
 const sent: WebviewMessage[] = []
 const api = {
   postMessage: (message: WebviewMessage) => {
-    sent.push(message)
+    sent.push(message.type === "agentManager.updateFromBase" ? structuredClone(message) : message)
     if (message.type === "acknowledgeSession") {
       queueMicrotask(() => post({ ...message, type: "sessionAcknowledged" }))
     }

--- a/packages/kilo-vscode/webview-ui/src/context/session.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/session.tsx
@@ -568,7 +568,7 @@ export const SessionProvider: ParentComponent = (props) => {
 
   function submission(sessionID?: string, model = selected(sessionID)) {
     return {
-      model: model ?? undefined,
+      model: model ? { providerID: model.providerID, modelID: model.modelID } : undefined,
       variant: variants.request(sessionID),
       agent: resolvePromptAgent({
         sessionID,


### PR DESCRIPTION
## What Problem This Solves
`/update-from-base` cleared the composer but did not start an update when a selected model was present.

## Why This Change Was Made
The selected model came from SolidJS store state and was forwarded as a proxy through the VS Code webview message boundary. Structured cloning rejected the proxy with `DataCloneError` before the extension host received the request. The submission now sends a plain model object.

## User Impact
`/update-from-base` reaches the owning managed worktree session again while preserving the selected model, agent, and variant.

## Evidence
- Focused session-provider, base-update, and slash-command tests pass, 47 tests and 218 assertions.
- `bun run compile` passes extension host and webview type checks, lint, and bundle validation.
- The regression fixture clones update messages and reproduced the transport failure before this fix.