### PR TITLE
fix(tui): submit and cancel custom answers in the question dialog

### DIFF
--- a/.changeset/question-custom-answer-submit.md
+++ b/.changeset/question-custom-answer-submit.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix the TUI question dialog so Enter submits and Escape cancels a custom answer while the prompt autocomplete mode is active.

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -25,6 +25,7 @@ export function QuestionPrompt(props: {
   const single = createMemo(() => questions().length === 1 && questions()[0]?.multiple !== true)
   const tabs = createMemo(() => (single() ? 1 : questions().length + 1)) // questions + confirm tab (no confirm for single select)
   const [tabHover, setTabHover] = createSignal<number | "confirm" | null>(null)
+  const [textareaTarget, setTextareaTarget] = createSignal<TextareaRenderable>()
   const [store, setStore] = createStore({
     tab: 0,
     answers: [] as QuestionAnswer[],
@@ -140,8 +141,13 @@ export function QuestionPrompt(props: {
   })
 
   useBindings(() => ({
-    mode: QUESTION_MODE,
+    // kilocode_change start - bind on the focused textarea so edit submit and cancel
+    // win over the global managed textarea input layer and any higher mode, such as
+    // the prompt autocomplete mode. Matches DialogPrompt.
+    target: textareaTarget,
+    priority: 1,
     enabled: store.editing && !confirm(),
+    // kilocode_change end
     commands: [
       {
         name: "prompt.clear",
@@ -438,6 +444,7 @@ export function QuestionPrompt(props: {
                       <textarea
                         ref={(val: TextareaRenderable) => {
                           textarea = val
+                          setTextareaTarget(val)
                           val.traits = { status: "ANSWER" }
                           queueMicrotask(() => {
                             val.focus()

--- a/packages/tui/test/cli/tui/question-custom-answer.test.tsx
+++ b/packages/tui/test/cli/tui/question-custom-answer.test.tsx
@@ -1,0 +1,202 @@
+/** @jsxImportSource @opentui/solid */
+import { TextareaRenderable } from "@opentui/core"
+import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
+import { testRender, useRenderer } from "@opentui/solid"
+import { expect, test } from "bun:test"
+import { mkdir } from "node:fs/promises"
+import path from "node:path"
+import { onCleanup } from "solid-js"
+import type { QuestionRequest } from "@kilocode/sdk/v2"
+import { tmpdir } from "../../fixture/fixture"
+import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
+import { TestTuiContexts } from "../../fixture/tui-environment"
+import { createEventSource } from "../../fixture/tui-sdk"
+
+async function wait(fn: () => boolean, timeout = 2000) {
+  const start = Date.now()
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
+    await Bun.sleep(10)
+  }
+}
+
+function request(): QuestionRequest {
+  return {
+    id: "question-1",
+    sessionID: "session-1",
+    questions: [
+      {
+        question: "Which format?",
+        header: "Format",
+        options: [{ label: "json", description: "JSON output" }],
+      },
+    ],
+  }
+}
+
+async function mount(input: { root: string; requests: { path: string; body: unknown }[] }) {
+  const state = path.join(input.root, "state")
+  await mkdir(state, { recursive: true })
+  await Bun.write(path.join(state, "kv.json"), "{}")
+
+  const events = createEventSource()
+  const fetch = (async (request: RequestInfo | URL, init?: RequestInit) => {
+    const url = new URL(request instanceof Request ? request.url : String(request))
+    const raw = request instanceof Request ? await request.clone().text() : await new Response(init?.body).text()
+    input.requests.push({ path: url.pathname, body: raw ? JSON.parse(raw) : undefined })
+    return new Response(JSON.stringify(true), { headers: { "content-type": "application/json" } })
+  }) as typeof globalThis.fetch
+
+  const [
+    { QuestionPrompt },
+    { SDKProvider },
+    { KVProvider },
+    { ThemeProvider },
+    { TuiConfigProvider },
+    { OpencodeKeymapProvider, registerOpencodeKeymap, getOpencodeModeStack },
+  ] = await Promise.all([
+    import("../../../src/routes/session/question"),
+    import("../../../src/context/sdk"),
+    import("../../../src/context/kv"),
+    import("../../../src/context/theme"),
+    import("../../../src/config"),
+    import("../../../src/keymap"),
+  ])
+
+  const config = createTuiResolvedConfig()
+  const refs: { keymap?: ReturnType<typeof createDefaultOpenTuiKeymap> } = {}
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    refs.keymap = keymap
+    onCleanup(registerOpencodeKeymap(keymap, renderer, config))
+    return (
+      <TestTuiContexts directory={input.root} paths={{ home: input.root, state, worktree: input.root }}>
+        <OpencodeKeymapProvider keymap={keymap}>
+          <TuiConfigProvider config={config}>
+            <KVProvider>
+              <ThemeProvider mode="dark">
+                <SDKProvider url="http://test" directory={input.root} fetch={fetch} events={events.source}>
+                  <box width={80} height={20}>
+                    <QuestionPrompt request={request()} />
+                  </box>
+                </SDKProvider>
+              </ThemeProvider>
+            </KVProvider>
+          </TuiConfigProvider>
+        </OpencodeKeymapProvider>
+      </TestTuiContexts>
+    )
+  }
+
+  const app = await testRender(() => <Harness />, { width: 80, height: 20, kittyKeyboard: true })
+  return {
+    app,
+    pushAutocompleteMode() {
+      if (!refs.keymap) throw new Error("keymap not ready")
+      return getOpencodeModeStack(refs.keymap).push("autocomplete")
+    },
+    async cleanup() {
+      app.renderer.destroy()
+    },
+  }
+}
+
+async function openCustomEditor(prompt: Awaited<ReturnType<typeof mount>>) {
+  await prompt.app.renderOnce()
+  await Bun.sleep(50)
+  await prompt.app.flush()
+  prompt.app.mockInput.pressArrow("down")
+  await prompt.app.flush()
+  prompt.app.mockInput.pressEnter()
+  await prompt.app.flush()
+  await wait(() => prompt.app.renderer.currentFocusedEditor instanceof TextareaRenderable)
+}
+
+test("custom answer submits with enter while the textarea is focused", async () => {
+  await using tmp = await tmpdir()
+  const requests: { path: string; body: unknown }[] = []
+  const prompt = await mount({ root: tmp.path, requests })
+
+  try {
+    await openCustomEditor(prompt)
+
+    await prompt.app.mockInput.typeText("markdown")
+    await prompt.app.flush()
+    prompt.app.mockInput.pressEnter()
+    await prompt.app.flush()
+    await Bun.sleep(50)
+
+    const reply = requests.find((item) => item.path === "/question/question-1/reply")
+    expect(reply).toBeDefined()
+    expect((reply?.body as { answers?: string[][] })?.answers).toEqual([["markdown"]])
+  } finally {
+    await prompt.cleanup()
+  }
+})
+
+test("custom answer submits with enter while the prompt autocomplete mode is active", async () => {
+  await using tmp = await tmpdir()
+  const requests: { path: string; body: unknown }[] = []
+  const prompt = await mount({ root: tmp.path, requests })
+
+  try {
+    await openCustomEditor(prompt)
+
+    const pop = prompt.pushAutocompleteMode()
+    await prompt.app.mockInput.typeText("markdown")
+    await prompt.app.flush()
+    prompt.app.mockInput.pressEnter()
+    await prompt.app.flush()
+    await Bun.sleep(50)
+    pop()
+
+    const reply = requests.find((item) => item.path === "/question/question-1/reply")
+    expect(reply).toBeDefined()
+    expect((reply?.body as { answers?: string[][] })?.answers).toEqual([["markdown"]])
+  } finally {
+    await prompt.cleanup()
+  }
+})
+
+test("escape cancels the custom answer edit while the prompt autocomplete mode is active", async () => {
+  await using tmp = await tmpdir()
+  const requests: { path: string; body: unknown }[] = []
+  const prompt = await mount({ root: tmp.path, requests })
+
+  try {
+    await openCustomEditor(prompt)
+
+    const pop = prompt.pushAutocompleteMode()
+    prompt.app.mockInput.pressEscape()
+    await prompt.app.flush()
+    await Bun.sleep(50)
+    pop()
+
+    expect(requests.find((item) => item.path === "/question/question-1/reject")).toBeUndefined()
+    expect(prompt.app.renderer.currentFocusedEditor).not.toBeInstanceOf(TextareaRenderable)
+  } finally {
+    await prompt.cleanup()
+  }
+})
+
+test("escape cancels the custom answer edit", async () => {
+  await using tmp = await tmpdir()
+  const requests: { path: string; body: unknown }[] = []
+  const prompt = await mount({ root: tmp.path, requests })
+
+  try {
+    await openCustomEditor(prompt)
+
+    prompt.app.mockInput.pressEscape()
+    await prompt.app.flush()
+    expect(requests.find((item) => item.path === "/question/question-1/reject")).toBeUndefined()
+
+    prompt.app.mockInput.pressEscape()
+    await prompt.app.flush()
+    expect(requests.find((item) => item.path === "/question/question-1/reject")).toBeDefined()
+  } finally {
+    await prompt.cleanup()
+  }
+})


### PR DESCRIPTION
## What Problem This Solves

In the TUI question dialog, the "Type your own answer" custom answer cannot be submitted or cancelled by keyboard. Enter and Escape do nothing while the answer `<textarea>` is focused, so the dialog can only be escaped with Ctrl+C.

Fixes #13986.

## Why This Change Was Made

The custom answer edit bindings in `QuestionPrompt` were registered with `mode: QUESTION_MODE`. The prompt autocomplete pushes its own `"autocomplete"` mode on the same keymap mode stack when the prompt shows suggestions. Any mode pushed after the question opens _shadows_ `QUESTION_MODE` and deactivates the dialog edit bindings.

When that happens, Enter falls through to the global managed-textarea input layer. That layer binds `input.submit` to `TextareaRenderable`, but the dialog textarea has no `onSubmit`, so the event is consumed with no effect. Escape is likewise handled by the higher mode instead of cancelling the edit. This is a regression from upstream PR #28835, which introduced the dedicated `QUESTION_MODE` but only handled a mode that was already active at mount.

The fix binds the edit layer to the focused textarea with `target` and `priority: 1`, the same pattern `DialogPrompt` already uses so dialog form semantics win over the managed textarea layer. This makes submit and cancel independent of the mode stack.

## User Impact

Custom answers can be submitted with Enter and cancelled with Escape in all cases, including while the prompt autocomplete mode is active. No behavior change for the standard flow.

## Evidence

Captured in the real VS Code integrated terminal running the actual `QuestionPrompt` component through the OpenTUI renderer. The reproduction opens the question, selects "Type your own answer", enters edit mode, pushes the prompt autocomplete mode that shadows `QUESTION_MODE`, types `Handbooks`, then presses Enter.

Before the fix, Enter is consumed by the managed textarea layer: focus stays on the textarea and no reply is sent.

<img width="900" alt="Real terminal before the fix: build BROKEN-BUILD, mode=autocomplete, focus=TextareaRenderable, replies=0, textarea=Handbooks, verdict Enter did nothing" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260910-question-dialog-broken.png" />

After the fix, Enter submits the answer: focus leaves the textarea and the reply `{"answers":[["Handbooks"]]}` reaches the server.

<img width="900" alt="Real terminal after the fix: build FIXED-BUILD, mode=autocomplete, focus=none, replies=1, textarea=null, verdict SUBMITTED with Enter, last reply answers Handbooks" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260910-question-dialog-fixed.png" />

Reproduction is covered by `packages/tui/test/cli/tui/question-custom-answer.test.tsx`. The two autocomplete-mode tests fail before the fix and pass after.

Checks run from `packages/tui/`:

```
bun test --timeout 30000    # 260 pass, 1 skip, 0 fail
bun run typecheck           # tsgo --noEmit, clean
```

Root `bun run lint` reports 0 errors.
