### PR TITLE
fix(ci): tolerate contract generation and Bun download failures

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,6 +1,13 @@
 name: containers
 
 on:
+  push:
+    branches:
+      - main # kilocode_change
+    paths:
+      - packages/containers/**
+      - .github/workflows/containers.yml
+      - package.json
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,13 +1,6 @@
 name: containers
 
 on:
-  push:
-    branches:
-      - main # kilocode_change
-    paths:
-      - packages/containers/**
-      - .github/workflows/containers.yml
-      - package.json
   workflow_dispatch:
 
 permissions:

--- a/packages/client/test/contract-identity.test.ts
+++ b/packages/client/test/contract-identity.test.ts
@@ -42,7 +42,7 @@ test("client and Server contracts generate identically", () => {
   const client = compile(ClientApi, { groupNames, endpointNames, omitEndpoints })
 
   expect(emitPromise(client)).toEqual(emitPromise(server))
-})
+}, 30_000) // kilocode_change - allow full contract generation on shared CI runners
 
 test("shared DTO schemas construct and decode plain objects", () => {
   const made = Prompt.make({ text: "hello" })

--- a/packages/containers/bun-node/Dockerfile
+++ b/packages/containers/bun-node/Dockerfile
@@ -19,8 +19,20 @@ RUN set -euo pipefail; \
   | tar -xJf - -C /usr/local --strip-components=1; \
   corepack enable
 
+# kilocode_change start - retry the installer and its internal release download
 RUN set -euo pipefail; \
-  curl -fsSL https://bun.sh/install | bash -s -- "bun-v${BUN_VERSION}"; \
+  for attempt in 1 2 3 4 5; do \
+    if curl -fsSL https://bun.sh/install | bash -s -- "bun-v${BUN_VERSION}"; then \
+      break; \
+    fi; \
+    if [ "$attempt" -eq 5 ]; then \
+      echo "Bun installation failed after 5 attempts" >&2; \
+      exit 1; \
+    fi; \
+    echo "Bun installation failed, retrying ($attempt/5)" >&2; \
+    sleep "$((attempt * 5))"; \
+  done; \
   bun --version; \
   node --version; \
   npm --version
+# kilocode_change end


### PR DESCRIPTION
## What Problem This Solves
The macOS client contract-generation test exceeded its 10-second timeout. Separately, the container build failed when GitHub returned HTTP 500 for the Bun ARM64 release download.

## Why This Change Was Made
Give only the full contract-generation test a 30-second limit without changing its assertions. Retry the complete Bun installer up to five times with increasing delays, so retries cover both the installer fetch and its internal binary download. Permanent failures still fail the build.

## User Impact
Automatic container publishing, image names, and supported architectures remain unchanged. This PR does not retire any images or remove pipeline steps.

## Evidence
The focused client tests pass on Bun 1.3.14, including three repeated contract-test runs. Client typecheck, lint, formatting, and workflow guards pass. A local HTTP fault-injection harness passes five installer scenarios covering success, temporary outer and inner download failures, and retry exhaustion.

Full container build verification is blocked locally because the Docker daemon is stopped. The full client suite has one local sandbox permission failure in its import-boundary test.