### PR TITLE
fix(cli): warn when board_post targets a stopped subagent

### DIFF
--- a/.changeset/board-post-recipient-state.md
+++ b/.changeset/board-post-recipient-state.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Report the direct recipient execution state in board_post results and warn when that recipient stopped, failed, was cancelled, or is unknown, so agents do not assume a finished subagent will read the message.

--- a/packages/opencode/src/kilocode/board/store.ts
+++ b/packages/opencode/src/kilocode/board/store.ts
@@ -665,7 +665,14 @@ export namespace BoardStore {
     const total = counts?.total ?? 0
     const active = counts?.active ?? 0
     const inactive = counts?.inactive ?? 0
-    return { observedAt: input.snapshot.observedAt, total, active, inactive, unknown: total - active - inactive }
+    return {
+      observedAt: input.snapshot.observedAt,
+      total,
+      active,
+      inactive,
+      unknown: total - active - inactive,
+      ...(target === ALL ? {} : { recipientState: input.snapshot.sessions.get(target)?.state ?? "unknown" }),
+    }
   })
 
   function titles(tx: DB | TX, root: string, ids: string[], verified = false) {

--- a/packages/opencode/src/kilocode/tool/board.ts
+++ b/packages/opencode/src/kilocode/tool/board.ts
@@ -177,18 +177,29 @@ export const BoardPostTool = Tool.define<
             to: message.to,
             snapshot: yield* snapshot(jobs, status),
           }).pipe(Effect.provideService(Database.Service, database))
