### PR TITLE
fix(vscode): resize Agent Manager worktree button

### DIFF
--- a/.changeset/resize-create-worktree-button.md
+++ b/.changeset/resize-create-worktree-button.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Resize and right-align the Agent Manager Create Worktree button.

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -2919,6 +2919,8 @@ body.am-wt-dragging-active * {
 
 /* Fixed footer for the submit button */
 .am-nv-dialog-footer {
+  display: flex;
+  justify-content: flex-end;
   flex-shrink: 0;
   padding: 14px 20px 20px;
 }
@@ -3285,7 +3287,7 @@ body.am-wt-dragging-active * {
 }
 
 .am-nv-submit {
-  width: 100%;
+  width: auto;
   justify-content: center;
 }
 


### PR DESCRIPTION
## What Problem This Solves
The Agent Manager Create Worktree action filled the entire dialog footer, making the primary action visually oversized.

## Why This Change Was Made
The footer now uses a flex layout with right alignment, and the button uses its intrinsic content width. This keeps the action compact while preserving its existing primary styling, height, loading state, and behavior.

## User Impact
The Create Worktree button is easier to scan and no longer stretches across the dialog footer.

## Evidence
Before:

<img width="700" alt="Agent Manager Create Worktree button before the fix" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260909-agent-manager-create-worktree-before.png" />

After:

<img width="700" alt="Agent Manager Create Worktree button after the fix" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260909-agent-manager-create-worktree-after.png" />

Validation:

- `bun run compile`
- `bun run lint`
- `bun run typecheck`
- `bun test tests/unit/agent-manager-arch.test.ts` (76 passed)
- Live visible VS Code Agent Manager verification
