### PR TITLE
feat(agent-manager): open notification Show in Agent Manager for its sessions

### DIFF
--- a/.changeset/agent-manager-notification-navigation.md
+++ b/.changeset/agent-manager-notification-navigation.md
@@ -2,4 +2,4 @@
 "kilo-code": patch
 ---
 
-Open attention notifications for Agent Manager sessions in Agent Manager instead of the sidebar, selecting the right project, worktree, and session tab
+Open attention notifications for Agent Manager sessions in Agent Manager instead of the sidebar, selecting the right project, worktree or Local tab, and session

--- a/.changeset/agent-manager-notification-navigation.md
+++ b/.changeset/agent-manager-notification-navigation.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Open attention notifications for Agent Manager sessions in Agent Manager instead of the sidebar, selecting the right project, worktree, and session tab

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -6,7 +6,6 @@ import { getErrorMessage } from "../kilo-provider-utils"
 import { resolveLocalDiffTarget } from "../diff/shared/target"
 import { DiffSourceCatalog } from "../diff/sources/catalog"
 import { getDiffMarkdownRender, setDiffMarkdownRender } from "../review-settings"
-import { isAbsolutePath } from "../path-utils"
 import { WorktreeManager, type CreateWorktreeResult } from "./WorktreeManager"
 import { remoteRef, WorktreeStateManager, type Worktree } from "./WorktreeStateManager"
 import { composeDiffId, normalizeScope } from "./diff-scope"
@@ -77,6 +76,8 @@ import { createMultiVersion, type MultiVersionHost } from "./provider-multi-vers
 import { handleProjectMessage, routeProjectSession, type ProjectMessageDeps } from "./project/messages"
 import { createProjectWiring, type ProjectWiring } from "./project/wiring"
 import { ProjectScope } from "./project/scope"
+import { revealManagedSession } from "./reveal-session"
+import { resolveWorktreeFile } from "./worktree-file-path"
 import type { AgentManagerOutMessage, AgentManagerInMessage } from "./types"
 import type { Host, PanelContext, OutputHandle, Disposable } from "./host"
 import { focusPanelPrompt, revealPanel } from "./focus-panel"
@@ -1640,34 +1641,10 @@ export class AgentManagerProvider implements Disposable {
     this.host.openFolder(target, true)
   }
 
