### PR TITLE
fix(goal): allow goals to replace running responses

### DIFF
--- a/.changeset/session-goals.md
+++ b/.changeset/session-goals.md
@@ -13,3 +13,5 @@ Keep the current goal running when replacement attachments are invalid. Make pen
 Disable clarification questions during active goals and delegated work while keeping permission approvals unchanged. Make safe, reversible decisions autonomously and report completion or blockers.
 
 Retain Active, Complete, Blocked, and Paused goals with their objective and reason until explicitly cleared. Let the working model explicitly report completion or a blocker with the Goal-only reporting tool, without a separate evaluator or independent verification claim. Pause no-action turns that have no explicit report. Keep complete goals complete after a backend restart and label their resume action as Restart.
+
+Starting a Goal while a response is running replaces that response after the Goal request is validated.

--- a/packages/opencode/src/kilocode/session/goal/runner.ts
+++ b/packages/opencode/src/kilocode/session/goal/runner.ts
@@ -1,4 +1,4 @@
-import { Cause, Deferred, Effect, Scope, Semaphore } from "effect"
+import { Cause, Deferred, Effect, Exit, Scope, Semaphore } from "effect"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { NamedError } from "@opencode-ai/core/util/error"
 import type { EventV2 } from "@opencode-ai/core/event"
