### PR TITLE
fix(vscode): scope plan opens to active session

### DIFF
--- a/.changeset/open-plan-session-scope.md
+++ b/.changeset/open-plan-session-scope.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep automatic plan opens scoped to the active agent session and its worktree.

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -874,7 +874,7 @@ export class AgentManagerProvider implements Disposable {
   private onBridgeMessage(m: AgentManagerInMessage): Record<string, unknown> | null | undefined {
     if (m.type !== "openFile") return undefined
 
-    const sessionId = this.activeSessionId
+    const sessionId = m.sessionID ?? this.activeSessionId
     const state = this.getStateManager()
     if (sessionId && state?.directoryFor(sessionId)) {
       this.openWorktreeFile(sessionId, m.filePath, m.line, m.column)

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -932,6 +932,7 @@ interface GenericOpenFileIn {
   filePath: string
   line?: number
   column?: number
+  sessionID?: string
 }
 
 interface PreviewImageIn {

--- a/packages/kilo-vscode/tests/unit/open-plan.test.ts
+++ b/packages/kilo-vscode/tests/unit/open-plan.test.ts
@@ -26,7 +26,9 @@ const update = (part: Part, sessionID = "session-1") =>
 
 describe("planOpens", () => {
   it("returns completed open_plan requests", () => {
-    expect(planOpens(update(done()))).toEqual([{ id: "part-1", path: ".kilo/plans/plan.md", sessionID: "session-1" }])
+    expect(planOpens(update(done()), "session-1")).toEqual([
+      { id: "part-1", path: ".kilo/plans/plan.md", sessionID: "session-1" },
+    ])
   })
 
   it("handles batched updates and ignores unrelated parts", () => {
@@ -39,7 +41,14 @@ describe("planOpens", () => {
       ],
     } satisfies Extract<ExtensionMessage, { type: "partsUpdated" }>
 
-    expect(planOpens(message)).toEqual([{ id: "part-1", path: ".kilo/plans/plan.md", sessionID: "session-1" }])
+    expect(planOpens(message, "session-1")).toEqual([
+      { id: "part-1", path: ".kilo/plans/plan.md", sessionID: "session-1" },
+    ])
+  })
+
+  it("ignores plans from sessions that are not active", () => {
+    expect(planOpens(update(done()), "session-2")).toEqual([])
+    expect(planOpens(update(done()), undefined)).toEqual([])
   })
 
   it("does not open incomplete or unmarked plan parts", () => {
@@ -52,7 +61,7 @@ describe("planOpens", () => {
       state: { ...done("part-unmarked").state, metadata: { plan: ".kilo/plans/plan.md" } },
     } satisfies Part
 
-    expect(planOpens(update(running))).toEqual([])
-    expect(planOpens(update(unmarked))).toEqual([])
+    expect(planOpens(update(running), "session-1")).toEqual([])
+    expect(planOpens(update(unmarked), "session-1")).toEqual([])
   })
 })

--- a/packages/kilo-vscode/tests/unit/plan-exit.test.ts
+++ b/packages/kilo-vscode/tests/unit/plan-exit.test.ts
@@ -55,6 +55,11 @@ describe("plan_exit renderer uses openFile not openDiff (source)", () => {
     expect(src).toContain("data.openFile")
   })
 
+  it("PlanExitCard scopes the file open to its message session", () => {
+    expect(src).toContain("data.openFile(i.plan, undefined, undefined, props.sessionID)")
+    expect(src).toContain("sessionID={props.message.sessionID}")
+  })
+
   it("uses a safe inert anchor href", () => {
     expect(src).toContain('href="#"')
     expect(src).not.toContain("href={display()}")

--- a/packages/kilo-vscode/webview-ui/src/App.tsx
+++ b/packages/kilo-vscode/webview-ui/src/App.tsx
@@ -139,7 +139,7 @@ export const DataBridge: Component<{ children: any }> = (props) => {
   }
 
   const unsubscribePlans = vscode.onMessage((message) => {
-    for (const plan of planOpens(message)) {
+    for (const plan of planOpens(message, session.currentSessionID())) {
       const id = `${plan.sessionID}:${plan.id}`
       if (opened.has(id)) continue
       opened.add(id)

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -52,7 +52,7 @@ function planExitInfo(part: SDKPart): { plan: string } | undefined {
   return { plan }
 }
 
-function PlanExitCard(props: { part: ToolPart }) {
+function PlanExitCard(props: { part: ToolPart; sessionID: string }) {
   const language = useLanguage()
   const server = useServer()
   const data = useData()
@@ -70,7 +70,7 @@ function PlanExitCard(props: { part: ToolPart }) {
     e.preventDefault()
     const i = info()
     if (!i || !data.openFile) return
-    data.openFile(i.plan)
+    data.openFile(i.plan, undefined, undefined, props.sessionID)
   }
   return (
     <Show when={info()}>
@@ -363,7 +363,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
                             </Show>
                           }
                         >
-                          {(tp) => <PlanExitCard part={tp()} />}
+                          {(tp) => <PlanExitCard part={tp()} sessionID={props.message.sessionID} />}
                         </Show>
                       }
                     >

--- a/packages/kilo-vscode/webview-ui/src/utils/open-plan.ts
+++ b/packages/kilo-vscode/webview-ui/src/utils/open-plan.ts
@@ -10,7 +10,7 @@ export type PlanOpen = {
   sessionID: string
 }
 
-export function planOpens(message: ExtensionMessage): PlanOpen[] {
+export function planOpens(message: ExtensionMessage, activeSessionID: string | undefined): PlanOpen[] {
   const updates: Update[] =
     message.type === "partUpdated" ? [message] : message.type === "partsUpdated" ? message.updates : []
 
@@ -19,7 +19,7 @@ export function planOpens(message: ExtensionMessage): PlanOpen[] {
     if (part.type !== "tool" || part.tool !== "open_plan" || part.state.status !== "completed") return []
     if (part.state.metadata?.open !== true) return []
     const path = part.state.metadata.plan
-    if (typeof path !== "string" || !path || !update.sessionID) return []
+    if (typeof path !== "string" || !path || update.sessionID !== activeSessionID) return []
     return [{ id: part.id, path, sessionID: update.sessionID }]
   })
 }


### PR DESCRIPTION
## What Problem This Solves
Automatic `open_plan` events can be received while another Agent Manager session or worktree is selected, causing the plan to open in the wrong context.

## Why This Change Was Made
Plan opens are owned by the agent session. The webview now accepts completed `open_plan` events only when their session ID matches the active session, and explicit session IDs are preserved through plan links and Agent Manager file-open handling.

## User Impact
Plans from background sessions no longer open in the selected worktree. Plans opened by the active session remain scoped to that session and its worktree.

## Evidence
- Focused tests: 22 passed.
- Extension lint and formatting checks passed.
- Extension and CLI bundles built successfully.
- Isolated VS Code Agent Manager test covered worktree switching during a real `open_plan` call, inactive-session filtering, and active-session document opening.