### PR TITLE
perf(core): skip source project resolve when sessions move without changes

### DIFF
--- a/.changeset/quick-worktrees-relocate.md
+++ b/.changeset/quick-worktrees-relocate.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Speed up Agent Manager worktree deletion by skipping a redundant source project resolve when sessions move without their changes.

--- a/packages/core/src/control-plane/move-session.ts
+++ b/packages/core/src/control-plane/move-session.ts
@@ -80,13 +80,16 @@ const layer = Layer.effect(
       const directory = AbsolutePath.make(input.destination.directory)
       if (current.location.directory === directory) return
 
-      const source = yield* project.resolve(current.location.directory)
       const destination = yield* project.resolve(directory)
       if (current.projectID !== destination.id) {
         return yield* new DestinationProjectMismatchError({ expected: current.projectID, actual: destination.id })
       }
 
-      const moveChanges = input.moveChanges && source.directory !== destination.directory
+      // kilocode_change start - resolving the source project spawns Git subprocesses, so skip it when no
+      // changes are moved (for example when a worktree is deleted). The source is only read by moveChanges.
+      const source = input.moveChanges ? yield* project.resolve(current.location.directory) : undefined
+      const moveChanges = source ? source.directory !== destination.directory : false
+      // kilocode_change end
       const sourceRepository = moveChanges ? yield* git.repo.discover(current.location.directory) : undefined
       if (moveChanges && !sourceRepository)
         return yield* new CaptureChangesError({ message: "Source is not a Git repository" })

--- a/packages/core/test/move-session.test.ts
+++ b/packages/core/test/move-session.test.ts
@@ -232,4 +232,63 @@ describe("MoveSession", () => {
       expect(yield* Effect.promise(() => fs.readFile(path.join(source, "untracked.txt"), "utf8"))).toBe("unrelated\n")
     }),
   )
+
+  // kilocode_change start - regression test for skipping the source resolve when moveChanges is false
+  it.live("moves a session without transferring changes when moveChanges is false", () =>
+    Effect.gen(function* () {
+      const root = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+      )
+      yield* Effect.promise(() => initRepo(root.path))
+      const source = abs(yield* Effect.promise(() => fs.realpath(root.path)))
+      const destination = abs(`${root.path}-move-no-changes`)
+      yield* Effect.addFinalizer(() =>
+        Effect.promise(() => fs.rm(destination, { recursive: true, force: true })).pipe(Effect.ignore),
+      )
+      yield* Effect.promise(() => $`git worktree add --detach ${destination} HEAD`.cwd(root.path).quiet())
+      const moved = abs(yield* Effect.promise(() => fs.realpath(destination)))
+      yield* Effect.promise(() => fs.writeFile(path.join(source, "tracked.txt"), "changed\n"))
+      yield* Effect.promise(() => fs.writeFile(path.join(source, "untracked.txt"), "new\n"))
+
+      const projectID = (yield* Project.Service.use((service) => service.resolve(source))).id
+      const sessionID = SessionV2.ID.make("ses_move_no_changes")
+      const { db } = yield* Database.Service
+      yield* db
+        .insert(ProjectTable)
+        .values({ id: projectID, worktree: source, sandboxes: [], time_created: 1, time_updated: 1 })
+        .run()
+        .pipe(Effect.orDie)
+      yield* db
+        .insert(SessionTable)
+        .values({
+          id: sessionID,
+          project_id: projectID,
+          slug: "move-no-changes",
+          directory: source,
+          title: "move no changes",
+          version: "test",
+          time_created: 1,
+          time_updated: 1,
+        })
+        .run()
+        .pipe(Effect.orDie)
+
+      yield* MoveSession.Service.use((service) =>
+        service.moveSession({ sessionID, destination: { directory: moved }, moveChanges: false }),
+      )
+
+      expect(yield* Effect.promise(() => fs.readFile(path.join(source, "tracked.txt"), "utf8"))).toBe("changed\n")
+      expect(yield* Effect.promise(() => Bun.file(path.join(source, "untracked.txt")).exists())).toBe(true)
+      expect(yield* Effect.promise(() => fs.readFile(path.join(moved, "tracked.txt"), "utf8"))).toBe("initial\n")
+      expect(
+        yield* db
+          .select({ directory: SessionTable.directory, path: SessionTable.path })
+          .from(SessionTable)
+          .where(eq(SessionTable.id, sessionID))
+          .get(),
+      ).toEqual({ directory: moved, path: "" })
+    }),
+  )
+  // kilocode_change end
 })


### PR DESCRIPTION
## What Problem This Solves

Deleting an Agent Manager worktree blocks on a session relocation that always resolves the source project, even though worktree deletion discards changes (`moveChanges: false`). On a controlled fixture that single resolve cost about 83 ms of a roughly 290 ms awaited delete.

## Why This Change Was Made

`MoveSession.moveSession` resolved both the source and the destination project before checking `input.moveChanges`. The source value is read only by the `moveChanges` comparison, so change-discarding moves paid for git subprocesses they never used. The function now resolves the destination first and resolves the source only when `input.moveChanges` is set.

Behavior is unchanged for moves that transfer changes.

## User Impact

Agent Manager worktree deletion is measurably faster. No user-visible behavior change other than latency.

## Evidence

Controlled fixture: 3,001 commits, 51 files, low disk churn to isolate resolve cost. Same build session, isolated VS Code, real Agent Manager create/delete, n=5, warm-up excluded.

| Metric | Before | After | Improvement |
|---|---:|---:|---:|
| Awaited delete | 289.8 ms | 218.4 ms | -24.6% |
| `move-sessions` stage | 160.3 ms | 84.4 ms | -47% |
| Server `moveSession` | 158.9 ms | 81.9 ms | -48% |
| `resolve-source` | 82.6 ms | eliminated | -82.6 ms |

Supporting run on a 137 MB / 501-commit fixture: `moveSession` median dropped from about 187 ms to about 108 ms, consistent with the stage result.

Checks:

- `bun test ./test/move-session.test.ts`: 4 pass, 0 fail
- `bun run typecheck` in `packages/core`: pass
- `bun run script/check-opencode-annotations.ts --worktree`: pass
- root `bun run lint`: 0 errors
