### PR TITLE
fix(cli): keep diagnostics edits responsive

### DIFF
--- a/.changeset/fast-fresh-diagnostics.md
+++ b/.changeset/fast-fresh-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Keep TypeScript file edits responsive while refreshing diagnostics after parallel edits, moves, deletes, and failed checks.

--- a/packages/opencode/src/kilocode/ts-check.ts
+++ b/packages/opencode/src/kilocode/ts-check.ts
@@ -57,6 +57,7 @@ export namespace TsCheck {
     if (!proc) return undefined
 
     const TIMEOUT = 30_000
+    const GRACE = 1_000
     let stopped = false
     const stop = () => {
       if (stopped || proc.exitCode != null) return
@@ -67,14 +68,29 @@ export namespace TsCheck {
         log.error("failed to kill typescript checker", { root, error })
       }
     }
+    const done = Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited])
+    void done.catch((error) => {
+      log.error("failed to collect typescript checker output", { root, error })
+    })
     const reap = async () => {
       stop()
+      const exited = await Promise.race([
+        proc.exited.then(() => true).catch(() => true),
+        Bun.sleep(GRACE).then(() => false),
+      ])
+      if (!exited && proc.exitCode == null) {
+        try {
+          proc.kill(9)
+        } catch (error) {
+          log.error("failed to force kill typescript checker", { root, error })
+        }
+      }
       await proc.exited.catch((error) => {
         log.error("failed to reap typescript checker", { root, error })
       })
+      await done.catch(() => undefined)
     }
 