@@ -233,7 +233,7 @@ export namespace Goal {
               if (session.time.archived || session.revert) {
                 yield* Effect.fail(new Error("Restore this session before starting a goal."))
               }
-              if (!replace || !GoalState.active(id))
+              if (!replace || (!starting && !GoalState.active(id)))
                 yield* state
                   .assertNotBusy(id)
                   .pipe(Effect.mapError(() => new Error("Stop the current response before starting a goal.")))
@@ -273,7 +273,11 @@ export namespace Goal {
             : undefined
           if (starting) yield* admit(true)
           if (intent && !intent.current()) return yield* Effect.interrupt
-          if (args && GoalState.active(id)) yield* ops.cancel(id, true)
+          // A new goal replaces an in-flight response after admission and attachment validation.
+          if (starting) {
+            const busy = yield* Effect.exit(state.assertNotBusy(id))
+            if (GoalState.active(id) || Exit.isFailure(busy)) yield* ops.cancel(id, true)
+          }
           if (intent && !intent.current()) return yield* Effect.interrupt
           if (args === "pause" || args === "clear") yield* pause(id, true)
           const prior = yield* ops.control.begin(id, false)

--- a/packages/opencode/src/kilocode/session/goal/runner.ts
+++ b/packages/opencode/src/kilocode/session/goal/runner.ts
@@ -273,10 +273,10 @@ export namespace Goal {
             : undefined
           if (starting) yield* admit(true)
           if (intent && !intent.current()) return yield* Effect.interrupt
-          // A new goal replaces an in-flight response after admission and attachment validation.
+          if (GoalState.active(id)) yield* ops.cancel(id, true)
           if (starting) {
             const busy = yield* Effect.exit(state.assertNotBusy(id))
-            if (GoalState.active(id) || Exit.isFailure(busy)) yield* ops.cancel(id, true)
+            if (Exit.isFailure(busy)) yield* ops.cancel(id, true)
           }
           if (intent && !intent.current()) return yield* Effect.interrupt
           if (args === "pause" || args === "clear") yield* pause(id, true)

--- a/packages/opencode/test/kilocode/session/goal.test.ts
+++ b/packages/opencode/test/kilocode/session/goal.test.ts
@@ -1177,7 +1177,8 @@ it.instance(
       })
       .pipe(Effect.forkChild)
     yield* run.wait(1)
-    expect(KiloSessionPromptQueue.active(run.session.id)).toBeDefined()
+    const base = KiloSessionPromptQueue.active(run.session.id)
+    expect(base).toBeDefined()
 
     yield* run.llm.hang
     const ack = yield* run.prompt.command({
@@ -1193,7 +1194,8 @@ it.instance(
       ...retained,
       "kilo.goal": { text: objective, active: true, status: "active" },
     })
-    expect(Exit.hasInterrupts(yield* Fiber.await(ordinary))).toBe(true)
+    yield* awaitWithTimeout(Fiber.await(ordinary), "ordinary response was not replaced")
+    expect(KiloSessionPromptQueue.active(run.session.id)).not.toBe(base)
     yield* run.prompt.cancel(run.session.id)
   }),
   30_000,

--- a/packages/opencode/test/kilocode/session/goal.test.ts
+++ b/packages/opencode/test/kilocode/session/goal.test.ts
@@ -1131,7 +1131,7 @@ it.instance(
   30_000,
 )
 
-for (const kind of ["archived", "reverted", "busy"] as const) {
+for (const kind of ["archived", "reverted"] as const) {
   it.instance(
     `rejects goal start and resume on a ${kind} session without cancelling its turn`,
     Effect.gen(function* () {
@@ -1144,21 +1144,12 @@ for (const kind of ["archived", "reverted", "busy"] as const) {
       if (kind === "archived") yield* run.sessions.setArchived({ sessionID: run.session.id, time: Date.now() })
       if (kind === "reverted")
         yield* run.sessions.setRevert({ sessionID: run.session.id, revert: { messageID: base }, summary: undefined })
-      if (kind === "busy")
-        yield* run.prompt.prompt({
-          sessionID: run.session.id,
-          noReply: true,
-          parts: [{ type: "text", text: "Keep the goal paused" }],
-        })
       const metadata = yield* run.metadata
       const before = yield* run.sessions.messages({ sessionID: run.session.id })
       for (const args of ["Replace the objective", "resume"]) {
         const exit = yield* run.command(args).pipe(Effect.exit)
         expect(Exit.isFailure(exit)).toBe(true)
-        if (Exit.isFailure(exit))
-          expect(String(Cause.squash(exit.cause))).toContain(
-            kind === "busy" ? "Stop the current response" : "Restore this session",
-          )
+        if (Exit.isFailure(exit)) expect(String(Cause.squash(exit.cause))).toContain("Restore this session")
         expect(yield* run.metadata).toEqual(metadata)
         expect(KiloSessionPromptQueue.active(run.session.id)).toBe(base)
         expect((yield* run.status.get(run.session.id)).type).toBe("busy")
@@ -1171,6 +1162,42 @@ for (const kind of ["archived", "reverted", "busy"] as const) {
     }),
   )
 }
+
+it.instance(
+  "replaces a running ordinary response when starting a goal",
+  Effect.gen(function* () {
+    const run = yield* setup()
+    yield* run.llm.hang
+    const ordinary = yield* run.prompt
+      .prompt({
+        sessionID: run.session.id,
+        agent: "code",
+        model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("test-model") },
+        parts: [{ type: "text", text: "Start ordinary work" }],
+      })
+      .pipe(Effect.forkChild)
+    yield* run.wait(1)
+    expect(KiloSessionPromptQueue.active(run.session.id)).toBeDefined()
+
+    yield* run.llm.hang
+    const ack = yield* run.prompt.command({
+      sessionID: run.session.id,
+      agent: "code",
+      command: "goal",
+      arguments: `-- ${objective}`,
+      model: "test/test-model",
+    })
+    expect(ack.info.role).toBe("assistant")
+    yield* run.wait(1)
+    expect(yield* run.metadata).toMatchObject({
+      ...retained,
+      "kilo.goal": { text: objective, active: true, status: "active" },
+    })
+    expect(Exit.hasInterrupts(yield* Fiber.await(ordinary))).toBe(true)
+    yield* run.prompt.cancel(run.session.id)
+  }),
+  30_000,
+)
 
 it.instance(
   "rechecks descendant attention after goal replacement cancellation",


### PR DESCRIPTION
## What Problem This Solves
Starting a Goal while an ordinary response is running returned a Bad Request because Goal admission rejected the busy session before the replacement path could cancel it.

## Why This Change Was Made
Goal submission is an explicit replacement action from the composer. The runner now validates the request and attachments first, cancels the in-flight response, then performs the existing idle admission checks before starting the Goal. Archived and reverted sessions, pending blockers, and invalid requests remain rejected.

## User Impact
Users can submit a Goal while the agent is working. The current response is interrupted and the validated Goal starts instead of showing a Bad Request error.

## Evidence
- Focused busy Goal regression: `bun test test/kilocode/session/goal.test.ts -t ordinary`
- CLI typecheck: `bun run typecheck`
- Full Goal suite previously passed: 76 tests
- CLI Goal tests previously passed: 7 tests