### PR TITLE
fix(agent-manager): explain empty repository worktree failures

### DIFF
--- a/.changeset/clear-empty-repository-worktree-error.md
+++ b/.changeset/clear-empty-repository-worktree-error.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Show an actionable message when creating worktrees from a repository with no commits.

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -31,6 +31,7 @@ import {
 
 const TEMP_PREFIX = ".kilo-delete-"
 const RM_OPTS: fs.RmOptions = { recursive: true, force: true, maxRetries: 3, retryDelay: 200 }
+const NO_COMMITS_MESSAGE = "This repository has no commits yet. Create an initial commit before using worktrees."
 
 function directory(branch: string): string {
   // Keep ordinary directory names, but isolate refs that need filesystem escaping.
@@ -226,6 +227,15 @@ export class WorktreeManager {
     }
   }
 
+  private async ensureCommit(): Promise<void> {
+    try {
+      await this.git.raw(["rev-parse", "--verify", "HEAD"])
+    } catch (error) {
+      this.log(`ensureCommit: ${error}`)
+      throw new Error(NO_COMMITS_MESSAGE)
+    }
+  }
+
   private async createWorktreeImpl(params: {
     prompt?: string
     existingBranch?: string
@@ -247,6 +257,10 @@ export class WorktreeManager {
       await this.git.raw(["check-ref-format", `refs/heads/${requested}`])
       await this.git.raw(["check-ref-format", "--branch", requested])
     }
+
+    // An explicit base branch skips defaultBranch(), so check the repository
+    // state here before trying to resolve a start point.
+    if (params.baseBranch) await this.ensureCommit()
 
     // Git LFS Pre-flight Check
     if (await this.repoUsesLfs()) {
@@ -1052,13 +1066,7 @@ export class WorktreeManager {
     }
 
     // Check if this is an empty repo with no commits (unborn branch).
-    // rev-parse --verify HEAD exits non-zero only when HEAD has no target
-    // commit, which is the definitive test for an unborn branch.
-    try {
-      await this.git.raw(["rev-parse", "--verify", "HEAD"])
-    } catch {
-      throw new Error("This repository has no commits yet. Create an initial commit before using worktrees.")
-    }
+    await this.ensureCommit()
 
     throw new Error("Could not determine default branch")
   }

--- a/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
+++ b/packages/kilo-vscode/src/agent-manager/WorktreeManager.ts
@@ -229,7 +229,8 @@ export class WorktreeManager {
 
   private async ensureCommit(): Promise<void> {
     try {
-      await this.git.raw(["rev-parse", "--verify", "HEAD"])
+      const commit = await this.git.raw(["rev-list", "-n", "1", "--all"])
+      if (!commit.trim()) throw new Error("No commits found")
     } catch (error) {
       this.log(`ensureCommit: ${error}`)
       throw new Error(NO_COMMITS_MESSAGE)

--- a/packages/kilo-vscode/src/agent-manager/provider-multi-version.ts
+++ b/packages/kilo-vscode/src/agent-manager/provider-multi-version.ts
@@ -7,6 +7,7 @@ import { resolveVersionModels, buildInitialMessages, type CreatedVersion } from 
 import { ensureSandbox } from "./sandbox-bootstrap"
 import type { LifecycleHost } from "./provider-lifecycle"
 import { Semaphore } from "./semaphore"
+import type { WorktreeCreationFailure } from "./worktree-create"
 
 const PROVISION_CONCURRENCY = 2
 
@@ -63,6 +64,7 @@ export async function createMultiVersion(
   // Phase 1: finish every shared-repository Git mutation before setup scripts
   // or agents can run their own Git commands in the new worktrees.
   const created: CreatedVersion[] = []
+  const failures: WorktreeCreationFailure[] = []
 
   const specs = Array.from({ length: versions }, (_, index) => ({
     index,
@@ -78,7 +80,7 @@ export async function createMultiVersion(
   }))
   const prepared: PreparedVersion[] = []
   for (const spec of specs) {
-    const version = await prepareVersion(host, spec)
+    const version = await prepareVersion(host, spec, failures)
     if (version) prepared.push(version)
   }
 
@@ -127,7 +129,8 @@ export async function createMultiVersion(
   })
 
   if (created.length === 0) {
-    host.error(`Failed to create any of the ${versions} multi-version worktrees.`)
+    const failure = failures.find((item) => item.code === "no_commits")
+    host.error(failure?.message ?? `Failed to create any of the ${versions} multi-version worktrees.`)
   }
 
   host.log(`Multi-version creation complete: ${created.length}/${versions} versions`)
@@ -153,7 +156,11 @@ interface PreparedVersion {
 }
 
 /** Create one version's worktree while the shared-repository Git barrier is active. */
-async function prepareVersion(host: MultiVersionHost, spec: VersionSpec): Promise<PreparedVersion | null> {
+async function prepareVersion(
+  host: MultiVersionHost,
+  spec: VersionSpec,
+  failures: WorktreeCreationFailure[],
+): Promise<PreparedVersion | null> {
   host.log(`Creating worktree ${spec.index + 1}/${spec.versions}`)
 
   const version = versionedName(spec.branchName || spec.worktreeName, spec.index, spec.versions)
@@ -165,6 +172,7 @@ async function prepareVersion(host: MultiVersionHost, spec: VersionSpec): Promis
     branchName: branch,
     name: version.branch,
     label: version.label,
+    onError: (failure) => failures.push(failure),
   })
   if (!wt) {
     host.log(`Failed to create worktree for version ${spec.index + 1}`)

--- a/packages/kilo-vscode/src/agent-manager/worktree-create.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-create.ts
@@ -1,7 +1,7 @@
 import type { Worktree, WorktreeStateManager } from "./WorktreeStateManager"
 import type { WorktreeManager, CreateWorktreeResult } from "./WorktreeManager"
 import { chooseBaseBranch } from "./base-branch"
-import { classifyWorktreeError } from "./git-import"
+import { classifyWorktreeError, type WorktreeSetupErrorCode } from "./git-import"
 import { PLATFORM } from "./constants"
 import type { AgentManagerOutMessage } from "./types"
 
@@ -13,6 +13,12 @@ export type CreateWorktreeOnDiskOptions = {
   existingBranch?: string
   name?: string
   label?: string
+  onError?: (failure: WorktreeCreationFailure) => void
+}
+
+export type WorktreeCreationFailure = {
+  message: string
+  code?: WorktreeSetupErrorCode
 }
 
 export type CreateWorktreeOnDiskResult = {
@@ -29,6 +35,12 @@ export interface CreateWorktreeOnDiskContext {
   log: (...args: unknown[]) => void
 }
 
+function report(opts: CreateWorktreeOnDiskOptions | undefined, failure: WorktreeCreationFailure): void {
+  const onError = opts?.onError
+  if (!onError) return
+  onError(failure)
+}
+
 /**
  * Create a git worktree on disk and register it in state. Returns null on failure.
  *
@@ -41,10 +53,12 @@ export async function createWorktreeOnDisk(
   const manager = ctx.getWorktreeManager()
   const state = ctx.getStateManager()
   if (!manager || !state) {
+    const message = "Open a folder that contains a git repository to use worktrees"
+    report(opts, { message, code: "not_git_repo" })
     ctx.postToWebview({
       type: "agentManager.worktreeSetup",
       status: "error",
-      message: "Open a folder that contains a git repository to use worktrees",
+      message,
       errorCode: "not_git_repo",
     })
     return null
@@ -68,11 +82,13 @@ export async function createWorktreeOnDisk(
     })
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error)
+    const errorCode = classifyWorktreeError(msg)
+    report(opts, { message: msg, code: errorCode })
     ctx.postToWebview({
       type: "agentManager.worktreeSetup",
       status: "error",
       message: msg,
-      errorCode: classifyWorktreeError(msg),
+      errorCode,
     })
     ctx.capture("Agent Manager Session Error", {
       source: PLATFORM,

--- a/packages/kilo-vscode/tests/unit/git-import.test.ts
+++ b/packages/kilo-vscode/tests/unit/git-import.test.ts
@@ -433,6 +433,12 @@ describe("classifyWorktreeError", () => {
     ).toBe("lfs_missing")
   })
 
+  it("detects a repository with no commits", () => {
+    expect(
+      classifyWorktreeError("This repository has no commits yet. Create an initial commit before using worktrees."),
+    ).toBe("no_commits")
+  })
+
   it("returns undefined for unrecognized errors", () => {
     expect(classifyWorktreeError('Branch "foo" already exists')).toBeUndefined()
     expect(classifyWorktreeError("Failed to create worktree: fatal: unknown error")).toBeUndefined()

--- a/packages/kilo-vscode/tests/unit/provider-multi-version.test.ts
+++ b/packages/kilo-vscode/tests/unit/provider-multi-version.test.ts
@@ -88,4 +88,45 @@ describe("multi-version provisioning", () => {
     expect(flow).toContain("setup:2")
     expect(flow.filter((event) => event.startsWith("prompt:"))).toHaveLength(3)
   })
+
+  it("uses the detailed no-commit error in the final notification", async () => {
+    const message = "This repository has no commits yet. Create an initial commit before using worktrees."
+    const error = mock(() => {})
+    const host = {
+      createOnDisk: mock(async (opts: { onError?: (failure: { message: string; code?: string }) => void }) => {
+        opts.onError?.({ message, code: "no_commits" })
+        return null
+      }),
+      log: () => {},
+      post: () => {},
+      error,
+    } as unknown as MultiVersionHost
+
+    await createMultiVersion({ id: "project-1" } as ProjectContext, host, {
+      type: "agentManager.createMultiVersion",
+      versions: 1,
+    })
+
+    expect(error).toHaveBeenCalledWith(message)
+  })
+
+  it("keeps the generic notification for other failures", async () => {
+    const error = mock(() => {})
+    const host = {
+      createOnDisk: mock(async (opts: { onError?: (failure: { message: string }) => void }) => {
+        opts.onError?.({ message: "Branch already exists" })
+        return null
+      }),
+      log: () => {},
+      post: () => {},
+      error,
+    } as unknown as MultiVersionHost
+
+    await createMultiVersion({ id: "project-1" } as ProjectContext, host, {
+      type: "agentManager.createMultiVersion",
+      versions: 1,
+    })
+
+    expect(error).toHaveBeenCalledWith("Failed to create any of the 1 multi-version worktrees.")
+  })
 })

--- a/packages/kilo-vscode/tests/unit/worktree-create.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-create.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from "bun:test"
+import os from "node:os"
+import path from "node:path"
+import fs from "node:fs/promises"
+import { WorktreeManager } from "../../src/agent-manager/WorktreeManager"
+import {
+  createWorktreeOnDisk,
+  type CreateWorktreeOnDiskContext,
+  type WorktreeCreationFailure,
+} from "../../src/agent-manager/worktree-create"
+import type { AgentManagerOutMessage } from "../../src/agent-manager/types"
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0, tempDirs.length).map((dir) => fs.rm(dir, { recursive: true, force: true })))
+})
+
+describe("createWorktreeOnDisk", () => {
+  it("reports no-commit failures to multi-version callers and the webview", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-wt-empty-"))
+    tempDirs.push(root)
+    const result = Bun.spawnSync(["git", "init", "-b", "main", root], { stdout: "ignore", stderr: "pipe" })
+    if (result.exitCode !== 0) throw new Error(Buffer.from(result.stderr).toString("utf8"))
+
+    const messages: AgentManagerOutMessage[] = []
+    const failures: WorktreeCreationFailure[] = []
+    const state = { getDefaultBaseBranch: () => undefined }
+    const ctx = {
+      getWorktreeManager: () => new WorktreeManager(root, () => {}),
+      getStateManager: () => state,
+      postToWebview: (message: AgentManagerOutMessage) => messages.push(message),
+      capture: () => {},
+      pushState: () => {},
+      log: () => {},
+    } as unknown as CreateWorktreeOnDiskContext
+
+    const value = await createWorktreeOnDisk(ctx, {
+      baseBranch: "main",
+      branchName: "feature",
+      onError: (failure) => failures.push(failure),
+    })
+
+    expect(value).toBeNull()
+    expect(failures).toEqual([
+      {
+        message: "This repository has no commits yet. Create an initial commit before using worktrees.",
+        code: "no_commits",
+      },
+    ])
+    expect(messages.at(-1)).toMatchObject({
+      type: "agentManager.worktreeSetup",
+      status: "error",
+      errorCode: "no_commits",
+    })
+  })
+})

--- a/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
@@ -429,6 +429,16 @@ describe("WorktreeManager.createWorktree", () => {
     )
   })
 
+  it("reports when an explicit base branch is selected in a repository with no commits", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-wt-empty-"))
+    tempDirs.push(root)
+    gitExec(["git", "init", "-b", "main", root])
+
+    await expect(createManager(root).createWorktree({ baseBranch: "main", branchName: "feature" })).rejects.toThrow(
+      "This repository has no commits yet. Create an initial commit before using worktrees.",
+    )
+  })
+
   it("throws when workspace is not a git repo", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-wt-nogit-"))
     tempDirs.push(dir)

--- a/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-manager.test.ts
@@ -439,6 +439,16 @@ describe("WorktreeManager.createWorktree", () => {
     )
   })
 
+  it("allows an explicit base branch from an orphan current branch", async () => {
+    const root = await createTempRepo()
+    gitExec(["git", "-C", root, "checkout", "--orphan", "orphan"])
+    gitExec(["git", "-C", root, "rm", "-rf", "."])
+
+    const result = await createManager(root).createWorktree({ baseBranch: "main", branchName: "feature" })
+
+    expect(result.parentBranch).toBe("main")
+  })
+
   it("throws when workspace is not a git repo", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "kilo-wt-nogit-"))
     tempDirs.push(dir)

--- a/packages/kilo-vscode/webview-ui/src/types/messages/agent-manager.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/agent-manager.ts
@@ -1,4 +1,4 @@
-export type WorktreeErrorCode = "git_not_found" | "not_git_repo" | "lfs_missing"
+export type WorktreeErrorCode = "git_not_found" | "not_git_repo" | "lfs_missing" | "no_commits"
 
 export interface BaseUpdateRequest {
   type: "agentManager.updateFromBase"


### PR DESCRIPTION
## What Problem This Solves
Creating a multi-version worktree from a valid Git repository with no commits showed only a generic failure notification.

## Why This Change Was Made
The new worktree dialog supplies an explicit base branch fallback, which bypassed the existing empty-repository check in `defaultBranch()`. The worktree creation failure then lost its classified error before multi-version orchestration displayed the final notification.

## User Impact
The setup screen and VS Code error notification now explain that the repository needs an initial commit. Other setup errors retain their existing detailed messages and generic fallback behavior.

## Evidence
- `bun run compile`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- 260 focused Agent Manager tests, 259 passed and 1 skipped
- Isolated VS Code self-test against a disposable empty Git repository verified the actionable setup message and notification