### PR TITLE
fix(agent-manager): preserve tab focus and order

### DIFF
--- a/.changeset/quiet-local-tabs.md
+++ b/.changeset/quiet-local-tabs.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Preserve Local tab order and remember the active tab when switching worktrees and projects in Agent Manager.

--- a/packages/kilo-vscode/tests/unit/agent-manager-selection-actions.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-selection-actions.test.ts
@@ -3,6 +3,7 @@ import { createRoot, createSignal } from "solid-js"
 import { needsLocalDraft } from "../../webview-ui/agent-manager/project/local-tabs"
 import { createTerminalState } from "../../webview-ui/agent-manager/terminal/state"
 import {
+  createTabMemory,
   rememberSelectionTab,
   selectLocalAction,
   selectWorktreeAction,
@@ -59,6 +60,32 @@ describe("selectWorktreeAction", () => {
 })
 
 describe("selectLocalAction", () => {
+  it.each(["ses-a2", "pending:draft", "review", "terminal:1"])("remembers Local %s in multi-project mode", (tab) => {
+    const memory: Record<string, string> = {}
+    const save = createTabMemory({
+      selection: () => "local",
+      tab: () => tab,
+      multi: () => true,
+      applied: () => "project-a",
+      active: () => "project-a",
+      owns: () => false,
+      pending: (id) => id.startsWith("pending:"),
+      locals: () => ["ses-a1", "ses-a2"],
+      localTab: (id) => id === "review" || id.startsWith("terminal:"),
+      set: (key, id) => {
+        memory[key] = id
+      },
+    })
+
+    save()
+    expect(memory.local).toBe(tab)
+    if (tab !== "ses-a2") return
+    const result = deps()
+    result.value.tabMemory = () => memory
+    selectLocalAction(result.value, [{ id: "ses-a1" }, { id: "ses-a2" }])
+    expect(result.calls).toEqual(["local:ses-a2"])
+  })
+
   it("restores the remembered second local tab", () => {
     const result = deps()
     result.value.tabMemory = () => ({ local: "ses-a2" })

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -280,6 +280,7 @@ const AgentManagerContent: Component = () => {
   const [projectStates, setProjectStates] = createSignal<Record<string, AgentManagerStateMessage>>({})
   const activeProjectId = () => projectList().find((p) => p.active)?.id ?? currentProjectId()
   const activateSelection = (target: AgentManagerSidebarTarget, restore?: boolean) => {
+    saveTabMemory()
     comments.cancel()
     vscode.postMessage({ type: "agentManager.activateSelection", target, restore })
   }
@@ -718,12 +719,13 @@ const AgentManagerContent: Component = () => {
     return id
   }
   const placeLocal = (id: string, pending: string | undefined, active: string | undefined) => {
+    const existing = localSessionIDs().includes(id)
     const next = pending
       ? replacePendingTab({ ids: localSessionIDs(), active }, pending, id)
       : openSessionTab({ ids: localSessionIDs(), active }, id)
     setLocalSessionIDs(next.ids)
     if (pending) tabOrderSync.replaceOrAppend(LOCAL, pending, id)
-    if (!pending) tabOrderSync.append(LOCAL, id)
+    if (!pending && !existing) tabOrderSync.append(LOCAL, id)
     if (pending && pending === active) setActivePendingId(undefined)
   }
   const focusLocalSession = (id: string) => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/selection-actions.ts
+++ b/packages/kilo-vscode/webview-ui/agent-manager/selection-actions.ts
@@ -46,7 +46,7 @@ export function createTabMemory(opts: {
     if (opts.multi() && opts.applied() !== opts.active()) return
     if (
       opts.multi() &&
-      !(sel === LOCAL ? (opts.localTab?.(tab) ?? (opts.pending(tab) || opts.locals().includes(tab))) : opts.owns(sel))
+      !(sel === LOCAL ? opts.localTab?.(tab) || opts.pending(tab) || opts.locals().includes(tab) : opts.owns(sel))
     )
       return
     rememberSelectionTab(opts.set, sel, tab)


### PR DESCRIPTION
## What Problem This Solves
Agent Manager could lose the last focused Local session in multi-project mode and move a restored Local tab to the end of the tab bar when switching worktrees or projects.

## Why This Change Was Made
Local session and draft memory was rejected when the special-tab callback returned false. Restoring an existing session also used the append path, which changed its saved position. Project activation now saves the outgoing tab before changing context, and existing Local sessions skip the append path.

## User Impact
Switching between Local, worktrees, and projects preserves the active Local session, pending draft, and tab order.

## Evidence
- `bun run compile`
- `bun test tests/unit/agent-manager-selection-actions.test.ts tests/unit/tab-order-sync.test.ts tests/unit/agent-manager-arch.test.ts`
- Isolated VS Code Agent Manager verification preserved a middle Local tab and restored it after a worktree round trip.

This change includes focused regression coverage and a patch changeset.