### PR TITLE
docs(kilo-docs): document task notifications and Keep Awake

### DIFF
--- a/packages/kilo-docs/lib/nav/getting-started.ts
+++ b/packages/kilo-docs/lib/nav/getting-started.ts
@@ -25,6 +25,8 @@ export const GettingStartedNav: NavSection[] = [
         subLinks: [
           { href: "/getting-started/settings/auto-approving-actions", children: "Auto-Approving Actions" },
           { href: "/getting-started/settings/sandboxing", children: "Sandboxing" },
+          { href: "/getting-started/settings/notifications", children: "Notifications" },
+          { href: "/getting-started/settings/keep-awake", children: "Keep Awake" },
         ],
       },
       { href: "/getting-started/adding-credits", children: "Adding Credits" },

--- a/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
+++ b/packages/kilo-docs/pages/code-with-ai/platforms/cli.md
@@ -136,6 +136,7 @@ The `kilo console` command and its browser interface are deprecated and will be 
 | `/reload` | - | Reload config, skills, agents, and commands from disk |
 | `/editor` | - | Open external editor |
 | `/auto-approve` | `/autoapprove`, `/approve-all`, `/approveall` | Toggle auto-approve mode for all permission prompts (saved to global config) |
+| `/caffeinate` | `/caffenate` | Toggle Keep Awake: prevent system sleep while Kilo sessions run |
 | `/privacy` | - | Toggle privacy mode (blurs PII in the TUI) |
 | `/exit` | `/quit`, `/q` | Exit the app |
 
@@ -194,6 +195,8 @@ CLI attention alerts are disabled by default. Enable and configure them by editi
 - Edit `~/.config/kilo/tui.jsonc` (or `tui.json`) for global settings.
 - Edit `.kilo/tui.json` (or `tui.jsonc`) for project settings.
 
