### PR TITLE
feat(cli): persist session selection updates

### DIFF
--- a/.changeset/update-session-selection.md
+++ b/.changeset/update-session-selection.md
@@ -1,0 +1,7 @@
+---
+"kilo-code": minor
+"@kilocode/cli": minor
+"@kilocode/sdk": minor
+---
+
+Support updating a session's agent and model without sending a message.

--- a/packages/opencode/src/kilocode/session/update-selection.ts
+++ b/packages/opencode/src/kilocode/session/update-selection.ts
@@ -1,0 +1,47 @@
+import { Agent } from "@/agent/agent"
+import { Provider } from "@/provider/provider"
+import { Session } from "@/session/session"
+import { SessionID } from "@/session/schema"
+import { Effect } from "effect"
+
+type Model = NonNullable<Session.Info["model"]>
+
+export const updateSessionSelection = Effect.fn("KiloSession.updateSelection")(function* (input: {
+  sessionID: SessionID
+  current: Session.Info
+  agent: string | undefined
+  model: Model | undefined
+}) {
+  if (input.agent === undefined && input.model === undefined) return
+
+  const agents = yield* Agent.Service
+  const providers = yield* Provider.Service
+  const sessions = yield* Session.Service
+  const agent = input.agent ?? input.current.agent ?? (yield* agents.defaultAgent())
+  const stored = input.model ?? input.current.model
+  const model =
+    stored ??
+    (yield* Effect.gen(function* () {
+      const profile = yield* agents.get(agent)
+      const fallback = profile.model ?? (yield* providers.defaultModel().pipe(Effect.orDie))
+      return {
+        id: fallback.modelID,
+        providerID: fallback.providerID,
+        ...(profile.model && profile.variant ? { variant: profile.variant } : {}),
+      }
+    }))
+  const variant = model.variant ?? "default"
+  const same =
+    input.current.agent === agent &&
+    input.current.model?.id === model.id &&
+    input.current.model.providerID === model.providerID &&
+    (input.current.model.variant ?? "default") === variant
+  if (same) return
+
+  yield* sessions.setAgentModel({
+    sessionID: input.sessionID,
+    agent,
+    model: { ...model, variant },
+    time: Date.now(),
+  })
+})

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -54,6 +54,7 @@ export const DeleteMessageQuery = Schema.Struct({
 // kilocode_change end
 export const StatusMap = Schema.Record(Schema.String, SessionStatus.Info)
 export const UpdatePayload = Schema.Struct({
+  ...Struct.pick(Session.Info.fields, ["agent", "model"]), // kilocode_change - persist picker selection without a message
   title: Schema.optional(Schema.String),
   metadata: Schema.optional(Session.Metadata),
   permission: Schema.optional(PermissionV1.Ruleset),

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -2,6 +2,7 @@ import { Image } from "@/image/image" // kilocode_change - classify user image v
 import { busyMessage, isBusy } from "@/kilocode/database/sqlite-error" // kilocode_change
 import { KiloSessionHttpApi } from "@/kilocode/server/httpapi/session-fork" // kilocode_change
 import { KiloSessionPromptQueue } from "@/kilocode/session/prompt-queue" // kilocode_change
+import { updateSessionSelection } from "@/kilocode/session/update-selection" // kilocode_change
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { KiloViewers } from "@/kilocode/presence/service" // kilocode_change
 import { Agent } from "@/agent/agent"
@@ -200,6 +201,14 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       payload: typeof UpdatePayload.Type
     }) {
       const current = yield* requireSession(ctx.params.sessionID)
+      // kilocode_change start - persist picker selection without a message
+      yield* updateSessionSelection({
+        sessionID: ctx.params.sessionID,
+        current,
+        agent: ctx.payload.agent,
+        model: ctx.payload.model,
+      })
+      // kilocode_change end
       if (ctx.payload.title !== undefined) {
         yield* session.setTitle({ sessionID: ctx.params.sessionID, title: ctx.payload.title })
       }
@@ -343,8 +352,8 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
               yield* events.publish(Session.Event.Error, {
                 sessionID: ctx.params.sessionID,
                 error: busy // kilocode_change
-                    ? new NamedError.Unknown({ message: busyMessage }).toObject() // kilocode_change
-                    : new NamedError.Unknown({ message: Cause.pretty(cause) }).toObject(), // kilocode_change
+                  ? new NamedError.Unknown({ message: busyMessage }).toObject() // kilocode_change
+                  : new NamedError.Unknown({ message: Cause.pretty(cause) }).toObject(), // kilocode_change
               })
             })
           }),

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -805,12 +805,41 @@ describe("session HttpApi", () => {
         })
         expect(created.title).toBe("created")
 
