### PR TITLE
docs(kilo-docs): mark Kilo Deploy end of life

### DIFF
--- a/packages/kilo-docs/markdoc/partials/deploy-eol.md
+++ b/packages/kilo-docs/markdoc/partials/deploy-eol.md
@@ -1,0 +1,3 @@
+{% callout type="warning" title="Kilo Deploy is end of life" %}
+Kilo Deploy is no longer available to new users, and support for the product is ending. This documentation is kept for reference by existing users and is no longer maintained.
+{% /callout %}

--- a/packages/kilo-docs/pages/deploy-secure/deploy.md
+++ b/packages/kilo-docs/pages/deploy-secure/deploy.md
@@ -5,6 +5,8 @@ description: "Deploy your applications with Kilo Code"
 
 # Deploy
 
+{% partial file="deploy-eol.md" /%}
+
 Kilo Deploy lets you ship **Next.js** and **static sites** directly from Kilo Code, with:
 
 - **One-click deployment** from the Kilo Code dashboard

--- a/packages/kilo-docs/pages/deploy-secure/index.md
+++ b/packages/kilo-docs/pages/deploy-secure/index.md
@@ -5,6 +5,8 @@ description: "Deploy applications and manage security with Kilo Code"
 
 # {% $markdoc.frontmatter.title %}
 
+{% partial file="deploy-eol.md" /%}
+
 {% callout type="generic" %}
 Deploy your applications directly from Kilo Code and manage security with AI-powered reviews and scans.
 {% /callout %}


### PR DESCRIPTION
## Summary

Mark Kilo Deploy as end of life on both the Deploy & Secure overview and the dedicated Deploy documentation page. The shared warning keeps the notice consistent while leaving the Security Agent documentation active.