### PR TITLE
fix(vscode): smooth reasoning block transitions

### DIFF
--- a/.changeset/reasoning-collapse-flicker.md
+++ b/.changeset/reasoning-collapse-flicker.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Smooth out reasoning blocks with auto-collapse enabled: the streaming viewport scrolls smoothly without a flickering scrollbar, finished blocks rest in place instead of jumping and collapsing, and new tool calls grow in instead of popping.

--- a/packages/kilo-ui/src/components/message-part.css
+++ b/packages/kilo-ui/src/components/message-part.css
@@ -514,30 +514,6 @@ html[data-theme="kilo-vscode"] [data-component="todos"] {
   }
 }
 
-@keyframes reasoning-card-down {
-  from {
-    grid-template-rows: 0fr;
-    opacity: 0;
-  }
-
-  to {
-    grid-template-rows: 1fr;
-    opacity: 1;
-  }
-}
-
-@keyframes reasoning-card-up {
-  from {
-    grid-template-rows: 1fr;
-    opacity: 1;
-  }
-
-  to {
-    grid-template-rows: 0fr;
-    opacity: 0;
-  }
-}
-
 /* Reasoning block: visually distinct from normal agent output.
    Reasoning stays open unless the user explicitly collapses it. */
 [data-component="reasoning-part"] {
@@ -620,38 +596,46 @@ html[data-theme="kilo-vscode"] [data-component="todos"] {
   }
 
   [data-slot="collapsible-content"] {
-    display: grid;
-    overflow: hidden;
-
-    > * {
-      min-height: 0;
-      overflow: hidden;
-    }
-
-    &[data-expanded] {
-      animation: reasoning-card-down 220ms cubic-bezier(0.23, 1, 0.32, 1);
-    }
-
-    &[data-closed] {
-      animation: reasoning-card-up 160ms cubic-bezier(0.77, 0, 0.175, 1);
-    }
+    display: block;
+    overflow: visible;
+    transition: none;
+    animation: none;
   }
 
   /* Streaming state: keep the block open while content grows. */
   &[data-streaming] {
-    &[data-auto-collapse] [data-slot="reasoning-content"] {
-      max-height: 120px;
-      overflow-y: auto;
-      scroll-behavior: smooth;
-      mask-image: linear-gradient(to bottom, transparent 0%, black 12px, black 85%, transparent 100%);
-      -webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 12px, black 85%, transparent 100%);
-    }
-
     /* Pulse the brain icon while streaming */
     [data-slot="reasoning-header"] [data-component="icon"] {
       animation: reasoning-pulse 2s ease-in-out infinite;
     }
   }
