### PR TITLE
perf(ui): render read-only todo checkbox without Kobalte

### DIFF
--- a/.changeset/todo-card-render.md
+++ b/.changeset/todo-card-render.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Speed up rendering of to-do list tool cards in the chat.

--- a/packages/kilo-ui/src/components/message-part.tsx
+++ b/packages/kilo-ui/src/components/message-part.tsx
@@ -3,6 +3,7 @@ import {
   createEffect,
   createMemo,
   createSignal,
+  createUniqueId,
   For,
   Match,
   onCleanup,
@@ -46,7 +47,6 @@ import { Card } from "./card"
 import { Collapsible } from "./collapsible"
 import { FileIcon } from "./file-icon"
 import { Icon } from "./icon"
-import { Checkbox } from "./checkbox"
 import { DiffChanges } from "./diff-changes"
 import { Markdown } from "./markdown"
 import { ImagePreview } from "./image-preview"
@@ -3296,6 +3296,54 @@ ToolRegistry.register({
   },
 })
 
+function TodoCheckbox(props: { checked: boolean; children: JSX.Element }) {
+  const id = createUniqueId()
+  const state = () => (props.checked ? "" : undefined)
+  return (
+    <div role="group" data-component="checkbox" data-readonly="" data-checked={state()}>
+      <input
+        type="checkbox"
+        id={`${id}-input`}
+        data-slot="checkbox-checkbox-input"
+        data-readonly=""
+        data-checked={state()}
+        checked={props.checked}
+        readOnly
+        aria-readonly="true"
+        aria-labelledby={`${id}-label`}
+        onChange={(event) => {
+          event.currentTarget.checked = props.checked
+        }}
+      />
+      <div data-slot="checkbox-checkbox-control" data-readonly="" data-checked={state()}>
+        <Show when={props.checked}>
+          <div data-slot="checkbox-checkbox-indicator" data-readonly="" data-checked="">
+            <svg viewBox="0 0 12 12" fill="none" width="10" height="10" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M3 7.17905L5.02703 8.85135L9 3.5"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="square"
+              />
+            </svg>
+          </div>
+        </Show>
+      </div>
+      <div data-slot="checkbox-checkbox-content">
+        <label
+          id={`${id}-label`}
+          for={`${id}-input`}
+          data-slot="checkbox-checkbox-label"
+          data-readonly=""
+          data-checked={state()}
+        >
+          {props.children}
+        </label>
+      </div>
+    </div>
+  )
+}
+
 ToolRegistry.register({
   name: "todowrite",
   render(props) {
@@ -3341,7 +3389,7 @@ ToolRegistry.register({
             </Show>
             <For each={shown()}>
               {(todo: TodoItem) => (
-                <Checkbox readOnly checked={todo.status === "completed"}>
+                <TodoCheckbox checked={todo.status === "completed"}>
                   <span
                     data-slot="message-part-todo-content"
                     data-completed={todo.status === "completed" ? "completed" : undefined}
@@ -3349,7 +3397,7 @@ ToolRegistry.register({
                   >
                     {todo.content}
                   </span>
-                </Checkbox>
+                </TodoCheckbox>
               )}
             </For>
             <Show when={view()?.mode === "compact" && (view()?.hiddenAfter ?? 0) > 0}>

--- a/packages/kilo-vscode/tests/accessibility.spec.ts
+++ b/packages/kilo-vscode/tests/accessibility.spec.ts
@@ -455,4 +455,27 @@ test.describe("webview accessibility ratchet", () => {
       await expect(page.getByRole("dialog")).toHaveAccessibleName(/.+/)
     }
   })
+
+  test("To-do cards render read-only checkboxes with labeled states", async ({ page }) => {
+    await open(page, "composite-webview--todo-write-completed")
+
+    const card = page.locator('[data-component="todos"]')
+    const done = card.getByRole("checkbox", { name: "Create a haiku about Jan" })
+    const active = card.getByRole("checkbox", { name: "Create a poem about Henk" })
+
+    await expect(done).toBeChecked()
+    await expect(active).not.toBeChecked()
+    await expect(done).toHaveAttribute("aria-readonly", "true")
+    await expect(active).toHaveAttribute("aria-readonly", "true")
+    await expect(card.locator('[data-component="checkbox"][data-readonly]')).toHaveCount(2)
+    await expect(card.locator('[data-slot="checkbox-checkbox-indicator"]')).toHaveCount(1)
+    await expect(card.locator('[data-slot="message-part-todo-content"][data-completed="completed"]')).toHaveText(
+      "Create a haiku about Jan",
+    )
+
+    await active.focus()
+    await page.keyboard.press("Space")
+    await expect(active).not.toBeChecked()
+    await expect(done).toBeChecked()
+  })
 })


### PR DESCRIPTION
## What Problem This Solves

The `todowrite` tool card rendered every to-do item with a full Kobalte `Checkbox` tree (Root + Input + Control + Indicator + Label + ErrorMessage, plus reactive state per item). The card is read-only, so that work buys no interactivity. A 6-item list cost about 8.9 ms of synchronous render in the isolated harness and 4.8 ms in the real webview, making it an outlier versus other non-diff tool cards.

## Why This Change Was Made

Replace the read-only Kobalte checkbox with lightweight markup that emits the same DOM slots and accessibility semantics: `data-component="checkbox"`, `checkbox-checkbox-input/control/indicator/label`, `data-readonly`, `data-checked`, a native checkbox with `aria-readonly="true"` and `role="group"`, and a label tied by `for`/`id`. The indicator mounts only when checked. No CSS changes.

## User Impact

No visual change. To-do cards render faster. The check icon for completed items, the unchecked box for pending items, in-progress styling, `data-completed`/`data-changed` attributes, and compact hidden-count rows are all unchanged.

## Evidence

Storybook harness (`BENCH_MODE=append BENCH_TOOLS=todowrite BENCH_REPEATS=7`, median of 3 runs):

| Build | `syncMs` |
|---|---|
| Before | 8.9 |
| After | 3.6 |

In-app VS Code profiling (isolated Extension Development Host, seeded 6-item `todowrite` session, collapse and expand remount, 34 iterations):

| Build | Median | p95 | DOM nodes / inputs / slots |
|---|---|---|---|
| Before | 4.8 ms | 5.3 ms | 42 / 6 / 32 |
| After | 3.9 ms | 4.7 ms | 42 / 6 / 32 |

`bun run typecheck` and `bun run lint` pass in `packages/kilo-vscode`. Added a Playwright test covering checked states, `aria-readonly`, label association, indicator count, and that Space does not toggle.

<img width="522" alt="To-do card in the VS Code chat showing completed, in-progress, and pending items" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260910-vscode-todo-card.png" />