+        // kilocode_change start - persist selection without creating a message
         const updated = yield* requestJson<Session.Info>(pathFor(SessionPaths.update, { sessionID: created.id }), {
           method: "PATCH",
           headers,
-          body: JSON.stringify({ title: "updated", time: { archived: 1 } }),
+          body: JSON.stringify({
+            title: "updated",
+            agent: "plan",
+            model: { id: "claude-opus", providerID: "anthropic", variant: "max" },
+            time: { archived: 1 },
+          }),
         })
-        expect(updated).toMatchObject({ id: created.id, title: "updated", time: { archived: 1 } })
+        expect(updated).toMatchObject({
+          id: created.id,
+          title: "updated",
+          agent: "plan",
+          model: { id: "claude-opus", providerID: "anthropic", variant: "max" },
+          time: { archived: 1 },
+        })
+        expect(
+          yield* requestJson<SessionV1.WithParts[]>(pathFor(SessionPaths.messages, { sessionID: created.id }), {
+            headers,
+          }),
+        ).toEqual([])
+        // kilocode_change end
+        // kilocode_change start - partial selection updates preserve the other field
+        const agentUpdated = yield* requestJson<Session.Info>(pathFor(SessionPaths.update, { sessionID: created.id }), {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify({ agent: "code" }),
+        })
+        expect(agentUpdated).toMatchObject({
+          agent: "code",
+          model: { id: "claude-opus", providerID: "anthropic", variant: "max" },
+        })
+        // kilocode_change end
 
         const forked = yield* requestJson<Session.Info>(pathFor(SessionPaths.fork, { sessionID: created.id }), {
           method: "POST",

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -4425,6 +4425,12 @@ export class Session2 extends HeyApiClient {
       sessionID: string
       directory?: string
       workspace?: string
+      agent?: string
+      model?: {
+        id: string
+        providerID: string
+        variant?: string
+      }
       title?: string
       metadata?: {
         [key: string]: unknown
@@ -4444,6 +4450,8 @@ export class Session2 extends HeyApiClient {
             { in: "path", key: "sessionID" },
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
+            { in: "body", key: "agent" },
+            { in: "body", key: "model" },
             { in: "body", key: "title" },
             { in: "body", key: "metadata" },
             { in: "body", key: "permission" },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -13198,6 +13198,12 @@ export type SessionGetResponse = SessionGetResponses[keyof SessionGetResponses]
 
 export type SessionUpdateData = {
   body?: {
+    agent?: string
+    model?: {
+      id: string
+      providerID: string
+      variant?: string
+    }
     title?: string
     metadata?: {
       [key: string]: unknown

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -6578,6 +6578,25 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "agent": {
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "providerID": {
+                        "type": "string"
+                      },
+                      "variant": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["id", "providerID"],
+                    "additionalProperties": false
+                  },
                   "title": {
                     "type": "string"
                   },


### PR DESCRIPTION
## Summary
- allow `session.update` to persist agent, model, and variant without adding a user message
- preserve the existing selection when only agent or model is updated
- regenerate the SDK and OpenAPI contract

This unblocks [Anaconda Desktop PR #346](https://github.com/anaconda/agentic-desktop/pull/346) for DESK-2675 so chat selectors can use Kilo as the durable per-session source of truth.