### PR TITLE
fix(cli): keep subagent plan follow-up isolated

### DIFF
--- a/.changeset/subagent-plan-followup.md
+++ b/.changeset/subagent-plan-followup.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep delegated subagents from opening the interactive Plan-mode follow-up when a `plan_exit` tool result appears in their session.

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -119,6 +119,8 @@ export namespace KiloSessionPrompt {
   export function shouldAskPlanFollowup(input: { messages: MessageV2.WithParts[]; abort: AbortSignal }) {
     if (input.abort.aborted) return false
     if (!supportsPlanFollowup()) return false
+    const user = input.messages.findLast((message) => message.info.role === "user")
+    if (!user || !planning({ name: user.info.agent })) return false
     const idx = input.messages.findLastIndex((m) => m.info.role === "user")
     return input.messages
       .slice(idx + 1)

--- a/packages/opencode/test/kilocode/plan-exit-detection.test.ts
+++ b/packages/opencode/test/kilocode/plan-exit-detection.test.ts
@@ -216,6 +216,23 @@ describe("plan_exit detection", () => {
       await expect(pending).resolves.toBe("break")
     }))
 
+  test("subagent plan_exit does not trigger the interactive plan follow-up", () =>
+    withInstance(async () => {
+      const seeded = await seed({
+        agent: "general",
+        tools: [
+          {
+            tool: "plan_exit",
+            input: {},
+            output: "Plan is ready at .kilo/plans/plan.md. Ending planning turn.",
+          },
+        ],
+      })
+
+      expect(SessionPrompt.shouldAskPlanFollowup({ messages: seeded.messages, abort: AbortSignal.any([]) })).toBe(false)
+      expect(await questions.list()).toHaveLength(0)
+    }))
+
   test("KiloSessionPrompt resolves plan follow-up through the supplied question service", () =>
     withInstance(async () => {
       const seeded = await seed({


### PR DESCRIPTION
## Issue

Fixes #13902

## Context

Delegated subagents can emit a completed `plan_exit` tool result without being in Plan mode. The generic follow-up detector treated that result as a planning session and blocked the parent workflow on an interactive question the parent cannot answer.

## Implementation

- Restrict the interactive plan follow-up to the current Plan/Architect agent.
- Add a regression test proving a `general` subagent does not open the follow-up.
- Add a CLI patch changeset.

## Screenshots / Video

N/A — no visual layout changes.

## How to Test

### Manual/local verification

- `git diff --check` passed.
- The focused regression test is included in `packages/opencode/test/kilocode/plan-exit-detection.test.ts`.

### Reviewer test steps

1. From `packages/opencode`, run `bun test ../opencode/test/kilocode/plan-exit-detection.test.ts`.
2. Confirm the existing Plan-mode follow-up tests still pass.
3. Confirm the new `general` subagent case returns no plan follow-up question.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.