### PR TITLE
test(jetbrains): fix flaky worktree fork dedupe test

### DIFF
--- a/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeSessionEditorManagerTest.kt
+++ b/packages/kilo-jetbrains/frontend/src/test/kotlin/ai/kilocode/client/agentManager/worktree/WorktreeSessionEditorManagerTest.kt
@@ -294,9 +294,11 @@ class WorktreeSessionEditorManagerTest : BasePlatformTestCase() {
 
         // A hover icon or menu item is easy to hit twice before the RPC answers.
         edt { manager.forkSession(session.id) }
-        pump()
+        // The first fork's RPC is recorded on the background dispatcher, so pump() alone can return
+        // before it lands. Wait for the in-flight call before firing the duplicate.
+        waitUntil { rpc.forks.size == 1 }
         edt { manager.forkSession(session.id) }
-        pump()
+        flush()
 
         assertEquals(1, rpc.forks.size)
 


### PR DESCRIPTION
## What Problem This Solves

The JetBrains CI job flaked in `WorktreeSessionEditorManagerTest > test a second fork of the same session is ignored while the first is in flight` with `expected:<1> but was:<0>` at `WorktreeSessionEditorManagerTest.kt:301`.

## Why This Change Was Made

The test called `pump()` after `forkSession()` and then asserted the first fork RPC had been recorded. `pump()` only flushes the EDT. `FakeSessionRpcApi.fork` records the call on the background dispatcher before awaiting `forkGate`, so under load the assertion could run before the coroutine was scheduled and see zero forks.

The fix waits for the in-flight RPC with the existing `waitUntil` helper before firing the duplicate, then `flush()` so an accidental second call would surface. This matches the established `GhStatusCoordinatorTest.awaitCalls(1)` pattern for the same "first RPC is in flight" check.

## User Impact

None. Test-only change.

## Evidence

- Full `./gradlew :frontend:test` from `packages/kilo-jetbrains/`: 3884 tests pass.
- 10 consecutive stress runs of `WorktreeSessionEditorManagerTest` with `cleanTest`: all pass.
- Forced reproduction with a widened race window in the fake RPC failed at line 301 with the old synchronization and passed with the fix.