+}
+
+html[data-theme="kilo-vscode"]
+  [data-component="reasoning-part"][data-auto-collapse]:not([data-manual])
+  [data-slot="reasoning-content"] {
+  max-height: 120px;
+  overflow-y: auto;
+  /* The viewport follows the stream on its own; a scrollbar that appears and
+     disappears with every chunk only adds flicker. */
+  scrollbar-width: none;
+  /* Finished blocks rest in this viewport scrolled to the end, so only the
+     top edge fades; the streaming rule below also fades the bottom. */
+  mask-image: linear-gradient(to bottom, transparent 0%, black 12px);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 12px);
+}
+
+html[data-theme="kilo-vscode"]
+  [data-component="reasoning-part"][data-auto-collapse][data-streaming]:not([data-manual])
+  [data-slot="reasoning-content"] {
+  mask-image: linear-gradient(to bottom, transparent 0%, black 12px, black 85%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0%, black 12px, black 85%, transparent 100%);
+}
+
+html[data-theme="kilo-vscode"]
+  [data-component="reasoning-part"][data-auto-collapse]:not([data-manual])
+  [data-slot="reasoning-content"]::-webkit-scrollbar {
+  display: none;
 }
 
 html[data-theme="kilo-vscode"] [data-component="text-part"] {
@@ -784,36 +768,5 @@ html[data-theme="kilo-vscode"] [data-component="reasoning-part"] {
     color: var(--text-weak);
     opacity: 0.9;
     line-height: var(--line-height-large);
-  }
-}
-
-/* The shared collapsible turns overflow visible when expanded, which let the
-   reasoning markdown spill below its box for a frame while the height changed.
-   Clip it at the box instead, and give the auto-collapse at the end of a
-   reasoning block a real animation, so the transcript slides instead of
-   jumping when a tall block closes. */
-[data-component="reasoning-part"] [data-slot="collapsible-content"][data-expanded] {
-  overflow: clip;
-}
-
-[data-component="reasoning-part"] [data-slot="collapsible-content"][data-closed] {
-  overflow: clip;
-  animation: kilo-reasoning-close 180ms ease-out;
-}
-
-@keyframes kilo-reasoning-close {
-  from {
-    height: var(--kb-collapsible-content-height);
-  }
-
-  to {
-    height: 0;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  [data-component="reasoning-part"] [data-slot="collapsible-content"][data-expanded],
-  [data-component="reasoning-part"] [data-slot="collapsible-content"][data-closed] {
-    animation-duration: 0.01ms;
   }
 }

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -12,6 +12,7 @@ import {
   type JSX,
 } from "solid-js"
 import stripAnsi from "strip-ansi"
+import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { createStore } from "solid-js/store"
 import { Dynamic } from "solid-js/web"
 import {
@@ -55,11 +56,12 @@ import { ToolApprovalProvider, resolveToolApproval, useToolApproval } from "./to
 export { ToolApprovalProvider, resolveToolApproval, ToolApprovalVisibilityProvider } from "./tool-approval"
 import { GrowBox } from "./grow-box"
 import { COLLAPSIBLE_SPRING } from "./motion"
-import { busy, createThrottledValue, useToolFade, useContextToolPending } from "./tool-utils"
+import { busy, createThrottledValue, useCollapsible, useToolFade, useContextToolPending } from "./tool-utils"
+export { useGrowIn } from "./tool-utils"
 import { readToolOpen, toolOpenKey } from "./tool-open-state"
 import { ContextToolGroupHeader, ContextToolExpandedList, ContextToolRollingResults } from "./context-tool-results"
 import { ShellRollingResults } from "./shell-rolling-results"
-import { reasoningHeading } from "./reasoning-heading"
+import { reasoningHeading, reasoningSummary } from "./reasoning-heading"
 import { extractFilePathFromHref } from "@opencode-ai/ui/file-path"
 import { normalize } from "./session-diff"
 import { deferredHighlight } from "../context/marked"
@@ -1770,13 +1772,13 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
   )
 }
 
-// Expanded mode tracks explicit user collapses so reactive or virtualized
+// Both modes track explicit user collapses so reactive or virtualized
 // remounts do not reopen a block the user closed.
 const userCollapsed = new Set<string>()
-// Auto-collapse mode preserves the original flow: streaming blocks open,
-// completed blocks collapse once, and manual opens survive later remounts.
+// Auto-collapse mode: blocks that streamed in this session stay open in the
+// capped viewport (nothing moves when reasoning ends), blocks loaded from
+// history start collapsed, and manual opens survive later remounts.
 const streamed = new Set<string>()
-const autocollapsed = new Set<string>()
 const userOpened = new Set<string>()
 const MAX_REASONING_STATE = 1000
 
@@ -1801,18 +1803,6 @@ PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props: MessagePartProp
     return (p.text ?? "").replace("[REDACTED]", "").trim()
   }
 
-  // Throttle markdown re-renders during streaming
-  const display = createThrottledValue(text)
-  const view = createMemo(() => reasoningHeading(display()))
-
-  const Header = () => (
-    <div data-slot="reasoning-header">
-      <Icon name="brain" size="small" />
-      <span data-slot="reasoning-label">{i18n.t("ui.reasoning.label" as never)}</span>
-      <Show when={view().title}>{(title) => <span data-slot="reasoning-title">{title()}</span>}</Show>
-    </div>
-  )
-
   // time.end is set by the processor on reasoning-end.
   // v1 parts lack time entirely → treat as historical.
   const done = () => {
@@ -1820,52 +1810,60 @@ PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props: MessagePartProp
     return !t || !!t.end
   }
 
