### PR TITLE
fix(vscode): make Escape session abort configurable

### DIFF
--- a/.changeset/quiet-escapes-abort.md
+++ b/.changeset/quiet-escapes-abort.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Add a setting to disable Escape aborts in the VS Code chat webview, preventing accidental interruption of running sessions.

--- a/packages/kilo-vscode/package.json
+++ b/packages/kilo-vscode/package.json
@@ -1214,6 +1214,11 @@
           "default": true,
           "description": "Cycle through reasoning effort variants with Shift+Tab in prompt inputs. Disable to keep Shift+Tab for keyboard focus navigation."
         },
+        "kilo-code.new.chat.abortOnEscape": {
+          "type": "boolean",
+          "default": true,
+          "description": "Abort a running Kilo session when Escape is pressed in the chat webview. Disable to keep Escape from interrupting work."
+        },
         "kilo-code.new.agentWorkStyle": {
           "type": "string",
           "scope": "application",

--- a/packages/kilo-vscode/src/kilo-provider/chat-settings.ts
+++ b/packages/kilo-vscode/src/kilo-provider/chat-settings.ts
@@ -8,6 +8,7 @@ export function buildChatSettingsMessage() {
     type: "chatSettingsLoaded" as const,
     settings: {
       shiftTabCyclesVariant: config.get<boolean>("shiftTabCyclesVariant", true),
+      abortOnEscape: config.get<boolean>("abortOnEscape", true),
     },
   }
 }
@@ -32,5 +33,5 @@ export function watchChatConfig(post: Post): vscode.Disposable {
 }
 
 export function validChatSetting(key: string, value: unknown) {
-  return key === "shiftTabCyclesVariant" && typeof value === "boolean"
+  return (key === "shiftTabCyclesVariant" || key === "abortOnEscape") && typeof value === "boolean"
 }

--- a/packages/kilo-vscode/tests/unit/chat-settings-message.test.ts
+++ b/packages/kilo-vscode/tests/unit/chat-settings-message.test.ts
@@ -48,10 +48,20 @@ describe("buildChatSettingsMessage", () => {
     expect(buildChatSettingsMessage().settings.shiftTabCyclesVariant).toBe(true)
   })
 
+  it("enables Escape aborts by default", () => {
+    expect(buildChatSettingsMessage().settings.abortOnEscape).toBe(true)
+  })
+
   it("returns the persisted cycling preference", () => {
     state.set("shiftTabCyclesVariant", false)
 
     expect(buildChatSettingsMessage().settings.shiftTabCyclesVariant).toBe(false)
+  })
+
+  it("returns the persisted Escape abort preference", () => {
+    state.set("abortOnEscape", false)
+
+    expect(buildChatSettingsMessage().settings.abortOnEscape).toBe(false)
   })
 })
 