-    const done = Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited])
     const timeout = Promise.withResolvers<"timeout">()
     const cancel = Promise.withResolvers<"abort">()
     const abort = () => {

--- a/packages/opencode/src/kilocode/ts-check.ts
+++ b/packages/opencode/src/kilocode/ts-check.ts
@@ -10,13 +10,28 @@ export namespace TsCheck {
 
   // Match: file(line,col): error TSxxxx: message
   const DIAG_RE = /^(.+?)\((\d+),(\d+)\):\s+(error|warning)\s+(TS\d+):\s+(.*)$/
+  const GLOBAL_RE = /\b(?:error|fatal)\s+TS\d+:/m
 
-  export async function run(root: string): Promise<Map<string, Diagnostic[]>> {
+  export async function run(root: string, signal?: AbortSignal): Promise<Map<string, Diagnostic[]> | undefined> {
+    if (signal?.aborted) {
+      log.warn("ts check aborted before resolve", { root })
+      return undefined
+    }
+
     const result = new Map<string, Diagnostic[]>()
-    const bin = await resolve(root)
+    const bin = await resolve(root).catch((error) => {
+      log.error("failed to resolve typescript checker", { root, error })
+      return undefined
+    })
+
+    if (signal?.aborted) {
+      log.warn("ts check aborted after resolve", { root })
+      return undefined
+    }
+
     if (!bin) {
-      log.info("no typescript checker found", { root })
-      return result
+      log.warn("no typescript checker found", { root })
+      return undefined
     }
 
     log.info("running ts check", { bin, root })
@@ -25,32 +40,88 @@ export namespace TsCheck {
     // --incremental writes a .tsbuildinfo cache so subsequent runs only
     // re-check changed files. First run is cold (~1.3s), warm runs
     // reuse the cache and typically finish in ~200-400ms.
-    const proc = Bun.spawn([bin, "--noEmit", "--pretty", "false", "--incremental"], {
-      cwd: root,
-      stdout: "pipe",
-      stderr: "pipe",
-      windowsHide: true,
-      env: { ...process.env },
-    })
+    const proc = (() => {
+      try {
+        return Bun.spawn([bin, "--noEmit", "--pretty", "false", "--incremental"], {
+          cwd: root,
+          stdout: "pipe",
+          stderr: "pipe",
+          windowsHide: true,
+          env: { ...process.env },
+        })
+      } catch (error) {
+        log.error("failed to spawn typescript checker", { root, bin, error })
+        return undefined
+      }
+    })()
+    if (!proc) return undefined
 
     const TIMEOUT = 30_000
-    const done = Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited])
-    const settled = await Promise.race([
-      done.then(([out, err]) => ({ out, err, timedOut: false as const })),
-      new Promise<{ out: string; err: string; timedOut: true }>((r) =>
-        setTimeout(() => r({ out: "", err: "", timedOut: true }), TIMEOUT),
-      ),
-    ])
-    if (settled.timedOut) {
-      log.warn("ts check timed out, killing process", { elapsed: Date.now() - start })
-      proc.kill()
+    let stopped = false
+    const stop = () => {
+      if (stopped || proc.exitCode != null) return
+      stopped = true
+      try {
+        proc.kill()
+      } catch (error) {
+        log.error("failed to kill typescript checker", { root, error })
+      }
     }
+    const reap = async () => {
+      stop()
+      await proc.exited.catch((error) => {
+        log.error("failed to reap typescript checker", { root, error })
+      })
+    }
+
+    const done = Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text(), proc.exited])
+    const timeout = Promise.withResolvers<"timeout">()
+    const cancel = Promise.withResolvers<"abort">()
+    const abort = () => {
+      stop()
+      cancel.resolve("abort")
+    }
+    const timer = setTimeout(() => timeout.resolve("timeout"), TIMEOUT)
+    signal?.addEventListener("abort", abort, { once: true })
+    if (signal?.aborted) abort()
+
+    const settled = await Promise.race([
+      done.then(([out, err, code]) => ({ kind: "done" as const, out, err, code })),
+      timeout.promise.then((kind) => ({ kind })),
+      cancel.promise.then((kind) => ({ kind })),
+    ])
+      .catch(async (error) => {
+        log.error("ts check failed", { root, error })
+        await reap()
+        return { kind: "failed" as const }
+      })
+      .finally(() => {
+        clearTimeout(timer)
+        signal?.removeEventListener("abort", abort)
+      })
+
+    if (settled.kind === "timeout") {
+      log.warn("ts check timed out, killing process", { root, elapsed: Date.now() - start })
+      await reap()
+      return undefined
+    }
+
+    if (settled.kind === "abort") {
+      log.warn("ts check aborted, killing process", { root, elapsed: Date.now() - start })
+      await reap()
+      return undefined
+    }
+
+    if (settled.kind === "failed") return undefined
 
     const stdout = settled.out
     const stderr = settled.err
+    const code = settled.code
+    const text = `${stdout}\n${stderr}`
 
     log.info("ts check done", {
       elapsed: Date.now() - start,
+      code,
       lines: stdout.split("\n").length,
     })
 
@@ -58,7 +129,7 @@ export namespace TsCheck {
       log.info("ts check stderr", { stderr: stderr.slice(0, 500) })
     }
 
-    for (const line of stdout.split("\n")) {
+    for (const line of text.split(/\r?\n/)) {
       const m = DIAG_RE.exec(line)
       if (!m) continue
       if (m.length < 7) continue
@@ -84,6 +155,26 @@ export namespace TsCheck {
       const arr = result.get(normalized) ?? []
       arr.push(diag)
       result.set(normalized, arr)
+    }
+
+    if (result.size === 0 && GLOBAL_RE.test(text)) {
+      log.warn("ts check reported a global compiler error", {
+        root,
+        code,
+        stdout: stdout.slice(0, 500),
+        stderr: stderr.slice(0, 500),
+      })
+      return undefined
+    }
+
+    if (code !== 0 && result.size === 0) {
+      log.warn("ts check failed without file diagnostics", {
+        root,
+        code,
+        stdout: stdout.slice(0, 500),
+        stderr: stderr.slice(0, 500),
+      })
+      return undefined
     }
 
     return result

--- a/packages/opencode/src/kilocode/ts-client.ts
+++ b/packages/opencode/src/kilocode/ts-client.ts
@@ -5,38 +5,73 @@
 
 import { LSPClient } from "../lsp/client"
 import { Bus } from "../bus"
+import { GlobalBus, type GlobalEvent } from "../bus/global"
 import { BusEvent } from "../bus/bus-event"
 import { TsCheck } from "./ts-check"
+import { Filesystem } from "../util/filesystem"
 import * as Log from "@opencode-ai/core/util/log"
 import { withTimeout } from "../util/timeout"
 import path from "path"
-import { Instance } from "./instance"
+import { capture, type InstanceContext } from "./instance"
 import { Schema } from "effect"
 
 export namespace TsClient {
   const log = Log.create({ service: "ts-client" })
+  // A check that took longer than this is treated as slow. Slow checks run in
+  // the background and never block the edit, write, or apply_patch tools.
+  const SLOW_CHECK_MS = 100
+  // Upper bound on the response-critical wait for a check known to be fast.
+  const WAIT_BUDGET_MS = 150
   const Diagnostics = BusEvent.define(
     "lsp.client.diagnostics",
     Schema.Struct({ serverID: Schema.String, path: Schema.String }),
   )
 
-  export function create(input: { root: string }): LSPClient.Info {
+  export function create(input: { root: string; ctx?: InstanceContext }): LSPClient.Info {
     const diagnostics = new Map<string, LSPClient.Diagnostic[]>()
-    // Pending tsgo run promise — used for coalescing rapid calls.
-    // Only set when waitForDiagnostics() triggers a run, NOT on
-    // notify.open() (which is a warm-up call from read.ts).
-    let pending: Promise<void> | undefined
+    const ctx = input.ctx ?? capture()
+    let revision = 0
+    let pending: { start: number; revision: number; controller: AbortController; promise: Promise<void> } | undefined
+    let duration: number | undefined
+    let checked: number | undefined
+    let closed = false
 
-    function check(): Promise<void> {
-      if (pending) return pending
-      pending = TsCheck.run(client.root)
-        .then((result) => {
+    function invalidate() {
+      revision++
+      checked = undefined
+      // A change can also invalidate dependent files and removed source paths.
+      diagnostics.clear()
+    }
+
+    function changed(event: GlobalEvent) {
+      if (closed || event.directory !== (ctx?.directory ?? input.root)) return
+      if (event.payload.type !== "file.edited" && event.payload.type !== "file.watcher.updated") return
+      const file = event.payload.properties?.file
+      if (typeof file !== "string" || file.endsWith(".tsbuildinfo")) return
+      invalidate()
+    }
+
+    GlobalBus.on("event", changed)
+
+    function run(): Promise<void> {
+      if (pending) return pending.promise
+      const current = revision
+      const controller = new AbortController()
+      const start = Date.now()
+      const clock = performance.now()
+      const promise = TsCheck.run(client.root, controller.signal)
+        .then(async (result) => {
+          if (closed || current !== revision || result === undefined) return
           diagnostics.clear()
-          for (const [file, diags] of result) {
-            diagnostics.set(file, diags)
+          for (const [file, items] of result) {
+            diagnostics.set(file, items)
           }
+          // Completion time cannot prove that a file was read after a write.
+          checked = start
+          if (!ctx) return
           for (const file of result.keys()) {
-            Bus.publish(Instance.current, Diagnostics, {
+            if (closed || current !== revision) return
+            await Bus.publish(ctx, Diagnostics, {
               path: file,
               serverID: client.serverID,
             })
@@ -46,9 +81,14 @@ export namespace TsClient {
           log.error("ts check failed", { error: err })
         })
         .finally(() => {
+          duration = performance.now() - clock
           pending = undefined
+          // Coalesce all writes during this run into one fresh project check.
+          // Failures alone do not trigger an automatic retry loop.
+          if (!closed && current !== revision) void run()
         })
-      return pending
+      pending = { start, revision: current, controller, promise }
+      return promise
     }
 
     const client: LSPClient.Info = {
@@ -84,15 +124,36 @@ export namespace TsClient {
       get diagnostics() {
         return diagnostics
       },
-      async waitForDiagnostics(_input: { path: string; version: number; mode?: "document" | "full"; after?: number }) {
-        // Run tsgo --noEmit and wait for results. Coalesces concurrent calls.
-        // 30s cap matches the process timeout in TsCheck.run(). Silent catch
-        // matches the real LSPClient's .catch(() => {}) on its 3s timeout.
-        await withTimeout(check(), 30_000).catch(() => {})
+      async waitForDiagnostics(input: { path: string; version: number; mode?: "document" | "full"; after?: number }) {
+        if (closed) return
+        const file = Filesystem.normalizePath(path.resolve(ctx?.directory ?? client.root, input.path))
+        const stat = await Bun.file(file)
+          .stat()
+          .catch(() => undefined)
+        if (closed) return
+        if (stat && checked !== undefined && stat.mtimeMs < checked) return
+        if (pending) {
+          // Tools such as apply_patch write all files before requesting results.
+          // Joining that run is safe, but a later write invalidates it.
+          if (pending.revision === revision && (!stat || stat.mtimeMs >= pending.start)) invalidate()
+          return
+        }
+        invalidate()
+        const task = run()
+        // Unknown or slow checkers must not block the tool. The check keeps
+        // running and the next tool call sees its result.
+        if (duration === undefined || duration > SLOW_CHECK_MS) return
+        await withTimeout(task, WAIT_BUDGET_MS).catch(() => {
+          log.debug("ts check still running, returning without diagnostics", { path: input.path })
+        })
       },
       async shutdown() {
         log.info("shutting down ts-client")
-        diagnostics.clear()
+        closed = true
+        GlobalBus.off("event", changed)
+        invalidate()
+        pending?.controller.abort()
+        await pending?.promise
       },
     }
 

--- a/packages/opencode/src/kilocode/ts-client.ts
+++ b/packages/opencode/src/kilocode/ts-client.ts
@@ -41,6 +41,7 @@ export namespace TsClient {
       checked = undefined
       // A change can also invalidate dependent files and removed source paths.
       diagnostics.clear()
+      pending?.controller.abort()
     }
 
     function changed(event: GlobalEvent) {
@@ -142,7 +143,7 @@ export namespace TsClient {
         const task = run()
         // Unknown or slow checkers must not block the tool. The check keeps
         // running and the next tool call sees its result.
-        if (duration === undefined || duration > SLOW_CHECK_MS) return
+        if (duration !== undefined && duration > SLOW_CHECK_MS) return
         await withTimeout(task, WAIT_BUDGET_MS).catch(() => {
           log.debug("ts check still running, returning without diagnostics", { path: input.path })
         })

--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -266,7 +266,7 @@ const layer = Layer.effect(
               result.push(existing)
               continue
             }
-            const client = TsClient.create({ root })
+            const client = TsClient.create({ root, ctx })
             s.clients.push(client)
             result.push(client)
             updated++

--- a/packages/opencode/test/kilocode/lsp-typescript-lightweight.test.ts
+++ b/packages/opencode/test/kilocode/lsp-typescript-lightweight.test.ts
@@ -4,12 +4,17 @@
 
 import { describe, test, expect, spyOn, afterEach } from "bun:test"
 import path from "path"
+import { utimes } from "node:fs/promises"
+import { DiagnosticSeverity } from "vscode-languageserver-types"
 import * as LSPServer from "../../src/lsp/server"
 import { TsClient } from "../../src/kilocode/ts-client"
 import { TsCheck } from "../../src/kilocode/ts-check"
+import { GlobalBus } from "../../src/bus/global"
+import type { LSPClient } from "../../src/lsp/client"
+import { withTimeout } from "../../src/util/timeout"
 import { Flag } from "@opencode-ai/core/flag/flag"
-import { Instance, type InstanceContext } from "../../src/kilocode/instance"
-import { disposeAllInstances } from "../fixture/fixture"
+import type { InstanceContext } from "../../src/kilocode/instance"
+import { disposeAllInstances, tmpdir } from "../fixture/fixture"
 import type { RuntimeFlags } from "../../src/effect/runtime-flags"
 
 afterEach(async () => {
@@ -19,6 +24,55 @@ afterEach(async () => {
 // Typescript.spawn doesn't use ctx, so a cast-through is fine for these tests.
 const fakeCtx = {} as InstanceContext
 const fakeFlags = {} as RuntimeFlags.Info
+
+const diag: LSPClient.Diagnostic = {
+  severity: DiagnosticSeverity.Error,
+  message: "broken",
+  range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+}
+
+function checker(root: string, ctx?: InstanceContext) {
+  const signals = new Map<number, ReturnType<typeof Promise.withResolvers<void>>>()
+  const calls: Array<{
+    signal?: AbortSignal
+    result: ReturnType<typeof Promise.withResolvers<Map<string, LSPClient.Diagnostic[]> | undefined>>
+  }> = []
+  const spy = spyOn(TsCheck, "run").mockImplementation((_root, signal) => {
+    const result = Promise.withResolvers<Map<string, LSPClient.Diagnostic[]> | undefined>()
+    calls.push({ signal, result })
+    signals.get(calls.length - 1)?.resolve()
+    return result.promise
+  })
+  const client = TsClient.create({ root, ctx })
+  return {
+    client,
+    calls,
+    started(index: number) {
+      if (calls.at(index)) return Promise.resolve()
+      const signal = Promise.withResolvers<void>()
+      signals.set(index, signal)
+      return withTimeout(signal.promise, 1_000, "checker did not start")
+    },
+    async finish(index: number, result?: Map<string, LSPClient.Diagnostic[]>) {
+      calls.at(index)!.result.resolve(result)
+      // Drain the resolved check and its cleanup, without a timing-based sleep.
+      await new Promise<void>((resolve) => setImmediate(resolve))
+    },
+    async [Symbol.asyncDispose]() {
+      const stopped = client.shutdown()
+      for (const call of calls) call.result.resolve(undefined)
+      await stopped
+      spy.mockRestore()
+    },
+  }
+}
+
+function changed(directory: string, file: string, event: "change" | "add" | "unlink" = "change") {
+  GlobalBus.emit("event", {
+    directory,
+    payload: { type: "file.watcher.updated", properties: { file, event } },
+  })
+}
 
 describe("typescript lightweight mode", () => {
   describe("spawn gate", () => {
@@ -50,7 +104,7 @@ describe("typescript lightweight mode", () => {
   })
 
   describe("TsClient", () => {
-    test("create returns a valid LSPClient.Info", () => {
+    test("create returns a valid LSPClient.Info", async () => {
       const client = TsClient.create({ root: "/tmp/test" })
       expect(client.serverID).toBe("typescript")
       expect(client.root).toBe("/tmp/test")
@@ -58,17 +112,184 @@ describe("typescript lightweight mode", () => {
       expect(typeof client.shutdown).toBe("function")
       expect(typeof client.waitForDiagnostics).toBe("function")
       expect(typeof client.notify.open).toBe("function")
+      await client.shutdown()
     })
 
     test("connection.sendRequest rejects with descriptive error", async () => {
       const client = TsClient.create({ root: "/tmp/test" })
       await expect(client.connection.sendRequest("anything")).rejects.toThrow("lightweight diagnostic mode")
+      await client.shutdown()
     })
 
     test("shutdown clears diagnostics", async () => {
       const client = TsClient.create({ root: "/tmp/test" })
       await client.shutdown()
       expect(client.diagnostics.size).toBe(0)
+    })
+
+    test("does not block on the first check or start concurrent checkers for a multi-file patch", async () => {
+      await using tmp = await tmpdir()
+      const first = path.join(tmp.path, "a.ts")
+      const second = path.join(tmp.path, "b.ts")
+      for (const file of [first, second]) {
+        await Bun.write(file, "export const value = 1\n")
+        await utimes(file, 1, 1)
+      }
+      await using test = checker(tmp.path)
+      // Both calls must return before the controlled checker is released.
+      await test.client.waitForDiagnostics({ path: first, version: 1 })
+      await test.client.waitForDiagnostics({ path: second, version: 1 })
+      expect(test.calls).toHaveLength(1)
+      await test.finish(
+        0,
+        new Map([
+          [first, [diag]],
+          [second, [diag]],
+        ]),
+      )
+      await test.client.waitForDiagnostics({ path: "b.ts", version: 1 })
+      expect(test.calls).toHaveLength(1)
+      expect(test.client.diagnostics.size).toBe(2)
+    })
+
+    test("coalesces parallel writes into one follow-up check without publishing the superseded result", async () => {
+      await using tmp = await tmpdir()
+      const file = path.join(tmp.path, "a.ts")
+      await Bun.write(file, "export const value = 1\n")
+      await utimes(file, 1, 1)
+      await using test = checker(tmp.path)
+      await test.client.waitForDiagnostics({ path: file, version: 1 })
+      changed(tmp.path, file)
+      changed(tmp.path, path.join(tmp.path, "b.ts"), "add")
+      await test.client.waitForDiagnostics({ path: file, version: 2 })
+      expect(test.calls).toHaveLength(1)
+      await test.finish(0, new Map([[file, [diag]]]))
+      expect(test.client.diagnostics.size).toBe(0)
+      expect(test.calls).toHaveLength(2)
+      await test.finish(1, new Map([[file, [diag]]]))
+      await test.client.waitForDiagnostics({ path: file, version: 2 })
+      expect(test.calls).toHaveLength(2)
+      expect(test.client.diagnostics.get(file)).toEqual([diag])
+    })
+
+    test("a delayed notification does not reuse a result from before the write", async () => {
+      await using tmp = await tmpdir()
+      const file = path.join(tmp.path, "a.ts")
+      await Bun.write(file, "export const value = 1\n")
+      await utimes(file, 1, 1)
+      const clock = spyOn(Date, "now").mockReturnValue(2_000)
+      await using test = checker(tmp.path)
+      try {
+        await test.client.waitForDiagnostics({ path: file, version: 1 })
+        // The checker read the old file before a write, then finished later.
+        await utimes(file, 2.5, 2.5)
+        clock.mockReturnValue(3_000)
+        await test.finish(0, new Map([[file, [diag]]]))
+        clock.mockReturnValue(4_000)
+        const waiting = test.client.waitForDiagnostics({ path: file, version: 2 })
+        await test.started(1)
+        expect(test.calls).toHaveLength(2)
+        expect(test.client.diagnostics.size).toBe(0)
+        await test.finish(1, new Map())
+        await waiting
+        expect(test.client.diagnostics.size).toBe(0)
+      } finally {
+        clock.mockRestore()
+      }
+    })
+
+    test("failed checks remain retryable for unchanged files without an automatic retry loop", async () => {
+      await using tmp = await tmpdir()
+      const file = path.join(tmp.path, "a.ts")
+      await Bun.write(file, "export const value = 1\n")
+      await utimes(file, 1, 1)
+      await using test = checker(tmp.path)
+      await test.client.waitForDiagnostics({ path: file, version: 1 })
+      await test.finish(0, undefined)
+      expect(test.calls).toHaveLength(1)
+      const waiting = test.client.waitForDiagnostics({ path: file, version: 1 })
+      await test.started(1)
+      expect(test.calls).toHaveLength(2)
+      await test.finish(1, new Map([[file, [diag]]]))
+      await waiting
+      expect(test.client.diagnostics.get(file)).toEqual([diag])
+    })
+
+    test("move and delete events invalidate old project errors without touching the removed source", async () => {
+      await using tmp = await tmpdir()
+      const file = path.join(tmp.path, "a.ts")
+      await Bun.write(file, "export const value = 1\n")
+      await utimes(file, 1, 1)
+      await using test = checker(tmp.path)
+      await test.client.waitForDiagnostics({ path: file, version: 1 })
+      await test.finish(0, new Map([[file, [diag]]]))
+      changed("/another/worktree", file, "unlink")
+      expect(test.client.diagnostics.has(file)).toBe(true)
+      changed(tmp.path, path.join(tmp.path, "tsconfig.tsbuildinfo"))
+      expect(test.client.diagnostics.has(file)).toBe(true)
+      changed(tmp.path, file, "unlink")
+      changed(tmp.path, path.join(tmp.path, "renamed.ts"), "add")
+      expect(test.client.diagnostics.size).toBe(0)
+      expect(test.calls).toHaveLength(1)
+    })
+
+    test("a failed refresh cannot restore old project errors or mark the cache fresh", async () => {
+      await using tmp = await tmpdir()
+      const file = path.join(tmp.path, "a.ts")
+      await Bun.write(file, "export const value = 1\n")
+      await utimes(file, 1, 1)
+      await using test = checker(tmp.path)
+      await test.client.waitForDiagnostics({ path: file, version: 1 })
+      await test.finish(0, new Map([[file, [diag]]]))
+      changed(tmp.path, file, "unlink")
+      const waiting = test.client.waitForDiagnostics({ path: file, version: 2 })
+      await test.started(1)
+      expect(test.client.diagnostics.size).toBe(0)
+      await test.finish(1, undefined)
+      await waiting
+      const retry = test.client.waitForDiagnostics({ path: file, version: 2 })
+      await test.started(2)
+      await test.finish(2, new Map())
+      await retry
+      expect(test.client.diagnostics.size).toBe(0)
+    })
+
+    test("shutdown aborts the checker, drops late results, and removes its event listener", async () => {
+      await using tmp = await tmpdir()
+      const count = GlobalBus.listenerCount("event")
+      await using test = checker(tmp.path)
+      await test.client.waitForDiagnostics({ path: "a.ts", version: 1 })
+      const stopped = test.client.shutdown()
+      expect(test.calls.at(0)!.signal?.aborted).toBe(true)
+      changed(tmp.path, path.join(tmp.path, "a.ts"))
+      await test.finish(0, new Map([[path.join(tmp.path, "a.ts"), [diag]]]))
+      await stopped
+      await test.client.waitForDiagnostics({ path: "a.ts", version: 2 })
+      expect(test.calls).toHaveLength(1)
+      expect(test.client.diagnostics.size).toBe(0)
+      expect(GlobalBus.listenerCount("event")).toBe(count)
+    })
+
+    test("routes invalidations by the supplied instance directory rather than the checker root", async () => {
+      await using tmp = await tmpdir()
+      const root = path.join(tmp.path, "package")
+      const file = path.join(root, "a.ts")
+      await Bun.write(file, "export const value = 1\n")
+      await utimes(file, 1, 1)
+      // The production caller passes ctx after async process/root discovery.
+      await Promise.resolve()
+      await using test = checker(root, { ...fakeCtx, directory: tmp.path })
+      await test.client.waitForDiagnostics({ path: file, version: 1 })
+      await test.finish(0, new Map())
+      changed(root, file)
+      await test.client.waitForDiagnostics({ path: "package/a.ts", version: 1 })
+      expect(test.calls).toHaveLength(1)
+      changed(tmp.path, file)
+      const waiting = test.client.waitForDiagnostics({ path: "package/a.ts", version: 2 })
+      await test.started(1)
+      await test.finish(1, new Map())
+      await waiting
+      expect(test.calls).toHaveLength(2)
     })
   })
 
@@ -85,6 +306,7 @@ describe("typescript lightweight mode", () => {
     test("lsp/lsp.ts uses TsClient for lightweight diagnostics", async () => {
       const src = await Bun.file(path.resolve(import.meta.dir, "../../src/lsp/lsp.ts")).text()
       expect(src).toContain("TsClient.create")
+      expect(src).toContain("TsClient.create({ root, ctx })")
       expect(src).toContain("flags.experimentalLspTool")
     })
   })

--- a/packages/opencode/test/kilocode/ts-check.test.ts
+++ b/packages/opencode/test/kilocode/ts-check.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test"
+import { watch } from "node:fs"
+import fs from "fs/promises"
+import path from "path"
+import { TsCheck } from "../../src/kilocode/ts-check"
+import { Filesystem } from "../../src/util/filesystem"
+import { tmpdir } from "../fixture/fixture"
+
+async function checker(root: string, input: { code?: number; stdout?: string; stderr?: string; wait?: boolean } = {}) {
+  const script = path.join(root, "node_modules", "typescript", "bin", "tsc.js")
+  const file =
+    process.platform === "win32"
+      ? path.join(root, "node_modules", ".bin", "tsc.cmd")
+      : path.join(root, "node_modules", "typescript", "bin", "tsc")
+  const ready = path.join(root, "checker-ready")
+  const done = path.join(root, "checker-done")
+  const body = input.wait
+    ? `await Bun.write(${JSON.stringify(ready)}, "")
+process.on("SIGTERM", async () => {
+  await Bun.write(${JSON.stringify(done)}, "")
+  process.exit(143)
+})
+setInterval(() => {}, 1000)
+`
+    : `process.stdout.write(${JSON.stringify(input.stdout ?? "")})
+process.stderr.write(${JSON.stringify(input.stderr ?? "")})
+process.exitCode = ${input.code ?? 0}
+`
+  await fs.mkdir(path.dirname(script), { recursive: true })
+  await Bun.write(script, body)
+  if (process.platform === "win32") {
+    await fs.mkdir(path.dirname(file), { recursive: true })
+    await Bun.write(file, `@echo off\r\n"${process.execPath}" "${script}" %*\r\n`)
+  } else {
+    await Bun.write(file, `#!/usr/bin/env bun\n${body}`)
+    await fs.chmod(file, 0o755)
+  }
+  return { file, ready, done }
+}
+
+async function waitFile(file: string) {
+  if (await Bun.file(file).exists()) return
+
+  const gate = Promise.withResolvers<void>()
+  const watcher = watch(path.dirname(file), { persistent: false }, (_event, name) => {
+    if (name?.toString() === path.basename(file)) gate.resolve()
+  })
+  watcher.once("error", gate.reject)
+  if (await Bun.file(file).exists()) gate.resolve()
+  const timer = setTimeout(() => gate.reject(new Error(`Timed out waiting for ${file}`)), 5_000)
+  try {
+    await gate.promise
+  } finally {
+    clearTimeout(timer)
+    watcher.close()
+  }
+}
+
+describe("TsCheck", () => {
+  test("returns an empty map for a clean checker", async () => {
+    await using tmp = await tmpdir()
+    await checker(tmp.path)
+
+    const result = await TsCheck.run(tmp.path)
+
+    expect(result).toEqual(new Map())
+  })
+
+  test("keeps parsed file diagnostics from a nonzero checker", async () => {
+    await using tmp = await tmpdir()
+    const file = path.join(tmp.path, "src", "broken.ts")
+    await fs.mkdir(path.dirname(file), { recursive: true })
+    await Bun.write(file, "const value: string = 1\n")
+    await checker(tmp.path, {
+      code: 2,
+      stdout: "src/broken.ts(1,7): error TS2322: Type 'number' is not assignable to type 'string'.\n",
+    })
+
+    const result = await TsCheck.run(tmp.path)
+    const items = result?.get(Filesystem.normalizePath(file))
+
+    expect(items).toHaveLength(1)
+    expect(items?.[0]?.code).toBe("TS2322")
+    expect(items?.[0]?.message).toContain("not assignable")
+  })
+
+  test("does not treat a failed checker without file diagnostics as clean", async () => {
+    await using tmp = await tmpdir()
+    await checker(tmp.path, { code: 1, stderr: "checker failed\n" })
+
+    expect(await TsCheck.run(tmp.path)).toBeUndefined()
+  })
+
+  test("does not treat a global compiler error as clean", async () => {
+    await using tmp = await tmpdir()
+    await checker(tmp.path, {
+      code: 1,
+      stdout: "error TS18003: No inputs were found in config file 'tsconfig.json'.\n",
+    })
+
+    expect(await TsCheck.run(tmp.path)).toBeUndefined()
+  })
+
+  test("returns undefined when already aborted", async () => {
+    await using tmp = await tmpdir()
+    const fixture = await checker(tmp.path, { stdout: "started\n" })
+    const signal = new AbortController()
+    signal.abort()
+
+    expect(await TsCheck.run(tmp.path, signal.signal)).toBeUndefined()
+    expect(await Bun.file(fixture.ready).exists()).toBe(false)
+  })
+
+  test("kills and reaps an aborted checker", async () => {
+    if (process.platform === "win32") return
+
+    await using tmp = await tmpdir()
+    const fixture = await checker(tmp.path, { wait: true })
+    const signal = new AbortController()
+    const task = TsCheck.run(tmp.path, signal.signal)
+
+    try {
+      await waitFile(fixture.ready)
+      signal.abort()
+      expect(await task).toBeUndefined()
+      await waitFile(fixture.done)
+    } finally {
+      signal.abort()
+      await task
+    }
+  }, 10_000)
+
+  test("a timed-out checker returns failure and is reaped", async () => {
+    if (process.platform === "win32") return
+
+    await using tmp = await tmpdir()
+    const fixture = await checker(tmp.path, { wait: true })
+    const signal = new AbortController()
+    const task = TsCheck.run(tmp.path, signal.signal)
+    try {
+      await waitFile(fixture.ready)
+      expect(await task).toBeUndefined()
+      expect(await Bun.file(fixture.done).exists()).toBe(true)
+    } finally {
+      signal.abort()
+      await task
+    }
+  }, 45_000)
+})


### PR DESCRIPTION
## What Problem This Solves

TypeScript diagnostics could block file edits for the full checker timeout. In this worktree, the root checker took 28 seconds cold and 6 seconds warm, even though the edit itself was otherwise fast. Parallel edits, failed checks, moves, and deletes could also leave stale or missing diagnostics.

## Why This Change Was Made

- Keep edit, write, and multi-file patch operations on a bounded response-critical path.
- Coalesce background checks and retry after writes that race an active check.
- Treat missing, failed, timed-out, and aborted checks as failures rather than clean results.
- Invalidate diagnostics on file edit, watcher update, move, and delete events.
- Pass the instance context explicitly when creating nested TypeScript clients so event routing works across worktrees and project roots.
- Add subprocess and concurrency regression coverage.
- Add forced checker cleanup so shutdown and timeout cannot leave a child process or pipe rejection behind.

## User Impact

File edits return promptly while diagnostics continue in the background. Fast checkers can still provide fresh diagnostics within the bounded wait. Slow or failed checkers no longer block edits or poison the cache with clean results. Multi-file patches reuse one checker run and schedule one coalesced refresh when writes race the check.

## Evidence

Focused checks:

- `bun test ./test/kilocode/lsp-typescript-lightweight.test.ts ./test/kilocode/ts-check.test.ts`, 22 passed.
- `bun run typecheck`, passed.
- `bunx prettier --check src/kilocode/ts-client.ts src/kilocode/ts-check.ts test/kilocode/lsp-typescript-lightweight.test.ts test/kilocode/ts-check.test.ts`, passed.
- `bun run script/check-opencode-annotations.ts --worktree`, passed.

Self-test measurements used the same isolated Agent Manager fixture, scripted 2000 ms model delay, native tsgo, formatter disabled, and warm session setup. The before capture used an `origin/main` baseline build. The after capture used the rebuilt PR code. The first sample in each four-run sequence was excluded as cold warm-up.

| Tool | Before warm mean | After warm mean | Change |
|---|---:|---:|---:|
| `edit` | 59.0 ms | 59.0 ms | 0.0% |
| `write` | 177.7 ms | 90.7 ms | 48.9% faster |
| two-file `apply_patch` | 156.3 ms | 69.7 ms | 55.4% faster |

Per-sample `edit` changes were 7.7% faster, 31.4% slower, and 22.3% faster, with no net mean regression. The after `apply_patch` series included a 186 ms outlier; it is retained in the evidence rather than hidden.

## Review Resolution

The automated review findings were addressed in commit `8051158bcc`:

- First checks now receive the same bounded wait as later fast checks.
- Invalidations abort the active checker so a follow-up check does not wait behind a stale 30-second process.
- Timeout, abort, and child-pipe cleanup use a grace period followed by force-kill and reaping.
- Failed checks remain retryable and cannot mark the diagnostics cache fresh.
- Instance context and relative paths are routed correctly for nested TypeScript roots.