+  // Throttle markdown re-renders during streaming
+  const display = createThrottledValue(text)
+  const view = createMemo(() => reasoningHeading(display(), !done()))
+
   const id = (props.part as any).id as string
-  const was = streamed.has(id)
   if (!done()) rememberReasoningState(streamed, id)
 
-  // Auto-collapse mode: streaming -> open, just-finished -> open briefly then
-  // collapse, historical -> collapsed. Expanded mode: open unless the user
-  // explicitly collapsed this reasoning part.
-  const initial = props.reasoningAutoCollapse ? !done() || was || userOpened.has(id) : !userCollapsed.has(id)
+  // Auto-collapse mode: streaming or streamed this session -> open (capped),
+  // historical -> collapsed, unless the user toggled it. Expanded mode: open
+  // unless the user explicitly collapsed this reasoning part.
+  const initial = props.reasoningAutoCollapse
+    ? !userCollapsed.has(id) && (streamed.has(id) || userOpened.has(id))
+    : !userCollapsed.has(id)
   const [open, setOpen] = createSignal(initial)
+  const [manual, setManual] = createSignal(props.reasoningAutoCollapse && userOpened.has(id))
+  const title = createMemo(() => {
+    const value = view().title
+    if (value) return value
+    if (!done() || open()) return ""
+    return reasoningSummary(view().body)
+  })
+
+  const Header = () => (
+    <div data-slot="reasoning-header">
+      <Icon name="brain" size="small" />
+      <span data-slot="reasoning-label">{i18n.t("ui.reasoning.label" as never)}</span>
+      <Show when={title()}>{(value) => <span data-slot="reasoning-title">{value()}</span>}</Show>
+    </div>
+  )
 
   const track = (value: boolean) => {
+    if (value) userCollapsed.delete(id)
+    else rememberReasoningState(userCollapsed, id)
     if (props.reasoningAutoCollapse) {
       if (value) rememberReasoningState(userOpened, id)
       else userOpened.delete(id)
-      setOpen(value)
-      return
+      setManual(value)
     }
-
-    if (value) userCollapsed.delete(id)
-    else rememberReasoningState(userCollapsed, id)
     setOpen(value)
   }
 
   // Reasoning has no built-in "force open" hook (unlike BasicTool's forceOpen