-          const warning = [
-            availability.total > 0 &&
-              availability.active === 0 &&
-              availability.unknown === 0 &&
-              "No other recipients were active at this post attempt.",
-            availability.inactive > 0 &&
-              `${availability.inactive} recipient(s) had finished invocations at this post attempt.`,
-            availability.unknown > 0 &&
-              `Availability was unknown for ${availability.unknown} recipient(s) at this post attempt.`,
-          ]
-            .filter(Boolean)
-            .join(" ")
+          const state = availability.recipientState
+          const direct =
+            state === undefined
+              ? undefined
+              : state === "unknown"
+                ? "The direct recipient's execution state was unknown at this post attempt. Do not assume it is running or will read this message. This post is stored only and does not wake or resume the recipient. Do not resume it just to deliver this note."
+                : state === "completed" || state === "error" || state === "cancelled"
+                  ? `The direct recipient's state was ${state} at this post attempt. Its invocation has ended; do not expect a reply to this message. This post is stored only and does not wake or resume the recipient. Do not resume it just to deliver this note.`
+                  : undefined
+          const warning =
+            direct ??
+            [
+              availability.total > 0 &&
+                availability.active === 0 &&
+                availability.unknown === 0 &&
+                "No other recipients were active at this post attempt.",
+              availability.inactive > 0 &&
+                `${availability.inactive} recipient(s) had finished invocations at this post attempt.`,
+              availability.unknown > 0 &&
+                `Availability was unknown for ${availability.unknown} recipient(s) at this post attempt.`,
+            ]
+              .filter(Boolean)
+              .join(" ")
           return {
             title: `${message.type} to ${message.to}`,
             output: JSON.stringify({

--- a/packages/opencode/test/kilocode/board-tools.test.ts
+++ b/packages/opencode/test/kilocode/board-tools.test.ts
@@ -232,8 +232,16 @@ describe("shared board tools", () => {
           const unknown = yield* send(child.id, "unknown")
           expect(unknown.metadata).toMatchObject({ fromLabel: root.session.title, toLabel: child.title })
           expect(JSON.parse(unknown.output)).toMatchObject({ fromLabel: root.session.title, toLabel: child.title })
-          expect(unknown.metadata.availability).toMatchObject({ total: 1, active: 0, inactive: 0, unknown: 1 })
-          expect(JSON.parse(unknown.output).warning).toContain("Availability was unknown")
+          expect(unknown.metadata.availability).toMatchObject({
+            total: 1,
+            active: 0,
+            inactive: 0,
+            unknown: 1,
+            recipientState: "unknown",
+          })
+          expect(JSON.parse(unknown.output).warning).toContain("execution state was unknown")
+          expect(JSON.parse(unknown.output).warning).toContain("Do not assume it is running")
+          expect(JSON.parse(unknown.output).warning).toContain("stored only")
           expect(yield* observed).toBe("unknown")
           const self = yield* Effect.exit(send("main", "main"))
           expect(self._tag).toBe("Failure")
@@ -250,7 +258,13 @@ describe("shared board tools", () => {
           const running = yield* send(child.id, "running")
           expect(JSON.parse(running.output)).not.toHaveProperty("warning")
           expect(JSON.parse(running.output).receipt).toContain("does not confirm delivery, reading, or action")
-          expect(running.metadata.availability).toMatchObject({ total: 1, active: 1, inactive: 0, unknown: 0 })
+          expect(running.metadata.availability).toMatchObject({
+            total: 1,
+            active: 1,
+            inactive: 0,
+            unknown: 0,
+            recipientState: "running",
+          })
           expect(yield* observed).toBe("running")
           yield* jobs.cancel(child.id)
 
@@ -268,9 +282,11 @@ describe("shared board tools", () => {
             expect(JSON.parse(result.output)).toMatchObject({
               to: child.id,
               body: "Follow-up work",
-              availability: { total: 1, active: 0, inactive: 1, unknown: 0 },
+              availability: { total: 1, active: 0, inactive: 1, unknown: 0, recipientState: state },
             })
-            expect(JSON.parse(result.output).warning).toContain("finished invocations at this post attempt")
+            expect(JSON.parse(result.output).warning).toContain(`state was ${state}`)
+            expect(JSON.parse(result.output).warning).toContain("Do not resume it just to deliver this note")
+            expect(JSON.parse(result.output).warning).toContain("stored only")
             expect(yield* observed).toBe(state)
             expect(result.metadata.availability).toEqual(JSON.parse(result.output).availability)
             expect((yield* send(child.id, state)).metadata.id).toBe(result.metadata.id)
@@ -283,12 +299,14 @@ describe("shared board tools", () => {
           yield* status.set(root.session.id, { type: "busy" })
           const broadcast = yield* send("ALL", "broadcast")
           expect(broadcast.metadata.availability).toMatchObject({ total: 1, active: 0, inactive: 1, unknown: 0 })
+          expect(broadcast.metadata.availability).not.toHaveProperty("recipientState")
           expect(JSON.parse(broadcast.output).warning).toContain("No other recipients were active at this post attempt")
           expect((yield* jobs.get(child.id))?.status).toBe("completed")
           yield* status.set(root.session.id, { type: "idle" })
           const missing = yield* sessions.create({ parentID: root.session.id, title: "Unknown worker" })
           const mixed = yield* send("ALL", "mixed")
           expect(mixed.metadata.availability).toMatchObject({ total: 2, active: 0, inactive: 1, unknown: 1 })
+          expect(mixed.metadata.availability).not.toHaveProperty("recipientState")
           expect(JSON.parse(mixed.output).warning).toContain("Availability was unknown")
           expect(JSON.parse(mixed.output).warning).not.toContain("No other recipients were active")
           yield* sessions.remove(missing.id)
@@ -300,16 +318,58 @@ describe("shared board tools", () => {
           ]) {
             const state = Schema.decodeUnknownSync(SessionStatus.Info)(value)
             yield* status.set(child.id, state)
-            expect(JSON.parse((yield* send(child.id, state.type)).output)).not.toHaveProperty("warning")
+            const active = yield* send(child.id, state.type)
+            expect(JSON.parse(active.output).availability).toMatchObject({ recipientState: state.type })
+            expect(JSON.parse(active.output)).not.toHaveProperty("warning")
             expect(yield* status.get(child.id)).toEqual(state)
             expect(String(yield* observed)).toBe(state.type)
           }
           yield* status.set(child.id, { type: "idle" })
           yield* jobs.start({ id: child.id, type: "other", run: Effect.succeed("Done") })
           yield* jobs.wait({ id: child.id, timeout: 1_000 })
-          expect((yield* send(child.id, "other")).metadata.availability.unknown).toBe(1)
+          expect((yield* send(child.id, "other")).metadata.availability).toMatchObject({
+            unknown: 1,
+            recipientState: "unknown",
+          })
           expect(yield* observed).toBe("unknown")
           expect(yield* sessions.messages({ sessionID: child.id })).toEqual([])
+        }),
+      options,
+    ),
+  )
+
+  it.live("reports the direct recipient state through the main alias without changing execution", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const sessions = yield* Session.Service
+          const jobs = yield* BackgroundJob.Service
+          const root = yield* seed("Alias root")
+          const child = yield* sessions.create({ parentID: root.session.id, title: "Alias worker" })
+          const ctx = yield* context(child.id, MessageID.ascending())
+          const post = yield* Tool.init(yield* BoardPostTool)
+          const send = (body: string, call: string) =>
+            post.execute({ to: "main", type: "INFO", body }, { ...ctx, callID: call })
+
+          const unknown = yield* send("Unknown main", "alias-unknown")
+          expect(unknown.metadata).toMatchObject({ to: "main", toLabel: root.session.title })
+          expect(unknown.metadata.availability).toMatchObject({
+            total: 1,
+            active: 0,
+            inactive: 0,
+            unknown: 1,
+            recipientState: "unknown",
+          })
+          expect(JSON.parse(unknown.output).warning).toContain("execution state was unknown")
+          expect(JSON.parse(unknown.output).warning).toContain("Do not assume it is running")
+
+          yield* jobs.start({ id: root.session.id, type: "task", run: Effect.succeed("Done") })
+          expect((yield* jobs.wait({ id: root.session.id, timeout: 1_000 })).info?.status).toBe("completed")
+          const completed = yield* send("Completed main", "alias-completed")
+          expect(completed.metadata.availability).toMatchObject({ inactive: 1, recipientState: "completed" })
+          expect(JSON.parse(completed.output).warning).toContain("state was completed")
+          expect(JSON.parse(completed.output).warning).toContain("stored only")
+          expect(yield* jobs.get(root.session.id)).toMatchObject({ status: "completed" })
         }),
       options,
     ),


### PR DESCRIPTION
## What Problem This Solves

In Kilo Swarm, a parent agent can post a board message to a task child that has already finished and continue to assume the child is still running. Task completion and board delivery are separate channels, so the message is stored but the child never reads it. The previous `board_post` response only returned aggregate availability counts and a generic warning that grouped completed, failed, and cancelled recipients together as "finished invocations".

## Why This Change Was Made

The parent already has lifecycle information, but it was not surfaced at the point where the mistaken action happens. Direct-target posts now return the observed recipient execution state and a specific warning when that recipient has already stopped, so a parent does not wait on or resume a child merely to deliver a note.

The change is deliberately narrow:

- Direct `board_post` targets get `availability.recipientState`.
- Completed, failed, cancelled, and unknown targets get an explicit warning that the post is stored only, does not wake the recipient, and should not trigger a resume just to deliver the note.
- Active targets carry the state without a warning.
- Broadcast posts, Task execution, and Agent Manager/user prompt queues are unchanged.

## User Impact

When a parent posts to a subagent that already finished, the `board_post` result now states the actual recipient state and warns that no reply should be expected. This reduces unnecessary wait or resume attempts against finished children.

## Evidence

- `bun test ./test/kilocode/board-tools.test.ts` (7 pass)
- `bun test ./test/kilocode/board/store.test.ts ./test/kilocode/board-live.test.ts ./test/kilocode/board-context.test.ts ./test/kilocode/server/board.test.ts` (46 pass)
- `bun run typecheck` clean
- Prettier and oxlint clean on the changed files
- End-to-end in a rebuilt isolated VS Code: a real `task` child completed, the parent's real `board_post` reported `recipientState: "completed"` and the new warning, and the child session stayed stopped with no additional prompt or execution.