+For VS Code sounds and notifications, see [Notifications](/docs/getting-started/settings/notifications).
+
 Use the following configuration for attention, desktop notification, sound, and volume controls:
 
 ```json
@@ -236,7 +239,7 @@ Supported sound names are `default`, `question`, `permission`, `error`, `done`, 
 
 The `attention.sound_pack` setting selects a sound pack registered by a TUI plugin. Setting an arbitrary pack name does not install or load a pack. Per-event file overrides remain the simplest way to customize sounds without a plugin.
 
-There is no notification slash command or command-palette toggle. Use `tui.json` or `tui.jsonc` so all attention behavior is controlled by the same configuration.
+There is no slash command or command-palette toggle for notifications or sounds. Use `tui.json` or `tui.jsonc` so all attention behavior is controlled by the same configuration. Keep Awake is separate and has its own `/caffeinate` command; see [Keep Awake](/docs/getting-started/settings/keep-awake).
 
 ## Slash Commands
 

--- a/packages/kilo-docs/pages/getting-started/settings/keep-awake.md
+++ b/packages/kilo-docs/pages/getting-started/settings/keep-awake.md
@@ -1,0 +1,51 @@
+---
+title: "Keep Awake"
+description: "Prevent system sleep while Kilo agents work"
+---
+
+# Keep Awake
+
+Keep Awake prevents the computer from sleeping while Kilo sessions are running. It does not keep the display on and does not disable screen locking. Agents can continue to use files, network services, and available credentials while the computer is locked.
+
+Keep Awake is off by default and is available on macOS, Linux, and Windows.
+
+{% tabs %}
+{% tab label="VS Code" %}
+
+Turn Keep Awake on or off with any of these controls:
+
+| Control | Action |
+|---|---|
+| Command Palette | Run **Toggle Keep Awake** (`kilo-code.new.toggleCaffeination`). |
+| Chat slash command | Type `/caffeinate`. The aliases `/caffenate` and `/keep-awake` also work. |
+| Agent Manager | Select the coffee icon in the Agent Manager header. |
+
+The Agent Manager coffee icon reflects the same state as the other controls.
+
+Kilo holds the sleep inhibitor only while at least one session is busy or retrying, and releases it when every session is idle. Keep Awake stops when the VS Code window reloads.
+
+The first time you enable Keep Awake, VS Code asks for confirmation. The answer is stored in the extension's global state, not in `kilo.jsonc`. Enable Keep Awake only in a trusted workspace. It is not available in a remote window.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+In the terminal UI, run the `/caffeinate` slash command. The alias `/caffenate` works too. You can also use the **Enable Keep Awake** and **Disable Keep Awake** entries in the **System** command category.
+
+Kilo holds the sleep inhibitor while any session is busy or retrying, and releases it when every session is idle. The first time you enable Keep Awake, a dialog explains what it does and asks you to confirm. The answer is stored in the TUI state, not in `kilo.jsonc`.
+
+{% /tab %}
+{% /tabs %}
+
+{% callout type="warning" %}
+Keep Awake prevents system sleep only. It does not keep the display on and does not disable screen locking. Agents may continue to access files, network services, and available credentials while the computer is locked. Enable it only if your organization's device policy permits it. On Linux, Keep Awake can also block manual suspend; turn it off before suspending.
+{% /callout %}
+
+## Platform support
+
+| Platform | Mechanism |
+|---|---|
+| macOS | `/usr/bin/caffeinate` |
+| Linux | `systemd-inhibit` |
+| Windows | `SetThreadExecutionState` through PowerShell |
+
+If the required command is not available, Kilo reports that Keep Awake is unavailable and does not start the inhibitor.

--- a/packages/kilo-docs/pages/getting-started/settings/notifications.md
+++ b/packages/kilo-docs/pages/getting-started/settings/notifications.md
@@ -1,0 +1,76 @@
+---
+title: "Notifications"
+description: "Configure sounds and alerts when Kilo needs your attention"
+---
+
+# Notifications
+
+Kilo can play a sound, show a VS Code notification, or show a native operating system notification when a session needs your attention. All three are off by default.
+
+{% tabs %}
+{% tab label="VS Code" %}
+
+Open Kilo Code Settings with the gear icon ({% codicon name="gear" /%}) and select **Notifications**.
+
+| Setting | Key | Default | Effect |
+|---|---|---|---|
+| Enable Sound Notifications | `kilo-code.new.attention.enabled` | `false` | Play a sound when a session completes, errors, or needs input. |
+| Sound | `kilo-code.new.attention.sound` | `default` | Select the sound. `default` uses a different sound per event; other choices use one sound for every event. |
+| Enable OS Notifications | `kilo-code.new.attention.OSNotifications` | `false` | Show a native notification when the VS Code window is not focused. |
+| Enable VS Code Notifications | `kilo-code.new.attention.notifications` | `false` | Show a VS Code notification when the affected session is not visible. |
+
+The sound picker and its **Test** button appear when sound notifications are enabled. **Test** plays the selected sound.
+
+The **Enable OS Notifications** row appears on macOS, Linux, and Windows. Its **Test** button sends a real native notification and reports success or failure.
+
+These settings are stored in your VS Code settings under `kilo-code.new.attention.*`. They are not part of `kilo.jsonc`.
+
+### When Kilo notifies you
+
+Kilo alerts on these events:
+
+- A session completes a turn.
+- A session needs your input.
+- A session needs permission.
+- A session stops because of an error.
+
+These rules apply to every channel:
+
+- Error notifications are held until the errored turn closes, so a retry that recovers reports completion instead of failure.
+- Alerts are suppressed while the session has an active goal.
+- A repeated request for the same question or permission alerts only once.
+- Manual aborts and auto-approved permissions do not alert.
+- Completion and error alerts come from root sessions only. Subagent turns do not alert.
+
+Alert text is translated into the extension's supported display languages.
+
+### Channels
+
+Each enabled channel decides independently. The OS notification follows window focus, and the VS Code notification follows session visibility.
+
+| VS Code window | Affected session | Native OS notification | VS Code notification |
+|---|---|---|---|
+| Focused | Visible | No | No |
+| Focused | Not visible | No | Yes |
+| Not focused | Visible | Yes | No |
+| Not focused | Not visible | Yes | Yes |
+
+Both channels can fire for the same event. The VS Code notification includes the workspace and session names and a **Show** button. **Show** focuses the Kilo sidebar and opens the session at its latest message.
+
+### Native notification support
+
+| Platform | Backend |
+|---|---|
+| macOS | `osascript` |
+| Linux | `notify-send` (libnotify) |
+| Windows | PowerShell toast |
+
+On Windows, Kilo reads the running editor's `win32AppUserModelId` from its `product.json` to attribute the toast. If that identity is missing or invalid, native notifications are unavailable and the **Test** button reports an error. VS Code notifications still work.
+
+{% /tab %}
+{% tab label="CLI" %}
+
+CLI attention behavior is configured in `tui.json` or `tui.jsonc`, not in the VS Code settings. See [CLI Notifications and Sounds](/docs/code-with-ai/platforms/cli#cli-notifications-and-sounds) for the configuration keys, sound overrides, and platform notes.
+
+{% /tab %}
+{% /tabs %}

--- a/packages/kilo-docs/pages/getting-started/settings/notifications.md
+++ b/packages/kilo-docs/pages/getting-started/settings/notifications.md
@@ -37,7 +37,7 @@ Kilo alerts on these events:
 These rules apply to every channel:
 
 - Error notifications are held until the errored turn closes, so a retry that recovers reports completion instead of failure.
-- Alerts are suppressed while the session has an active goal.
+- Completion alerts are suppressed while the session has an active goal.
 - A repeated request for the same question or permission alerts only once.
 - Manual aborts and auto-approved permissions do not alert.
 - Completion and error alerts come from root sessions only. Subagent turns do not alert.


### PR DESCRIPTION
## What Problem This Solves

The task attention notifications feature in the VS Code extension and the Keep Awake / `/caffeinate` feature are shipped but undocumented. The CLI docs also claimed there is no notification slash command or command-palette toggle, which is now misleading for Keep Awake.

## Why This Change Was Made

Every documented claim was verified against the implementation, including the notification settings keys and defaults, trigger rules, channel behavior, native platform support, and the Keep Awake driver and controls.

- Add a Notifications settings page covering the VS Code settings, triggers, channel rules, Show action, and native platform support.
- Add a Keep Awake settings page covering the Command Palette, sidebar slash command, Agent Manager button, CLI `/caffeinate`, consent, and platform support.
- Add `/caffeinate` to the CLI System Commands table.
- Scope the CLI notification toggle statement to notifications and sounds, and link to Keep Awake.

Docs-only change, so no changeset is required.

## Evidence

- `bun run script/check-md-table-padding.ts` reports no padded tables.
- `bun run test` in `packages/kilo-docs` passes (22 tests).
- `bun run typecheck` in `packages/kilo-docs` only reports the pre-existing missing `@xyflow/react` module errors, unrelated to this change.