### PR TITLE
fix(cli): list sessions across all projects instead of crashing

### DIFF
--- a/.changeset/fix-session-list-all.md
+++ b/.changeset/fix-session-list-all.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix `kilo session list --all` crashing with "undefined is not an object" instead of listing sessions across all projects.

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -99,7 +99,7 @@ export const SessionListCommand = effectCmd({
   handler: Effect.fn("Cli.session.list")(function* (args) {
     // kilocode_change start
     const sessions = args.all
-      ? [...Session.listGlobal({ roots: true, limit: args.maxCount, search: args.search })]
+      ? yield* Session.Service.use((svc) => svc.listGlobal({ roots: true, limit: args.maxCount, search: args.search }))
       : yield* Session.Service.use((svc) => svc.list({ roots: true, limit: args.maxCount, search: args.search }))
     // kilocode_change end
 

--- a/packages/opencode/test/cli/smokes/read-only.test.ts
+++ b/packages/opencode/test/cli/smokes/read-only.test.ts
@@ -87,6 +87,22 @@ describe("opencode read-only commands (smoke)", () => {
     60_000,
   )
 
+  // kilocode_change start
+  // `session list --all` lists sessions across all projects via the global
+  // listing path (KiloSession.listGlobal). Regression: the handler used to
+  // spread the Effect returned by Session.listGlobal instead of yielding it,
+  // crashing the formatter with "undefined is not an object".
+  cliIt.live(
+    "session list --all: exits 0",
+    ({ opencode }) =>
+      Effect.gen(function* () {
+        const r = yield* opencode.spawn(["session", "list", "--all"])
+        opencode.expectExit(r, 0, "session list --all")
+      }),
+    60_000,
+  )
+  // kilocode_change end
+
   // `stats` aggregates token usage from the session DB. Empty DB → all zeros.
   cliIt.live(
     "stats: exits 0",


### PR DESCRIPTION
## What

`kilo session list --all` crashes with `Error: Unexpected error — undefined is not an object (evaluating 'f.id.length')` in table format, or `'L.time.updated'` with `--format json`. Exit code 1. Plain `kilo session list` works fine.

## Root cause

The `--all` branch of the list handler spread the result of `Session.listGlobal()`: `[...Session.listGlobal({ roots: true, ... })]`.

`listGlobal` returns an `Effect`, and an Effect's `Symbol.iterator` is the single-shot generator adapter meant for `yield*` inside `Effect.gen` — so the spread produces a 1-element array containing an internal Effect wrapper, not session rows. The formatters then dereference `.id` / `.time.updated` on that wrapper and crash.

The flag was added in 93ce148f33 when `listGlobal` was still a synchronous generator (spreading was correct then). When the non-`--all` branch was later migrated to `yield* Session.Service.use(...)`, the `--all` branch was missed.

## Fix

Yield the service method instead, mirroring the non-`--all` branch: `yield* Session.Service.use((svc) => svc.listGlobal({ roots: true, ... }))`.

`svc.listGlobal` self-provides `Database.Service`, so no extra wiring is needed.

## Verification

Adds a `session list --all` case to the read-only CLI smoke suite — it fails on the old code and passes with the fix. Also verified end-to-end from source against a database with sessions in multiple projects: table and JSON output both render correctly.

