### PR TITLE
fix(vscode): add PR sidebar review margins

### DIFF
--- a/packages/kilo-vscode/webview-ui/agent-manager/pr/pr-panel.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/pr/pr-panel.css
@@ -875,7 +875,7 @@
   white-space: nowrap;
 }
 .am-pr-review {
-  padding: 12px 0;
+  padding: 12px;
   min-width: 0;
 }
 


### PR DESCRIPTION
## What Problem This Solves
The PR sidebar review section rendered its heading and load controls flush against the panel edge, unlike the surrounding PR sections.

## Why This Change Was Made
Apply the same horizontal inset used by the other PR sidebar sections while preserving the review flow and diff layout.

## User Impact
The `Files and review` section and its load controls now align with the Branch, Status, and Review rows.

## Before and After
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img width="500" alt="Before: PR review content flush with the panel edge" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260908-pr-sidebar-margin-before.png" /></td>
<td><img width="500" alt="After: PR review content has horizontal inset" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260908-pr-sidebar-margin-after.png" /></td>
</tr>
</table>

Diff: `.am-pr-review` changes from `padding: 12px 0` to `padding: 12px`, adding the horizontal inset.

## Validation
- `bun test tests/unit/pr-review-render.test.ts`
- `bunx prettier --check webview-ui/agent-manager/pr/pr-panel.css`
- `bun run bundle`