### PR TITLE
fix(vscode): restore speech button cursor

### DIFF
--- a/.changeset/quiet-speech-cursor.md
+++ b/.changeset/quiet-speech-cursor.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep the speech-to-text button pointer stable while microphone capture or transcription is in progress.

--- a/packages/kilo-vscode/webview-ui/src/styles/prompt-input.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/prompt-input.css
@@ -640,8 +640,11 @@
 }
 
 .prompt-speech-button--starting {
-  cursor: progress;
   opacity: 0.7;
+}
+
+.prompt-speech-button[data-loading] {
+  cursor: pointer;
 }
 
 .prompt-speech-button--recording::after {


### PR DESCRIPTION
## What Problem This Solves
The speech-to-text button shows a progress cursor while microphone startup or transcription is active. This cursor is distracting and is not needed for the control.

## Why This Change Was Made
The shared icon-button loading state applies `cursor: progress` to the speech control. The speech-specific progress rule is removed, and the loading speech button keeps its normal pointer cursor.

## User Impact
The speech-to-text spinner, busy state, disabled behavior, and accessibility attributes are unchanged. Only the mouse cursor behavior changes.

## Evidence
- `bun run lint` passed.
- Prettier check passed for the changed CSS.
- `git diff --check` passed.
- Full typecheck and compile are blocked by existing missing workspace/generated modules, including `@opencode-ai/core/npm` and `@opencode-ai/core/installation/version`.
