### PR TITLE
docs(agent-manager): document PR review, merge, and push-fix workflow

### DIFF
--- a/packages/kilo-docs/pages/automate/agent-manager-workflows.md
+++ b/packages/kilo-docs/pages/automate/agent-manager-workflows.md
@@ -171,7 +171,7 @@ Layer review in before asking a teammate:
 - **`/review branch [base] [guidance]`** — review the whole branch vs. its detected or specified base, with optional guidance.
 - **`/review <commit-hash>` or `/review <PR URL or number>`** — review a specific commit or pull request.
 - **`kilo review` in CI** — automated PR review. See [Code Reviews](/docs/automate/code-reviews/overview) for the setup.
-- **Human review** — push the branch from the session terminal and `gh pr create`. The PR badge appears on the worktree and stays in sync with CI and reviews.
+- **Human review** — push the branch from the session terminal and `gh pr create`. The PR badge appears on the worktree and stays in sync with CI and reviews. Review, comment on, and merge the pull request from the internal PR panel; see [Reviewing a pull request](/docs/automate/agent-manager#reviewing-a-pull-request).
 
 A typical sequence: self-review in the diff panel → `/review` → push → CI review → teammate review.
 

--- a/packages/kilo-docs/pages/automate/agent-manager.md
+++ b/packages/kilo-docs/pages/automate/agent-manager.md
@@ -113,7 +113,7 @@ Worktrees share Git object storage with the main repository, but each worktree i
 
 Each worktree item displays a **PR status badge** when its branch has an associated pull request. The badge shows the PR number (e.g. `#142`) and is color-coded to reflect the current state at a glance. Click the badge to open the internal PR panel. Use **Open in browser** in the panel header to open the pull request on GitHub.
 
-If the pull request has unresolved review threads, the badge also shows a comment count. Click the count to open the PR panel at its comments section.
+If the pull request has unresolved review threads, the badge also shows a comment count. The badge, the hover-card link, and the count all open the PR panel at its comments section.
 
 {% callout type="info" %}
 The GitHub CLI (`gh`) must be installed and authenticated for PR badges to work. If `gh` is missing or not logged in, badges won't appear.
@@ -174,7 +174,7 @@ The selected worktree controls the panel. The panel shows the worktree branch an
 
 The panel header provides the **Push Pull Request Fixes** toggle, **Refresh**, **Copy PR link**, **Open in browser**, and **Close**. The panel body contains:
 
-- **Summary:** merge readiness, review status, checks, unresolved comments, and conversation counts, each with a jump action
+- **Summary:** merge readiness, review status, checks, unresolved comments, and conversation counts. Checks, comments, and conversation include a jump action.
 - **Files and review:** load the PR files and post inline review comments (see below)
 - **Reviewers:** requested and completed reviewers with avatars and states (see below)
 - **Checks:** passed, failed, running, cancelled, or skipped checks, with duration and browser links when available
@@ -211,7 +211,7 @@ Use **Files and review** to load the changed files. Select **Load PR files** to 
 To comment on a line, select a line or drag across lines in one gutter of the unified diff. You can comment on the new version (right side) or the old version (left side). A multiline selection is posted as a range. In the comment form:
 
 - Switch between **Write** and **Preview**. `Cmd+Enter` / `Ctrl+Enter` submits.
-- Use **Insert suggestion** to wrap the selected text in a `suggestion` fence. When you view a comment that contains a `suggestion` fence, use **Preview change** to see the proposed diff and **Apply to worktree** to write it into the local worktree file. Applying a suggestion does not stage, commit, or push. The worktree branch and HEAD must match the PR head, and the target lines must still match, or the apply fails.
+- Use **Insert suggestion** on a new-version (right side) line comment or a reply to wrap the selected text in a `suggestion` fence. When you view a comment that contains a `suggestion` fence, use **Preview change** to see the proposed diff and **Apply to worktree** to write it into the local worktree file. Applying a suggestion does not stage, commit, or push. The worktree branch and HEAD must match the PR head, and the target lines must still match, or the apply fails.
 - Submit the review as **Comment**, **Approve**, or **Request changes**. You cannot approve or request changes on your own pull request. Approve needs no body; the other decisions require one.
 
 For review threads and comments:

--- a/packages/kilo-docs/pages/automate/agent-manager.md
+++ b/packages/kilo-docs/pages/automate/agent-manager.md
@@ -111,7 +111,9 @@ Worktrees share Git object storage with the main repository, but each worktree i
 
 ### PR Status Badges
 
-Each worktree item displays a **PR status badge** when its branch has an associated pull request. The badge shows the PR number (e.g. `#142`) and is color-coded to reflect the current state at a glance. Click the badge to open the PR in your browser.
+Each worktree item displays a **PR status badge** when its branch has an associated pull request. The badge shows the PR number (e.g. `#142`) and is color-coded to reflect the current state at a glance. Click the badge to open the internal PR panel. Use **Open in browser** in the panel header to open the pull request on GitHub.
+
+If the pull request has unresolved review threads, the badge also shows a comment count. Click the count to open the PR panel at its comments section.
 
 {% callout type="info" %}
 The GitHub CLI (`gh`) must be installed and authenticated for PR badges to work. If `gh` is missing or not logged in, badges won't appear.
@@ -145,13 +147,13 @@ When checks are pending on an open PR, the badge pulses to indicate activity.
 
 #### Badge icon
 
-The badge shows a **checkmark** icon when the PR review status is "Approved", and a **branch** icon in all other cases.
+The badge shows the pull request icon. A status icon appears beside the number when there is a terminal signal, evaluated in this order: **checks failing** (cross), **changes requested** (warning), **approved** (checkmark). Merged and closed pull requests show no status icon, and an open pull request with no terminal signal shows none either.
 
 #### Hover card details
 
 Hovering over a worktree item shows a card with additional PR details:
 
-- **PR number** with a link icon to open it in the browser
+- **PR number** with a link icon that opens the PR panel
 - **State** — Open, Draft, Merged, or Closed
 - **Review** — Approved, Changes Requested, or Pending (when a review exists)
 - **Checks** — how many checks passed out of the total (e.g. `8/10 passed`)
@@ -162,34 +164,98 @@ PR badges update automatically in the background. The active worktree refreshes 
 
 ### Reviewing a pull request
 
-The PR review panel is available when the selected worktree has an associated pull request. Open it in either of these ways:
+The PR panel is available when the selected worktree has an associated pull request. Open it in any of these ways:
 
 - Click the pull request icon in the Agent Manager toolbar
+- Click the PR badge on a worktree, or the link icon in its hover card
 - Press `Cmd+Shift+R` (macOS) or `Ctrl+Shift+R` (Windows/Linux)
 
 The selected worktree controls the panel. The panel shows the worktree branch and its parent branch, so confirm that you are reviewing the intended branch. The PR association uses the detection methods described above, including the branch tracking ref, branch name, or current commit SHA.
 
-The panel includes:
+The panel header provides the **Push Pull Request Fixes** toggle, **Refresh**, **Copy PR link**, **Open in browser**, and **Close**. The panel body contains:
 
-- **Status:** Open, Draft, Merged, or Closed
-- **Review status:** Approved, Changes Requested, or Review Pending
+- **Summary:** merge readiness, review status, checks, unresolved comments, and conversation counts, each with a jump action
+- **Files and review:** load the PR files and post inline review comments (see below)
+- **Reviewers:** requested and completed reviewers with avatars and states (see below)
 - **Checks:** passed, failed, running, cancelled, or skipped checks, with duration and browser links when available
-- **Reviewers:** requested reviewers and their current state, such as Approved, Changes requested, Commented, or Awaiting
-- **Description and summary:** the PR description, file count, additions, deletions, and unresolved comment count
+- **Comments:** unresolved review threads first, then a collapsed **Resolved** group
+- **Conversation:** description, comments and reviews, commits, and lifecycle events (see below)
 
-#### Review comments
+#### Merge readiness
 
-Expand a comment to read its Markdown body, replies, file and line location, and a bounded diff hunk around the commented line. Outdated threads show an **Outdated** label. Unresolved threads appear first. Resolved threads move into the **Resolved** group and are collapsed by default. Click a thread row to expand or collapse it.
+The summary shows the merge state before the merge controls:
 
-Use the actions on an expanded thread to:
+| State | Meaning |
+|---|---|
+| Ready to merge | The branch is clean and can merge |
+| Branch is behind the base branch | Update the branch before merging |
+| Merging blocked | Required reviews or other requirements are not met |
+| Checks are failing | A check failed, so the merge is unstable |
+| Draft pull request | Mark the pull request ready for review before merging |
+| Merge conflicts | The branch conflicts with the base, so resolve conflicts first |
+| Checking mergeability | GitHub has not reported a state yet |
 
-- **Send** the comment, its diff context, and replies to the current agent. **Send all unresolved** sends the unresolved threads together, up to the panel limit.
-- **Resolve** or **Unresolve** the GitHub conversation. The panel refreshes the thread state after the action completes.
-- **Copy** the formatted thread context
-- **Open file** at the comment location in the selected worktree
-- **Open on GitHub** at the comment
+Merge controls appear only when you have write permission. Choose **Create merge commit**, **Squash and merge**, or **Rebase and merge** from the split button. Agent Manager remembers the last method you used per repository and preselects it when the repository allows it.
 
-The panel header also provides **Copy PR link**, **Open in browser**, and **Close**. Sending a comment gives it to Kilo as review context. It does not post a reply to GitHub. The panel intentionally has no reply composer; write replies in GitHub.
+- **Update branch:** shown when the branch is behind. This asks GitHub to merge the base branch into the PR branch.
+- **Fix with Kilo:** shown for merge conflicts. It lists the conflicting files and starts an update-from-base request, which asks the agent to resolve the conflicts in the worktree.
+- **Enable auto-merge:** available when the repository allows auto-merge. GitHub merges the pull request when its requirements are met. Use **Disable auto-merge** to cancel it.
+- **Merge pull request:** when the branch is clean, the primary button merges immediately after a confirmation that names the selected method.
+
+Merge actions run through `gh` against GitHub. Agent Manager refuses to update the branch or merge when the PR head changed since the panel last loaded; refresh the panel and try again.
+
+#### Inline review comments and reviews
+
+Use **Files and review** to load the changed files. Select **Load PR files** to start, or **Load latest PR files** to refresh after a new commit. Existing drafts stay saved with their original commit. The panel loads up to the GitHub limit of 3000 files and disables review when the diff is too large.
+
+To comment on a line, select a line or drag across lines in one gutter of the unified diff. You can comment on the new version (right side) or the old version (left side). A multiline selection is posted as a range. In the comment form:
+
+- Switch between **Write** and **Preview**. `Cmd+Enter` / `Ctrl+Enter` submits.
+- Use **Insert suggestion** to wrap the selected text in a `suggestion` fence. When you view a comment that contains a `suggestion` fence, use **Preview change** to see the proposed diff and **Apply to worktree** to write it into the local worktree file. Applying a suggestion does not stage, commit, or push. The worktree branch and HEAD must match the PR head, and the target lines must still match, or the apply fails.
+- Submit the review as **Comment**, **Approve**, or **Request changes**. You cannot approve or request changes on your own pull request. Approve needs no body; the other decisions require one.
+
+For review threads and comments:
+
+- **Reply** to a thread from the thread card.
+- **Resolve** or **Unresolve** a thread.
+- **Edit** or **Delete** your own comments and replies. You need the matching GitHub permission.
+- **React** with the GitHub reaction set. Click a reaction pill to toggle it, or use the reaction picker.
+- **Fix with Kilo** sends a thread to the current agent as review context. **Fix N with Kilo** sends the unresolved threads together, up to the panel limit. With an active Agent Manager terminal, the label becomes **Send to terminal** or **Send N unresolved to terminal** and the threads go to that terminal instead.
+- **Copy** copies the formatted thread. **Show in diff**, **Open file**, and **Open on GitHub** jump to the comment location.
+
+Outdated threads show an **Outdated** label. Unresolved threads appear first, and resolved threads move into the **Resolved** group and are collapsed by default.
+
+Sending a thread gives it to Kilo as review context, and it does not post anything to GitHub. Use the reply form to post to GitHub.
+
+#### Checks
+
+Each failing check offers **Fix with Kilo**, which sends the failure summary and log commands to the current agent. With an active Agent Manager terminal, the label becomes **Send failures to terminal**.
+
+#### Conversation
+
+The conversation lists the pull request description and history in one timeline:
+
+- **Description** at the top
+- **Comments and reviews** as cards, with reviewer states and reactions
+- **Commits** as rows. Consecutive commits by one author collapse into one expandable group.
+- **Lifecycle events:** merged, closed, reopened, and force-push, with the actor
+- **Show earlier activity** when GitHub has timeline items before the loaded window. It opens the pull request on GitHub.
+
+Use a comment card's **Fix with Kilo** action to hand it to the agent. **Dismiss** hides a comment from the next send, and **Restore** brings it back. **Fix N with Kilo** or **Send N to terminal** sends the actionable comments together.
+
+#### Reviewers
+
+The Reviewers section shows each requested or completed reviewer with an avatar and one of these GitHub-style states: **Approved**, **Changes requested**, **Commented**, or **Awaiting**.
+
+#### Push Pull Request Fixes
+
+**Push Pull Request Fixes** controls whether fix prompts ask the agent to commit and push so the pull request updates. The default is on.
+
+- Set it in **Settings > Agent Behaviour > Push Pull Request Fixes** (`kilo-code.new.agentManager.pushFixes`).
+- Toggle the same setting from the PR panel header with the **Push Pull Request Fixes** button.
+- When it is on, fix prompts for PR review comments and CI failures include: "When the changes pass local checks, commit them and push to this branch so the pull request updates. Do not force-push."
+- Update from base follows the same setting. With it on, the agent is asked to push the branch after a clean merge. With it off, it is not.
+- Permission prompts still confirm commits and pushes. Turning the setting on does not auto-approve them.
 
 ### Creating a New Worktree Session
 
@@ -382,6 +448,10 @@ The worktree creation base and the diff comparison base are separate. The Branch
 Add comments in the diff panel or in the rendered view of a Markdown document. Click **Send all to chat** to send the collected comments to chat. If an Agent Manager terminal is active, the comments are sent to that terminal instead. Press `Cmd+Enter` (macOS) or `Ctrl+Enter` (Windows/Linux) to use the same action from the review panel.
 
 After sending, the local comment collection is cleared. To discard collected comments without sending them, click **Clear all** in the chat input.
+
+### PR review comments in the diff
+
+When the selected worktree has an associated pull request, its review threads also appear inline at their file and line in the Agent Manager diff panel and the full-screen review. The inline cards support the same reply, resolve, unresolve, reaction, and send actions as the PR panel. Threads with no matching line in the current diff appear under **Comments outside the current diff**.
 
 ### Diff Scope
 


### PR DESCRIPTION
## What Problem This Solves

The Agent Manager reference still described the old PR panel: it claimed the panel has no reply composer and that the PR badge opens in the browser. Both are now false. The page also omitted the merge readiness states, inline review comments and suggestions, the conversation timeline, reviewer avatars, and the Push Pull Request Fixes setting.

## Why This Change Was Made

The PR workflow shipped several features that are not documented. Every claim in the new text was verified against the extension source before writing. The stale statements were corrected against the current behavior.

## User Impact

`packages/kilo-docs/pages/automate/agent-manager.md` now documents:

- PR badge behavior: opens the internal panel, status indicator, unresolved comment count
- Merge readiness states, write-permission gating, Update branch, merge methods with a remembered per-repo preference, auto-merge, and the conflict list with Fix with Kilo
- Inline PR review: file loading, line and multiline comments, Write/Preview, `suggestion` fences with Preview and Apply to worktree (no staging, commit, or push), Comment/Approve/Request changes, edit, delete, reply, resolve, unresolve, and reactions
- The conversation timeline: description, comments and reviews, grouped commits, lifecycle events, and Show earlier activity
- Reviewer avatars and states
- `kilo-code.new.agentManager.pushFixes` (default on), its Settings location, the panel toggle, the commit and push instruction, and the update-from-base behavior

The badge and hover-card text was corrected, and `agent-manager-workflows.md` gained a cross-link.

## Evidence

- `bun run script/check-md-table-padding.ts` from the repo root: 404 files checked, no padded tables.
- `bun run test` in `packages/kilo-docs`: 22 tests passed (content integrity, headings, redirects, sitemap).

Docs-only, so no changeset.
