### PR TITLE
fix(vscode): reduce redundant PR sidebar polling

### DIFF
--- a/.changeset/reduce-pr-sidebar-polling.md
+++ b/.changeset/reduce-pr-sidebar-polling.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Reduce redundant GitHub PR sidebar polling when views, sections, or projects are not consuming the data.

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -26,6 +26,7 @@ import { handleBaseUpdate } from "./base-update"
 import { pushFixes } from "../kilo-provider/push-fixes-settings"
 import { GitStatsPoller, type LocalStats, type WorktreePresenceResult, type WorktreeStats } from "./GitStatsPoller"
 import { createPollers, type ProjectPollers } from "./project/pollers"
+import { validInterest } from "./project/interest"
 import { GitOps } from "./GitOps"
 import type { GitExecutable } from "../util/git-executable"
 import { versionedName } from "./branch-name"
@@ -488,7 +489,8 @@ export class AgentManagerProvider implements Disposable {
   }
 
   private async onMessage(msg: Record<string, unknown>): Promise<Record<string, unknown> | null> {
-    if (this.prBridge.handleMessage(msg)) return null
+    if (!validInterest(msg, (id) => this.contexts.usable(id) !== undefined) || this.prBridge.handleMessage(msg))
+      return null
     if (this.projectPollers.handleInterest(msg)) return null
     if (msg.type === "requestFileSearch" && typeof msg.sessionID !== "string" && this.activeSessionId) {
       return { ...msg, sessionID: this.activeSessionId }

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -489,9 +489,8 @@ export class AgentManagerProvider implements Disposable {
   }
 
   private async onMessage(msg: Record<string, unknown>): Promise<Record<string, unknown> | null> {
-    if (!validInterest(msg, (id) => this.contexts.usable(id) !== undefined) || this.prBridge.handleMessage(msg))
-      return null
-    if (this.projectPollers.handleInterest(msg)) return null
+    const valid = validInterest(msg, (id) => this.contexts.usable(id) !== undefined)
+    if (!valid || this.prBridge.handleMessage(msg) || this.projectPollers.handleInterest(msg)) return null
     if (msg.type === "requestFileSearch" && typeof msg.sessionID !== "string" && this.activeSessionId) {
       return { ...msg, sessionID: this.activeSessionId }
     }

--- a/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
+++ b/packages/kilo-vscode/src/agent-manager/AgentManagerProvider.ts
@@ -489,6 +489,7 @@ export class AgentManagerProvider implements Disposable {
 
   private async onMessage(msg: Record<string, unknown>): Promise<Record<string, unknown> | null> {
     if (this.prBridge.handleMessage(msg)) return null
+    if (this.projectPollers.handleInterest(msg)) return null
     if (msg.type === "requestFileSearch" && typeof msg.sessionID !== "string" && this.activeSessionId) {
       return { ...msg, sessionID: this.activeSessionId }
     }

--- a/packages/kilo-vscode/src/agent-manager/PRStatusPoller.ts
+++ b/packages/kilo-vscode/src/agent-manager/PRStatusPoller.ts
@@ -19,6 +19,7 @@ import { TIMELINE_QUERY, parseTimeline } from "./pr/timeline"
 import type { PRResult, GhThread, GhReviewRequest, GhReview, GhTimelineItem } from "./pr/am-pr-types"
 import { withContext } from "./pr/pr-comment-context"
 import { oid } from "../shared/pr-comment-preview"
+import { RequestGate } from "./pr/request-gate"
 
 interface PRStatusPollerOptions {
   getWorktrees: () => Worktree[]
@@ -43,6 +44,8 @@ const BACKOFF_MULTIPLIER = 2
 const PR_LOOKUP_TTL = 10_000 // 10 seconds — short TTL; only the active worktree polls so this stays cheap
 const FULL_SYNC_INTERVAL = 120_000 // 2 minutes — periodic sync of ALL worktrees (badges stay fresh)
 const FULL_SYNC_CONCURRENCY = 3 // max parallel gh processes during a full sync (caps the burst)
+const TERMINAL_INTERVAL = 300_000
+const reads = new RequestGate<{ stdout: string; stderr: string }>()
 
 export class PRStatusPoller {
   private timer: ReturnType<typeof setTimeout> | undefined
@@ -57,11 +60,16 @@ export class PRStatusPoller {
   private rich = true
   private activeWorktreeId: string | undefined
   private cachedRepo: { owner: string; name: string; root: string } | undefined
+  private repoRequest: Promise<{ owner: string; name: string; root: string }> | undefined
   private prCache = new Map<string, { result: PRResult | null; expires: number }>()
   /** Reviewer avatars are stable, so look them up once per login and reuse them. */
   private readonly avatars = new Map<string, string>()
   private readonly resolvedAvatars = new Set<string>()
   private lastFullSync = 0 // timestamp of last full (all-worktree) sync
+  private interests: Set<string> | undefined
+  private readonly details = new Set<string>()
+  private readonly requests = new RequestGate()
+  private readonly polls = new Map<string, number>()
   private readonly intervalMs: number
   private readonly semaphore: Semaphore | undefined
   private generation = 0
@@ -82,7 +90,8 @@ export class PRStatusPoller {
     options?: Omit<ExecFileOptionsWithStringEncoding, "encoding">,
   ): Promise<{ stdout: string; stderr: string }> {
     const invoke = () => execWithShellEnv(cmd, args, options)
-    return this.semaphore ? this.semaphore.run(invoke) : invoke()
+    const key = JSON.stringify([options?.cwd ?? "", cmd, args])
+    return reads.run(key, () => (this.semaphore ? this.semaphore.run(invoke) : invoke()))
   }
 
   private gh(
@@ -108,13 +117,10 @@ export class PRStatusPoller {
     this.visible = visible
     if (!this.active) return
     if (visible) {
-      // Resume — expire all PR caches and fetch all worktrees once to catch up,
-      // then resume the normal active-only poll cycle.
+      // Resume without clearing useful cached data or creating an all-worktree burst.
       if (this.timer) clearTimeout(this.timer)
       this.timer = undefined
-      this.prCache.clear()
-      this.lastHash.clear()
-      this.lastFullSync = 0
+      this.lastFullSync = Date.now()
       void this.poll()
       return
     }
@@ -140,19 +146,25 @@ export class PRStatusPoller {
     this.ghProbeTime = 0
     this.rich = true
     this.cachedRepo = undefined
+    this.repoRequest = undefined
+    this.activeWorktreeId = undefined
     this.prCache.clear()
     this.avatars.clear()
     this.resolvedAvatars.clear()
     this.lastFullSync = 0
+    this.interests = undefined
+    this.details.clear()
+    this.requests.clear()
+    this.polls.clear()
   }
 
   /** Force-refresh a specific worktree immediately, bypassing the PR cache. */
   refresh(worktreeId: string): void {
+    if (!this.active || !this.visible) return
     const wt = this.options.getWorktrees().find((w) => w.id === worktreeId)
     if (wt) this.prCache.delete(this.key(wt.branch, wt.path))
     this.lastHash.delete(worktreeId)
-    if (!this.active) return
-    void this.fetchOne(worktreeId, this.generation, true)
+    void this.request(worktreeId, this.generation, true)
   }
 
   setActiveWorktreeId(id: string | undefined): void {
@@ -160,7 +172,22 @@ export class PRStatusPoller {
     this.activeWorktreeId = id
     // When switching to a different worktree, fetch it immediately so the
     // badge updates without waiting for the next poll cycle.
-    if (id && id !== prev && this.active) void this.fetchOne(id)
+    if (id && id !== prev && this.active && this.visible) {
+      void this.request(id, this.generation, this.full(id), true)
+    }
+  }
+
+  setWorktreeInterest(ids: Iterable<string>): void {
+    const next = new Set(ids)
+    this.interests = next
+  }
+
+  setDetailInterest(id: string | undefined): void {
+    const previous = this.details.values().next().value as string | undefined
+    this.details.clear()
+    if (id) this.details.add(id)
+    if (!id || id === previous || !this.active || !this.visible) return
+    void this.request(id, this.generation, true, true)
   }
 
   private start(): void {
@@ -238,7 +265,10 @@ export class PRStatusPoller {
     const now = Date.now()
     const initial = this.lastHash.size === 0
     const full = initial || now - this.lastFullSync >= FULL_SYNC_INTERVAL
-    const targets = full ? worktrees : worktrees.filter((wt) => wt.id === this.activeWorktreeId)
+    const interested = worktrees.filter((wt) => this.interested(wt.id))
+    const targets = full
+      ? interested
+      : interested.filter((wt) => wt.id === this.activeWorktreeId || this.details.has(wt.id))
     if (full) this.lastFullSync = now
 
     if (targets.length === 0) {
@@ -246,7 +276,7 @@ export class PRStatusPoller {
       return
     }
 
-    const thunks = targets.map((wt) => () => this.fetchOne(wt.id, generation))
+    const thunks = targets.map((wt) => () => this.request(wt.id, generation, this.full(wt.id)))
     const results = full
       ? await settled(thunks, FULL_SYNC_CONCURRENCY)
       : await Promise.allSettled(thunks.map((fn) => fn()))
@@ -262,7 +292,7 @@ export class PRStatusPoller {
   private async fetchOne(
     worktreeId: string,
     generation = this.generation,
-    full = this.activeWorktreeId === worktreeId,
+    full = this.full(worktreeId),
   ): Promise<void> {
     const wt = this.target(worktreeId)
     if (!wt) return
@@ -319,6 +349,45 @@ export class PRStatusPoller {
       this.handleError(worktreeId, branch, wt.path, err)
       throw err // propagate so fetchAll can track failures for backoff
     }
+  }
+
+  private request(worktreeId: string, generation: number, full: boolean, force = false): Promise<void> {
+    if (!this.active || !this.visible) return Promise.resolve()
+    const key = `${worktreeId}:${full ? "full" : "summary"}`
+    if (!full) {
+      const detail = this.requests.get(`${worktreeId}:full`)
+      if (detail) {
+        // The full request is already represented by the gate. The summary
+        // caller should not start a second request while it is in flight.
+        return detail
+      }
+    }
+    const current = this.requests.get(key)
+    if (current) return current
+    if (!force && !this.due(worktreeId, full, key)) return Promise.resolve()
+    return this.requests.run(key, async () => {
+      this.polls.set(key, Date.now())
+      await this.fetchOne(worktreeId, generation, full)
+    })
+  }
+
+  private interested(worktreeId: string): boolean {
+    return this.interests === undefined || this.interests.has(worktreeId) || this.details.has(worktreeId)
+  }
+
+  private full(worktreeId: string): boolean {
+    if (this.interests === undefined) return this.activeWorktreeId === worktreeId
+    return this.details.has(worktreeId)
+  }
+
+  private due(worktreeId: string, full: boolean, key: string): boolean {
+    const wt = this.target(worktreeId)
+    if (!wt) return false
+    const result = this.prCache.get(this.key(wt.branch, wt.path))?.result
+    if (!result || result.state === "open") return true
+    if (result.state === "merged" && !full) return false
+    const last = this.polls.get(key)
+    return last === undefined || Date.now() - last >= TERMINAL_INTERVAL
   }
 
   private extras(pr: PRResult, cwd: string) {
@@ -475,14 +544,22 @@ export class PRStatusPoller {
   private async getRepoInfo(cwd: string): Promise<{ owner: string; name: string }> {
     const root = this.options.getWorkspaceRoot() ?? cwd
     if (this.cachedRepo?.root === root) return this.cachedRepo
-    const { stdout } = await this.gh(["repo", "view", "--json", "owner,name"], {
+    if (this.repoRequest) return this.repoRequest
+    const request = this.gh(["repo", "view", "--json", "owner,name"], {
       cwd,
       timeout: 10_000,
     })
-    const data = JSON.parse(stdout)
-    const info = { owner: data.owner.login as string, name: data.name as string, root }
-    this.cachedRepo = info
-    return info
+      .then(({ stdout }) => {
+        const data = JSON.parse(stdout)
+        const info = { owner: data.owner.login as string, name: data.name as string, root }
+        this.cachedRepo = info
+        return info
+      })
+      .finally(() => {
+        if (this.repoRequest === request) this.repoRequest = undefined
+      })
+    this.repoRequest = request
+    return request
   }
 
   private async fetchReviewers(prNumber: number, cwd: string): Promise<{ items: PRReviewer[]; ok: boolean }> {

--- a/packages/kilo-vscode/src/agent-manager/PRStatusPoller.ts
+++ b/packages/kilo-vscode/src/agent-manager/PRStatusPoller.ts
@@ -37,6 +37,14 @@ interface PRStatusPollerOptions {
   getBranch?: (worktree: Worktree) => Promise<string | undefined>
 }
 
+interface RequestEntry {
+  full: boolean
+  generation: number
+  promise: Promise<void>
+  upgrade?: Promise<void>
+  next?: Promise<void>
+}
+
 const GH_PROBE_TTL = 300_000 // 5 minutes — gh installation state rarely changes at runtime
 const GH_PROBE_FAILURE_TTL = 30_000 // 30 seconds — retry faster after a failed probe
 const MAX_BACKOFF = 120_000 // 2 minutes — cap for exponential backoff on repeated errors
@@ -60,7 +68,7 @@ export class PRStatusPoller {
   private rich = true
   private activeWorktreeId: string | undefined
   private cachedRepo: { owner: string; name: string; root: string } | undefined
-  private repoRequest: Promise<{ owner: string; name: string; root: string }> | undefined
+  private readonly repoRequests = new Map<string, Promise<{ owner: string; name: string; root: string }>>()
   private prCache = new Map<string, { result: PRResult | null; expires: number }>()
   /** Reviewer avatars are stable, so look them up once per login and reuse them. */
   private readonly avatars = new Map<string, string>()
@@ -68,8 +76,9 @@ export class PRStatusPoller {
   private lastFullSync = 0 // timestamp of last full (all-worktree) sync
   private interests: Set<string> | undefined
   private readonly details = new Set<string>()
-  private readonly requests = new RequestGate()
+  private readonly requests = new Map<string, RequestEntry>()
   private readonly polls = new Map<string, number>()
+  private readonly branches = new Map<string, string>()
   private readonly intervalMs: number
   private readonly semaphore: Semaphore | undefined
   private generation = 0
@@ -99,7 +108,8 @@ export class PRStatusPoller {
     options?: Omit<ExecFileOptionsWithStringEncoding, "encoding">,
   ): Promise<{ stdout: string; stderr: string }> {
     const invoke = () => execGhRead(args, options)
-    return this.semaphore ? this.semaphore.run(invoke) : invoke()
+    const key = JSON.stringify([options?.cwd ?? "", "github", args])
+    return reads.run(key, () => (this.semaphore ? this.semaphore.run(invoke) : invoke()))
   }
 
   setEnabled(enabled: boolean): void {
@@ -131,7 +141,7 @@ export class PRStatusPoller {
     }
   }
 
-  stop(): void {
+  stop(preserveDemand = false): void {
     this.generation++
     this.active = false
     if (this.timer) {
@@ -146,25 +156,26 @@ export class PRStatusPoller {
     this.ghProbeTime = 0
     this.rich = true
     this.cachedRepo = undefined
-    this.repoRequest = undefined
-    this.activeWorktreeId = undefined
+    if (!preserveDemand) this.activeWorktreeId = undefined
     this.prCache.clear()
     this.avatars.clear()
     this.resolvedAvatars.clear()
     this.lastFullSync = 0
-    this.interests = undefined
-    this.details.clear()
-    this.requests.clear()
+    if (!preserveDemand) {
+      this.interests = undefined
+      this.details.clear()
+    }
     this.polls.clear()
+    this.branches.clear()
   }
 
   /** Force-refresh a specific worktree immediately, bypassing the PR cache. */
   refresh(worktreeId: string): void {
-    if (!this.active || !this.visible) return
     const wt = this.options.getWorktrees().find((w) => w.id === worktreeId)
     if (wt) this.prCache.delete(this.key(wt.branch, wt.path))
     this.lastHash.delete(worktreeId)
-    void this.request(worktreeId, this.generation, true)
+    if (!this.active || !this.visible) return
+    this.fire(this.request(worktreeId, this.generation, true, true))
   }
 
   setActiveWorktreeId(id: string | undefined): void {
@@ -173,25 +184,24 @@ export class PRStatusPoller {
     // When switching to a different worktree, fetch it immediately so the
     // badge updates without waiting for the next poll cycle.
     if (id && id !== prev && this.active && this.visible) {
-      void this.request(id, this.generation, this.full(id), true)
+      this.fire(this.request(id, this.generation, this.full(id), true))
     }
   }
 
   setWorktreeInterest(ids: Iterable<string>): void {
-    const next = new Set(ids)
+    const valid = new Set(this.options.getWorktrees().map((wt) => wt.id))
+    const next = new Set([...ids].filter((id) => valid.has(id)))
+    if (next.size === this.interests?.size && [...next].every((id) => this.interests?.has(id))) return
     this.interests = next
   }
 
   setDetailInterest(id: string | undefined): void {
-    const previous = this.details.values().next().value as string | undefined
     this.details.clear()
-    if (id) this.details.add(id)
-    if (!id || id === previous || !this.active || !this.visible) return
-    void this.request(id, this.generation, true, true)
+    if (id && this.options.getWorktrees().some((wt) => wt.id === id)) this.details.add(id)
   }
 
   private start(): void {
-    this.stop()
+    this.stop(true)
     this.active = true
     // Don't override this.visible — it may already be set to false by
     // setVisible() before setEnabled(true) is called.
@@ -262,6 +272,12 @@ export class PRStatusPoller {
     // for sessions that aren't selected (e.g. CI results changing).
     // The very first poll (lastHash empty) also fetches everything.
     const worktrees = this.options.getWorktrees()
+    for (const key of this.polls.keys()) {
+      if (!worktrees.some((wt) => key === `${wt.id}:full` || key === `${wt.id}:summary`)) this.polls.delete(key)
+    }
+    for (const id of this.branches.keys()) {
+      if (!worktrees.some((wt) => wt.id === id)) this.branches.delete(id)
+    }
     const now = Date.now()
     const initial = this.lastHash.size === 0
     const full = initial || now - this.lastFullSync >= FULL_SYNC_INTERVAL
@@ -301,13 +317,11 @@ export class PRStatusPoller {
     try {
       branch = this.options.getBranch ? await this.options.getBranch(wt) : wt.branch
       if (this.stale(generation)) return
+      this.branches.set(worktreeId, branch ?? wt.branch)
       const pr = await this.cachedFetchPR(branch ?? wt.branch, wt.path)
       if (this.stale(generation)) return
       if (!pr) {
-        const hash = `${worktreeId}:${branch ?? wt.branch}:none`
-        if (this.lastHash.get(worktreeId) === hash) return
-        this.lastHash.set(worktreeId, hash)
-        this.options.onStatus(worktreeId, null, undefined, branch)
+        this.empty(worktreeId, branch ?? wt.branch, branch)
         return
       }
 
@@ -351,24 +365,61 @@ export class PRStatusPoller {
     }
   }
 
+  private empty(worktreeId: string, branch: string, name?: string): void {
+    const hash = `${worktreeId}:${branch}:none`
+    if (this.lastHash.get(worktreeId) === hash) return
+    this.lastHash.set(worktreeId, hash)
+    this.options.onStatus(worktreeId, null, undefined, name)
+  }
+
   private request(worktreeId: string, generation: number, full: boolean, force = false): Promise<void> {
     if (!this.active || !this.visible) return Promise.resolve()
-    const key = `${worktreeId}:${full ? "full" : "summary"}`
-    if (!full) {
-      const detail = this.requests.get(`${worktreeId}:full`)
-      if (detail) {
-        // The full request is already represented by the gate. The summary
-        // caller should not start a second request while it is in flight.
-        return detail
-      }
-    }
+    const key = worktreeId
     const current = this.requests.get(key)
-    if (current) return current
-    if (!force && !this.due(worktreeId, full, key)) return Promise.resolve()
-    return this.requests.run(key, async () => {
-      this.polls.set(key, Date.now())
+    if (current) {
+      if (current.generation !== generation) {
+        if (current.next) return current.next
+        const next = current.promise.then(
+          () => {
+            if (this.requests.get(key) === current) this.requests.delete(key)
+            return this.request(worktreeId, generation, full, force)
+          },
+          () => {
+            if (this.requests.get(key) === current) this.requests.delete(key)
+            return this.request(worktreeId, generation, full, force)
+          },
+        )
+        current.next = next
+        return next
+      }
+      if (!full || current.full) return current.promise
+      if (current.upgrade) return current.upgrade
+      const upgrade = current.promise.then(
+        () => {
+          if (this.requests.get(key) === current) this.requests.delete(key)
+          return this.request(worktreeId, generation, true, force)
+        },
+        () => {
+          if (this.requests.get(key) === current) this.requests.delete(key)
+          return this.request(worktreeId, generation, true, force)
+        },
+      )
+      current.upgrade = upgrade
+      return upgrade
+    }
+    if (!force && !this.due(worktreeId, full)) return Promise.resolve()
+    const entry = {} as RequestEntry
+    entry.full = full
+    entry.generation = generation
+    const run = async () => {
+      this.polls.set(`${worktreeId}:${full ? "full" : "summary"}`, Date.now())
       await this.fetchOne(worktreeId, generation, full)
+    }
+    entry.promise = run().finally(() => {
+      if (this.requests.get(key) === entry) this.requests.delete(key)
     })
+    this.requests.set(key, entry)
+    return entry.promise
   }
 
   private interested(worktreeId: string): boolean {
@@ -380,13 +431,24 @@ export class PRStatusPoller {
     return this.details.has(worktreeId)
   }
 
-  private due(worktreeId: string, full: boolean, key: string): boolean {
+  private fire(promise: Promise<void>): void {
+    void promise.catch((err) => this.options.log("PR polling request failed", err))
+  }
+
+  private due(worktreeId: string, full: boolean): boolean {
     const wt = this.target(worktreeId)
     if (!wt) return false
-    const result = this.prCache.get(this.key(wt.branch, wt.path))?.result
-    if (!result || result.state === "open") return true
-    if (result.state === "merged" && !full) return false
-    const last = this.polls.get(key)
+    const branch = this.branches.get(worktreeId) ?? wt.branch
+    const cached = this.prCache.get(this.key(branch, wt.path))
+    if (!cached) return true
+    if (cached.result === null) {
+      const last = this.polls.get(`${worktreeId}:${full ? "full" : "summary"}`)
+      return last === undefined || Date.now() - last >= TERMINAL_INTERVAL
+    }
+    const result = cached.result
+    if (result.state === "open" || result.state === "draft") return true
+    if (full) return true
+    const last = this.polls.get(`${worktreeId}:${full ? "full" : "summary"}`)
     return last === undefined || Date.now() - last >= TERMINAL_INTERVAL
   }
 
@@ -544,7 +606,9 @@ export class PRStatusPoller {
   private async getRepoInfo(cwd: string): Promise<{ owner: string; name: string }> {
     const root = this.options.getWorkspaceRoot() ?? cwd
     if (this.cachedRepo?.root === root) return this.cachedRepo
-    if (this.repoRequest) return this.repoRequest
+    const key = `${root}\0${cwd}`
+    const current = this.repoRequests.get(key)
+    if (current) return current
     const request = this.gh(["repo", "view", "--json", "owner,name"], {
       cwd,
       timeout: 10_000,
@@ -556,9 +620,9 @@ export class PRStatusPoller {
         return info
       })
       .finally(() => {
-        if (this.repoRequest === request) this.repoRequest = undefined
+        if (this.repoRequests.get(key) === request) this.repoRequests.delete(key)
       })
-    this.repoRequest = request
+    this.repoRequests.set(key, request)
     return request
   }
 

--- a/packages/kilo-vscode/src/agent-manager/PRStatusPoller.ts
+++ b/packages/kilo-vscode/src/agent-manager/PRStatusPoller.ts
@@ -43,6 +43,7 @@ interface RequestEntry {
   promise: Promise<void>
   upgrade?: Promise<void>
   next?: Promise<void>
+  forced?: boolean
 }
 
 const GH_PROBE_TTL = 300_000 // 5 minutes — gh installation state rarely changes at runtime
@@ -127,10 +128,11 @@ export class PRStatusPoller {
     this.visible = visible
     if (!this.active) return
     if (visible) {
-      // Resume without clearing useful cached data or creating an all-worktree burst.
+      // Resume without clearing useful cached data. Mark the full sync due so
+      // visible rows catch up through the bounded, interest-filtered sync.
       if (this.timer) clearTimeout(this.timer)
       this.timer = undefined
-      this.lastFullSync = Date.now()
+      this.lastFullSync = 0
       void this.poll()
       return
     }
@@ -172,8 +174,15 @@ export class PRStatusPoller {
   /** Force-refresh a specific worktree immediately, bypassing the PR cache. */
   refresh(worktreeId: string): void {
     const wt = this.options.getWorktrees().find((w) => w.id === worktreeId)
-    if (wt) this.prCache.delete(this.key(wt.branch, wt.path))
+    if (!wt) return
+    // The Changes editor reports `branch: "HEAD"` and resolves the real branch
+    // through getBranch, so invalidate the resolved-branch entry, not wt.branch.
+    const branch = this.branches.get(worktreeId) ?? wt.branch
+    this.prCache.delete(this.key(branch, wt.path))
+    this.branches.delete(worktreeId)
     this.lastHash.delete(worktreeId)
+    this.polls.delete(`${worktreeId}:full`)
+    this.polls.delete(`${worktreeId}:summary`)
     if (!this.active || !this.visible) return
     this.fire(this.request(worktreeId, this.generation, true, true))
   }
@@ -192,7 +201,11 @@ export class PRStatusPoller {
     const valid = new Set(this.options.getWorktrees().map((wt) => wt.id))
     const next = new Set([...ids].filter((id) => valid.has(id)))
     if (next.size === this.interests?.size && [...next].every((id) => this.interests?.has(id))) return
+    const added = [...next].filter((id) => !this.interests?.has(id))
     this.interests = next
+    if (!this.active || !this.visible) return
+    // Refresh rows that just became visible instead of waiting for a full sync.
+    for (const id of added) this.fire(this.request(id, this.generation, this.full(id)))
   }
 
   setDetailInterest(id: string | undefined): void {
@@ -379,21 +392,23 @@ export class PRStatusPoller {
     if (current) {
       if (current.generation !== generation) {
         if (current.next) return current.next
-        const next = current.promise.then(
-          () => {
-            if (this.requests.get(key) === current) this.requests.delete(key)
-            return this.request(worktreeId, generation, full, force)
-          },
-          () => {
-            if (this.requests.get(key) === current) this.requests.delete(key)
-            return this.request(worktreeId, generation, full, force)
-          },
-        )
+        // Retry with the latest generation so a rapid restart does not wait on
+        // an obsolete generation that fetchOne would reject as stale.
+        const retry = () => this.request(worktreeId, this.generation, full, force)
+        const next = current.promise.then(retry, retry)
         current.next = next
         return next
       }
-      if (!full || current.full) return current.promise
-      if (current.upgrade) return current.upgrade
+      if (current.full) {
+        // A forced refresh during an in-flight read must run again afterwards,
+        // otherwise the caller sees the pre-mutation result.
+        if (force) current.forced = true
+        return current.promise
+      }
+      if (current.upgrade) {
+        if (force) current.forced = true
+        return current.upgrade
+      }
       const upgrade = current.promise.then(
         () => {
           if (this.requests.get(key) === current) this.requests.delete(key)
@@ -417,6 +432,9 @@ export class PRStatusPoller {
     }
     entry.promise = run().finally(() => {
       if (this.requests.get(key) === entry) this.requests.delete(key)
+      if (entry.forced && this.active && this.visible) {
+        this.fire(this.request(worktreeId, this.generation, true, true))
+      }
     })
     this.requests.set(key, entry)
     return entry.promise
@@ -447,7 +465,6 @@ export class PRStatusPoller {
     }
     const result = cached.result
     if (result.state === "open" || result.state === "draft") return true
-    if (full) return true
     const last = this.polls.get(`${worktreeId}:${full ? "full" : "summary"}`)
     return last === undefined || Date.now() - last >= TERMINAL_INTERVAL
   }

--- a/packages/kilo-vscode/src/agent-manager/pr-status-bridge.ts
+++ b/packages/kilo-vscode/src/agent-manager/pr-status-bridge.ts
@@ -132,7 +132,8 @@ export class PRStatusBridge {
 
   /** Handle an incoming webview message. Returns true if handled. */
   handleMessage(m: Record<string, unknown>): boolean {
-    if (this.reviews.handle(m) || this.suggestions.handle(m)) return true
+    const special = this.special(m)
+    if (special !== undefined) return special
     if (m.type === "agentManager.refreshPR") {
       if (typeof m.projectId === "string" && m.projectId !== this.host.projectId?.()) return true
       this.poller.refresh(m.worktreeId as string)
@@ -158,6 +159,25 @@ export class PRStatusBridge {
     )
       return this.comment(m, `${m.type}Result`)
     return false
+  }
+
+  private special(m: Record<string, unknown>): boolean | undefined {
+    if (this.reviews.handle(m) || this.suggestions.handle(m)) return true
+    return this.interest(m)
+  }
+
+  private interest(m: Record<string, unknown>): boolean | undefined {
+    if (m.type === "agentManager.prInterest") {
+      if (typeof m.projectId === "string" && m.projectId !== this.host.projectId?.()) return false
+      if (!Array.isArray(m.worktreeIds) || m.worktreeIds.some((id) => typeof id !== "string")) return true
+      this.poller.setWorktreeInterest(m.worktreeIds as string[])
+      return true
+    }
+    if (m.type !== "agentManager.prDetailInterest") return
+    if (typeof m.projectId === "string" && m.projectId !== this.host.projectId?.()) return false
+    if (m.worktreeId !== undefined && typeof m.worktreeId !== "string") return true
+    this.poller.setDetailInterest(m.worktreeId as string | undefined)
+    return true
   }
 
   private handleReaction(m: Record<string, unknown>): boolean {

--- a/packages/kilo-vscode/src/agent-manager/pr-status-bridge.ts
+++ b/packages/kilo-vscode/src/agent-manager/pr-status-bridge.ts
@@ -176,7 +176,10 @@ export class PRStatusBridge {
     if (m.type !== "agentManager.prDetailInterest") return
     if (typeof m.projectId === "string" && m.projectId !== this.host.projectId?.()) return false
     if (m.worktreeId !== undefined && typeof m.worktreeId !== "string") return true
+    if (m.activeWorktreeId !== undefined && typeof m.activeWorktreeId !== "string") return true
     this.poller.setDetailInterest(m.worktreeId as string | undefined)
+    // Track the selected worktree so it is discovered even before it has a PR.
+    this.poller.setActiveWorktreeId(m.activeWorktreeId as string | undefined)
     return true
   }
 

--- a/packages/kilo-vscode/src/agent-manager/pr/request-gate.ts
+++ b/packages/kilo-vscode/src/agent-manager/pr/request-gate.ts
@@ -11,12 +11,4 @@ export class RequestGate<T = void> {
     this.requests.set(key, promise)
     return promise
   }
-
-  get(key: string): Promise<T> | undefined {
-    return this.requests.get(key)
-  }
-
-  clear(): void {
-    this.requests.clear()
-  }
 }

--- a/packages/kilo-vscode/src/agent-manager/pr/request-gate.ts
+++ b/packages/kilo-vscode/src/agent-manager/pr/request-gate.ts
@@ -1,0 +1,22 @@
+export class RequestGate<T = void> {
+  private readonly requests = new Map<string, Promise<T>>()
+
+  run(key: string, fn: () => Promise<T>): Promise<T> {
+    const current = this.requests.get(key)
+    if (current) return current
+
+    const promise = fn().finally(() => {
+      if (this.requests.get(key) === promise) this.requests.delete(key)
+    })
+    this.requests.set(key, promise)
+    return promise
+  }
+
+  get(key: string): Promise<T> | undefined {
+    return this.requests.get(key)
+  }
+
+  clear(): void {
+    this.requests.clear()
+  }
+}

--- a/packages/kilo-vscode/src/agent-manager/project/interest.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/interest.ts
@@ -1,0 +1,6 @@
+export function validInterest(message: Record<string, unknown>, usable: (id: string) => boolean): boolean {
+  if (message.type !== "agentManager.prInterest" && message.type !== "agentManager.prDetailInterest") return true
+  const id = message.projectId
+  if (id != null && typeof id !== "string") return false
+  return id == null || usable(id)
+}

--- a/packages/kilo-vscode/src/agent-manager/project/messages.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/messages.ts
@@ -246,8 +246,15 @@ async function addProject(deps: ProjectMessageDeps): Promise<void> {
 
 async function removeProject(id: string, deps: ProjectMessageDeps): Promise<void> {
   if (disabled(deps)) return
+  const wasActive = deps.contexts.active()?.id === id
   await deps.contexts.remove(id)
   await deps.registry.remove(id)
+  if (wasActive) {
+    // Re-activate the fallback project so its PR poller drops the removed
+    // project's worktree interest and resumes polling the new active project.
+    const next = deps.contexts.active()
+    if (next) deps.activate(next)
+  }
   deps.push()
 }
 

--- a/packages/kilo-vscode/src/agent-manager/project/pollers.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/pollers.ts
@@ -98,6 +98,7 @@ export class ProjectPollers {
   private readonly cache = new Map<string, { worktrees?: StatsOutMessage; local?: StatsOutMessage }>()
   private readonly interests = new Map<string, string[]>()
   private readonly details = new Map<string, string | undefined>()
+  private known: Set<string> | undefined
 
   constructor(
     private readonly deps: PollerDeps,
@@ -138,8 +139,10 @@ export class ProjectPollers {
    * stop pollers for projects that were collapsed, removed, or activated.
    */
   sync(contexts: ProjectContexts): void {
+    const snapshots = contexts.snapshots()
+    this.known = new Set(snapshots.map((snap) => snap.id))
     const wanted = new Set<string>()
-    for (const snap of contexts.snapshots()) {
+    for (const snap of snapshots) {
       if (snap.active || !snap.expanded || snap.missing) continue
       const ctx = contexts.get(snap.id)
       if (!ctx?.peekState()) continue
@@ -161,8 +164,10 @@ export class ProjectPollers {
       pair.pr.poller.stop()
       this.pollers.delete(id)
       this.cache.delete(id)
-      this.interests.delete(id)
-      this.details.delete(id)
+      if (!this.known.has(id)) {
+        this.interests.delete(id)
+        this.details.delete(id)
+      }
     }
   }
 
@@ -174,7 +179,10 @@ export class ProjectPollers {
   }
 
   setInterest(projectId: string, ids: Iterable<string>): boolean {
+    if (this.known && !this.known.has(projectId)) return true
     const next = [...ids]
+    const current = this.interests.get(projectId)
+    if (current?.length === next.length && current.every((id, i) => id === next[i])) return true
     this.interests.set(projectId, next)
     const pair = this.pollers.get(projectId)
     if (!pair) return true
@@ -183,6 +191,7 @@ export class ProjectPollers {
   }
 
   setDetailInterest(projectId: string, id: string | undefined): boolean {
+    if (this.known && !this.known.has(projectId)) return true
     this.details.set(projectId, id)
     const pair = this.pollers.get(projectId)
     if (!pair) return true
@@ -211,6 +220,7 @@ export class ProjectPollers {
     this.cache.clear()
     this.interests.clear()
     this.details.clear()
+    this.known = undefined
   }
 }
 

--- a/packages/kilo-vscode/src/agent-manager/project/pollers.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/pollers.ts
@@ -24,7 +24,13 @@ import type { WorktreeStateManager } from "../WorktreeStateManager"
 export interface PollerPair {
   stats: { setEnabled(enabled: boolean): void; setVisible(visible: boolean): void; stop(): void }
   pr: {
-    poller: { setEnabled(enabled: boolean): void; setVisible(visible: boolean): void; stop(): void }
+    poller: {
+      setEnabled(enabled: boolean): void
+      setVisible(visible: boolean): void
+      setWorktreeInterest(ids: Iterable<string>): void
+      setDetailInterest(id: string | undefined): void
+      stop(): void
+    }
     replay?(): void
   }
 }
@@ -90,6 +96,8 @@ function createPollerPair(ctx: ProjectContext, deps: PollerDeps): PollerPair {
 export class ProjectPollers {
   private readonly pollers = new Map<string, PollerPair>()
   private readonly cache = new Map<string, { worktrees?: StatsOutMessage; local?: StatsOutMessage }>()
+  private readonly interests = new Map<string, string[]>()
+  private readonly details = new Map<string, string | undefined>()
 
   constructor(
     private readonly deps: PollerDeps,
@@ -138,6 +146,9 @@ export class ProjectPollers {
       wanted.add(snap.id)
       if (this.pollers.has(snap.id)) continue
       const pair = this.create(ctx, this.recording(snap.id))
+      const ids = this.interests.get(snap.id)
+      if (ids) pair.pr.poller.setWorktreeInterest(ids)
+      if (this.details.has(snap.id)) pair.pr.poller.setDetailInterest(this.details.get(snap.id))
       pair.stats.setVisible(this.deps.visible())
       pair.pr.poller.setVisible(this.deps.visible())
       pair.stats.setEnabled(true)
@@ -150,6 +161,8 @@ export class ProjectPollers {
       pair.pr.poller.stop()
       this.pollers.delete(id)
       this.cache.delete(id)
+      this.interests.delete(id)
+      this.details.delete(id)
     }
   }
 
@@ -160,6 +173,35 @@ export class ProjectPollers {
     }
   }
 
+  setInterest(projectId: string, ids: Iterable<string>): boolean {
+    const next = [...ids]
+    this.interests.set(projectId, next)
+    const pair = this.pollers.get(projectId)
+    if (!pair) return true
+    pair.pr.poller.setWorktreeInterest(next)
+    return true
+  }
+
+  setDetailInterest(projectId: string, id: string | undefined): boolean {
+    this.details.set(projectId, id)
+    const pair = this.pollers.get(projectId)
+    if (!pair) return true
+    pair.pr.poller.setDetailInterest(id)
+    return true
+  }
+
+  handleInterest(message: Record<string, unknown>): boolean {
+    if (message.type === "agentManager.prInterest" && typeof message.projectId === "string") {
+      if (!Array.isArray(message.worktreeIds) || message.worktreeIds.some((id) => typeof id !== "string")) return true
+      return this.setInterest(message.projectId, message.worktreeIds as string[])
+    }
+    if (message.type === "agentManager.prDetailInterest" && typeof message.projectId === "string") {
+      if (message.worktreeId !== undefined && typeof message.worktreeId !== "string") return true
+      return this.setDetailInterest(message.projectId, message.worktreeId as string | undefined)
+    }
+    return false
+  }
+
   dispose(): void {
     for (const pair of this.pollers.values()) {
       pair.stats.stop()
@@ -167,6 +209,8 @@ export class ProjectPollers {
     }
     this.pollers.clear()
     this.cache.clear()
+    this.interests.clear()
+    this.details.clear()
   }
 }
 

--- a/packages/kilo-vscode/src/agent-manager/project/pollers.ts
+++ b/packages/kilo-vscode/src/agent-manager/project/pollers.ts
@@ -28,7 +28,6 @@ export interface PollerPair {
       setEnabled(enabled: boolean): void
       setVisible(visible: boolean): void
       setWorktreeInterest(ids: Iterable<string>): void
-      setDetailInterest(id: string | undefined): void
       stop(): void
     }
     replay?(): void
@@ -97,7 +96,6 @@ export class ProjectPollers {
   private readonly pollers = new Map<string, PollerPair>()
   private readonly cache = new Map<string, { worktrees?: StatsOutMessage; local?: StatsOutMessage }>()
   private readonly interests = new Map<string, string[]>()
-  private readonly details = new Map<string, string | undefined>()
   private known: Set<string> | undefined
 
   constructor(
@@ -151,7 +149,6 @@ export class ProjectPollers {
       const pair = this.create(ctx, this.recording(snap.id))
       const ids = this.interests.get(snap.id)
       if (ids) pair.pr.poller.setWorktreeInterest(ids)
-      if (this.details.has(snap.id)) pair.pr.poller.setDetailInterest(this.details.get(snap.id))
       pair.stats.setVisible(this.deps.visible())
       pair.pr.poller.setVisible(this.deps.visible())
       pair.stats.setEnabled(true)
@@ -164,10 +161,11 @@ export class ProjectPollers {
       pair.pr.poller.stop()
       this.pollers.delete(id)
       this.cache.delete(id)
-      if (!this.known.has(id)) {
-        this.interests.delete(id)
-        this.details.delete(id)
-      }
+    }
+    // Drop demand for projects that are no longer in the registry, including
+    // ones that were collapsed before removal and have no running pair.
+    for (const id of this.interests.keys()) {
+      if (!this.known.has(id)) this.interests.delete(id)
     }
   }
 
@@ -190,23 +188,10 @@ export class ProjectPollers {
     return true
   }
 
-  setDetailInterest(projectId: string, id: string | undefined): boolean {
-    if (this.known && !this.known.has(projectId)) return true
-    this.details.set(projectId, id)
-    const pair = this.pollers.get(projectId)
-    if (!pair) return true
-    pair.pr.poller.setDetailInterest(id)
-    return true
-  }
-
   handleInterest(message: Record<string, unknown>): boolean {
     if (message.type === "agentManager.prInterest" && typeof message.projectId === "string") {
       if (!Array.isArray(message.worktreeIds) || message.worktreeIds.some((id) => typeof id !== "string")) return true
       return this.setInterest(message.projectId, message.worktreeIds as string[])
-    }
-    if (message.type === "agentManager.prDetailInterest" && typeof message.projectId === "string") {
-      if (message.worktreeId !== undefined && typeof message.worktreeId !== "string") return true
-      return this.setDetailInterest(message.projectId, message.worktreeId as string | undefined)
     }
     return false
   }
@@ -219,7 +204,6 @@ export class ProjectPollers {
     this.pollers.clear()
     this.cache.clear()
     this.interests.clear()
-    this.details.clear()
     this.known = undefined
   }
 }

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -860,6 +860,18 @@ interface RefreshPRIn {
   worktreeId: string
 }
 
+interface PRInterestIn {
+  type: "agentManager.prInterest"
+  projectId?: string
+  worktreeIds: string[]
+}
+
+interface PRDetailInterestIn {
+  type: "agentManager.prDetailInterest"
+  projectId?: string
+  worktreeId?: string
+}
+
 interface OpenPRIn {
   type: "agentManager.openPR"
   projectId?: string
@@ -1211,6 +1223,8 @@ export type AgentManagerInMessage =
   | RequestDiffBranchesIn
   | SetDiffBaseBranchIn
   | RefreshPRIn
+  | PRInterestIn
+  | PRDetailInterestIn
   | OpenPRIn
   | CommentActionIn
   | CommentReactionIn

--- a/packages/kilo-vscode/src/agent-manager/types.ts
+++ b/packages/kilo-vscode/src/agent-manager/types.ts
@@ -870,6 +870,7 @@ interface PRDetailInterestIn {
   type: "agentManager.prDetailInterest"
   projectId?: string
   worktreeId?: string
+  activeWorktreeId?: string
 }
 
 interface OpenPRIn {

--- a/packages/kilo-vscode/tests/fixtures/pr-review-render.tsx
+++ b/packages/kilo-vscode/tests/fixtures/pr-review-render.tsx
@@ -34,11 +34,10 @@ const snapshot: PRDiffSnapshot = {
 const [visible, setVisible] = createSignal(true)
 const [own, setOwn] = createSignal(false)
 const [closed, setClosed] = createSignal(false)
-let refreshed = 0
 const release = mount(() => (
   <>
     <Show when={visible()}>
-      <PRFiles {...target} own={own()} closed={closed()} onRefresh={() => refreshed++} />
+      <PRFiles {...target} own={own()} closed={closed()} />
     </Show>
     <div id="published">
       <PRCommentMarkdown
@@ -141,7 +140,6 @@ assert.match(node('[data-slot="review-head"]').textContent ?? "", new RegExp(sna
 button("submit", composer()).click()
 assert.equal((last() as { snapshotId?: string }).snapshotId, snapshot.id)
 respond(last(), {})
-assert.equal(refreshed, 1)
 assert.equal(files().querySelector('[data-action="line"]'), null)
 node<HTMLButtonElement>('button[data-path="src/second.ts"]').click()
 await wait()

--- a/packages/kilo-vscode/tests/unit/agent-project-pollers.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-project-pollers.test.ts
@@ -115,6 +115,19 @@ describe("ProjectPollers", () => {
     expect(made.get(extra.id)!.detail).toBe("wt-1")
   })
 
+  it("drops interest for projects outside the current registry", () => {
+    const contexts = setup([stored("prj-extra")])
+    expand(contexts, "prj-extra")
+    const { made, create, deps } = fakes()
+    const pollers = new ProjectPollers(deps, (ctx) => create(ctx))
+    pollers.sync(contexts)
+
+    expect(
+      pollers.handleInterest({ type: "agentManager.prInterest", projectId: "unknown", worktreeIds: ["wt-1"] }),
+    ).toBe(true)
+    expect(made.has("unknown")).toBe(false)
+  })
+
   it("does not start pollers for the active project", () => {
     const contexts = setup([])
     contexts.active()

--- a/packages/kilo-vscode/tests/unit/agent-project-pollers.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-project-pollers.test.ts
@@ -41,6 +41,8 @@ interface FakePair {
   enabled: { stats: boolean; pr: boolean }
   visible: { stats: boolean; pr: boolean }
   stopped: { stats: boolean; pr: boolean }
+  interest: string[]
+  detail: string | undefined
 }
 
 function fakes() {
@@ -58,6 +60,8 @@ function fakes() {
           poller: {
             setEnabled: (v) => (rec.enabled.pr = v),
             setVisible: (v) => (rec.visible.pr = v),
+            setWorktreeInterest: (v) => (rec.interest = [...v]),
+            setDetailInterest: (v) => (rec.detail = v),
             stop: () => (rec.stopped.pr = true),
           },
         },
@@ -65,6 +69,8 @@ function fakes() {
       enabled: { stats: false, pr: false },
       visible: { stats: true, pr: true },
       stopped: { stats: false, pr: false },
+      interest: [],
+      detail: undefined,
     }
     made.set(ctx.id, rec)
     return rec.pair
@@ -92,6 +98,21 @@ describe("ProjectPollers", () => {
     const rec = made.get("prj-extra")
     expect(rec).toBeDefined()
     expect(rec!.enabled).toEqual({ stats: true, pr: true })
+  })
+
+  it("applies interest queued before a background poller starts", () => {
+    const extra = stored("prj-extra")
+    const contexts = setup([extra])
+    expand(contexts, "prj-extra")
+    const { made, create, deps } = fakes()
+    const pollers = new ProjectPollers(deps, (ctx) => create(ctx))
+
+    pollers.setInterest(extra.id, ["wt-1"])
+    pollers.setDetailInterest(extra.id, "wt-1")
+    pollers.sync(contexts)
+
+    expect(made.get(extra.id)!.interest).toEqual(["wt-1"])
+    expect(made.get(extra.id)!.detail).toBe("wt-1")
   })
 
   it("does not start pollers for the active project", () => {
@@ -183,7 +204,13 @@ function recorder() {
     return {
       stats: { setEnabled: () => {}, setVisible: () => {}, stop: () => {} },
       pr: {
-        poller: { setEnabled: () => {}, setVisible: () => {}, stop: () => {} },
+        poller: {
+          setEnabled: () => {},
+          setVisible: () => {},
+          setWorktreeInterest: () => {},
+          setDetailInterest: () => {},
+          stop: () => {},
+        },
         replay: () => replayed.push(ctx.id),
       },
     }

--- a/packages/kilo-vscode/tests/unit/agent-project-pollers.test.ts
+++ b/packages/kilo-vscode/tests/unit/agent-project-pollers.test.ts
@@ -42,7 +42,6 @@ interface FakePair {
   visible: { stats: boolean; pr: boolean }
   stopped: { stats: boolean; pr: boolean }
   interest: string[]
-  detail: string | undefined
 }
 
 function fakes() {
@@ -61,7 +60,6 @@ function fakes() {
             setEnabled: (v) => (rec.enabled.pr = v),
             setVisible: (v) => (rec.visible.pr = v),
             setWorktreeInterest: (v) => (rec.interest = [...v]),
-            setDetailInterest: (v) => (rec.detail = v),
             stop: () => (rec.stopped.pr = true),
           },
         },
@@ -70,7 +68,6 @@ function fakes() {
       visible: { stats: true, pr: true },
       stopped: { stats: false, pr: false },
       interest: [],
-      detail: undefined,
     }
     made.set(ctx.id, rec)
     return rec.pair
@@ -108,23 +105,24 @@ describe("ProjectPollers", () => {
     const pollers = new ProjectPollers(deps, (ctx) => create(ctx))
 
     pollers.setInterest(extra.id, ["wt-1"])
-    pollers.setDetailInterest(extra.id, "wt-1")
     pollers.sync(contexts)
 
     expect(made.get(extra.id)!.interest).toEqual(["wt-1"])
-    expect(made.get(extra.id)!.detail).toBe("wt-1")
   })
 
   it("drops interest for projects outside the current registry", () => {
-    const contexts = setup([stored("prj-extra")])
+    const extra = stored("prj-extra")
+    const contexts = setup([extra])
     expand(contexts, "prj-extra")
     const { made, create, deps } = fakes()
     const pollers = new ProjectPollers(deps, (ctx) => create(ctx))
     pollers.sync(contexts)
+    pollers.setInterest(extra.id, ["wt-1"])
 
-    expect(
-      pollers.handleInterest({ type: "agentManager.prInterest", projectId: "unknown", worktreeIds: ["wt-1"] }),
-    ).toBe(true)
+    pollers.handleInterest({ type: "agentManager.prInterest", projectId: "unknown", worktreeIds: ["wt-2"] })
+    pollers.sync(contexts)
+
+    expect(made.get(extra.id)!.interest).toEqual(["wt-1"])
     expect(made.has("unknown")).toBe(false)
   })
 
@@ -221,7 +219,6 @@ function recorder() {
           setEnabled: () => {},
           setVisible: () => {},
           setWorktreeInterest: () => {},
-          setDetailInterest: () => {},
           stop: () => {},
         },
         replay: () => replayed.push(ctx.id),

--- a/packages/kilo-vscode/tests/unit/am-pr-status-bridge.test.ts
+++ b/packages/kilo-vscode/tests/unit/am-pr-status-bridge.test.ts
@@ -291,6 +291,36 @@ describe("PRStatusPoller batched GitHub queries", () => {
     bridge.poller.refresh("wt1")
     expect(fetch).toHaveBeenCalledWith("wt1", internal.generation, true)
   })
+
+  it("upgrades an in-flight summary request before starting full details", async () => {
+    const tree = { id: "wt1", path: "/repo/wt1", branch: "feature" }
+    const poller = new PRStatusPoller({
+      getWorktrees: () => [tree] as never,
+      getWorkspaceRoot: () => "/repo",
+      onStatus: () => undefined,
+      log: () => undefined,
+    })
+    const internal = poller as unknown as {
+      active: boolean
+      visible: boolean
+      generation: number
+      request: (id: string, generation: number, full: boolean, force?: boolean) => Promise<void>
+      fetchOne: (id: string, generation: number, full: boolean) => Promise<void>
+    }
+    internal.active = true
+    internal.visible = true
+    const done = Promise.withResolvers<void>()
+    const fetch = spyOn(internal, "fetchOne").mockImplementation(() => done.promise)
+
+    const summary = internal.request("wt1", 0, false, true)
+    const full = internal.request("wt1", 0, true, true)
+    expect(fetch).toHaveBeenCalledTimes(1)
+    done.resolve()
+    await summary
+    await full
+    expect(fetch).toHaveBeenCalledTimes(2)
+    poller.stop()
+  })
   it("loads checks and reviewers with one request and isolates projects and detached worktrees", async () => {
     let root = "/alpha"
     const tree = { id: "wt1", path: "/alpha/feature", branch: "feature" }

--- a/packages/kilo-vscode/tests/unit/am-pr-status-bridge.test.ts
+++ b/packages/kilo-vscode/tests/unit/am-pr-status-bridge.test.ts
@@ -321,6 +321,67 @@ describe("PRStatusPoller batched GitHub queries", () => {
     expect(fetch).toHaveBeenCalledTimes(2)
     poller.stop()
   })
+
+  it("repeats a forced refresh that arrives during an in-flight request", async () => {
+    const tree = { id: "wt1", path: "/repo/wt1", branch: "feature" }
+    const poller = new PRStatusPoller({
+      getWorktrees: () => [tree] as never,
+      getWorkspaceRoot: () => "/repo",
+      onStatus: () => undefined,
+      log: () => undefined,
+    })
+    const internal = poller as unknown as {
+      active: boolean
+      visible: boolean
+      generation: number
+      request: (id: string, generation: number, full: boolean, force?: boolean) => Promise<void>
+      fetchOne: (id: string, generation: number, full: boolean) => Promise<void>
+    }
+    internal.active = true
+    internal.visible = true
+    const first = Promise.withResolvers<void>()
+    const second = Promise.withResolvers<void>()
+    const fetch = spyOn(internal, "fetchOne")
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(() => second.promise)
+
+    const run = internal.request("wt1", 0, true, true)
+    const forced = internal.request("wt1", 0, true, true)
+    expect(fetch).toHaveBeenCalledTimes(1)
+    first.resolve()
+    await run
+    expect(fetch).toHaveBeenCalledTimes(2)
+    second.resolve()
+    await forced
+    poller.stop()
+  })
+
+  it("invalidates the resolved branch cache on refresh", () => {
+    const tree = { id: "diff", path: "/repo", branch: "HEAD" }
+    const poller = new PRStatusPoller({
+      getWorktrees: () => [tree] as never,
+      getWorkspaceRoot: () => "/repo",
+      getBranch: async () => "feature",
+      onStatus: () => undefined,
+      log: () => undefined,
+    })
+    const internal = poller as unknown as {
+      branches: Map<string, string>
+      prCache: Map<string, unknown>
+      active: boolean
+      visible: boolean
+    }
+    internal.branches.set("diff", "feature")
+    internal.prCache.set("/repo\u0000feature", { result: pr, expires: Infinity })
+    internal.active = false
+    internal.visible = false
+
+    poller.refresh("diff")
+
+    expect(internal.prCache.size).toBe(0)
+    expect(internal.branches.has("diff")).toBe(false)
+    poller.stop()
+  })
   it("loads checks and reviewers with one request and isolates projects and detached worktrees", async () => {
     let root = "/alpha"
     const tree = { id: "wt1", path: "/alpha/feature", branch: "feature" }

--- a/packages/kilo-vscode/tests/unit/pr-request-gate.test.ts
+++ b/packages/kilo-vscode/tests/unit/pr-request-gate.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test"
+import { RequestGate } from "../../src/agent-manager/pr/request-gate"
+
+describe("RequestGate", () => {
+  it("shares an in-flight request for the same key", async () => {
+    const gate = new RequestGate()
+    let count = 0
+    const run = async () => {
+      count++
+    }
+
+    await Promise.all([gate.run("pr:one", run), gate.run("pr:one", run)])
+
+    expect(count).toBe(1)
+  })
+
+  it("allows a new request after the previous one settles", async () => {
+    const gate = new RequestGate()
+    let count = 0
+
+    await gate.run("pr:one", async () => {
+      count++
+    })
+    await gate.run("pr:one", async () => {
+      count++
+    })
+
+    expect(count).toBe(2)
+  })
+
+  it("keeps separate PRs independent", async () => {
+    const gate = new RequestGate()
+    const done = new Set<string>()
+
+    await Promise.all([
+      gate.run("pr:one", async () => done.add("one")),
+      gate.run("pr:two", async () => done.add("two")),
+    ])
+
+    expect(done).toEqual(new Set(["one", "two"]))
+  })
+})

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -369,15 +369,18 @@ const AgentManagerContent: Component = () => {
     if (!pr) return undefined
     return { pr, selected, wt: worktrees().find((w) => w.id === selected) }
   })
-  const prDetail = createMemo(() => {
-    if (!prOpen() || history() || reviewActive()) return
-    return activePR()?.selected
+  const prActive = createMemo(() => {
+    const selected = selection()
+    if (history() || reviewActive() || !selected || selected === LOCAL) return
+    return selected
   })
+  const prDetail = createMemo(() => (prOpen() ? prActive() : undefined))
   createEffect(() =>
     vscode.postMessage({
       type: "agentManager.prDetailInterest",
       projectId: activeProjectId(),
       worktreeId: prDetail(),
+      activeWorktreeId: prActive(),
     }),
   )
   const diffs = createWorktreeDiffs(vscode, activeProjectId)

--- a/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/AgentManagerApp.tsx
@@ -369,6 +369,17 @@ const AgentManagerContent: Component = () => {
     if (!pr) return undefined
     return { pr, selected, wt: worktrees().find((w) => w.id === selected) }
   })
+  const prDetail = createMemo(() => {
+    if (!prOpen() || history() || reviewActive()) return
+    return activePR()?.selected
+  })
+  createEffect(() =>
+    vscode.postMessage({
+      type: "agentManager.prDetailInterest",
+      projectId: activeProjectId(),
+      worktreeId: prDetail(),
+    }),
+  )
   const diffs = createWorktreeDiffs(vscode, activeProjectId)
   createEffect(on(activeProjectId, diffs.reset, { defer: true }))
   const diffDatas = diffs.diffDatas
@@ -2277,6 +2288,10 @@ const AgentManagerContent: Component = () => {
             onCreate={creation.schedule}
             onSelect={activateSelection}
             onOpenComments={(projectId, worktreeId) => comments.open({ projectId, worktreeId })}
+            onPRInterest={(projectId, worktreeIds) =>
+              vscode.postMessage({ type: "agentManager.prInterest", projectId, worktreeIds })
+            }
+            sidebarVisible={!sidebarCollapsed()}
             bindings={kb()}
             t={t}
             onSearchRef={(ref) => (sidebarSearchMenu = ref)}
@@ -2294,6 +2309,10 @@ const AgentManagerContent: Component = () => {
             currentSessionID={session.currentSessionID}
             selectLocal={selectLocal}
             selectWorktree={selectWorktree}
+            onPRInterest={(projectId, worktreeIds) =>
+              vscode.postMessage({ type: "agentManager.prInterest", projectId, worktreeIds })
+            }
+            sidebarVisible={!sidebarCollapsed()}
             onOpenComments={(worktreeId) => comments.open({ projectId: activeProjectId(), worktreeId })}
             activityFor={(id) => (id === null ? activity.local() : activity.agent(id))}
             repoBranch={repoBranch}

--- a/packages/kilo-vscode/webview-ui/agent-manager/ProjectList.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ProjectList.tsx
@@ -49,6 +49,8 @@ interface Props {
   defaultBase?: (projectId: string) => string | undefined
   onCreate?: (projectId: string) => void
   onSelect?: (target: AgentManagerSidebarTarget, restore?: boolean) => void
+  onPRInterest?: (projectId: string, worktreeIds: string[]) => void
+  sidebarVisible?: boolean
   onOpenComments?: (projectId: string, worktreeId: string) => void
   busy: (projectId: string, id: string) => boolean
   blocked: (projectId: string, id: string) => boolean
@@ -241,6 +243,8 @@ export const ProjectList: Component<Props> = (props) => {
           t={props.t}
           onSelectLocal={(projectId) => select({ projectId, kind: "local" })}
           onSelectWorktree={(projectId, worktreeId) => select({ projectId, kind: "worktree", worktreeId })}
+          onPRInterest={props.onPRInterest}
+          sidebarVisible={props.sidebarVisible}
           onOpenComments={props.onOpenComments}
           onNewWorktree={newWorktree}
           shortcutMap={props.shortcutMap}

--- a/packages/kilo-vscode/webview-ui/agent-manager/ProjectSidebarBody.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ProjectSidebarBody.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createEffect, createMemo, createSignal, onCleanup, type Component } from "solid-js"
+import { For, Show, createEffect, createMemo, createSignal, on, onCleanup, type Component } from "solid-js"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import {
   DragDropProvider,
@@ -123,7 +123,12 @@ export const ProjectSidebarBody: Component<Props> = (props) => {
           .filter((wt) => !wt.sectionId || !sections().find((section) => section.id === wt.sectionId)?.collapsed)
           .map((wt) => wt.id),
   )
-  createEffect(() => props.onPRInterest?.(props.project.id, interest()))
+  createEffect(
+    on(
+      () => [props.selectedProject, interest()] as const,
+      ([, ids]) => props.onPRInterest?.(props.project.id, ids),
+    ),
+  )
   onCleanup(() => props.onPRInterest?.(props.project.id, []))
   const completion = createWorktreeCompletion(
     () => sortWorktrees(worktrees(), order()),

--- a/packages/kilo-vscode/webview-ui/agent-manager/ProjectSidebarBody.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/ProjectSidebarBody.tsx
@@ -65,6 +65,8 @@ interface Props {
   t: LanguageContextValue["t"]
   onSelectLocal: (projectId: string) => void
   onSelectWorktree: (projectId: string, worktreeId: string) => void
+  onPRInterest?: (projectId: string, worktreeIds: string[]) => void
+  sidebarVisible?: boolean
   onOpenComments?: (projectId: string, worktreeId: string) => void
   onNewWorktree: (projectId: string) => void
   shortcutMap?: () => Map<string, number>
@@ -114,6 +116,15 @@ export const ProjectSidebarBody: Component<Props> = (props) => {
   const sections = () => store.sections()
   const worktrees = () => store.worktrees()
   const order = () => store.worktreeOrder()
+  const interest = createMemo(() =>
+    props.sidebarVisible === false
+      ? []
+      : worktrees()
+          .filter((wt) => !wt.sectionId || !sections().find((section) => section.id === wt.sectionId)?.collapsed)
+          .map((wt) => wt.id),
+  )
+  createEffect(() => props.onPRInterest?.(props.project.id, interest()))
+  onCleanup(() => props.onPRInterest?.(props.project.id, []))
   const completion = createWorktreeCompletion(
     () => sortWorktrees(worktrees(), order()),
     () => props.project.id,

--- a/packages/kilo-vscode/webview-ui/agent-manager/SidebarBody.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/SidebarBody.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createMemo, createSignal, type Component } from "solid-js"
+import { For, Show, createEffect, createMemo, createSignal, onCleanup, type Component } from "solid-js"
 import { Icon } from "@kilocode/kilo-ui/icon"
 import {
   DragDropProvider,
@@ -46,6 +46,8 @@ export interface SidebarBodyProps {
   currentSessionID: () => string | undefined
   selectLocal: () => void
   selectWorktree: (id: string) => void
+  onPRInterest?: (projectId: string | undefined, worktreeIds: string[]) => void
+  sidebarVisible?: boolean
   onOpenComments?: (id: string) => void
   activityFor: (id: string | null) => Activity
   repoBranch: () => string | undefined
@@ -100,6 +102,15 @@ export const SidebarBody: Component<SidebarBodyProps> = (props) => {
   const top = createMemo(() =>
     buildTopLevelItems(props.sections(), ungrouped(), sorted(), props.sidebarWorktreeOrder()),
   )
+  const interest = createMemo(() =>
+    props.sidebarVisible === false
+      ? []
+      : sorted()
+          .filter((wt) => !wt.sectionId || !props.sections().find((section) => section.id === wt.sectionId)?.collapsed)
+          .map((wt) => wt.id),
+  )
+  createEffect(() => props.onPRInterest?.(props.projectId, interest()))
+  onCleanup(() => props.onPRInterest?.(props.projectId, []))
   const vscode = useVSCode()
   const updateBase = useBaseUpdate()
   const localState = () => props.activityFor(null)

--- a/packages/kilo-vscode/webview-ui/agent-manager/pr/PRCommentForm.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/pr/PRCommentForm.tsx
@@ -33,7 +33,7 @@ type Props = { projectId?: string; worktreeId: string } & (
       source?: string
       closed?: boolean
       onCancel: () => void
-      onSuccess: () => void
+      onSuccess?: () => void
     })
   | (PRTarget & {
       action: "review"
@@ -42,7 +42,7 @@ type Props = { projectId?: string; worktreeId: string } & (
       own?: boolean
       closed?: boolean
       blocked?: boolean
-      onSuccess: () => void
+      onSuccess?: () => void
     })
   | {
       action: "edit"

--- a/packages/kilo-vscode/webview-ui/agent-manager/pr/PRFiles.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/pr/PRFiles.tsx
@@ -209,7 +209,6 @@ export function PRFiles(props: PRTarget & { own?: boolean; closed?: boolean }) {
                 head={snapshot().head}
                 own={props.own}
                 closed={props.closed}
-                onSuccess={() => undefined}
               />
             </Show>
           </>

--- a/packages/kilo-vscode/webview-ui/agent-manager/pr/PRFiles.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/pr/PRFiles.tsx
@@ -26,7 +26,7 @@ function trim(next: Map<string, State>, active: string) {
   }
 }
 
-export function PRFiles(props: PRTarget & { own?: boolean; closed?: boolean; onRefresh: () => void }) {
+export function PRFiles(props: PRTarget & { own?: boolean; closed?: boolean }) {
   const { t } = useLanguage()
   const vscode = useVSCode()
   let composer: HTMLDivElement | undefined
@@ -194,14 +194,7 @@ export function PRFiles(props: PRTarget & { own?: boolean; closed?: boolean; onR
                     snapshotId={snapshot().id}
                     closed={props.closed}
                     onCancel={() => patch({ anchor: undefined })}
-                    onSuccess={(() => {
-                      const id = key()
-                      const refresh = props.onRefresh
-                      return () => {
-                        patch({ anchor: undefined }, id)
-                        refresh()
-                      }
-                    })()}
+                    onSuccess={() => patch({ anchor: undefined }, key())}
                   />
                 </div>
               )}
@@ -216,7 +209,7 @@ export function PRFiles(props: PRTarget & { own?: boolean; closed?: boolean; onR
                 head={snapshot().head}
                 own={props.own}
                 closed={props.closed}
-                onSuccess={props.onRefresh}
+                onSuccess={() => undefined}
               />
             </Show>
           </>

--- a/packages/kilo-vscode/webview-ui/agent-manager/pr/PRPanel.tsx
+++ b/packages/kilo-vscode/webview-ui/agent-manager/pr/PRPanel.tsx
@@ -295,7 +295,6 @@ export const PRPanel: Component<PRPanelProps> = (props) => {
             prUrl={props.pr.url}
             own={props.pr.viewerDidAuthor}
             closed={props.pr.state === "closed" || props.pr.state === "merged"}
-            onRefresh={props.onRefresh}
           />
           <Show when={(props.pr.reviewers ?? []).length > 0}>
             <PRReviewers reviewers={props.pr.reviewers ?? []} />

--- a/packages/kilo-vscode/webview-ui/src/types/messages/agent-manager.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/agent-manager.ts
@@ -20,6 +20,7 @@ export interface PRDetailInterestRequest {
   type: "agentManager.prDetailInterest"
   projectId?: string
   worktreeId?: string
+  activeWorktreeId?: string
 }
 
 export interface TerminalFont {

--- a/packages/kilo-vscode/webview-ui/src/types/messages/agent-manager.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/agent-manager.ts
@@ -10,6 +10,18 @@ export interface BaseUpdateRequest {
   agent?: string
 }
 
+export interface PRInterestRequest {
+  type: "agentManager.prInterest"
+  projectId?: string
+  worktreeIds: string[]
+}
+
+export interface PRDetailInterestRequest {
+  type: "agentManager.prDetailInterest"
+  projectId?: string
+  worktreeId?: string
+}
+
 export interface TerminalFont {
   fontFamily: string
   fontSize: number

--- a/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
+++ b/packages/kilo-vscode/webview-ui/src/types/messages/webview-messages.ts
@@ -1560,6 +1560,8 @@ export interface DismissAgentMigrationBannerMessage {
 
 export type WebviewMessage =
   | import("./agent-manager").BaseUpdateRequest
+  | import("./agent-manager").PRInterestRequest
+  | import("./agent-manager").PRDetailInterestRequest
   | { type: "sessionActivity"; state: Activity }
   | { type: "acknowledgeSession"; sessionID: string; eventID: string }
   | DocumentRequestMessage


### PR DESCRIPTION
## What Problem This Solves
PR status polling was issuing unnecessary GitHub reads for hidden sections, collapsed sidebars, selected chats without an open PR panel, terminal PRs, concurrent pollers, and duplicate post-review refreshes. These reads competed with GitHub traffic generated by agents.

## Why This Change Was Made
This implements the highest-confidence reductions from #13968 without changing the PR status data contract:

- Report sidebar row interest from the webview and filter collapsed or hidden worktrees.
- Track PR-detail interest separately from focused chat selection.
- Stop fast polling for merged PRs and slow closed PRs to a five-minute interval.
- Coalesce identical reads within a poller and across concurrent PR poller instances.
- Coalesce repository metadata lookups.
- Avoid a second forced refresh from the webview after review actions.
- Avoid clearing caches and triggering an all-worktree burst when the Agent Manager becomes visible again.

## User Impact
Visible PR rows and opened review details retain their existing refresh behavior. Hidden sections and non-consuming rows stop creating new reads. Opening a PR or selecting a worktree still forces the relevant refresh. Merged PRs stay cached until explicitly opened, while closed PRs continue slow reopening checks.

## Evidence
- `bun run lint` passes.
- 93 focused Agent Manager tests pass.
- Agent Manager architecture/file-size tests pass.
- Narrowed host and webview typechecks report no errors in changed modules.
- Full typecheck remains blocked by existing SDK/module mismatches in `AgentManagerProvider.ts` and generated dependencies.
- Extension bundle is blocked by the existing missing `chromium-bidi/package.json` dependency.

Related to #13968.