-  /** Open a file from a worktree or local session in the VS Code editor.
-   * Absolute paths are opened directly; relative paths resolve against the
-   * context's worktree directory (repo root for local) with symlink-traversal
-   * protection. The id may be a worktree id, session id, or `local`. */
+  /** Open a file from a worktree or local session in the VS Code editor. */
   private openWorktreeFile(id: string, filePath: string, line?: number, column?: number): void {
-    if (isAbsolutePath(filePath)) {
-      this.host.openFile(filePath, line, column)
-      return
-    }
-    const state = this.getStateManager()
-    if (!state) return
-    const worktree = state.getWorktree(id)
-    const session = worktree ? undefined : state.getSession(id)
-    const base = worktree?.path ?? (session?.worktreeId ? state.getWorktree(session.worktreeId)?.path : this.getRoot())
-    if (!base) return
-    // Resolve real paths to prevent symlink traversal and normalize for
-    // consistent comparison on both Unix and Windows.
-    let resolved: string
-    try {
-      const root = fs.realpathSync(base)
-      resolved = fs.realpathSync(path.resolve(base, filePath))
-      // Directory-boundary check: append path.sep so "/foo/bar" won't match "/foo/bar2/..."
-      if (resolved !== root && !resolved.startsWith(root + path.sep)) return
-    } catch (err) {
-      console.error("[Kilo New] AgentManagerProvider: Cannot resolve file path:", err)
-      return
-    }
-    this.host.openFile(resolved, line, column)
+    const target = resolveWorktreeFile(this.getStateManager(), id, filePath, this.getRoot())
+    if (target) this.host.openFile(target, line, column)
   }
 
   private postToWebview(message: AgentManagerOutMessage): void {
@@ -1757,6 +1734,23 @@ export class AgentManagerProvider implements Disposable {
   /** Expose worktree session→directory mappings for the auto-approve toggle. */
   public getSessionDirectories(): ReadonlyMap<string, string> {
     return this.panel?.sessions.getSessionDirectories() ?? new Map()
+  }
+
+  /**
+   * Reveal a session Agent Manager owns: activate its project, open the panel,
+   * and select its worktree and session tab. False means Agent Manager does not
+   * own the session (or its worktree is gone) and the caller should fall back.
+   */
+  public revealSession(sessionId: string): Promise<boolean> {
+    return revealManagedSession(sessionId, this.contexts, {
+      directories: () => this.getSessionDirectories(),
+      activate: (ctx) => this.activateProject(ctx),
+      projects: () => this.pushProjects(),
+      open: () => this.openPanel(),
+      state: () => this.waitForStateReady("revealSession"),
+      ready: () => this.waitForReady(),
+      post: (message) => this.panel?.postMessage(message),
+    })
   }
 
   public getWorktreeDirectories(): string[] {

--- a/packages/kilo-vscode/src/agent-manager/reveal-session.ts
+++ b/packages/kilo-vscode/src/agent-manager/reveal-session.ts
@@ -6,17 +6,22 @@ export interface ManagedSessionTarget {
   context: ProjectContext
   projectId: string
   sessionId: string
-  worktreeId: string
+  /** Absent for a session in the project's Local tabs. */
+  worktreeId?: string
 }
 
 interface RevealMessage {
   type: "agentManager.revealSession"
   projectId: string
   sessionId: string
-  worktreeId: string
+  worktreeId?: string
 }
 
-/** Resolve a live Agent Manager session only while its owning worktree remains present. */
+/**
+ * Resolve a session Agent Manager owns, or undefined when the sidebar should
+ * handle it. Worktree ownership requires the worktree to still exist and still
+ * match the session's directory, so a removed worktree falls back.
+ */
 export function resolveManagedSession(
   contexts: ProjectContexts,
   directories: ReadonlyMap<string, string>,
@@ -25,12 +30,20 @@ export function resolveManagedSession(
   const directory = directories.get(sessionId)
   if (!directory) return
   const context = contexts.byDirectory(directory) ?? contexts.byLiveSession(sessionId)
-  const state = context?.peekState()
+  if (!context) return
+  const state = context.peekState()
   const session = state?.getSession(sessionId)
+  // A Local tab has no worktree. The panel also tracks plain sidebar sessions
+  // discovered in the project root, so only a session Agent Manager persisted
+  // counts as owned; anything else keeps the sidebar.
+  if (session && !session.worktreeId) {
+    if (!samePath(context.root, directory)) return
+    return { context, projectId: context.id, sessionId }
+  }
   const worktree = session?.worktreeId
     ? state?.getWorktree(session.worktreeId)
     : state?.getWorktrees().find((item) => samePath(item.path, directory))
-  if (!context || !worktree || !samePath(worktree.path, directory)) return
+  if (!worktree || !samePath(worktree.path, directory)) return
   return { context, projectId: context.id, sessionId, worktreeId: worktree.id }
 }
 
@@ -61,9 +74,13 @@ export async function revealManagedSession(
 ): Promise<boolean> {
   const target = resolveManagedSession(contexts, deps.directories(), sessionId)
   if (!target) return false
-  contexts.activate(target.projectId)
-  deps.activate(target.context)
-  deps.projects()
+  // Re-activating the project the panel already shows would reset its PR,
+  // stats, and busy-session state for no gain, so only switch when needed.
+  if (contexts.active()?.id !== target.projectId) {
+    contexts.activate(target.projectId)
+    deps.activate(target.context)
+    deps.projects()
+  }
   deps.open()
   await deps.state()
   if (!(await deps.ready())) return false

--- a/packages/kilo-vscode/src/agent-manager/reveal-session.ts
+++ b/packages/kilo-vscode/src/agent-manager/reveal-session.ts
@@ -1,0 +1,77 @@
+import type { ProjectContext } from "./project/context"
+import type { ProjectContexts } from "./project/contexts"
+import { samePath } from "./project/paths"
+
+export interface ManagedSessionTarget {
+  context: ProjectContext
+  projectId: string
+  sessionId: string
+  worktreeId: string
+}
+
+interface RevealMessage {
+  type: "agentManager.revealSession"
+  projectId: string
+  sessionId: string
+  worktreeId: string
+}
+
+/** Resolve a live Agent Manager session only while its owning worktree remains present. */
+export function resolveManagedSession(
+  contexts: ProjectContexts,
+  directories: ReadonlyMap<string, string>,
+  sessionId: string,
+): ManagedSessionTarget | undefined {
+  const directory = directories.get(sessionId)
+  if (!directory) return
+  const context = contexts.byDirectory(directory) ?? contexts.byLiveSession(sessionId)
+  const state = context?.peekState()
+  const session = state?.getSession(sessionId)
+  const worktree = session?.worktreeId
+    ? state?.getWorktree(session.worktreeId)
+    : state?.getWorktrees().find((item) => samePath(item.path, directory))
+  if (!context || !worktree || !samePath(worktree.path, directory)) return
+  return { context, projectId: context.id, sessionId, worktreeId: worktree.id }
+}
+
+export interface RevealDeps {
+  /** Session→directory map for sessions Agent Manager currently tracks. */
+  directories: () => ReadonlyMap<string, string>
+  /** Re-wire provider state for the newly activated project. */
+  activate: (context: ProjectContext) => void
+  /** Publish the project catalog so the webview applies the new active project. */
+  projects: () => void
+  open: () => void
+  /** Resolve once the project's worktree state is loaded. */
+  state: () => Promise<void>
+  /** Resolve false when the panel closed before it was ready. */
+  ready: () => Promise<boolean>
+  post: (message: RevealMessage) => void
+}
+
+/**
+ * Focus an Agent Manager-owned session. The project is activated and published
+ * before the reveal is posted, so the webview never rejects the message as
+ * belonging to its previous project.
+ */
+export async function revealManagedSession(
+  sessionId: string,
+  contexts: ProjectContexts,
+  deps: RevealDeps,
+): Promise<boolean> {
+  const target = resolveManagedSession(contexts, deps.directories(), sessionId)
+  if (!target) return false
+  contexts.activate(target.projectId)
+  deps.activate(target.context)
+  deps.projects()
+  deps.open()
+  await deps.state()
+  if (!(await deps.ready())) return false
+  deps.post({
+    type: "agentManager.revealSession",
+    projectId: target.projectId,
+    sessionId,
+    worktreeId: target.worktreeId,
+  })
+  return true
+}

--- a/packages/kilo-vscode/src/agent-manager/worktree-file-path.ts
+++ b/packages/kilo-vscode/src/agent-manager/worktree-file-path.ts
@@ -1,0 +1,35 @@
+import * as fs from "fs"
+import * as path from "path"
+import { isAbsolutePath } from "../path-utils"
+import type { WorktreeStateManager } from "./WorktreeStateManager"
+
+/**
+ * Resolve a file reference from a worktree or local session to an absolute
+ * path. Absolute inputs pass through; relative inputs resolve against the
+ * context's worktree directory (repo root for local). Real paths are resolved
+ * so a symlink cannot escape that directory, and out-of-bounds or unresolvable
+ * paths return undefined. The id may be a worktree id, session id, or `local`.
+ */
+export function resolveWorktreeFile(
+  state: WorktreeStateManager | undefined,
+  id: string,
+  file: string,
+  root: string | undefined,
+): string | undefined {
+  if (isAbsolutePath(file)) return file
+  if (!state) return
+  const worktree = state.getWorktree(id)
+  const session = worktree ? undefined : state.getSession(id)
+  const base = worktree?.path ?? (session?.worktreeId ? state.getWorktree(session.worktreeId)?.path : root)
+  if (!base) return
+  try {
+    const dir = fs.realpathSync(base)
+    const resolved = fs.realpathSync(path.resolve(base, file))
+    // Directory-boundary check: append path.sep so "/foo/bar" won't match "/foo/bar2/...".
+    if (resolved !== dir && !resolved.startsWith(dir + path.sep)) return
+    return resolved
+  } catch (err) {
+    console.error("[Kilo New] AgentManagerProvider: Cannot resolve file path:", err)
+    return
+  }
+}

--- a/packages/kilo-vscode/src/extension.ts
+++ b/packages/kilo-vscode/src/extension.ts
@@ -283,6 +283,7 @@ export async function activate(context: vscode.ExtensionContext) {
     visible: (sessionID) => connectionService.isVisible(sessionID),
     os: showOSNotification,
     show: async (sessionID, directory) => {
+      if (await agentManagerProvider.revealSession(sessionID)) return
       await vscode.commands.executeCommand("kilo-code.SidebarProvider.focus")
       await provider.openSession(sessionID, directory)
     },

--- a/packages/kilo-vscode/tests/unit/agent-manager-reveal-session.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-reveal-session.test.ts
@@ -1,62 +1,136 @@
 import { describe, expect, it } from "bun:test"
 import { revealManagedSession, resolveManagedSession } from "../../src/agent-manager/reveal-session"
+import type { ProjectContexts } from "../../src/agent-manager/project/contexts"
 
-function contexts(state: {
-  getSession: (id: string) => { worktreeId: string } | undefined
-  getWorktree: (id: string) => unknown
-}) {
-  const context = { id: "project-a", peekState: () => state }
-  return {
-    activate: () => context,
+const ROOT = "/repo"
+const WORKTREE = { id: "worktree-a", path: "/repo/worktree-a" }
+
+/** One project whose state reports the given managed sessions and worktrees. */
+function contexts(
+  opts: {
+    sessions?: Record<string, { worktreeId: string | null }>
+    worktrees?: Array<{ id: string; path: string }>
+    active?: string
+  } = {},
+) {
+  const state = {
+    getSession: (id: string) => opts.sessions?.[id],
+    getWorktree: (id: string) => opts.worktrees?.find((item) => item.id === id),
+    getWorktrees: () => opts.worktrees ?? [],
+  }
+  const context = { id: "project-a", root: ROOT, peekState: () => state }
+  const activated: string[] = []
+  const value = {
+    active: () => (opts.active === undefined ? undefined : { id: opts.active }),
+    activate: (id: string) => {
+      activated.push(id)
+      return context
+    },
     byDirectory: () => context,
     byLiveSession: () => undefined,
-  } as never
+  } as unknown as ProjectContexts
+  return { value, activated }
+}
+
+function deps(directory: string, calls: string[], messages: unknown[] = []) {
+  return {
+    directories: () => new Map([["session-a", directory]]),
+    activate: () => calls.push("activate"),
+    projects: () => calls.push("projects"),
+    open: () => calls.push("open"),
+    state: async () => void calls.push("state"),
+    ready: async () => true,
+    post: (message: unknown) => messages.push(message),
+  }
 }
 
 describe("resolveManagedSession", () => {
   it("resolves the owning project and worktree for a tracked session", () => {
-    const worktree = { id: "worktree-a", path: "/repo/worktree-a" }
     const result = resolveManagedSession(
-      contexts({ getSession: () => ({ worktreeId: worktree.id }), getWorktree: () => worktree }),
-      new Map([["session-a", worktree.path]]),
+      contexts({ sessions: { "session-a": { worktreeId: WORKTREE.id } }, worktrees: [WORKTREE] }).value,
+      new Map([["session-a", WORKTREE.path]]),
       "session-a",
     )
 
-    expect(result).toMatchObject({ projectId: "project-a", sessionId: "session-a", worktreeId: "worktree-a" })
+    expect(result).toMatchObject({ projectId: "project-a", sessionId: "session-a", worktreeId: WORKTREE.id })
   })
 
   it("falls back when the worktree was removed or the directory is stale", () => {
     const result = resolveManagedSession(
-      contexts({ getSession: () => ({ worktreeId: "worktree-a" }), getWorktree: () => undefined }),
-      new Map([["session-a", "/repo/worktree-a"]]),
+      contexts({ sessions: { "session-a": { worktreeId: WORKTREE.id } } }).value,
+      new Map([["session-a", WORKTREE.path]]),
       "session-a",
     )
 
     expect(result).toBeUndefined()
   })
 
-  it("activates the project before revealing and scrolling the session", async () => {
-    const worktree = { id: "worktree-a", path: "/repo/worktree-a" }
-    const calls: string[] = []
-    const messages: unknown[] = []
-    const result = await revealManagedSession(
+  it("resolves a session Agent Manager persisted in its Local tabs", () => {
+    const result = resolveManagedSession(
+      contexts({ sessions: { "session-a": { worktreeId: null } } }).value,
+      new Map([["session-a", ROOT]]),
       "session-a",
-      contexts({ getSession: () => ({ worktreeId: worktree.id }), getWorktree: () => worktree }),
-      {
-        directories: () => new Map([["session-a", worktree.path]]),
-        activate: () => calls.push("activate"),
-        projects: () => calls.push("projects"),
-        open: () => calls.push("open"),
-        state: async () => void calls.push("state"),
-        ready: async () => true,
-        post: (message) => messages.push(message),
-      },
     )
 
+    expect(result).toMatchObject({ projectId: "project-a", sessionId: "session-a" })
+    expect(result?.worktreeId).toBeUndefined()
+  })
+
+  it("leaves a sidebar session in the project root to the sidebar", () => {
+    // The panel also tracks live sessions listed from the project root, so a
+    // root directory alone must not count as Agent Manager ownership.
+    const result = resolveManagedSession(contexts().value, new Map([["session-a", ROOT]]), "session-a")
+
+    expect(result).toBeUndefined()
+  })
+})
+
+describe("revealManagedSession", () => {
+  it("activates the project before revealing and scrolling the session", async () => {
+    const calls: string[] = []
+    const messages: unknown[] = []
+    const project = contexts({
+      sessions: { "session-a": { worktreeId: WORKTREE.id } },
+      worktrees: [WORKTREE],
+      active: "project-b",
+    })
+
+    const result = await revealManagedSession("session-a", project.value, deps(WORKTREE.path, calls, messages))
+
     expect(result).toBe(true)
+    expect(project.activated).toEqual(["project-a"])
     expect(calls).toEqual(["activate", "projects", "open", "state"])
     expect(messages).toEqual([
-      { type: "agentManager.revealSession", projectId: "project-a", sessionId: "session-a", worktreeId: "worktree-a" },
+      { type: "agentManager.revealSession", projectId: "project-a", sessionId: "session-a", worktreeId: WORKTREE.id },
+    ])
+  })
+
+  it("does not re-activate the project the panel already shows", async () => {
+    // Re-activating resets PR, stats, and busy-session state, so revealing a
+    // session in the current project must not touch it.
+    const calls: string[] = []
+    const project = contexts({
+      sessions: { "session-a": { worktreeId: WORKTREE.id } },
+      worktrees: [WORKTREE],
+      active: "project-a",
+    })
+
+    const result = await revealManagedSession("session-a", project.value, deps(WORKTREE.path, calls))
+
+    expect(result).toBe(true)
+    expect(project.activated).toEqual([])
+    expect(calls).toEqual(["open", "state"])
+  })
+
+  it("reveals a Local session without a worktree", async () => {
+    const messages: unknown[] = []
+    const project = contexts({ sessions: { "session-a": { worktreeId: null } }, active: "project-a" })
+
+    const result = await revealManagedSession("session-a", project.value, deps(ROOT, [], messages))
+
+    expect(result).toBe(true)
+    expect(messages).toEqual([
+      { type: "agentManager.revealSession", projectId: "project-a", sessionId: "session-a", worktreeId: undefined },
     ])
   })
 })

--- a/packages/kilo-vscode/tests/unit/agent-manager-reveal-session.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-manager-reveal-session.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test"
+import { revealManagedSession, resolveManagedSession } from "../../src/agent-manager/reveal-session"
+
+function contexts(state: {
+  getSession: (id: string) => { worktreeId: string } | undefined
+  getWorktree: (id: string) => unknown
+}) {
+  const context = { id: "project-a", peekState: () => state }
+  return {
+    activate: () => context,
+    byDirectory: () => context,
+    byLiveSession: () => undefined,
+  } as never
+}
+
+describe("resolveManagedSession", () => {
+  it("resolves the owning project and worktree for a tracked session", () => {
+    const worktree = { id: "worktree-a", path: "/repo/worktree-a" }
+    const result = resolveManagedSession(
+      contexts({ getSession: () => ({ worktreeId: worktree.id }), getWorktree: () => worktree }),
+      new Map([["session-a", worktree.path]]),
+      "session-a",
+    )
+
+    expect(result).toMatchObject({ projectId: "project-a", sessionId: "session-a", worktreeId: "worktree-a" })
+  })
+
+  it("falls back when the worktree was removed or the directory is stale", () => {
+    const result = resolveManagedSession(
+      contexts({ getSession: () => ({ worktreeId: "worktree-a" }), getWorktree: () => undefined }),
+      new Map([["session-a", "/repo/worktree-a"]]),
+      "session-a",
+    )
+
+    expect(result).toBeUndefined()
+  })
+
+  it("activates the project before revealing and scrolling the session", async () => {
+    const worktree = { id: "worktree-a", path: "/repo/worktree-a" }
+    const calls: string[] = []
+    const messages: unknown[] = []
+    const result = await revealManagedSession(
+      "session-a",
+      contexts({ getSession: () => ({ worktreeId: worktree.id }), getWorktree: () => worktree }),
+      {
+        directories: () => new Map([["session-a", worktree.path]]),
+        activate: () => calls.push("activate"),
+        projects: () => calls.push("projects"),
+        open: () => calls.push("open"),
+        state: async () => void calls.push("state"),
+        ready: async () => true,
+        post: (message) => messages.push(message),
+      },
+    )
+
+    expect(result).toBe(true)
+    expect(calls).toEqual(["activate", "projects", "open", "state"])
+    expect(messages).toEqual([
+      { type: "agentManager.revealSession", projectId: "project-a", sessionId: "session-a", worktreeId: "worktree-a" },
+    ])
+  })
+})

--- a/packages/kilo-vscode/tests/unit/worktree-file-path.test.ts
+++ b/packages/kilo-vscode/tests/unit/worktree-file-path.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import { resolveWorktreeFile } from "../../src/agent-manager/worktree-file-path"
+import type { WorktreeStateManager } from "../../src/agent-manager/WorktreeStateManager"
+
+function state(worktree: { id: string; path: string }) {
+  return {
+    getWorktree: (id: string) => (id === worktree.id ? worktree : undefined),
+    getSession: () => undefined,
+  } as unknown as WorktreeStateManager
+}
+
+function repo() {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "kilo-worktree-")))
+  fs.writeFileSync(path.join(root, "file.ts"), "")
+  return root
+}
+
+describe("resolveWorktreeFile", () => {
+  it("resolves a relative path against the worktree directory", () => {
+    const root = repo()
+
+    expect(resolveWorktreeFile(state({ id: "wt", path: root }), "wt", "file.ts", undefined)).toBe(
+      path.join(root, "file.ts"),
+    )
+  })
+
+  it("returns absolute paths untouched, even without state", () => {
+    const file = path.join(repo(), "file.ts")
+
+    expect(resolveWorktreeFile(undefined, "wt", file, undefined)).toBe(file)
+  })
+
+  it("rejects a relative path that escapes the worktree directory", () => {
+    const root = repo()
+    const outside = repo()
+    const target = path.relative(root, path.join(outside, "file.ts"))
+
+    expect(resolveWorktreeFile(state({ id: "wt", path: root }), "wt", target, undefined)).toBeUndefined()
+  })
+
+  it("falls back to the project root for a local context", () => {
+    const root = repo()
+
+    expect(resolveWorktreeFile(state({ id: "wt", path: root }), "local", "file.ts", root)).toBe(
+      path.join(root, "file.ts"),
+    )
+  })
+})

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -982,13 +982,13 @@ const AgentManagerContent: Component = () => {
     return true
   }
 
-  const focusManagedSession = (worktreeId: string, sid: string) => {
+  const focusManagedSession = (worktreeId: string, sid: string, scrollToBottom = false) => {
     selectWorktree(worktreeId)
     closeHistory()
     terms.setActiveId(undefined)
     setActivePendingId(undefined)
     setReviewActive(false)
-    session.selectSession(sid)
+    session.selectSession(sid, { scrollToBottom })
     requestChatFocus()
     return true
   }
@@ -1400,6 +1400,11 @@ const AgentManagerContent: Component = () => {
       }
 
       if (msg.type === "agentManager.focusContextRequested") focusCtl.report()
+      if (msg.type === "agentManager.revealSession") {
+        if (currentProjectId() !== msg.projectId) return
+        focusManagedSession(msg.worktreeId, msg.sessionId, true)
+        return
+      }
       if (msg.type === "agentManager.state" && msg.isGitRepo === false && !sessionsLoaded()) setSessionsLoaded(true)
       if (msg.type === "agentManager.state") preserveSidebarScroll(() => stateHandlers.state(msg))
       stateHandlers.browser(msg)

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -682,7 +682,7 @@ const AgentManagerContent: Component = () => {
     if (!pending && !existing) tabOrderSync.append(LOCAL, id)
     if (pending && pending === active) setActivePendingId(undefined)
   }
-  const focusLocalSession = (id: string) => {
+  const focusLocalSession = (id: string, scrollToBottom = false) => {
     const pending = activePendingId()
     const replace = pending && localSessionIDs().includes(pending) ? pending : undefined
     placeLocal(id, replace, replace)
@@ -690,7 +690,7 @@ const AgentManagerContent: Component = () => {
     terms.setActiveId(undefined)
     setReviewActive(false)
     setSelection(LOCAL)
-    session.selectSession(id)
+    session.selectSession(id, { scrollToBottom })
     requestChatFocus()
   }
   persistLocalTabs({
@@ -1402,7 +1402,8 @@ const AgentManagerContent: Component = () => {
       if (msg.type === "agentManager.focusContextRequested") focusCtl.report()
       if (msg.type === "agentManager.revealSession") {
         if (currentProjectId() !== msg.projectId) return
-        focusManagedSession(msg.worktreeId, msg.sessionId, true)
+        if (msg.worktreeId) focusManagedSession(msg.worktreeId, msg.sessionId, true)
+        else focusLocalSession(msg.sessionId, true)
         return
       }
       if (msg.type === "agentManager.state" && msg.isGitRepo === false && !sessionsLoaded()) setSessionsLoaded(true)

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -923,7 +923,8 @@ export interface AgentManagerSelectionActivatedMessage {
 export interface AgentManagerRevealSessionMessage {
   type: "agentManager.revealSession"
   projectId: string
-  worktreeId: string
+  /** Absent when the session lives in the project's Local tabs. */
+  worktreeId?: string
   sessionId: string
 }
 

--- a/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/extension-messages.ts
@@ -919,6 +919,14 @@ export interface AgentManagerSelectionActivatedMessage {
   target: AgentManagerSidebarTarget
 }
 
+/** Host request to select a managed session and scroll its chat to the latest message. */
+export interface AgentManagerRevealSessionMessage {
+  type: "agentManager.revealSession"
+  projectId: string
+  worktreeId: string
+  sessionId: string
+}
+
 export interface AgentManagerProjectSessionsMessage {
   type: "agentManager.projectSessions"
   projectId: string
@@ -1660,6 +1668,7 @@ export type ExtensionMessage =
   | AgentManagerWorktreeDeletedMessage
   | AgentManagerProjectsMessage
   | AgentManagerSelectionActivatedMessage
+  | AgentManagerRevealSessionMessage
   | AgentManagerProjectSessionsMessage
   | AgentManagerRunStatusMessage
   | AgentManagerCaffeinationMessage


### PR DESCRIPTION
## Issue

Fixes #13922

## Context

Attention notifications (added in #13771) always opened their **Show** action through the sidebar. When the notification came from an Agent Manager session, that pulled the session out of the panel the user is actually working in and into the sidebar. The sidebar is only the right destination for sessions Agent Manager does not own.

## Implementation

`AttentionService`'s `show` callback now asks Agent Manager first. `AgentManagerProvider.revealSession()` returns `false` when Agent Manager does not own the session, and the existing sidebar path runs unchanged.

Ownership is resolved host-side from `getSessionDirectories()`. The session's directory is matched back to its owning project context and worktree, and the reveal is refused unless the worktree still exists and still matches that directory. That makes the stale cases (worktree removed, session moved back to Local, directory no longer owned) fall back to the sidebar instead of selecting the wrong thing.

Ordering matters in the host: the project is activated **and** the project catalog is published before the reveal message is posted. The webview rejects messages for a project other than its applied one, so without the catalog push the reveal could be dropped when the notification came from a non-active project.

The webview side reuses `focusManagedSession`, which already selects the worktree, clears review/terminal state, and selects the session tab. It gained a `scrollToBottom` flag so the reveal path passes `selectSession(id, { scrollToBottom: true })` — the same one-shot request `MessageList` consumes for the sidebar in #13771, so a later switch back still restores the saved scroll position.

Two notes for reviewers:

- Reveal orchestration lives in `reveal-session.ts` rather than the provider because `AgentManagerProvider.ts` is at its enforced `maxLines` cap.
- For the same reason, the path-resolution body of `openWorktreeFile` moved unchanged into `worktree-file-path.ts`. This is the only refactor in the PR and is behavior-preserving; it is covered by new tests, since that symlink-traversal logic previously had none.

## Screenshots / Video


https://github.com/user-attachments/assets/5c97b251-3f1c-4c47-830f-728b796b17df



## How to Test

### Manual/local verification

- Ran `bun run extension:isolated` and confirmed a worktree agent that asks a question raises a notification whose **Show** focuses Agent Manager, selects that worktree and session tab, and scrolls to the latest message
- Confirmed a sidebar (non-Agent-Manager) session still opens in the sidebar
- Confirmed deleting the worktree before clicking **Show** falls back to the sidebar instead of failing

### Reviewer test steps

1. Open Agent Manager and start a worktree agent
2. Prompt it so it needs attention, e.g. "Ask me to choose between two implementation approaches"
3. Click **Show** on the notification
4. Confirm Agent Manager is focused with the correct project, worktree, and session tab selected, scrolled to the latest message
5. Repeat with a normal sidebar session and confirm **Show** still opens the sidebar
6. Delete an Agent Manager worktree that has a pending notification, click **Show**, and confirm it falls back to the sidebar

### Blocked checks and substitute verification

- `bun run test:unit` (full extension suite) could not complete in the available time budget; substitute verification was the targeted suites `agent-manager-reveal-session`, `worktree-file-path`, `agent-manager-arch`, `attention`, `agent-manager-focus`, `agent-manager-focus-panel`, `agent-manager-provider-lifecycle`, `agent-manager-session-restore`, `agent-manager-selection-actions`, `project-message-ownership`, `project-local-navigation`, `session-scroll-bottom`, and `presence-registration-contract`, all passing
- `bun run check-kilocode-change` cannot run in this Windows PowerShell environment (the script is shell-specific); verified instead by searching the package for `kilocode_change`, which returns no matches — and markers are not required in `packages/kilo-vscode/`
- `src/agent-manager/__tests__/AgentManagerProvider.spec.ts` fails (1 pass / 10 fail), but it fails identically on a clean checkout of `main`; verified by stashing this branch's changes and re-running, so it is pre-existing and unrelated

All checks above were executed by the agent. `bun run typecheck`, `bun run lint`, `bun run knip`, and `bun run format` pass.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

sylwester-liljegren