-  // ratchet) — mirror that one-way-open behavior here so jumping a chat
+  // ratchet) - mirror that one-way-open behavior here so jumping a chat
   // search match to a collapsed reasoning block reveals it, the same as it
   // does for tool calls. Recorded into userOpened/userCollapsed the same way
   // a manual open would be, so it stays open across remounts/re-renders.
   createEffect(() => {
     if (!props.forceOpen || open()) return
-    if (props.reasoningAutoCollapse) rememberReasoningState(userOpened, id)
-    else userCollapsed.delete(id)
-    setOpen(true)
-  })
-
-  createEffect(() => {
-    if (!props.reasoningAutoCollapse) return
-    // Skip auto-collapse for blocks the user explicitly opened.
-    if (done() && open() && !autocollapsed.has(id) && !userOpened.has(id)) {
-      rememberReasoningState(autocollapsed, id)
-      setOpen(false)
+    userCollapsed.delete(id)
+    if (props.reasoningAutoCollapse) {
+      rememberReasoningState(userOpened, id)
+      setManual(true)
     }
-  })
-
-  onCleanup(() => {
-    if (done()) streamed.delete(id)
+    setOpen(true)
   })
 
   // Auto-scroll the content container while streaming.
@@ -1873,8 +1871,34 @@ PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props: MessagePartProp
   // effect: by the time the effect runs the DOM has already grown, so reading
   // scrollHeight post-update incorrectly reports the user as scrolled away
   // whenever a streaming chunk is > 10px tall.
+  let content: HTMLDivElement | undefined
+  let frame: HTMLDivElement | undefined
   let ref: HTMLDivElement | undefined
+  let body: HTMLDivElement | undefined
   let scrolled = false
+  let follow: number | undefined
+
+  const stop = () => {
+    if (follow === undefined) return
+    cancelAnimationFrame(follow)
+    follow = undefined
+  }
+
+  const [mounted, setMounted] = createSignal(initial)
+  createEffect(() => {
+    if (open()) setMounted(true)
+  })
+
+  // The content mounts in its initial state without an animation so streaming
+  // blocks are not clipped at a stale measured height and historical blocks
+  // do not animate in on every virtualized remount. The measured close runs
+  // from the live (capped) height, so the auto-collapse never jumps.
+  useCollapsible({
+    content: () => content,
+    body: () => frame,
+    open,
+    defer: true,
+  })
 
   const onScroll = (e: Event) => {
     const el = e.currentTarget as HTMLDivElement
@@ -1882,14 +1906,35 @@ PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props: MessagePartProp
   }
 
   const onWheel = (e: WheelEvent) => {
-    if (e.deltaY < 0) scrolled = true
+    if (e.deltaY < 0) {
+      scrolled = true
+      stop()
+    }
   }
 
-  createEffect(() => {
-    display()
-    if (!done() && ref && !scrolled) {
-      ref.scrollTop = ref.scrollHeight
+  const tick = () => {
+    follow = undefined
+    if (done() || scrolled || !ref) return
+    const target = Math.max(0, ref.scrollHeight - ref.clientHeight)
+    const rest = target - ref.scrollTop
+    if (Math.abs(rest) < 0.5) {
+      ref.scrollTop = target
+      return
     }
+    ref.scrollTop += rest * 0.25
+    follow = requestAnimationFrame(tick)
+  }
+
+  createResizeObserver(
+    () => body,
+    () => {
+      if (done() || !ref || scrolled || follow !== undefined) return
+      follow = requestAnimationFrame(tick)
+    },
+  )
+
+  onCleanup(() => {
+    stop()
   })
 
   return (
@@ -1898,24 +1943,36 @@ PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props: MessagePartProp
         data-component="reasoning-part"
         data-streaming={!done() ? "" : undefined}
         data-auto-collapse={props.reasoningAutoCollapse ? "" : undefined}
+        data-manual={manual() ? "" : undefined}
       >
         <Show
-          when={view().body}
+          when={view().body || !done()}
           fallback={
             <div data-slot="collapsible-trigger" data-static="">
               <Header />
             </div>
           }
         >
-          <Collapsible open={open()} onOpenChange={track} class="tool-collapsible">
+          {/* forceMount keeps the content mounted so useCollapsible can measure
+              the live height on close instead of Kobalte presence unmounting it. */}
+          <Collapsible open={open()} onOpenChange={track} forceMount class="tool-collapsible">
             <Collapsible.Trigger>
               <Header />
               <Collapsible.Arrow />
             </Collapsible.Trigger>
             <Collapsible.Content>
-              <div data-slot="reasoning-details">
-                <div data-slot="reasoning-content" ref={ref} onScroll={onScroll} onWheel={onWheel}>
-                  <Markdown text={view().body} cacheKey={id} streaming={!done()} />
+              <div
+                ref={content}
+                style={{ overflow: "clip", height: initial ? "auto" : "0px", display: initial ? "" : "none" }}
+              >
+                <div ref={frame} data-slot="reasoning-details">
+                  <div data-slot="reasoning-content" ref={ref} onScroll={onScroll} onWheel={onWheel}>
+                    <div data-slot="reasoning-body" ref={body}>
+                      <Show when={mounted()}>
+                        <Markdown text={view().body} cacheKey={id} streaming={!done()} />
+                      </Show>
+                    </div>
+                  </div>
                 </div>
               </div>
             </Collapsible.Content>
@@ -2169,9 +2226,9 @@ ToolRegistry.register({
               animate={props.reveal}
               onClick={data.openFile ? () => data.openFile!(filepath) : undefined}
             />
-    )}
+          )}
         </For>
-      <Show when={images().length > 0}>
+        <Show when={images().length > 0}>
           <div data-slot="tool-read-images">
             <For each={images()}>
               {(file) => (
@@ -2904,24 +2961,26 @@ ToolRegistry.register({
       const diffs = files().flatMap((file) => {
         const diff = view(file)
         return diff
-          ? [{
-              file: file.relativePath,
-              patch: diff.patch,
-              status:
-                file.type === "add"
-                  ? ("added" as const)
-                  : file.type === "delete"
-                    ? ("deleted" as const)
-                    : ("modified" as const),
-              additions:
-                file.type === "add" && diff.additions === 0
-                  ? diff.fileDiff.hunks.reduce((sum, hunk) => sum + hunk.additionLines, 0)
-                  : diff.additions,
-              deletions:
-                file.type === "delete" && diff.deletions === 0
-                  ? diff.fileDiff.hunks.reduce((sum, hunk) => sum + hunk.deletionLines, 0)
-                  : diff.deletions,
-            }]
+          ? [
+              {
+                file: file.relativePath,
+                patch: diff.patch,
+                status:
+                  file.type === "add"
+                    ? ("added" as const)
+                    : file.type === "delete"
+                      ? ("deleted" as const)
+                      : ("modified" as const),
+                additions:
+                  file.type === "add" && diff.additions === 0
+                    ? diff.fileDiff.hunks.reduce((sum, hunk) => sum + hunk.additionLines, 0)
+                    : diff.additions,
+                deletions:
+                  file.type === "delete" && diff.deletions === 0
+                    ? diff.fileDiff.hunks.reduce((sum, hunk) => sum + hunk.deletionLines, 0)
+                    : diff.deletions,
+              },
+            ]
           : []
       })
       const first = diffs[0]
@@ -3070,11 +3129,7 @@ ToolRegistry.register({
                                       <span data-slot="apply-patch-directory">{`\u2066${getDirectory(file.relativePath)}\u2069`}</span>
                                     </Show>
 
-                                    <span
-                                      data-slot="apply-patch-filename"
-                                    >
-                                      {getFilename(file.relativePath)}
-                                    </span>
+                                    <span data-slot="apply-patch-filename">{getFilename(file.relativePath)}</span>
                                   </div>
                                 </div>
                                 <div data-slot="apply-patch-trigger-actions">

--- a/packages/kilo-ui/src/components/reasoning-heading.test.ts
+++ b/packages/kilo-ui/src/components/reasoning-heading.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { reasoningHeading } from "./reasoning-heading"
+import { reasoningHeading, reasoningSummary } from "./reasoning-heading"
 
 describe("reasoning heading", () => {
   test("promotes a leading strong line into the title", () => {
@@ -7,6 +7,19 @@ describe("reasoning heading", () => {
       title: "Counting distinct users",
       body: "I should aggregate the fixed version first.",
     })
+  })
+
+  test("promotes an unfinished strong line while streaming", () => {
+    expect(reasoningHeading("**Assessing the", true)).toEqual({ title: "Assessing the", body: "" })
+  })
+
+  test("keeps an unfinished strong line in the body when complete", () => {
+    expect(reasoningHeading("**Assessing the")).toEqual({ body: "**Assessing the" })
+  })
+
+  test("keeps multiline unfinished strong text in the body while streaming", () => {
+    const text = "**Assessing the\nnext possibility"
+    expect(reasoningHeading(text, true)).toEqual({ body: text })
   })
 
   test("promotes heading syntax and keeps the remaining markdown", () => {
@@ -71,7 +84,9 @@ describe("reasoning heading", () => {
   })
 
   test("preserves reasoning after an interrupted HTML comment", () => {
-    expect(reasoningHeading("**Assessing search behavior**\n\n<!--\nActually reconsider the alternate endpoint.")).toEqual({
+    expect(
+      reasoningHeading("**Assessing search behavior**\n\n<!--\nActually reconsider the alternate endpoint."),
+    ).toEqual({
       title: "Assessing search behavior",
       body: "Actually reconsider the alternate endpoint.",
     })
@@ -79,5 +94,21 @@ describe("reasoning heading", () => {
 
   test("treats a titleless placeholder comment as empty", () => {
     expect(reasoningHeading("<!-- -->")).toEqual({ body: "" })
+  })
+
+  test("cuts a summary at the first sentence", () => {
+    expect(reasoningSummary("Inspect the query. Then compare the results.")).toBe("Inspect the query.")
+  })
+
+  test("truncates a long summary at a word boundary", () => {
+    const text =
+      "This is a deliberately long reasoning summary that should stop cleanly at the last complete word before the limit"
+    expect(reasoningSummary(text)).toBe(
+      "This is a deliberately long reasoning summary that should stop cleanly at the last…",
+    )
+  })
+
+  test("strips markdown from a summary", () => {
+    expect(reasoningSummary("Review **the `query`** before continuing.")).toBe("Review the query before continuing.")
   })
 })

--- a/packages/kilo-ui/src/components/reasoning-heading.ts
+++ b/packages/kilo-ui/src/components/reasoning-heading.ts
@@ -36,8 +36,18 @@ function pick(src: string, expr: RegExp, group = 1): ReasoningHeading | undefine
   }
 }
 
-export function reasoningHeading(text: string): ReasoningHeading {
+export function reasoningHeading(text: string, partial = false): ReasoningHeading {
   const src = text.replace(/\r\n?/g, "\n").trim()
+  if (partial && !src.includes("\n")) {
+    const mark = src.startsWith("**") ? "**" : src.startsWith("__") ? "__" : ""
+    if (mark && !src.endsWith(mark)) {
+      return {
+        title: clean(src.slice(mark.length)),
+        body: "",
+      }
+    }
+  }
+
   return (
     pick(src, /^<h[1-6][^>]*>([\s\S]*?)<\/h[1-6]>[ \t]*(?:\n|$)?/i) ??
     pick(src, /^#{1,6}[ \t]+([^\n]+?)(?:[ \t]+#+[ \t]*)?(?:\n|$)/) ??
@@ -46,4 +56,23 @@ export function reasoningHeading(text: string): ReasoningHeading {
       body: visible(src),
     }
   )
+}
+
+export function reasoningSummary(body: string): string {
+  const line = body
+    .split("\n")
+    .map((item) => item.trim())
+    .find((item) => item.length > 0)
+  if (!line) return ""
+
+  const text = clean(line)
+  if (!text) return ""
+
+  const end = text.search(/[.!?](?:\s|$)/)
+  if (end !== -1 && end + 1 <= 90) return text.slice(0, end + 1)
+  if (text.length <= 90) return text
+
+  const head = text.slice(0, 90).trimEnd()
+  const cut = head.lastIndexOf(" ")
+  return `${(cut > 0 ? head.slice(0, cut) : head).trimEnd()}…`
 }

--- a/packages/kilo-ui/src/components/tool-utils.ts
+++ b/packages/kilo-ui/src/components/tool-utils.ts
@@ -105,14 +105,21 @@ export function useCollapsible(options: {
   open: () => boolean
   measure?: () => number
   onOpen?: () => void
+  // Skip the mount run so content rendered in its initial state does not
+  // animate in; the caller renders the matching inline styles itself.
+  defer?: boolean
 }) {
   const reduce = useReducedMotion()
   let heightAnim: AnimationPlaybackControls | undefined
   let fadeAnim: AnimationPlaybackControls | undefined
   let gen = 0
+  let first = true
 
   createEffect(
     on(options.open, (isOpen) => {
+      const skip = first && options.defer
+      first = false
+      if (skip) return
       const content = options.content()
       const body = options.body()
       if (!content || !body) return
@@ -173,6 +180,68 @@ export function useCollapsible(options: {
     ++gen
     heightAnim?.stop()
     fadeAnim?.stop()
+  })
+}
+
+export function useGrowIn(el: () => HTMLElement | undefined, enabled: boolean) {
+  const reduce = useReducedMotion()
+  let height: AnimationPlaybackControls | undefined
+  let obs: ResizeObserver | undefined
+  let gen = 0
+
+  // Height only: the parts reveal their own text with useToolFade, and a
+  // wrapper fade would hide that wipe.
+  const clear = (node: HTMLElement) => {
+    node.style.height = ""
+    node.style.overflow = ""
+  }
+
+  onMount(() => {
+    if (!enabled || reduce()) return
+    const node = el()
+    if (!node) return
+    const id = ++gen
+    node.style.overflow = "clip"
+    node.style.height = "0px"
+
+    queueMicrotask(() => {
+      if (gen !== id) return
+      const value = el()
+      if (!value) return
+      const child = value.firstElementChild ?? value
+      let target = Math.ceil(value.scrollHeight || child.getBoundingClientRect().height)
+      const done = (anim: AnimationPlaybackControls) => {
+        if (gen !== id || height !== anim) return
+        obs?.disconnect()
+        height = undefined
+        clear(value)
+      }
+      const start = (from: number, to: number) => {
+        const anim = animate(value, { height: [`${from}px`, `${to}px`] }, COLLAPSIBLE_SPRING)
+        height = anim
+        void anim.finished.then(() => done(anim)).catch(() => undefined)
+      }
+
+      start(0, target)
+      obs = new ResizeObserver(() => {
+        if (gen !== id || !height) return
+        const next = Math.ceil(child.getBoundingClientRect().height)
+        if (Math.abs(next - target) <= 1) return
+        const from = value.getBoundingClientRect().height
+        height.stop()
+        target = next
+        start(from, next)
+      })
+      obs.observe(child)
+    })
+  })
+
+  onCleanup(() => {
+    ++gen
+    obs?.disconnect()
+    height?.stop()
+    const node = el()
+    if (node) clear(node)
   })
 }
 

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -1866,7 +1866,6 @@ export class AgentManagerProvider implements Disposable {
     }
     this.pushState()
   }
-
   private async disposeAsync(): Promise<void> {
     await this.stateReady?.catch((err) => this.log("dispose: stateReady rejected:", err))
     await this.contexts.dispose()

--- a/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
@@ -302,6 +302,11 @@ describe("Bash tool static terminal preview (source)", () => {
 })
 
 describe("Expanded tool motion and typography (source)", () => {
+  const reasoning =
+    fs
+      .readFileSync(KILO_MESSAGE_PART_FILE, "utf-8")
+      .match(/PART_MAPPING\["reasoning"\][\s\S]*?(?=\nfunction useToolReveal)/)?.[0] ?? ""
+
   it("animates completed rolling shell details", () => {
     const src = fs.readFileSync(SHELL_ROLLING_FILE, "utf-8")
     expect(src).toContain("useCollapsible({")
@@ -315,6 +320,28 @@ describe("Expanded tool motion and typography (source)", () => {
       /html\[data-theme="kilo-vscode"\] \[data-component="reasoning-part"\][\s\S]*?(?=@keyframes reasoning-pulse)/,
     )?.[0]
     expect(block).toMatch(/\[data-component="markdown"\]\s*\{[^}]*line-height:\s*160%;/)
+  })
+
+  it("animates reasoning details with the mounted collapsible hook", () => {
+    // forceMount is a Collapsible root prop; on Content it is a no-op attribute
+    // and Kobalte presence unmounts the details before the close can animate.
+    expect(reasoning).toMatch(/<Collapsible[^>]*\bforceMount\b[^>]*>/)
+    expect(reasoning).not.toMatch(/<Collapsible\.Content[^>]*forceMount/)
+    expect(reasoning).toContain("useCollapsible(")
+  })
+
+  it("keeps the reasoning viewport capped until a manual open", () => {
+    const css = fs.readFileSync(KILO_MESSAGE_PART_CSS_FILE, "utf-8")
+    const cap = css.match(
+      /\[data-component="reasoning-part"\]\[data-auto-collapse\]:not\(\[data-manual\]\)\s+\[data-slot="reasoning-content"\]\s*\{[^}]*\}/,
+    )?.[0]
+    expect(cap).toContain("max-height: 120px")
+    expect(cap).not.toContain("data-streaming")
+  })
+
+  it("does not smooth streaming reasoning scroll updates", () => {
+    const css = fs.readFileSync(KILO_MESSAGE_PART_CSS_FILE, "utf-8")
+    expect(css).not.toContain("scroll-behavior: smooth")
   })
 })
 

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -15,6 +15,7 @@ import {
   ToolRegistry,
   ToolApprovalProvider,
   resolveToolApproval,
+  useGrowIn,
 } from "@kilocode/kilo-ui/message-part"
 import type { MessageFeedbackControls } from "@kilocode/kilo-ui/message-part"
 import type {
@@ -275,6 +276,12 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
             return part as unknown as ToolPart
           })
           const forceOpen = createMemo(() => !!props.forceOpenPartID && part.id === props.forceOpenPartID)
+          const live =
+            part.type === "tool"
+              ? part.state.status === "pending" || part.state.status === "running"
+              : (part.type === "reasoning" || part.type === "text") && !!part.time && !part.time.end
+          let el: HTMLDivElement | undefined
+          useGrowIn(() => el, live)
 
           // Lights up when this part is behind the hovered/focused task-timeline
           // bar, using that bar's own color so the two stay easy to correlate.
@@ -307,6 +314,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
               }
             >
               <div
+                ref={el}
                 data-component="tool-part-wrapper"
                 data-part-type={part.type}
                 data-part-id={part.id}


### PR DESCRIPTION
## What Problem This Solves

Reasoning blocks could flicker during fast responses. The viewport could show a scrollbar briefly, the finished block could jump while collapsing, and a tool that arrived immediately afterward could pop in before the reasoning settled.

## Why This Change Was Made

The reasoning viewport now stays capped and in place when streaming ends instead of auto-collapsing. New live parts grow in with the same spring used by the reasoning details, so the reasoning and following tool transition overlap. The streaming follow uses an eased animation frame loop, and the capped viewport hides its scrollbar. Historical reasoning remains collapsed, while streamed blocks preserve their compact-open state across virtualized remounts. A collapsed block without an explicit heading gets a short summary title.

## User Impact

- Fast reasoning no longer jumps or abruptly minimizes when the next tool starts.
- The streaming viewport follows new text without a flickering scrollbar.
- Completed reasoning stays available in a compact viewport until the user collapses it.
- Manually opening a block shows its full content without the compact cap.
- New live tool cards reveal with a height transition instead of appearing at full height.

## Evidence

Focused browser verification used a temporary Storybook scenario rendered through the real sidebar `AssistantMessage`:

- The reasoning to tool handoff had a maximum single-frame container change of 6.1px.
- The tool wrapper produced 38 intermediate heights and cleared its inline animation styles.
- The compact reasoning viewport stayed capped at 120px and had no scrollbar.
- The manual-expanded state showed the full reasoning content.

<img width="760" alt="Completed reasoning in the capped compact viewport with the following tool visible" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260909-reasoning-auto-compact.png" />

<img width="760" alt="Reasoning manually expanded to show the full content" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260909-reasoning-manual-expanded.png" />

Checks:

- `bun run compile` from `packages/kilo-vscode/`
- `bun run typecheck` from `packages/kilo-vscode/`
- `bun run lint` from `packages/kilo-vscode/`
- `bun run knip` from `packages/kilo-vscode/`
- `bun test src/components/reasoning-heading.test.ts` from `packages/kilo-ui/`
- `bun test tests/unit/kilo-ui-contract.test.ts tests/unit/font-size-arch.test.ts tests/unit/agent-manager-arch.test.ts` from `packages/kilo-vscode/`
