### PR TITLE
fix(vscode): stop tool reveal replay and settle encrypted reasoning

### DIFF
--- a/.changeset/quiet-worktree-tool-reveals.md
+++ b/.changeset/quiet-worktree-tool-reveals.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Keep tool reveal animations from replaying when switching Agent Manager worktrees or sessions, and settle encrypted reasoning blocks as soon as the response moves on instead of pulsing until the whole reasoning item finishes.

--- a/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/labs-tool-call-lab/search-previews-chromium-linux.png
+++ b/packages/kilo-docs/public/img/screenshot-tests/kilo-vscode/visual-regression/labs-tool-call-lab/search-previews-chromium-linux.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:007c4973e3ce3e81263f39ab1bdcbc103a7ae5880ad0c251a51f77847a9e58a6
-size 746937
+oid sha256:a68684b9797ae06e326fe9cbbdc0016b58c49d56152091017efc297396f9b1d7
+size 746967

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -162,6 +162,10 @@ export interface MessagePartProps {
    * lets that one nested item open instead of every file in the patch. */
   forceOpenFile?: string
   reasoningAutoCollapse?: boolean
+  /** True when the stream has moved past this reasoning part. Encrypted
+   * reasoning items hold every summary's `time.end` until the whole item
+   * finishes, so the caller settles finished summaries from the part order. */
+  settled?: boolean
   showAssistantCopyPartID?: string | null
   showTurnDiffSummary?: boolean
   turnDiffSummary?: () => JSX.Element
@@ -1077,6 +1081,7 @@ export function Part(props: MessagePartProps) {
         forceOpen={props.forceOpen}
         forceOpenFile={props.forceOpenFile}
         reasoningAutoCollapse={props.reasoningAutoCollapse}
+        settled={props.settled}
         showAssistantCopyPartID={props.showAssistantCopyPartID}
         showTurnDiffSummary={props.showTurnDiffSummary}
         turnDiffSummary={props.turnDiffSummary}
@@ -1857,9 +1862,10 @@ PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props: MessagePartProp
     return (p.text ?? "").replace("[REDACTED]", "").trim()
   }
 
-  // time.end is set by the processor on reasoning-end.
-  // v1 parts lack time entirely → treat as historical.
+  // time.end is set by the processor on reasoning-end. The caller marks a part
+  // settled once a later part started. v1 parts lack time entirely → historical.
   const done = () => {
+    if (props.settled) return true
     const t = (props.part as any).time
     return !t || !!t.end
   }

--- a/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
+++ b/packages/kilo-vscode/tests/unit/kilo-ui-contract.test.ts
@@ -343,6 +343,16 @@ describe("Expanded tool motion and typography (source)", () => {
     const css = fs.readFileSync(KILO_MESSAGE_PART_CSS_FILE, "utf-8")
     expect(css).not.toContain("scroll-behavior: smooth")
   })
+
+  it("settles encrypted reasoning summaries once the stream moved past them", () => {
+    // Encrypted reasoning items only set time.end on their summaries when the
+    // whole item finishes, so the transcript settles them from the part order.
+    expect(reasoning).toContain("if (props.settled) return true")
+    const src = fs.readFileSync(ASSISTANT_MESSAGE_FILE, "utf-8")
+    expect(src).toContain("if (props.message.time.completed) return true")
+    expect(src).toContain("return index >= 0 && index < all.length - 1")
+    expect(src).toContain("settled={settled()}")
+  })
 })
 
 describe("HighlightedText @mention regex fallback and click handler (source)", () => {

--- a/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/AssistantMessage.tsx
@@ -280,10 +280,19 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
           // their header and body bleed 6px past this wrapper, so the grow-in
           // clip would trim their sides for the whole stream and then release
           // them when the text stops growing, resizing the block at the end.
-          const live =
-            part.type === "tool"
-              ? part.state.status === "pending" || part.state.status === "running"
-              : part.type === "text" && !!part.time && !part.time.end
+          // Tool parts are excluded too: worktree and session switches remount
+          // them, so the wrapper would replay the reveal on an already-seen tool.
+          // Encrypted reasoning items only set time.end on their summaries once
+          // the whole item finishes, so a summary the stream already moved past
+          // would keep pulsing. Read the full store list: props.parts is a chunk.
+          const settled = createMemo(() => {
+            if (part.type !== "reasoning") return false
+            if (props.message.time.completed) return true
+            const all = (data.store.part?.[props.message.id] ?? props.parts ?? []) as SDKPart[]
+            const index = all.findIndex((item) => item.id === part.id)
+            return index >= 0 && index < all.length - 1
+          })
+          const live = part.type === "text" && !!part.time && !part.time.end
           let el: HTMLDivElement | undefined
           useGrowIn(() => el, live)
 
@@ -350,6 +359,7 @@ export const AssistantMessage: Component<AssistantMessageProps> = (props) => {
                                       forceOpen={forceOpen()}
                                       forceOpenFile={forceOpen() ? props.forceOpenFile : undefined}
                                       reasoningAutoCollapse={display.reasoningAutoCollapse()}
+                                      settled={settled()}
                                       feedback={props.feedback}
                                       throughput={throughputEl()}
                                       readonly={props.readonly}


### PR DESCRIPTION
## What Problem This Solves

Two transcript behaviors regressed after the smooth reasoning block transitions work (#13962, #13974):

- Switching Agent Manager worktrees or sessions remounts the transcript and replays the reveal animation of the last still-running tool. The card grows from zero height again and shifts the layout.
- With encrypted reasoning (OpenAI Responses with `store: false`, used by the GPT-5 family through the Kilo gateway), every reasoning summary keeps `time.end` unset until the whole reasoning item finishes. The box stays in its streaming state (pulsing header, streaming mask, follow-to-bottom) for 5 to 30 seconds after its text has stopped.

## Why This Change Was Made

- The `useGrowIn` wrapper added for streaming text also matched pending and running tools. Worktree and session switches remount those parts, so an already-seen live tool animated on every switch. Tool parts are now excluded from the wrapper and keep the original status-gated `animate` and `reveal` behavior. This restores the pre-regression behavior without touching the new reasoning transitions.
- Reasoning blocks keep their own height and streaming animations. They are excluded from the outer wrapper, which also fixes the 6px side clipping reported in #13974.
- For encrypted reasoning, the provider cannot emit `reasoning-end` earlier because the encrypted continuation state only arrives on `output_item.done`. The renderer now settles a summary as done when a later part exists in the message or when the message is complete, instead of waiting for `time.end`.

## User Impact

- No reveal replay or layout jump when switching worktrees or sessions while a tool is running.
- Encrypted reasoning summaries stop pulsing as soon as the response moves on, and the turn status reflects the newest part rather than a stale summary.
- Streaming text keeps its smooth grow-in, and reasoning keeps its smooth height, collapse, and streaming behavior.

## Evidence

- `bun test tests/unit/kilo-ui-contract.test.ts` from `packages/kilo-vscode/`: 55 pass, including a new contract test for the settled reasoning path.
- `bun run compile` from `packages/kilo-vscode/`: host typecheck, webview typecheck, lint, and bundle all pass.
- Database inspection of local sessions showed encrypted reasoning summaries receiving `time.end` 5 to 30 seconds after their text ended, all at the same timestamp as the parent reasoning item.

## Manual Test

1. Use a GPT-5 family model through the Kilo gateway. Send a prompt that produces several reasoning summaries before a tool call. The earlier summary boxes should stop pulsing when the next summary or tool card appears.
2. Start a slow tool in one worktree, switch to another worktree, then switch back. The running tool card should return at its normal height without replaying its reveal.
3. Confirm a Claude-style model still settles each reasoning box when its own text ends, and that streaming text still grows in smoothly.
