### PR TITLE
feat(agent-manager): regroup toolbar actions

### DIFF
--- a/.changeset/agent-manager-toolbar-groups.md
+++ b/.changeset/agent-manager-toolbar-groups.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Regroup the Agent Manager toolbar: optional session panels (documents, subagents) sit left of a separator, and the fixed workbench (changes, PR, apply, open in VS Code, browser, run, terminal) keeps stable positions on the right. Toolbar icons render at a uniform 1px stroke and dim when disabled. Open the full-screen review from the changes panel header instead of a toolbar button.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/tab-bar-full-context-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/tab-bar-full-context-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b571c4468c869325ae8b3c9d6848f2dd80f9c7efe35a92f6dda4698f79891e90
-size 2985
+oid sha256:baa2065b2a4a1489bae16b76e4df8e49ff586324600ca2792cd1eb4309140b55
+size 3035

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/tab-bar-with-review-tab-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/agentmanager/tab-bar-with-review-tab-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:16fdb6361199c58a8e99ad2661dc47791b0f4737ada16760151a26e7ebdd8bd1
-size 3044
+oid sha256:2694489c7ca4b3764c5cf93cfd9ef543dabd16225b4447feaa3b1e259aa05e34
+size 2714

--- a/packages/kilo-ui/src/components/icon.tsx
+++ b/packages/kilo-ui/src/components/icon.tsx
@@ -8,7 +8,8 @@ const icons: Record<string, { path: string; viewBox: string }> = {
   },
   "pull-request": {
     viewBox: "0 0 20 20",
-    path: `<path d="M1.875 4.0625a2.8125 2.8125 0 1 1 3.75 2.6525v6.57a2.8138 2.8138 0 1 1-1.875 0V6.715A2.8125 2.8125 0 0 1 1.875 4.0625Zm7.096-.22125L11.96625.84625A.3125.3125 0 0 1 12.5 1.0675V3.125h1.25A3.125 3.125 0 0 1 16.875 6.25v7.035a2.8138 2.8138 0 1 1-1.875 0V6.25a1.25 1.25 0 0 0-1.25-1.25H12.5v2.0575a.3125.3125 0 0 1-.53375.22125L8.97125 4.34125a.3125.3125 0 0 1 0-.4425ZM4.6875 3.125a.9375.9375 0 1 0 0 1.875.9375.9375 0 0 0 0-1.875Zm0 11.875a.9375.9375 0 1 0 0 1.875.9375.9375 0 0 0 0-1.875Zm10.3125.9375a.9375.9375 0 1 0 1.875 0 .9375.9375 0 0 0-1.875 0Z" fill="currentColor"/>`,
+    // Stroked at 1.25 on the 20-unit grid (1px at 16px) to match the other outline icons.
+    path: `<circle cx="4.6875" cy="4.0625" r="1.875" stroke="currentColor" stroke-width="1.25"/><circle cx="4.6875" cy="15.9375" r="1.875" stroke="currentColor" stroke-width="1.25"/><circle cx="15.9375" cy="15.9375" r="1.875" stroke="currentColor" stroke-width="1.25"/><path d="M4.6875 5.9375V14.0625M15.9375 14.0625V6.25A2.5 2.5 0 0 0 13.4375 3.75H9.6875M11.5625 1.875L9.6875 3.75L11.5625 5.625" stroke="currentColor" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>`,
   },
   refresh: {
     viewBox: "0 0 20 20",

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -1716,14 +1716,6 @@ const AgentManagerContent: Component = () => {
     setReviewActive(true)
   }
 
-  const toggleReviewTab = () => {
-    if (reviewActive()) {
-      closeReviewTab()
-      return
-    }
-    openReviewTab()
-  }
-
   // Deferred close: flip signal immediately for instant UI feedback,
   // the <Show> unmount triggers heavy FileDiff cleanup but the tab bar
   // and chat view are already visible before that work runs.
@@ -2365,8 +2357,8 @@ const AgentManagerContent: Component = () => {
           worktreeStats={worktreeStats}
           applyState={apply.applyStateForSelection}
           reviewScope={review.scope}
+          onApply={metrics.click("apply_to_local", "tab_toolbar", openApplyDialog)}
           onOpen={openWindow}
-          onApply={openApplyDialog}
           runStatuses={runStatuses}
           runConfigured={runScriptConfigured}
           onRun={(id) => runWorktree(id, sideCtl.destination())}
@@ -2375,16 +2367,24 @@ const AgentManagerContent: Component = () => {
           reviewActive={reviewActive}
           onToggleDiff={toggleDiffPanel}
           {...browser.tabs}
-          onToggleReview={metrics.click("fullscreen_review", "tab_toolbar", toggleReviewTab)}
+          onToggleBrowser={metrics.click("browser", "tab_toolbar", browser.tabs.onToggleBrowser, () => ({
+            action: browser.tabs.browserOpen() ? "close" : "open",
+          }))}
           prStatus={() => activePR()?.pr}
           prOpen={prOpen}
-          onTogglePR={togglePRPanel}
+          onTogglePR={metrics.click("pull_request", "tab_toolbar", togglePRPanel, () => ({
+            action: prOpen() ? "close" : "open",
+          }))}
           documentsOpen={documentInspector.isOpen}
           documentsAvailable={documentInspector.available}
-          onToggleDocuments={documentInspector.toggle}
+          onToggleDocuments={metrics.click("documents", "tab_toolbar", documentInspector.toggle, () => ({
+            action: documentInspector.isOpen() ? "close" : "open",
+          }))}
           subagentsAvailable={() => subagentCtl.tabs.tabs().length > 0 || subagentCtl.toolbar.available().length > 0}
           subagentsOpen={() => sidePanel() === SidePanel.Subagents}
-          onToggleSubagents={subagentCtl.toolbar.toggle}
+          onToggleSubagents={metrics.click("subagents", "tab_toolbar", subagentCtl.toolbar.toggle, () => ({
+            action: sidePanel() === SidePanel.Subagents ? "close" : "open",
+          }))}
           terminalDestination={sideCtl.destination}
           terminalDestinationActive={() => sidePanel() === SidePanel.Terminal}
           terminalKeybind={() => kb().showTerminal ?? ""}

--- a/packages/kilo-vscode/webview-ui/agent-manager/TabBar.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/TabBar.tsx
@@ -44,8 +44,8 @@ export interface TabBarProps {
   applyState: () => { status: string } | undefined
   /** Active diff scope; applying to local is only possible from the branch scope. */
   reviewScope: () => DiffScope
-  onOpen: () => void
   onApply: () => void
+  onOpen: () => void
   runStatuses: () => Record<string, RunStatus>
   runConfigured: () => boolean
   onRun: (id: string) => void
@@ -56,7 +56,6 @@ export interface TabBarProps {
   onToggleBrowser: () => void
   reviewActive: () => boolean
   onToggleDiff: () => void
-  onToggleReview: () => void
   prStatus: () => PRStatus | undefined
   prOpen: () => boolean
   onTogglePR: () => void
@@ -138,45 +137,128 @@ export const TabBar: Component<TabBarProps> = (props) => (
               if (!state) return false
               return state.status === "checking" || state.status === "applying"
             }
+            const panels = () => props.documentsAvailable() || props.subagentsAvailable()
             return (
               <>
+                {/* Session panels: re-open handles for panels this session produced.
+                     They grow outward to the left so the workbench never shifts. */}
+                <Show when={panels()}>
+                  <span class="am-tab-session-panels">
+                    <Show when={props.documentsAvailable()}>
+                      <Tooltip value={props.t("agentManager.documents.toggle")} placement="bottom" openDelay={0}>
+                        <IconButton
+                          icon="book-open-check"
+                          size="small"
+                          variant="ghost"
+                          aria-label={props.t("agentManager.documents.toggle")}
+                          class={props.documentsOpen() ? "am-tab-diff-btn-active" : ""}
+                          onClick={props.onToggleDocuments}
+                        />
+                      </Tooltip>
+                    </Show>
+                    <Show when={props.subagentsAvailable()}>
+                      <Tooltip value="Subagents" placement="bottom" openDelay={0}>
+                        <IconButton
+                          icon="task"
+                          size="small"
+                          variant="ghost"
+                          aria-label="Subagents"
+                          class={props.subagentsOpen() ? "am-tab-diff-btn-active" : ""}
+                          onClick={props.onToggleSubagents}
+                        />
+                      </Tooltip>
+                    </Show>
+                    <span class="am-tab-actions-separator" />
+                  </span>
+                </Show>
+                {/* Workbench: fixed slots anchored to the right edge.
+                     Changes first so its stats can grow without moving a pillar. */}
+                <TooltipKeybind
+                  title={props.t("agentManager.diff.toggle")}
+                  keybind={props.bindings().toggleDiff ?? ""}
+                  placement="bottom"
+                  openDelay={0}
+                >
+                  <button
+                    class={`am-diff-toggle-btn ${props.diffOpen() && !props.reviewActive() ? "am-tab-diff-btn-active" : ""} ${hasChanges() ? "am-diff-toggle-has-changes" : ""}`}
+                    onClick={props.onToggleDiff}
+                    aria-label={props.t("agentManager.diff.toggle")}
+                  >
+                    <Icon name="layers" size="small" />
+                    <Show when={hasChanges()}>
+                      <span class="am-diff-toggle-stats">
+                        <Show when={stats()!.files > 0}>
+                          <span class="am-stat-files">{stats()!.files}f</span>
+                        </Show>
+                        <span class="am-stat-additions">+{stats()!.additions}</span>
+                        <span class="am-stat-deletions">−{stats()!.deletions}</span>
+                      </span>
+                    </Show>
+                  </button>
+                </TooltipKeybind>
+                <Show when={props.prStatus()}>
+                  {(pr) => (
+                    <Tooltip value={`PR #${pr().number}`} placement="bottom" openDelay={0}>
+                      <IconButton
+                        icon="pull-request"
+                        size="small"
+                        variant="ghost"
+                        aria-label={`PR #${pr().number}`}
+                        class={props.prOpen() ? "am-tab-diff-btn-active" : ""}
+                        onClick={props.onTogglePR}
+                      />
+                    </Tooltip>
+                  )}
+                </Show>
                 <Show when={isWorktree()}>
-                  <>
-                    <Tooltip value={props.t("agentManager.open.tooltip")} placement="bottom" openDelay={0}>
+                  <Tooltip
+                    value={
+                      props.reviewScope() === "branch"
+                        ? props.t("agentManager.apply.tooltip")
+                        : props.t("agentManager.diff.applyBranchOnly")
+                    }
+                    placement="bottom"
+                    openDelay={0}
+                  >
+                    <span class="am-tab-apply">
                       <IconButton
                         size="small"
                         variant="ghost"
-                        icon="folder"
-                        aria-label={props.t("agentManager.open.button")}
-                        onClick={props.onOpen}
+                        icon="check"
+                        aria-label={props.t("agentManager.apply.globalButton")}
+                        aria-busy={applyBusy()}
+                        onClick={props.onApply}
+                        disabled={!hasChanges() || applyBusy() || props.reviewScope() !== "branch"}
                       />
-                    </Tooltip>
-                    <Tooltip
-                      value={
-                        props.reviewScope() === "branch"
-                          ? props.t("agentManager.apply.tooltip")
-                          : props.t("agentManager.diff.applyBranchOnly")
-                      }
-                      placement="bottom"
-                      openDelay={0}
-                    >
-                      <span class="am-tab-apply">
-                        <IconButton
-                          size="small"
-                          variant="ghost"
-                          icon="check"
-                          aria-label={props.t("agentManager.apply.globalButton")}
-                          aria-busy={applyBusy()}
-                          onClick={props.onApply}
-                          disabled={!hasChanges() || applyBusy() || props.reviewScope() !== "branch"}
-                        />
-                        <Show when={applyBusy()}>
-                          <Spinner class="am-apply-spinner" />
-                        </Show>
-                      </span>
-                    </Tooltip>
-                  </>
+                      <Show when={applyBusy()}>
+                        <Spinner class="am-apply-spinner" />
+                      </Show>
+                    </span>
+                  </Tooltip>
+                  <Tooltip value={props.t("agentManager.open.tooltip")} placement="bottom" openDelay={0}>
+                    <IconButton
+                      size="small"
+                      variant="ghost"
+                      icon="folder"
+                      aria-label={props.t("agentManager.open.button")}
+                      onClick={props.onOpen}
+                    />
+                  </Tooltip>
                 </Show>
+                <Show when={props.browserAutomation()}>
+                  <Tooltip value={props.t("agentManager.browser.title")} placement="bottom" openDelay={0}>
+                    <IconButton
+                      icon="globe"
+                      size="small"
+                      variant="ghost"
+                      aria-label={props.t("agentManager.browser.title")}
+                      class={props.browserOpen() ? "am-tab-diff-btn-active" : ""}
+                      onClick={props.onToggleBrowser}
+                    />
+                  </Tooltip>
+                </Show>
+                {/* Run and Terminal form the fixed tail: a run sends its output
+                     to the terminal destination, so cause and effect stay adjacent. */}
                 <Show when={sel()}>
                   {(() => {
                     const rid = () => (sel() === LOCAL ? LOCAL : (sel() as string))
@@ -185,7 +267,7 @@ export const TabBar: Component<TabBarProps> = (props) => (
                     const configured = props.runConfigured
                     const title = () => (configured() ? (active() ? "Stop" : "Run") : "Configure run script")
                     return (
-                      <span class={`am-split-button ${active() ? "am-run-active" : ""}`}>
+                      <span class="am-split-button">
                         <TooltipKeybind
                           title={title()}
                           keybind={props.bindings().runScript ?? ""}
@@ -232,94 +314,9 @@ export const TabBar: Component<TabBarProps> = (props) => (
                     )
                   })()}
                 </Show>
-                <Show when={props.prStatus()}>
-                  {(pr) => (
-                    <Tooltip value={`PR #${pr().number}`} placement="bottom" openDelay={0}>
-                      <IconButton
-                        icon="pull-request"
-                        size="small"
-                        variant="ghost"
-                        aria-label={`PR #${pr().number}`}
-                        class={props.prOpen() ? "am-tab-diff-btn-active" : ""}
-                        onClick={props.onTogglePR}
-                      />
-                    </Tooltip>
-                  )}
-                </Show>
-                <Show when={props.documentsAvailable()}>
-                  <Tooltip value={props.t("agentManager.documents.toggle")} placement="bottom" openDelay={0}>
-                    <IconButton
-                      icon="book-open-check"
-                      size="small"
-                      variant="ghost"
-                      aria-label={props.t("agentManager.documents.toggle")}
-                      class={props.documentsOpen() ? "am-tab-diff-btn-active" : ""}
-                      onClick={props.onToggleDocuments}
-                    />
-                  </Tooltip>
-                </Show>
-                <Show when={props.subagentsAvailable()}>
-                  <Tooltip value="Subagents" placement="bottom" openDelay={0}>
-                    <IconButton
-                      icon="task"
-                      size="small"
-                      variant="ghost"
-                      aria-label="Subagents"
-                      class={props.subagentsOpen() ? "am-tab-diff-btn-active" : ""}
-                      onClick={props.onToggleSubagents}
-                    />
-                  </Tooltip>
-                </Show>
-                <TooltipKeybind
-                  title={props.t("agentManager.diff.toggle")}
-                  keybind={props.bindings().toggleDiff ?? ""}
-                  placement="bottom"
-                  openDelay={0}
-                >
-                  <button
-                    class={`am-diff-toggle-btn ${props.diffOpen() && !props.reviewActive() ? "am-tab-diff-btn-active" : ""} ${hasChanges() ? "am-diff-toggle-has-changes" : ""}`}
-                    onClick={props.onToggleDiff}
-                    aria-label={props.t("agentManager.diff.toggle")}
-                  >
-                    <Icon name="layers" size="small" />
-                    <Show when={hasChanges()}>
-                      <span class="am-diff-toggle-stats">
-                        <Show when={stats()!.files > 0}>
-                          <span class="am-stat-files">{stats()!.files}f</span>
-                        </Show>
-                        <span class="am-stat-additions">+{stats()!.additions}</span>
-                        <span class="am-stat-deletions">−{stats()!.deletions}</span>
-                      </span>
-                    </Show>
-                  </button>
-                </TooltipKeybind>
-                <Show when={props.browserAutomation()}>
-                  <Tooltip value={props.t("agentManager.browser.title")} placement="bottom" openDelay={0}>
-                    <IconButton
-                      icon="globe"
-                      size="small"
-                      variant="ghost"
-                      aria-label={props.t("agentManager.browser.title")}
-                      class={props.browserOpen() ? "am-tab-diff-btn-active" : ""}
-                      onClick={props.onToggleBrowser}
-                    />
-                  </Tooltip>
-                </Show>
               </>
             )
           })()}
-          <Show when={props.selection() !== null}>
-            <Tooltip value={props.t("command.review.toggle")} placement="bottom" openDelay={0}>
-              <IconButton
-                icon="expand"
-                size="small"
-                variant="ghost"
-                aria-label={props.t("command.review.toggle")}
-                class={props.reviewActive() ? "am-tab-diff-btn-active" : ""}
-                onClick={props.onToggleReview}
-              />
-            </Tooltip>
-          </Show>
           {/* Terminal destination split button: the primary action
                follows the user's setting (VS Code integrated terminal
                or the embedded side panel), the dropdown picks which.

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -1021,12 +1021,6 @@ html[data-theme="kilo-vscode"]
   }
 }
 
-/* Green accent when running — uses VS Code's standard green token */
-.am-run-active,
-.am-run-active [data-component="icon"] {
-  color: var(--vscode-testing-iconPassed, #34d399) !important;
-}
-
 .am-stat-files {
   color: var(--text-muted);
 }
@@ -1745,6 +1739,54 @@ body.am-wt-dragging-active * {
   border-left: 1px solid var(--border-weak-base);
 }
 
+/* Optional session panel handles sit left of the fixed workbench buttons,
+   separated by a hairline so they read as a different class of control. */
+.am-tab-session-panels {
+  display: flex;
+  align-items: center;
+  align-self: stretch;
+  gap: 4px;
+}
+
+.am-tab-actions-separator {
+  width: 1px;
+  align-self: stretch;
+  margin: 6px 4px;
+  background: var(--border-weak-base);
+  flex-shrink: 0;
+}
+
+/* Ghost icon buttons do not dim their icon when disabled (the ghost variant
+   sets color on the svg itself), so a disabled Apply looked identical to an
+   enabled toggle and kept the pointer cursor. */
+.am-tab-actions [data-component="icon-button"]:disabled {
+  cursor: default;
+}
+
+.am-tab-actions [data-component="icon-button"]:disabled [data-slot="icon-svg"] {
+  color: var(--icon-disabled);
+}
+
+/* Normalize stroke weight to 1px at 16px (codicon weight). Upstream icons
+   draw at stroke 1 on a 20-unit grid, which renders as a 0.8px hairline;
+   Kilo icons draw at 2, which renders bolder. Filled icons are unaffected.
+   Upstream icons render via an SVG sprite, so the value is set on the svg
+   and inherited by the sprite paths, which carry no explicit stroke-width.
+   Scoped to the tab bar until the same value rolls out in kilo-ui. */
+.am-tab-actions [data-slot="icon-svg"] {
+  stroke-width: 1.25;
+}
+
+/* Kilo icons render inline with an explicit stroke-width attribute, which
+   beats the inherited value, so override per grid. */
+.am-tab-actions [data-slot="icon-svg"][viewBox="0 0 20 20"] [stroke] {
+  stroke-width: 1.25;
+}
+
+.am-tab-actions [data-slot="icon-svg"][viewBox="0 0 24 24"] [stroke] {
+  stroke-width: 1.5;
+}
+
 .am-tab-apply {
   display: flex;
   position: relative;
@@ -1920,6 +1962,8 @@ body.am-wt-dragging-active * {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  /* Digits keep one width so count changes do not shift the buttons to the left. */
+  font-variant-numeric: tabular-nums;
 }
 
 .am-diff-toggle-btn.am-tab-diff-btn-active .am-stat-files {

--- a/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/agent-manager.stories.tsx
@@ -1343,7 +1343,6 @@ export const TabBarWithReviewTab: Story = {
         </div>
         <MockTabAdd />
         <div class="am-tab-actions">
-          <IconButton icon="expand" size="small" variant="ghost" label="Review" class="am-tab-diff-btn-active" />
           <IconButton icon="console" size="small" variant="ghost" label="Terminal" />
         </div>
       </div>
@@ -1383,8 +1382,27 @@ export const TabBarSingleTab: Story = {
 
 const MockFullContextActions = () => (
   <div class="am-tab-actions">
-    <TooltipKeybind title="Open this worktree in VS Code" keybind="" placement="bottom">
-      <IconButton icon="folder" size="small" variant="ghost" aria-label="Open this worktree in VS Code" />
+    <span class="am-tab-session-panels">
+      <TooltipKeybind title="Documents" keybind="" placement="bottom">
+        <IconButton icon="book-open-check" size="small" variant="ghost" label="Documents" />
+      </TooltipKeybind>
+      <TooltipKeybind title="Subagents" keybind="" placement="bottom">
+        <IconButton icon="task" size="small" variant="ghost" label="Subagents" />
+      </TooltipKeybind>
+      <span class="am-tab-actions-separator" />
+    </span>
+    <TooltipKeybind title="Toggle diff" keybind="" placement="bottom">
+      <button class="am-diff-toggle-btn am-diff-toggle-has-changes" title="Toggle diff">
+        <Icon name="layers" size="small" />
+        <span class="am-diff-toggle-stats">
+          <span class="am-stat-files">4f</span>
+          <span class="am-stat-additions">+32</span>
+          <span class="am-stat-deletions">−8</span>
+        </span>
+      </button>
+    </TooltipKeybind>
+    <TooltipKeybind title="Pull request" keybind="" placement="bottom">
+      <IconButton icon="pull-request" size="small" variant="ghost" label="Pull request" />
     </TooltipKeybind>
     <TooltipKeybind title="Apply selected worktree changes to local branch" keybind="" placement="bottom">
       <IconButton
@@ -1393,6 +1411,12 @@ const MockFullContextActions = () => (
         variant="ghost"
         aria-label="Apply selected worktree changes to local branch"
       />
+    </TooltipKeybind>
+    <TooltipKeybind title="Open this worktree in VS Code" keybind="" placement="bottom">
+      <IconButton icon="folder" size="small" variant="ghost" aria-label="Open this worktree in VS Code" />
+    </TooltipKeybind>
+    <TooltipKeybind title="Browser" keybind="" placement="bottom">
+      <IconButton icon="globe" size="small" variant="ghost" label="Browser" />
     </TooltipKeybind>
     <span class="am-split-button">
       <TooltipKeybind title="Run" keybind="⌘R" placement="bottom">
@@ -1404,28 +1428,6 @@ const MockFullContextActions = () => (
         </button>
       </TooltipKeybind>
     </span>
-    <TooltipKeybind title="Pull request" keybind="" placement="bottom">
-      <IconButton icon="pull-request" size="small" variant="ghost" label="Pull request" />
-    </TooltipKeybind>
-    <TooltipKeybind title="Documents" keybind="" placement="bottom">
-      <IconButton icon="book-open-check" size="small" variant="ghost" label="Documents" />
-    </TooltipKeybind>
-    <TooltipKeybind title="Subagents" keybind="" placement="bottom">
-      <IconButton icon="task" size="small" variant="ghost" label="Subagents" />
-    </TooltipKeybind>
-    <TooltipKeybind title="Toggle diff" keybind="" placement="bottom">
-      <button class="am-diff-toggle-btn am-diff-toggle-has-changes" title="Toggle diff">
-        <Icon name="layers" size="small" />
-        <span class="am-diff-toggle-stats">
-          <span class="am-stat-files">4f</span>
-          <span class="am-stat-additions">+32</span>
-          <span class="am-stat-deletions">−8</span>
-        </span>
-      </button>
-    </TooltipKeybind>
-    <TooltipKeybind title="Toggle review" keybind="" placement="bottom">
-      <IconButton icon="expand" size="small" variant="ghost" label="Toggle review" />
-    </TooltipKeybind>
     <div class="am-split-button">
       <TooltipKeybind title="Open Terminal" keybind="" placement="bottom">
         <IconButton icon="console" size="small" variant="ghost" label="Open Terminal" />


### PR DESCRIPTION
## What Problem This Solves

The Agent Manager tab toolbar mixed worktree commands, review controls, optional session panels, runtime tools, and fullscreen review in an unstable order. Optional controls could shift frequently used buttons, the toolbar fullscreen action duplicated the Changes panel header action, disabled Apply looked interactive, and toolbar icons used inconsistent visual weights.

## Why This Change Was Made

- Group Documents and Subagents as optional session-panel handles on the left, with a separator that only renders when either panel exists.
- Keep the workbench controls stable on the right in this order: Changes, PR, Apply, Open in VS Code, Browser, Run, Terminal.
- Keep Run and Terminal adjacent because Run sends output to the configured terminal destination. Browser stays in the workbench because both the agent and user can use it to test localhost applications.
- Remove the duplicate fullscreen button from the toolbar. Fullscreen review remains available from the Changes panel header.
- Add `tab_toolbar` PostHog telemetry for PR, Apply, Documents, Subagents, and Browser, alongside the existing toolbar events, so future button removals can be data-driven.
- Normalize Agent Manager toolbar outline icons to an effective 1px stroke at 16px, redraw the PR icon as a matching outline glyph, dim disabled icons, remove the disabled pointer cursor, and remove the green Run-active tint.
- Track the shared icon-button migration in follow-up issue #13915.

## User Impact

The toolbar keeps its main workbench controls in stable positions as optional panels appear. Disabled Apply is visibly disabled while its tooltip remains available to explain why. Open-panel active states remain highlighted. Running uses the normal icon colour and the play/stop glyph change to communicate state.

## Evidence

### Before

<img width="700" alt="Agent Manager toolbar before the update" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260908-agent-manager-toolbar-before.png" />

### After

<img width="700" alt="Agent Manager toolbar after the update" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260908-agent-manager-toolbar-after.png" />

### Disabled Apply

<img width="700" alt="Disabled Apply button with no hover background" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260908-agent-manager-toolbar-disabled-after.png" />

### Changes panel open

<img width="700" alt="Changes button active with the diff panel open" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260908-agent-manager-toolbar-diff-open.png" />

Validation completed:

- `bun run compile` in `packages/kilo-vscode/`
- `bun test tests/unit/agent-manager-telemetry.test.ts tests/unit/agent-manager-terminal-side.test.ts`, 27 passed
- Isolated VS Code self-test against the same shadow workspace and worktrees before and after the change
- Verified computed icon stroke values, disabled Apply colour and cursor, Changes active state, and tooltip behaviour
