### PR TITLE
fix(vscode): stabilize streaming reasoning layout

### DIFF
--- a/.changeset/steady-reasoning-block-width.md
+++ b/.changeset/steady-reasoning-block-width.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep reasoning blocks at a steady width and stop them from flickering while the reasoning streams.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/streaming-reasoning-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/composite-webview/streaming-reasoning-chromium-linux.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3da47a9cf5a9b3456d5b2b544ad6c5f20d2d5691278773b9bd49dcb90571074d
+size 11719

--- a/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
@@ -397,6 +397,15 @@ describe("AssistantMessage visible row contract (source)", () => {
     expect(src).toContain("if (!planExitInfo(part)) return")
   })
 
+  it("keeps reasoning parts out of the wrapper grow-in clip", () => {
+    // The reasoning header and body bleed 6px past the wrapper, so a grow-in
+    // clip trims their sides while the text streams and releases them when it
+    // stops, resizing the block at the end of the stream.
+    const live = src.match(/const live =[\s\S]*?useGrowIn\(/)?.[0] ?? ""
+    expect(live).toContain('part.type === "text" && !!part.time && !part.time.end')
+    expect(live).not.toContain('part.type === "reasoning"')
+  })
+
   it("uses the native recall tool without a separate memory badge", () => {
     const tools = fs.readFileSync(KILO_MESSAGE_PART_FILE, "utf-8")
     expect(src).not.toContain("assistant-memory-badge")

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -276,10 +276,14 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
             return part as unknown as ToolPart
           })
           const forceOpen = createMemo(() => !!props.forceOpenPartID && part.id === props.forceOpenPartID)
+          // Reasoning blocks are excluded: they animate their own height and
+          // their header and body bleed 6px past this wrapper, so the grow-in
+          // clip would trim their sides for the whole stream and then release
+          // them when the text stops growing, resizing the block at the end.
           const live =
             part.type === "tool"
               ? part.state.status === "pending" || part.state.status === "running"
-              : (part.type === "reasoning" || part.type === "text") && !!part.time && !part.time.end
+              : part.type === "text" && !!part.time && !part.time.end
           let el: HTMLDivElement | undefined
           useGrowIn(() => el, live)
 

--- a/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
+++ b/packages/kilo-vscode/webview-ui/src/stories/composite.stories.tsx
@@ -12,6 +12,7 @@ import type { AssistantMessage as SDKAssistantMessage, ReasoningPart, TextPart, 
 import { StoryProviders, defaultMockData, mockSessionValue } from "./StoryProviders"
 import { AssistantMessage } from "../components/chat/AssistantMessage"
 import { For } from "solid-js"
+import { createStore } from "solid-js/store"
 import { TranscriptRowView } from "../components/chat/TranscriptRow"
 import { messageTurns } from "../context/session-queue"
 import { transcriptRows } from "../context/transcript-rows"
@@ -725,6 +726,41 @@ export const TitleOnlyReasoning: Story = {
     return (
       <StoryProviders data={data} sessionID={SESSION_ID}>
         <AssistantMessage message={baseAssistantMessage} />
+      </StoryProviders>
+    )
+  },
+}
+
+export const StreamingReasoning: Story = {
+  name: "Reasoning - streaming then finished",
+  render: () => {
+    const [part, setPart] = createStore<ReasoningPart>({
+      id: "part-reasoning-stream",
+      sessionID: SESSION_ID,
+      messageID: ASST_MSG_ID,
+      type: "reasoning",
+      text: "**Checking the streaming layout**\n\nInspect how the block behaves while the text grows.",
+      time: { start: now - 1000 },
+    })
+    return (
+      <StoryProviders data={dataWith([part])} sessionID={SESSION_ID} status="busy">
+        <div data-testid="reasoning-stream-host">
+          <button
+            type="button"
+            data-testid="reasoning-append"
+            onClick={() => setPart("text", (value) => `${value} ${"More reasoning output. ".repeat(6)}`)}
+          >
+            Append reasoning
+          </button>
+          <button
+            type="button"
+            data-testid="reasoning-finish"
+            onClick={() => setPart("time", { start: now - 1000, end: now })}
+          >
+            Finish reasoning
+          </button>
+          <AssistantMessage message={baseAssistantMessage} />
+        </div>
       </StoryProviders>
     )
   },


### PR DESCRIPTION
## What Problem This Solves

Reasoning blocks changed width when streaming completed and could flicker while new reasoning text arrived. The live grow-in wrapper clipped the reasoning block's 6px horizontal bleed and its animated height could lag behind streamed content.

## Why This Change Was Made

Reasoning blocks already manage their own open, close, and streaming height behavior. They no longer use the outer grow-in wrapper, so their content is not clipped while the block grows and no competing height spring restarts for every streamed update.

A deterministic `StreamingReasoning` composite story and a source contract test cover the behavior. A patch changeset is included.

## User Impact

- Reasoning keeps the same width during streaming and after completion.
- Streamed reasoning text is not clipped by a lagging wrapper height.
- The existing text and tool grow-in behavior is unchanged.

## Evidence

### Before and after

Before, the streaming block loses its rounded side edges because the outer clip trims the 6px bleed:

<img width="700" alt="Before fix, reasoning block is clipped during streaming" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260909-reasoning-layout-before-streaming.png" />

After, the streaming block keeps the same visible edges as the completed block:

<img width="700" alt="After fix, reasoning block keeps stable edges during streaming" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260909-reasoning-layout-after-streaming.png" />

### Measurements

Measured at 420px viewport width with motion enabled while appending streamed reasoning chunks:

| Metric | Before | After |
|---|---:|---:|
| Painted block width while streaming | 370.0px | 382.0px |
| Painted block width after completion | 382.0px | 382.0px |
| Frames with content clipped by wrapper | 102 / 109 | 0 / 110 |
| Maximum clipped height | 97.52px | 0px |

### Validation

- `bun run typecheck`
- `bun run lint`
- `bun test tests/unit/kilo-ui-contract.test.ts` (54 pass)
- `bun run test:unit` (5490 pass, 2 skipped)
- Playwright Storybook geometry harness for streaming and completed reasoning states
