### PR TITLE
fix(vscode): prevent clipped expanded PR comments

### DIFF
--- a/.changeset/hide-expanded-pr-comment-preview.md
+++ b/.changeset/hide-expanded-pr-comment-preview.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep expanded Agent Manager PR comments readable by hiding their duplicate header previews.

--- a/packages/kilo-vscode/tests/diff-scroll-preservation.spec.ts
+++ b/packages/kilo-vscode/tests/diff-scroll-preservation.spec.ts
@@ -77,14 +77,12 @@ for (const width of [420, 200]) {
     await header.scrollIntoViewIfNeeded()
     await header.focus()
     const original = await header.evaluateHandle((el) => el)
-    const title = await header.locator(".am-pr-comment-preview").textContent()
     const position = await header.evaluate((el) => ({
       x: el.getBoundingClientRect().x,
       y: el.getBoundingClientRect().y,
     }))
 
     async function stable() {
-      await expect(header.locator(".am-pr-comment-preview")).toHaveText(title!)
       await expect(card).toHaveCount(1)
       await expect(header).toHaveCount(1)
       await expect(header).toBeFocused()
@@ -95,6 +93,7 @@ for (const width of [420, 200]) {
 
     async function inline() {
       await expect(header).toHaveAttribute("aria-expanded", "true")
+      await expect(header.locator(".am-pr-comment-preview")).toHaveCount(0)
       await expect(diff.locator(".am-pr-diff-context-marker + [data-component='diff']")).toHaveCount(0)
       await expect(annotation.locator(".am-pr-comment-head")).toHaveCount(0)
       await expect(annotation.locator(".am-pr-comment-body").first()).toContainText("This throws when")
@@ -142,6 +141,7 @@ for (const width of [420, 200]) {
       await expect(diff).toHaveCount(0)
       await expect(card.locator(".am-pr-comment-body")).toHaveCount(0)
       await expect(header).toHaveAttribute("aria-expanded", "false")
+      await expect(header.locator(".am-pr-comment-preview")).toContainText("This throws when")
       await stable()
       if (input === "click") await header.click()
       if (input !== "click") await page.keyboard.press(input)

--- a/packages/kilo-vscode/tests/fixtures/pr-comments-render.tsx
+++ b/packages/kilo-vscode/tests/fixtures/pr-comments-render.tsx
@@ -334,14 +334,13 @@ const resolvedRow = rows.find((node) => /reviewer/.test(node.textContent ?? ""))
 assert.ok(resolvedRow, "resolved row is present")
 assert.equal(resolvedRow!.getAttribute("aria-expanded"), "false")
 assert.ok(resolvedRow!.querySelector(".am-pr-comment-preview"), "collapsed row shows a preview")
-const summary = resolvedRow!.querySelector(".am-pr-comment-preview")!.textContent
 assert.doesNotMatch(root.textContent ?? "", /second paragraph only shows when expanded/)
 
 // The row expands into a full card whose unresolve action is enabled.
 ;(resolvedRow as HTMLButtonElement).click()
 await window.happyDOM.waitUntilComplete()
 assert.equal(resolvedRow!.getAttribute("aria-expanded"), "true")
-assert.equal(resolvedRow!.querySelector(".am-pr-comment-preview")!.textContent, summary)
+assert.equal(resolvedRow!.querySelector(".am-pr-comment-preview"), null)
 assert.match(root.textContent ?? "", /second paragraph only shows when expanded/)
 const card = resolvedRow!.parentElement!
 assert.equal(card.querySelector(".am-pr-diff-file")!.textContent, "packages/kilo-ui/src/components/other.tsx:3")

--- a/packages/kilo-vscode/webview-ui/agent-manager/pr/PRCommentCard.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/pr/PRCommentCard.tsx
@@ -128,7 +128,7 @@ export function PRCommentCard(props: Props) {
             {t("agentManager.import.pullRequest")}
           </span>
         </Show>
-        <Show when={!props.inline || !props.open}>
+        <Show when={!props.open}>
           <span class="am-pr-comment-preview">{preview(props.comment.body)}</span>
         </Show>
         <div class="am-pr-comment-tags">


### PR DESCRIPTION
## What Problem This Solves

Expanded Agent Manager PR comments retained a one-line preview in the header. At narrow widths, that duplicate preview was ellipsized and made long comments appear cut off on the right.

## Why This Change Was Made

Render the preview only while a comment is collapsed. Expanded comments already render the complete body, so removing the duplicate header preview gives the body the full available width and matches the existing PR conversation behavior.

## User Impact

Long Agent Manager PR comments remain readable when expanded. Collapsed comments still show their summary, including inline review comments.

## Validation

- `bun test tests/unit/pr-review-render.test.ts`
- `bun run lint`
- `bun run bundle`
- `bunx prettier --check webview-ui/agent-manager/pr/PRCommentCard.tsx tests/fixtures/pr-comments-render.tsx tests/diff-scroll-preservation.spec.ts`
- `git diff --check`
