### PR TITLE
fix(vscode): refine auto-merge split button

### DIFF
--- a/.changeset/refine-pr-merge-split-button.md
+++ b/.changeset/refine-pr-merge-split-button.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Refine the Agent Manager auto-merge button with centered content, a muted blue split-button treatment, and a clean chevron hover state.

--- a/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/agent-manager.css
@@ -2769,9 +2769,8 @@ body.am-wt-dragging-active * {
 }
 
 /* Split button: a main action with an attached dropdown chevron. The segments
-   sit flush inside one rounded outline; hovering a segment highlights exactly
-   the action that will trigger, and the segment divider makes the two click
-   targets distinguishable. */
+   sit flush inside one rounded outline, and hovering a segment highlights the
+   action that will trigger. */
 .am-split-button {
   display: inline-flex;
   align-items: center;
@@ -2793,38 +2792,70 @@ body.am-wt-dragging-active * {
   gap: 0;
   align-items: stretch;
   border-radius: 2px;
-  background: var(--surface-brand-base);
-  color: #ffffff;
+  background: color-mix(in srgb, var(--surface-brand-base) 88%, var(--vscode-editor-background));
+  color: var(--text-on-brand-base, var(--vscode-button-foreground, #ffffff));
 }
 
 .am-split-button[data-variant="primary"] > [data-component="button"] {
+  flex: 1 1 auto;
+  min-width: 0;
   min-height: 26px;
   border: 0;
   border-radius: 2px 0 0 2px;
   background: transparent;
   color: inherit;
+  justify-content: center;
+  text-align: center;
+  transition: background-color 160ms ease;
 }
 
 .am-split-button[data-variant="primary"] > .am-split-arrow {
-  width: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  width: 32px;
+  min-width: 32px;
   height: auto;
   min-height: 26px;
-  border-left: 1px solid rgba(255, 255, 255, 0.28);
+  padding: 0;
+  border: 0;
   border-radius: 0 2px 2px 0;
   background: transparent;
   color: inherit;
   opacity: 1;
+  appearance: none;
+  cursor: pointer;
+  transition: background-color 160ms ease;
 }
 
 .am-split-button[data-variant="primary"] > .am-split-arrow [data-component="icon"],
 .am-split-button[data-variant="primary"] > .am-split-arrow [data-slot="icon-svg"] {
-  color: #ffffff;
+  color: color-mix(in srgb, var(--text-on-brand-base, var(--vscode-button-foreground, #ffffff)) 64%, transparent);
+  fill: none;
+  transition:
+    color 160ms ease,
+    transform 160ms ease;
 }
 
-.am-split-button[data-variant="primary"] > [data-component="button"]:hover:not(:disabled),
+.am-split-button[data-variant="primary"] > .am-split-arrow[data-expanded] [data-slot="icon-svg"] {
+  transform: rotate(180deg);
+}
+
+.am-split-button[data-variant="primary"] > [data-component="button"]:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--surface-brand-hover) 88%, var(--vscode-editor-background));
+}
+
 .am-split-button[data-variant="primary"] > .am-split-arrow:hover:not(:disabled),
 .am-split-button[data-variant="primary"] > .am-split-arrow[data-expanded] {
-  background: var(--surface-brand-hover);
+  background: color-mix(in srgb, var(--surface-brand-hover) 72%, var(--surface-brand-base));
+}
+
+.am-split-button[data-variant="primary"] > .am-split-arrow:hover:not(:disabled) [data-component="icon"],
+.am-split-button[data-variant="primary"] > .am-split-arrow:hover:not(:disabled) [data-slot="icon-svg"],
+.am-split-button[data-variant="primary"] > .am-split-arrow[data-expanded] [data-component="icon"],
+.am-split-button[data-variant="primary"] > .am-split-arrow[data-expanded] [data-slot="icon-svg"] {
+  color: color-mix(in srgb, var(--text-on-brand-base, var(--vscode-button-foreground, #ffffff)) 76%, transparent);
 }
 
 .am-split-button[data-variant="primary"][data-disabled] {
@@ -2837,6 +2868,20 @@ body.am-wt-dragging-active * {
   color: inherit;
   opacity: 1;
   cursor: not-allowed;
+}
+
+.am-split-button[data-variant="primary"] > .am-split-arrow:focus-visible {
+  outline: 1px solid var(--border-focus, var(--vscode-focusBorder));
+  outline-offset: -1px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .am-split-button[data-variant="primary"] > [data-component="button"],
+  .am-split-button[data-variant="primary"] > .am-split-arrow,
+  .am-split-button[data-variant="primary"] > .am-split-arrow [data-component="icon"],
+  .am-split-button[data-variant="primary"] > .am-split-arrow [data-slot="icon-svg"] {
+    transition: none;
+  }
 }
 
 .am-split-menu {

--- a/packages/kilo-vscode/webview-ui/agent-manager/pr/pr-panel.css
+++ b/packages/kilo-vscode/webview-ui/agent-manager/pr/pr-panel.css
@@ -1083,7 +1083,16 @@
 }
 
 .am-pr-merge-footer .am-split-button {
-  flex-shrink: 0;
+  flex: 1 1 auto;
+  min-width: 0;
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.am-pr-merge-footer .am-split-button[data-variant="primary"]:hover:not([data-disabled]) {
+  transform: translateY(-1px);
+  box-shadow: 0 3px 10px color-mix(in srgb, var(--surface-brand-base) 35%, transparent);
 }
 
 .am-pr-merge-controls {
@@ -1114,6 +1123,12 @@
   width: 12px;
   height: 12px;
   margin-right: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .am-pr-merge-footer .am-split-button {
+    transition: none;
+  }
 }
 
 .am-pr-merge-confirm {


### PR DESCRIPTION
## What Problem This Solves

The Agent Manager auto-merge split button had an uneven action layout and a visually disconnected dropdown chevron. The chevron could also render a dark fill artifact instead of a clean stroke.

## Why This Change Was Made

The primary merge action now fills the available footer column and centers its label. The dropdown trigger uses a consistent compact hit area, muted theme-aware colors, a seamless blue surface, and a dedicated right-segment hover state. The chevron is explicitly stroke-only, rotates when expanded, and respects reduced-motion preferences.

## User Impact

Auto-merge controls now match the existing split-button interaction pattern while retaining the blue primary-action treatment. Hovering the right segment clearly identifies the dropdown without introducing a hard divider or an overly bright icon.

## Evidence

Normal state:

<img width="700" alt="Agent Manager auto-merge button in its normal state" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260909-agent-manager-auto-merge-normal.png" />

Right-segment hover state:

<img width="700" alt="Agent Manager auto-merge button with the dropdown segment hovered" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260909-agent-manager-auto-merge-right-hover.png" />

Validation completed with `bun run compile`, the focused Agent Manager architecture test suite, and isolated VS Code visual checks for normal and right-segment hover states.
