### PR TITLE
fix(vscode): release terminal tab widths after close

### DIFF
--- a/.changeset/fix-terminal-tab-close-resize.md
+++ b/.changeset/fix-terminal-tab-close-resize.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Fix Agent Manager terminal tabs getting stuck at an expanded width after closing a tab.

--- a/packages/kilo-vscode/tests/unit/agent-manager-terminal-layout.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-terminal-layout.test.ts
@@ -11,6 +11,10 @@ import {
 const css = readFileSync(resolve(import.meta.dir, "../../webview-ui/agent-manager/agent-manager.css"), "utf8")
 const app = readFileSync(resolve(import.meta.dir, "../../webview-ui/agent-manager/AgentManagerApp.tsx"), "utf8")
 const subagent = readFileSync(resolve(import.meta.dir, "../../webview-ui/agent-manager/SubagentPanel.tsx"), "utf8")
+const side = readFileSync(
+  resolve(import.meta.dir, "../../webview-ui/agent-manager/terminal/SideTerminalPanel.tsx"),
+  "utf8",
+)
 const terminal = readFileSync(
   resolve(import.meta.dir, "../../webview-ui/agent-manager/terminal/TerminalTab.tsx"),
   "utf8",
@@ -47,6 +51,12 @@ test("hides keyboard hints only in inspector tabs", () => {
   expect(
     readFileSync(resolve(import.meta.dir, "../../webview-ui/agent-manager/terminal/render.tsx"), "utf8"),
   ).not.toContain("showKeybind={false}")
+})
+
+test("releases frozen widths after terminal close clicks", () => {
+  expect(app).toContain("requestAnimationFrame(releaseTabs)")
+  expect(side).toContain("requestAnimationFrame(release)")
+  expect(side).toContain("close(term.id, api.focus, api.release)")
 })
 
 test("limits inspector layout updates during resize", () => {

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -634,12 +634,14 @@ const AgentManagerContent: Component = () => {
   const isPending = (id: string) => id.startsWith(PENDING_PREFIX)
   reportRemoteSessions(vscode, localSessionIDs, managedSessions, isPending)
 
+  const releaseTabs = () => setTabWidths(false)
   const freezeTabs = () => {
     const bar = document.querySelector(".am-tab-bar")
-    if (bar instanceof HTMLElement && bar.matches(":hover")) setTabWidths(true)
+    if (!(bar instanceof HTMLElement) || !bar.matches(":hover")) return
+    setTabWidths(true)
+    requestAnimationFrame(releaseTabs)
   }
 
-  const releaseTabs = () => setTabWidths(false)
   const worktreeTabOrder = () => registry.active().tabOrder()
   const setWorktreeTabOrder: Setter<Record<string, string[]>> = (v) => registry.active().setTabOrder(v)
 

--- a/packages/kilo-vscode/webview-ui/agent-manager/SubagentPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/SubagentPanel.tsx
@@ -53,9 +53,10 @@ const SubagentContent: Component<Props & { activity: (id: string) => Activity }>
   const language = useLanguage()
   const ids = () => props.tabs().map((tab) => tab.id)
   const title = (id: string) => props.tabs().find((tab) => tab.id === id)?.title ?? "Sub-agent"
-  const close = (id: string, focus: { restore: () => void }) => {
+  const close = (id: string, focus: { restore: () => void }, release: () => void) => {
     props.onClose(id)
     session.releaseSession(id)
+    requestAnimationFrame(release)
     if (ids().length > 0) focus.restore()
   }
   const closeOthers = (id: string) => {
@@ -120,9 +121,9 @@ const SubagentContent: Component<Props & { activity: (id: string) => Activity }>
                 if (event.button !== 1) return
                 event.preventDefault()
                 event.stopPropagation()
-                close(id, api.focus)
+                close(id, api.focus, api.release)
               }}
-              onClose={() => close(id, api.focus)}
+              onClose={() => close(id, api.focus, api.release)}
               onCloseOthers={() => closeOthers(id)}
             />
           )

--- a/packages/kilo-vscode/webview-ui/agent-manager/terminal/SideTerminalPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/terminal/SideTerminalPanel.tsx
@@ -59,8 +59,9 @@ export const SideTerminalPanel: Component<Props> = (props) => {
   const ids = () => sides().map((term) => term.id)
   const active = () => props.state.sideActiveFor(props.contextKey())
   const pending = () => props.state.pendingSide(props.contextKey())
-  const close = (id: string, focus: { restore: () => void }) => {
+  const close = (id: string, focus: { restore: () => void }, release: () => void) => {
     props.onClose(id)
+    requestAnimationFrame(release)
     if (ids().length > 0) focus.restore()
   }
 
@@ -102,9 +103,9 @@ export const SideTerminalPanel: Component<Props> = (props) => {
                 if (event.button !== 1) return
                 event.preventDefault()
                 event.stopPropagation()
-                close(term.id, api.focus)
+                close(term.id, api.focus, api.release)
               }}
-              onClose={() => close(term.id, api.focus)}
+              onClose={() => close(term.id, api.focus, api.release)}
               onCloseOthers={() => props.onCloseOthers(term.id)}
               onStop={(event) => {
                 event.stopPropagation()


### PR DESCRIPTION
## What Problem This Solves
Closing an Agent Manager terminal tab can leave the tab strip width-frozen. The remaining tab can expand or move its close hitbox, preventing reliable subsequent closes.

## Why This Change Was Made
Terminal tabs freeze their widths before removal to avoid pointer reflow, but the close paths did not release those inline width constraints after the DOM mutation. This change releases the constraints on the next animation frame, matching the existing session-tab close behavior.

## User Impact
Terminal, side-terminal, and subagent tabs close normally without leaving stale width or flex styles on the remaining tabs.

## Evidence
- `bun test tests/unit/agent-manager-terminal-layout.test.ts tests/unit/agent-manager-terminal-state.test.ts tests/unit/agent-manager-terminal-side.test.ts` (67 passed)
- `bun run lint` (passed)
- Prettier check for all changed files (passed)
- Full typecheck and extension bundle were blocked by missing workspace dependencies and generated SDK modules in this checkout.