### PR TITLE
fix(agent-manager): open PR buttons in sidebar

### DIFF
--- a/.changeset/open-pr-sidebar-from-agent-manager.md
+++ b/.changeset/open-pr-sidebar-from-agent-manager.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Open Agent Manager worktree PR buttons in the internal PR sidebar instead of directly in GitHub.

--- a/packages/kilo-vscode/tests/fixtures/pr-comments-render.tsx
+++ b/packages/kilo-vscode/tests/fixtures/pr-comments-render.tsx
@@ -935,7 +935,7 @@ const release = render(
             openKeybind=""
             pr={badge()}
             onOpenComments={() => navigation.open(target)}
-            onOpenPR={() => clicked.push("external")}
+            onOpenPR={() => navigation.open(target)}
             onClick={() => clicked.push("row")}
             onDelete={noop}
             onStartRename={noop}
@@ -965,6 +965,16 @@ const release = render(
   second,
 )
 const indicator = () => second.querySelector<HTMLButtonElement>(".am-pr-badge-comments")
+second.querySelector<HTMLElement>(".am-pr-badge")!.click()
+setProject(target.projectId)
+setSelection(target.worktreeId)
+await window.happyDOM.waitUntilComplete()
+assert.equal(visible(), true)
+assert.deepEqual(clicked, ["select", "refresh"])
+setVisible(false)
+clicked.length = 0
+setProject("project-a")
+setSelection("local")
 assert.equal(indicator(), null)
 setBadge({ ...base, unresolvedThreads: 1 })
 assert.equal(indicator()?.getAttribute("aria-label"), "1 unresolved review thread")
@@ -1153,7 +1163,7 @@ await window.happyDOM.waitUntilComplete()
 assert.equal(second.querySelector(".am-pr-panel-title")?.textContent, "Updated")
 assert.equal(jumps, 2)
 second.querySelector<HTMLElement>(".am-pr-badge-number")!.click()
-assert.equal(clicked.at(-1), "external")
+assert.equal(clicked.at(-1), "refresh")
 assert.ok(!clicked.includes("row"))
 setBadge((prev) => ({ ...prev, unresolvedThreads: 0 }))
 assert.equal(indicator(), null)

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -2277,6 +2277,7 @@ const AgentManagerContent: Component = () => {
             onCreate={creation.schedule}
             onSelect={activateSelection}
             onOpenComments={(projectId, worktreeId) => comments.open({ projectId, worktreeId })}
+            onOpenPR={(projectId, worktreeId) => comments.open({ projectId, worktreeId })}
             bindings={kb()}
             t={t}
             onSearchRef={(ref) => (sidebarSearchMenu = ref)}
@@ -2295,6 +2296,7 @@ const AgentManagerContent: Component = () => {
             selectLocal={selectLocal}
             selectWorktree={selectWorktree}
             onOpenComments={(worktreeId) => comments.open({ projectId: activeProjectId(), worktreeId })}
+            onOpenPR={(worktreeId) => comments.open({ projectId: activeProjectId(), worktreeId })}
             activityFor={(id) => (id === null ? activity.local() : activity.agent(id))}
             repoBranch={repoBranch}
             localStats={localStats}

--- a/packages/kilo-vscode/webview-ui/agent-manager/ProjectList.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ProjectList.tsx
@@ -50,6 +50,7 @@ interface Props {
   onCreate?: (projectId: string) => void
   onSelect?: (target: AgentManagerSidebarTarget, restore?: boolean) => void
   onOpenComments?: (projectId: string, worktreeId: string) => void
+  onOpenPR?: (projectId: string, worktreeId: string) => void
   busy: (projectId: string, id: string) => boolean
   blocked: (projectId: string, id: string) => boolean
   activityFor: (projectId: string, worktreeId: string | null) => Activity
@@ -242,6 +243,7 @@ export const ProjectList: Component<Props> = (props) => {
           onSelectLocal={(projectId) => select({ projectId, kind: "local" })}
           onSelectWorktree={(projectId, worktreeId) => select({ projectId, kind: "worktree", worktreeId })}
           onOpenComments={props.onOpenComments}
+          onOpenPR={props.onOpenPR}
           onNewWorktree={newWorktree}
           shortcutMap={props.shortcutMap}
         />

--- a/packages/kilo-vscode/webview-ui/agent-manager/ProjectSidebarBody.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ProjectSidebarBody.tsx
@@ -66,6 +66,7 @@ interface Props {
   onSelectLocal: (projectId: string) => void
   onSelectWorktree: (projectId: string, worktreeId: string) => void
   onOpenComments?: (projectId: string, worktreeId: string) => void
+  onOpenPR?: (projectId: string, worktreeId: string) => void
   onNewWorktree: (projectId: string) => void
   shortcutMap?: () => Map<string, number>
 }
@@ -328,10 +329,7 @@ export const ProjectSidebarBody: Component<Props> = (props) => {
           onCopyPath={() => navigator.clipboard.writeText(worktree.path)}
           onOpen={() => post({ type: "agentManager.openWorktree", worktreeId: worktree.id })}
           onOpenComments={() => props.onOpenComments?.(props.project.id, worktree.id)}
-          onOpenPR={() => {
-            const url = props.prs?.[worktree.id]?.url
-            post({ type: "agentManager.openPR", worktreeId: worktree.id, ...(url ? { url } : {}) })
-          }}
+          onOpenPR={() => props.onOpenPR?.(props.project.id, worktree.id)}
         />
       </div>
     )

--- a/packages/kilo-vscode/webview-ui/agent-manager/SidebarBody.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/SidebarBody.tsx
@@ -47,6 +47,7 @@ export interface SidebarBodyProps {
   selectLocal: () => void
   selectWorktree: (id: string) => void
   onOpenComments?: (id: string) => void
+  onOpenPR?: (id: string) => void
   activityFor: (id: string | null) => Activity
   repoBranch: () => string | undefined
   localStats: () => LocalGitStats | undefined
@@ -340,15 +341,9 @@ export const SidebarBody: Component<SidebarBodyProps> = (props) => {
                                 }
                                 runStatus={props.runStatuses()[wt.id]}
                                 onOpenComments={() => props.onOpenComments?.(wt.id)}
-                                onOpenPR={props.track("open_pull_request", "worktree_menu", () => {
-                                  const url = props.prStatuses()[wt.id]?.url
-                                  vscode.postMessage({
-                                    type: "agentManager.openPR",
-                                    projectId: props.projectId,
-                                    worktreeId: wt.id,
-                                    ...(url ? { url } : {}),
-                                  })
-                                })}
+                                onOpenPR={props.track("open_pull_request", "worktree_menu", () =>
+                                  props.onOpenPR?.(wt.id),
+                                )}
                                 sections={props.sections()}
                                 currentSectionId={wt.sectionId}
                                 onMoveToSection={(secId) => props.moveToSection([wt.id], secId)}


### PR DESCRIPTION
## What Problem This Solves
Agent Manager worktree PR buttons opened GitHub directly, which skipped the integrated PR review view.

## Why This Change Was Made
Route PR badge and hover-card actions through the existing PR navigation controller for both legacy and multi-project Agent Manager sidebars. Explicit links inside the PR panel remain external.

## User Impact
Clicking a worktree PR button selects the owning worktree and opens its PR in the Agent Manager sidebar.

## Evidence
- `bun run lint`
- `bun test tests/unit/agent-manager-arch.test.ts`
- `bun test tests/unit/pr-comments-render.test.ts`
- `bun run bundle`
- Prettier checks passed.
- Full typecheck remains blocked by existing SDK and missing dependency mismatches in the worktree.