@@ -109,10 +119,13 @@ describe("timeline settings", () => {
 })
 
 describe("validChatSetting", () => {
-  it("accepts only boolean cycling updates", () => {
+  it("accepts only boolean chat setting updates", () => {
     expect(validChatSetting("shiftTabCyclesVariant", true)).toBe(true)
     expect(validChatSetting("shiftTabCyclesVariant", false)).toBe(true)
+    expect(validChatSetting("abortOnEscape", true)).toBe(true)
+    expect(validChatSetting("abortOnEscape", false)).toBe(true)
     expect(validChatSetting("shiftTabCyclesVariant", "false")).toBe(false)
+    expect(validChatSetting("abortOnEscape", "false")).toBe(false)
     expect(validChatSetting("unknown", true)).toBe(false)
   })
 })

--- a/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/ChatView.tsx
@@ -25,6 +25,7 @@ import { useVSCode } from "../../context/vscode"
 import { useLanguage } from "../../context/language"
 import { useWorktreeMode } from "../../context/worktree-mode"
 import { useServer } from "../../context/server"
+import { useConfig } from "../../context/config"
 import { TranscriptSearchProvider } from "../../context/transcript-search"
 import { isPromptBlocked, isSuggesting, isQuestioning } from "./prompt-input-utils"
 import { showTabStrip } from "../../utils/local-tabs"
@@ -59,6 +60,7 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   const language = useLanguage()
   const worktreeMode = useWorktreeMode()
   const server = useServer()
+  const { settings } = useConfig()
   const tabs = useLocalTabs()
   // Show "Show Changes" only in the standalone sidebar, not inside Agent Manager
   const isSidebar = () => worktreeMode === undefined
@@ -111,7 +113,13 @@ export const ChatView: Component<ChatViewProps> = (props) => {
   onMount(() => {
     if (props.readonly) return
     const handler = (e: KeyboardEvent) => {
-      if (e.key !== "Escape" || (!session.submitting() && session.status() === "idle") || e.defaultPrevented) return
+      if (
+        e.key !== "Escape" ||
+        settings()["chat.abortOnEscape"] === false ||
+        (!session.submitting() && session.status() === "idle") ||
+        e.defaultPrevented
+      )
+        return
       e.preventDefault()
       session.abort()
     }

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -1118,7 +1118,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       ghost.dismiss()
       return
     }
-    if (e.key === "Escape" && isBusy()) {
+    if (e.key === "Escape" && settings()["chat.abortOnEscape"] !== false && isBusy()) {
       e.preventDefault()
       e.stopPropagation()
       session.abort()

--- a/packages/kilo-vscode/webview-ui/src/components/settings/DisplayTab.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/settings/DisplayTab.tsx
@@ -97,6 +97,19 @@ const DisplayTab: Component = () => {
         </SettingsRow>
 
         <SettingsRow
+          title={language.t("settings.display.abortOnEscape.title")}
+          description={language.t("settings.display.abortOnEscape.description")}
+        >
+          <Switch
+            checked={Boolean(settings()["chat.abortOnEscape"] ?? true)}
+            onChange={(checked: boolean) => updateSetting("chat.abortOnEscape", checked)}
+            hideLabel
+          >
+            {language.t("settings.display.abortOnEscape.title")}
+          </Switch>
+        </SettingsRow>
+
+        <SettingsRow
           title={language.t("settings.display.tokenThroughput.title")}
           description={language.t("settings.display.tokenThroughput.description")}
         >

--- a/packages/kilo-vscode/webview-ui/src/context/config.tsx
+++ b/packages/kilo-vscode/webview-ui/src/context/config.tsx
@@ -74,7 +74,10 @@ function loadedSettings(message: ExtensionMessage): Record<string, unknown> | un
     return { "indexing.showButtonWhenDisabled": message.settings.showButtonWhenDisabled }
   }
   if (message.type === "chatSettingsLoaded") {
-    return { "chat.shiftTabCyclesVariant": message.settings.shiftTabCyclesVariant }
+    return {
+      "chat.shiftTabCyclesVariant": message.settings.shiftTabCyclesVariant,
+      "chat.abortOnEscape": message.settings.abortOnEscape,
+    }
   }
   if (message.type === "throughputSettingLoaded") return { showTokenThroughput: message.visible }
   if (message.type === "autoApprovalReasonSettingLoaded") return { showAutoApprovalReason: message.visible }
@@ -252,6 +255,7 @@ export const ConfigProvider: ParentComponent = (props) => {
     if (message.type !== "chatSettingsLoaded") return
     mergeSettings({
       "chat.shiftTabCyclesVariant": message.settings.shiftTabCyclesVariant,
+      "chat.abortOnEscape": message.settings.abortOnEscape,
     })
   })
 

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -1105,6 +1105,9 @@ export const dict = {
   "settings.display.shiftTabCycle.title": "Cycle Reasoning Effort with Shift+Tab",
   "settings.display.shiftTabCycle.description":
     "Press Shift+Tab in a prompt input to switch to the next reasoning effort level. Disable to keep Shift+Tab for keyboard focus navigation.",
+  "settings.display.abortOnEscape.title": "Abort Session with Escape",
+  "settings.display.abortOnEscape.description":
+    "Stop a running session when Escape is pressed in the chat webview. Disable this to prevent accidental interruptions while dismissing dialogs or editing text.",
   "settings.display.terminalCommand.title": "Terminal Command Blocks",
   "settings.display.terminalCommand.description": "Choose whether terminal command blocks start expanded or collapsed.",
   "settings.display.terminalCommand.expanded": "Expanded",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -1069,6 +1069,9 @@ export const dict = {
   "settings.display.shiftTabCycle.title": "使用 Shift+Tab 切换推理强度",
   "settings.display.shiftTabCycle.description":
     "在提示输入框中按 Shift+Tab 可切换到下一个推理强度等级。禁用此选项可将 Shift+Tab 用于键盘焦点导航。",
+  "settings.display.abortOnEscape.title": "使用 Escape 中断会话",
+  "settings.display.abortOnEscape.description":
+    "在聊天 Webview 中按 Escape 停止正在运行的会话。禁用此选项可避免在关闭对话框或编辑文本时意外中断任务。",
   "settings.display.terminalCommand.title": "终端命令块",
   "settings.display.terminalCommand.description": "选择终端命令块的初始状态：展开或折叠。",
   "settings.display.terminalCommand.expanded": "展开",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -1032,6 +1032,9 @@ export const dict = {
   "settings.display.shiftTabCycle.title": "使用 Shift+Tab 切換推理強度",
   "settings.display.shiftTabCycle.description":
     "在提示輸入框中按 Shift+Tab 可切換至下一個推理強度等級。停用此選項可保留 Shift+Tab 用於鍵盤焦點導覽。",
+  "settings.display.abortOnEscape.title": "使用 Escape 中斷工作階段",
+  "settings.display.abortOnEscape.description":
+    "在聊天 Webview 中按 Escape 停止正在執行的工作階段。停用此選項可避免關閉對話框或編輯文字時意外中斷工作。",
   "settings.display.terminalCommand.title": "終端命令區塊",
   "settings.display.terminalCommand.description": "選擇終端命令區塊的初始狀態：展開或收合。",
   "settings.display.terminalCommand.expanded": "展開",

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -491,6 +491,7 @@ export interface ChatSettingsLoadedMessage {
   type: "chatSettingsLoaded"
   settings: {
     shiftTabCyclesVariant: boolean
+    abortOnEscape: boolean
   }
 }
 


### PR DESCRIPTION
## Issue
Fixes #13835

## Context
Pressing Escape while Kilo is busy currently aborts the active session. This is useful for intentional cancellation but can also be triggered accidentally. This change adds a preference while preserving the existing behavior by default.

## Implementation
- Add `kilo-code.new.chat.abortOnEscape`, defaulting to `true`.
- Expose the preference in the VS Code Display settings and sync it through chat settings.
- Honor it in both ChatView's global Escape handler and PromptInput's busy-session handler.
- Keep Escape-based ghost-text dismissal independent.
- Add English, Simplified Chinese, and Traditional Chinese strings plus a changeset.

## Screenshots / Video
N/A — this is a behavior/settings change without a new visual state beyond the standard settings row.

## How to Test
### Manual/local verification
- `npm exec --yes bun -- test tests/unit/chat-settings-message.test.ts` from `packages/kilo-vscode` — 9 passed, 0 failed.
- `git diff --check` — passed.

### Reviewer test steps
1. Open Kilo Code's VS Code Display settings.
2. Disable **Abort on Escape**.
3. Start a session, press Escape, and confirm the session remains active.
4. Re-enable the setting and confirm Escape aborts the session as before.
5. Confirm Escape still dismisses ghost text when present.

### Blocked checks and substitute verification
- `npm exec --yes bun -- run typecheck` from `packages/kilo-vscode` could not complete because this checkout lacks installed workspace dependencies and `tsgo`. The focused unit test above was executed successfully with npm-provided Bun.

## Checklist
- [x] Issue linked above.
- [x] Tests/verification described.
- [x] Screenshots/video are not applicable to this behavior/settings change.
- [x] Changeset added.
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.