### PR TITLE
feat(vscode): reference a model inline in the prompt with @

### DIFF
--- a/.changeset/inline-model-references.md
+++ b/.changeset/inline-model-references.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": minor
+---
+
+Reference a model inline in the prompt with `@`, opening a model picker that inserts an `@provider/model` mention for Agent Manager or subagent instructions.

--- a/packages/kilo-vscode/tests/unit/file-mention-utils.test.ts
+++ b/packages/kilo-vscode/tests/unit/file-mention-utils.test.ts
@@ -21,6 +21,8 @@ import {
   TERMINAL_RESULT,
   GIT_CHANGES_RESULT,
   WORKTREES_RESULT,
+  MODEL_RESULT,
+  modelReferenceToken,
   filePickerNamed,
   defaultMentionIndex,
 } from "../../webview-ui/src/hooks/file-mention-utils"
@@ -75,17 +77,29 @@ describe("buildMentionResults", () => {
   it("includes special mentions for empty mention query", () => {
     const result = buildMentionResults("", [])
     expect(result[0]).toEqual({
+      type: "model",
+      value: "model",
+      label: "Model",
+      description: "Reference a model for subagents",
+    })
+    expect(result[1]).toEqual({
       type: "terminal",
       value: "terminal",
       label: "Terminal",
       description: "Active terminal output",
     })
-    expect(result[1]).toEqual({
+    expect(result[2]).toEqual({
       type: "git-changes",
       value: "git-changes",
       label: "Git changes",
       description: "Current session/worktree changes",
     })
+  })
+
+  it("offers the model reference entry for its label and aliases", () => {
+    expect(buildMentionResults("model", [])).toContainEqual(MODEL_RESULT)
+    expect(buildMentionResults("models", [])).toContainEqual(MODEL_RESULT)
+    expect(buildMentionResults("llm", [])).toContainEqual(MODEL_RESULT)
   })
 
   it("ranks terminal above a file the query fits less well", () => {
@@ -121,6 +135,7 @@ describe("buildMentionResults", () => {
   it("keeps the menu order for a bare @, entries above the files", () => {
     const result = buildMentionResults("", ["src/index.ts"])
     expect(result).toEqual([
+      MODEL_RESULT,
       TERMINAL_RESULT,
       GIT_CHANGES_RESULT,
       PAST_CHATS_RESULT,
@@ -743,7 +758,7 @@ describe("session mentions", () => {
   describe("buildMentionResults", () => {
     it("offers the past-chats picker alongside the other special mentions", () => {
       const result = buildMentionResults("", [])
-      expect(result[0]).toEqual(TERMINAL_RESULT)
+      expect(result[0]).toEqual(MODEL_RESULT)
       expect(result).toContainEqual(PAST_CHATS_RESULT)
       expect(result).toContainEqual(FILE_PICKER_RESULT)
     })
@@ -897,5 +912,18 @@ describe("session mentions", () => {
       expect(attachments.map((item) => item.url)).toEqual(["session:ses_a", "session:ses_b"])
       expect(attachments.map((item) => item.source?.text.value)).toEqual(["@Fix auth bug", "@Fix auth bug (2)"])
     })
+  })
+})
+
+describe("modelReferenceToken", () => {
+  it("builds the provider/model inline token", () => {
+    expect(modelReferenceToken("anthropic", "claude-sonnet-4")).toBe("anthropic/claude-sonnet-4")
+    expect(modelReferenceToken("openrouter", "anthropic/claude-sonnet-4")).toBe("openrouter/anthropic/claude-sonnet-4")
+  })
+
+  it("is rediscovered by syncMentionedPaths as a mention token", () => {
+    const token = modelReferenceToken("anthropic", "claude-sonnet-4")
+    const kept = syncMentionedPaths(new Set([token]), `use @${token} for the subagent`)
+    expect(kept.has(token)).toBe(true)
   })
 })

--- a/packages/kilo-vscode/tests/unit/use-file-mention.test.ts
+++ b/packages/kilo-vscode/tests/unit/use-file-mention.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
 import { useFileMention } from "../../webview-ui/src/hooks/useFileMention"
-import { FILE_PICKER_RESULT, TERMINAL_RESULT } from "../../webview-ui/src/hooks/file-mention-utils"
+import { FILE_PICKER_RESULT, MODEL_RESULT, TERMINAL_RESULT } from "../../webview-ui/src/hooks/file-mention-utils"
 import type { ExtensionMessage, WebviewMessage } from "../../webview-ui/src/types/messages"
 
 declare global {
@@ -335,6 +335,65 @@ describe("useFileMention", () => {
 
     expect(input.value).toBe("@Fix auth bug ")
     expect(mention.mentionedSessions().get("Fix auth bug")?.id).toBe("ses_a")
+
+    dispose.fn?.()
+  })
+
+  it("opens the model picker from the @ menu and inserts an inline model reference", () => {
+    const posted: WebviewMessage[] = []
+    const handlers = new Set<(message: ExtensionMessage) => void>()
+    const ctx = {
+      postMessage: (message: WebviewMessage) => posted.push(message),
+      onMessage: (handler: (message: ExtensionMessage) => void) => {
+        handlers.add(handler)
+        return () => handlers.delete(handler)
+      },
+    }
+
+    const dispose: { fn?: () => void } = {}
+    const mention = createRoot((root) => {
+      dispose.fn = root
+      return useFileMention(ctx, undefined, () => false)
+    })
+
+    const input = editor("@mod")
+    mockDocument(input)
+    try {
+      mention.selectMention(MODEL_RESULT, input, () => {})
+      expect(mention.modelPicker()).toBe(true)
+      expect(mention.showMention()).toBe(false)
+
+      mention.selectModelReference("anthropic", "claude-sonnet-4", () => {})
+    } finally {
+      restoreDocument()
+    }
+
+    expect(mention.modelPicker()).toBe(false)
+    expect(input.value).toBe("@anthropic/claude-sonnet-4 ")
+    expect(mention.mentionedModels().has("anthropic/claude-sonnet-4")).toBe(true)
+    // Model references are inline text, never file attachments.
+    expect(mention.mentionedPaths().has("anthropic/claude-sonnet-4")).toBe(false)
+    expect(mention.parseFileAttachments(input.value)).toEqual([])
+
+    dispose.fn?.()
+  })
+
+  it("seeds known model references from restored text without treating them as files", () => {
+    const ctx = {
+      postMessage: () => {},
+      onMessage: () => () => {},
+    }
+    const modelKeys = () => new Set(["anthropic/claude-sonnet-4"])
+    const dispose: { fn?: () => void } = {}
+    const mention = createRoot((root) => {
+      dispose.fn = root
+      return useFileMention(ctx, undefined, () => false, undefined, modelKeys)
+    })
+
+    mention.seedFromText("use @anthropic/claude-sonnet-4 for the subagent")
+    expect(mention.mentionedModels().has("anthropic/claude-sonnet-4")).toBe(true)
+    expect(mention.mentionedPaths().has("anthropic/claude-sonnet-4")).toBe(false)
+    expect(mention.parseFileAttachments("use @anthropic/claude-sonnet-4 for the subagent")).toEqual([])
 
     dispose.fn?.()
   })
@@ -1515,6 +1574,7 @@ describe("useFileMention", () => {
     }
 
     expect(mention.mentionResults()).toEqual([
+      MODEL_RESULT,
       { type: "terminal", value: "terminal", label: "Terminal", description: "Active terminal output" },
       { type: "past-chats", value: "past-chats", label: "Past chats", description: "Search previous sessions" },
       FILE_PICKER_RESULT,
@@ -1528,6 +1588,7 @@ describe("useFileMention", () => {
 
     mention.onInput("@", 1)
     expect(mention.mentionResults()).toEqual([
+      MODEL_RESULT,
       { type: "terminal", value: "terminal", label: "Terminal", description: "Active terminal output" },
       { type: "past-chats", value: "past-chats", label: "Past chats", description: "Search previous sessions" },
       FILE_PICKER_RESULT,
@@ -1675,6 +1736,7 @@ describe("useFileMention", () => {
     state.mention.onInput("@", 1)
 
     expect(state.mention.mentionResults()).toEqual([
+      MODEL_RESULT,
       { type: "terminal", value: "terminal", label: "Terminal", description: "Active terminal output" },
       { type: "past-chats", value: "past-chats", label: "Past chats", description: "Search previous sessions" },
       FILE_PICKER_RESULT,

--- a/packages/kilo-vscode/tests/unit/use-file-mention.test.ts
+++ b/packages/kilo-vscode/tests/unit/use-file-mention.test.ts
@@ -398,6 +398,58 @@ describe("useFileMention", () => {
     dispose.fn?.()
   })
 
+  it("reclassifies a restored model reference once the catalog loads after seeding", () => {
+    const ctx = {
+      postMessage: () => {},
+      onMessage: () => () => {},
+    }
+    // The catalog is empty while the draft is restored, so the seed cannot yet
+    // tell the token is a model reference.
+    let catalog = new Set<string>()
+    const modelKeys = () => catalog
+    const dispose: { fn?: () => void } = {}
+    const mention = createRoot((root) => {
+      dispose.fn = root
+      return useFileMention(ctx, undefined, () => false, undefined, modelKeys)
+    })
+
+    const text = "use @anthropic/claude-sonnet-4 for the subagent"
+    mention.seedFromText(text)
+    expect(mention.mentionedPaths().has("anthropic/claude-sonnet-4")).toBe(true)
+
+    catalog = new Set(["anthropic/claude-sonnet-4"])
+    mention.seedFromText(text)
+    expect(mention.mentionedModels().has("anthropic/claude-sonnet-4")).toBe(true)
+    expect(mention.mentionedPaths().has("anthropic/claude-sonnet-4")).toBe(false)
+    expect(mention.parseFileAttachments(text)).toEqual([])
+
+    dispose.fn?.()
+  })
+
+  it("never turns a catalog model reference into a file attachment", () => {
+    const ctx = {
+      postMessage: () => {},
+      onMessage: () => () => {},
+    }
+    // Simulate a path that was seeded before the catalog was available.
+    let catalog = new Set<string>()
+    const modelKeys = () => catalog
+    const dispose: { fn?: () => void } = {}
+    const mention = createRoot((root) => {
+      dispose.fn = root
+      return useFileMention(ctx, undefined, () => false, undefined, modelKeys)
+    })
+
+    const text = "use @anthropic/claude-sonnet-4 for the subagent"
+    mention.seedFromText(text)
+    mention.addPaths(["anthropic/claude-sonnet-4"], "/workspace")
+    catalog = new Set(["anthropic/claude-sonnet-4"])
+
+    expect(mention.parseFileAttachments(text)).toEqual([])
+
+    dispose.fn?.()
+  })
+
   it("waits for past chats before treating a spaced query as prose", async () => {
     const posted: WebviewMessage[] = []
     const handlers = new Set<(message: ExtensionMessage) => void>()

--- a/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/PromptInput.tsx
@@ -21,7 +21,7 @@ import { useLanguage } from "../../context/language"
 import { useVSCode } from "../../context/vscode"
 import { useConfig } from "../../context/config"
 import { useProvider } from "../../context/provider"
-import { ModelSelector } from "../shared/ModelSelector"
+import { ModelSelector, ModelSelectorBase } from "../shared/ModelSelector"
 import { ModeSwitcher } from "../shared/ModeSwitcher"
 import { SandboxButtonBase, SandboxTooltipContent } from "../shared/SandboxButton"
 import { SpeechToTextButton } from "../speech-to-text/SpeechToTextButton"
@@ -150,6 +150,11 @@ interface PromptInputProps {
   resolveEmbeddedTerminal?: (context?: string) => Promise<string | undefined>
 }
 
+// The `@` model entry reopens the shared model selector through its
+// programmatic-open event, keyed to this prompt scope so the chat model
+// selector and slash-command opens are unaffected.
+const MENTION_MODEL_TRIGGER = "mention-model"
+
 function MentionItemContent(props: { item: MentionResult }) {
   const item = props.item
   const language = useLanguage()
@@ -177,6 +182,14 @@ function MentionItemContent(props: { item: MentionResult }) {
     return (
       <>
         <Icon name="history" class="file-mention-icon" />
+        <span class="file-mention-name">{item.label}</span>
+        <span class="file-mention-dir">{item.description}</span>
+      </>
+    )
+  if (item.type === "model")
+    return (
+      <>
+        <Icon name="models" class="file-mention-icon" />
         <span class="file-mention-name">{item.label}</span>
         <span class="file-mention-dir">{item.description}</span>
       </>
@@ -231,7 +244,17 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     return rest === "unassigned" ? undefined : rest
   }
   const hasGit = () => server.gitInstalled()
-  const mention = useFileMention(vscode, sid, hasGit, props.worktrees)
+  const modelKeys = () => new Set(provider.models().map((model) => `${model.providerID}/${model.id}`))
+  const mention = useFileMention(vscode, sid, hasGit, props.worktrees, modelKeys)
+  // Picking the `@` model entry reuses the shared model selector: it is
+  // mounted hidden and opened through its programmatic-open event. The mention
+  // latch resets immediately because the selector owns its own open state, so
+  // dismissing it by clicking outside cannot leave the latch stuck open.
+  createEffect(() => {
+    if (!mention.modelPicker()) return
+    mention.closeMention()
+    window.dispatchEvent(new CustomEvent("openModelPicker", { detail: { source: MENTION_MODEL_TRIGGER } }))
+  })
   const terminal = useTerminalContext(props.resolveEmbeddedTerminal)
   const git = useGitChangesContext(vscode, ctx, hasGit)
   const imageAttach = useImageAttachments()
@@ -705,10 +728,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const highlightMentions = () => {
     const paths = new Set(mention.mentionedPaths())
     for (const token of mention.mentionedSessions().keys()) paths.add(token)
+    for (const token of mention.mentionedModels()) paths.add(token)
     if (hasTerminalMention(text())) paths.add("terminal")
     if (hasGit() && hasGitChangesMention(text())) paths.add("git-changes")
     return paths
   }
+  // Model references are inline text tokens, not files, so they must not be
+  // styled as or behave like clickable path mentions.
+  const isModelMention = (text: string) => mention.mentionedModels().has(text.replace(/^@/, ""))
   const placeholder = () => {
     switch (server.connectionState()) {
       case "connecting":
@@ -1653,6 +1680,20 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           />
         </div>
       </Show>
+      <div class="mention-model-anchor" aria-hidden="true">
+        <ModelSelectorBase
+          value={null}
+          trigger={MENTION_MODEL_TRIGGER}
+          collapsed
+          onSelect={(providerID, modelID) => {
+            if (providerID && modelID) mention.selectModelReference(providerID, modelID, adjustHeight)
+          }}
+          onCancel={() => {
+            mention.closeMention()
+            textareaRef?.focus()
+          }}
+        />
+      </div>
       <Show when={mention.showMention()}>
         <div class="file-mention-dropdown" ref={dropdownRef}>
           <Show
@@ -1813,9 +1854,12 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                 <Show when={seg().highlight} fallback={<span>{seg().text}</span>}>
                   <span
                     class="prompt-input-file-mention"
-                    classList={{ "prompt-input-file-mention--file": isPathMention(seg().text) }}
+                    classList={{
+                      "prompt-input-file-mention--file": isPathMention(seg().text) && !isModelMention(seg().text),
+                    }}
                     onClick={(e) => {
                       if (!isPathMention(seg().text)) return
+                      if (isModelMention(seg().text)) return
                       if (mention.mentionedSessions().has(seg().text.replace(/^@/, ""))) return
                       e.preventDefault()
                       e.stopPropagation()

--- a/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/shared/ModelSelector.tsx
@@ -140,6 +140,12 @@ export interface ModelSelectorBaseProps {
   trigger?: string
   /** Disable this prompt-scoped selector while a permission owns the prompt. */
   blocked?: boolean
+  /**
+   * Force the compact list layout. Used by inline `@` model references, where
+   * there is no current model for the preview pane and picking is a one-click,
+   * insert-only action. The persisted chat-selector preference is not changed.
+   */
+  collapsed?: boolean
 }
 
 export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
@@ -162,8 +168,14 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
 
   const [open, setOpen] = createSignal(false)
   // Shared, host-persisted expand/collapse preference (see VSCodeProvider).
-  const expanded = vscode.getModelSelectorExpanded
-  const setExpanded = vscode.setModelSelectorExpanded
+  // Inline `@` model references force the compact layout and must not read or
+  // write that preference.
+  const preferExpanded = vscode.getModelSelectorExpanded
+  const expanded = () => !props.collapsed && preferExpanded()
+  const setExpanded = (value: boolean) => {
+    if (props.collapsed) return
+    vscode.setModelSelectorExpanded(value)
+  }
   const [search, setSearch] = createSignal("")
   const hasSearch = () => search().trim().length > 0
   const [selectedKey, setSelectedKey] = createSignal(CLEAR_KEY)
@@ -914,30 +926,34 @@ export const ModelSelectorBase: Component<ModelSelectorBaseProps> = (props) => {
                       }
                     }}
                   />
-                  <Tooltip
-                    value={expanded() ? language.t("dialog.model.collapse") : language.t("dialog.model.expand")}
-                    placement="top"
-                  >
-                    <IconButton
-                      icon={expanded() ? "collapse" : "expand"}
-                      size="small"
-                      variant="ghost"
-                      aria-label={expanded() ? language.t("dialog.model.collapse") : language.t("dialog.model.expand")}
-                      aria-expanded={expanded()}
-                      aria-controls={previewID}
-                      onClick={() => {
-                        if (expanded()) {
-                          setPreActiveKey(null)
-                          setPreviewKey(null)
+                  <Show when={!props.collapsed}>
+                    <Tooltip
+                      value={expanded() ? language.t("dialog.model.collapse") : language.t("dialog.model.expand")}
+                      placement="top"
+                    >
+                      <IconButton
+                        icon={expanded() ? "collapse" : "expand"}
+                        size="small"
+                        variant="ghost"
+                        aria-label={
+                          expanded() ? language.t("dialog.model.collapse") : language.t("dialog.model.expand")
                         }
-                        setExpanded(!expanded())
-                        requestAnimationFrame(() => {
-                          searchRef?.focus()
-                          scrollRow(preActiveKey() ?? selectedKey(), "nearest")
-                        })
-                      }}
-                    />
-                  </Tooltip>
+                        aria-expanded={expanded()}
+                        aria-controls={previewID}
+                        onClick={() => {
+                          if (expanded()) {
+                            setPreActiveKey(null)
+                            setPreviewKey(null)
+                          }
+                          setExpanded(!expanded())
+                          requestAnimationFrame(() => {
+                            searchRef?.focus()
+                            scrollRow(preActiveKey() ?? selectedKey(), "nearest")
+                          })
+                        }}
+                      />
+                    </Tooltip>
+                  </Show>
                 </div>
 
                 <div

--- a/packages/kilo-vscode/webview-ui/src/hooks/file-mention-utils.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/file-mention-utils.ts
@@ -26,6 +26,17 @@ export type WorktreeReference = {
 
 export const PAST_CHATS_MENTION = "past-chats"
 
+const model = {
+  result: {
+    type: "model",
+    value: "model",
+    label: "Model",
+    description: "Reference a model for subagents",
+  },
+  aliases: ["models", "llm"],
+  gate: null,
+} as const
+
 const terminal = {
   result: {
     type: "terminal",
@@ -76,7 +87,7 @@ const picker = {
   gate: null,
 } as const
 
-const entries = [terminal, changes, chats, worktrees, picker] as const
+const entries = [model, terminal, changes, chats, worktrees, picker] as const
 type MentionEntry = (typeof entries)[number]["result"]
 
 export type MentionResult =
@@ -104,6 +115,7 @@ export const GIT_CHANGES_RESULT = changes.result
 export const FILE_PICKER_RESULT = picker.result
 export const PAST_CHATS_RESULT = chats.result
 export const WORKTREES_RESULT = worktrees.result
+export const MODEL_RESULT = model.result
 
 /**
  * Whether the query spells out the Browse files entry rather than just leaving
@@ -245,6 +257,11 @@ export function sessionMentionFilename(title: string, id: string) {
     .replace(/\s+/g, "-")
     .slice(0, 50)
   return `${slug || id}.md`
+}
+
+/** The inline token for referencing a model: `@providerID/modelID`. */
+export function modelReferenceToken(providerID: string, modelID: string) {
+  return `${providerID}/${modelID}`
 }
 
 /**

--- a/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
@@ -22,6 +22,7 @@ import {
   getMentionRemovalRange,
   findMentionRange,
   mentionSettled,
+  modelReferenceToken,
   sessionMentionText,
   sessionMentionToken,
   syncMentionedSessions as _syncMentionedSessions,
@@ -60,10 +61,14 @@ export interface FileMention {
   mentionedPaths: Accessor<Set<string>>
   /** Mentioned past chats, keyed by their `@title` token in the text. */
   mentionedSessions: Accessor<Map<string, SessionSearchItem>>
+  /** Mentioned model references, keyed by their `@providerID/modelID` token. */
+  mentionedModels: Accessor<Set<string>>
   /** Whether the past-chat session picker (AM-style search) is open. */
   sessionPicker: Accessor<boolean>
   /** Directory-scoped past chats shown in the session picker. */
   sessionCandidates: Accessor<SessionSearchItem[]>
+  /** Whether the inline model reference picker is open. */
+  modelPicker: Accessor<boolean>
   worktreePicker: Accessor<boolean>
   worktreeCandidates: Accessor<WorktreeReference[]>
   selectWorktree: (
@@ -138,6 +143,8 @@ export interface FileMention {
     setText: (text: string) => void,
     onSelect?: () => void,
   ) => void
+  /** Insert a model reference picked from the model picker as an @-mention. */
+  selectModelReference: (providerID: string, modelID: string, onSelect?: () => void) => void
 }
 
 export function useFileMention(
@@ -145,14 +152,17 @@ export function useFileMention(
   sessionID?: Accessor<string | undefined>,
   git?: Accessor<boolean>,
   worktrees?: Accessor<WorktreeReference[]>,
+  modelKeys?: Accessor<Set<string>>,
 ): FileMention {
   const [mentionedPaths, setMentionedPaths] = createSignal<Set<string>>(new Set())
   const [mentionedSessions, setMentionedSessions] = createSignal<Map<string, SessionSearchItem>>(new Map())
+  const [mentionedModels, setMentionedModels] = createSignal<Set<string>>(new Set())
   const [mentionQuery, setMentionQuery] = createSignal<string | null>(null)
   const [mentionResults, setMentionResults] = createSignal<MentionResult[]>([])
   const [mentionIndex, setMentionIndex] = createSignal(0)
   const [sessionPicker, setSessionPicker] = createSignal(false)
   const [sessionCandidates, setSessionCandidates] = createSignal<SessionSearchItem[]>([])
+  const [modelPicker, setModelPicker] = createSignal(false)
   const [worktreePicker, setWorktreePicker] = createSignal(false)
   const worktreeCandidates = () => worktrees?.().filter((worktree) => !worktree.disabled) ?? []
   let workspaceDir = ""
@@ -164,6 +174,9 @@ export function useFileMention(
   // Same accumulation for past-chat mentions, keyed by their exact visible
   // token. Duplicate titles receive a numeric suffix so they cannot overwrite.
   const knownSessions = new Map<string, SessionSearchItem>()
+  // Model references are kept apart from knownPaths: they are inline text
+  // tokens, not files, so they must never turn into file attachments.
+  const knownModels = new Set<string>()
   const knownWorktrees = new Map<string, WorktreeReference>()
   const references = () => {
     for (const worktree of worktrees?.() ?? []) {
@@ -216,6 +229,8 @@ export function useFileMention(
     setText: (text: string) => void
     onSelect?: () => void
   } | null = null
+  // The `@query` range that the open model picker will replace on selection.
+  let modelPickerState: { textarea: HTMLTextAreaElement; atStart: number; atEnd: number } | null = null
   let pendingArrowSnap: { timer: ReturnType<typeof setTimeout>; prevValue: string; prevPosition: number } | undefined
   // Offset of the "@" that opened the current query, the mention inserted at
   // each "@" offset, and the last spaced query the file search resolved to
@@ -254,6 +269,8 @@ export function useFileMention(
     sessionTimer = undefined
     setSessionCandidates([])
     setWorktreePicker(false)
+    setModelPicker(false)
+    modelPickerState = null
     setMentionResults([])
     setMentionIndex(0)
     return value
@@ -461,6 +478,7 @@ export function useFileMention(
     setMentionResults([])
     setSessionPicker(false)
     setWorktreePicker(false)
+    setModelPicker(false)
   }
 
   const closeSessionPicker = () => {
@@ -471,6 +489,7 @@ export function useFileMention(
     references()
     setMentionedPaths(() => _syncMentionedPaths(knownPaths, text))
     setMentionedSessions(() => _syncMentionedSessions(knownSessions, text))
+    setMentionedModels(() => _syncMentionedPaths(knownModels, text))
   }
 
   // Past chats are searched client-side (fuzzysort, same as the Agent Manager
@@ -557,6 +576,18 @@ export function useFileMention(
       return
     }
 
+    if (result.type === "model") {
+      // Switch the dropdown into the model picker; the actual insertion
+      // happens when a model is picked there.
+      const match = before.match(AT_PATTERN)!
+      const prefix = /^\s/.test(match[0]) ? 1 : 0
+      const atPos = match.index! + prefix
+      modelPickerState = { textarea, atStart: atPos, atEnd: cursor }
+      closeMention()
+      setModelPicker(true)
+      return
+    }
+
     // Past chats resolve their token again here: inline results are built from
     // a shared candidate list, so two chats with the same title would otherwise
     // insert the same token and overwrite each other in knownSessions.
@@ -620,6 +651,35 @@ export function useFileMention(
       onSelect,
     )
 
+  const selectModelReference = (providerID: string, modelID: string, onSelect?: () => void) => {
+    const state = modelPickerState
+    modelPickerState = null
+    setModelPicker(false)
+    if (!state) return
+    const textarea = state.textarea
+    if (!textarea.isConnected) return
+    const token = modelReferenceToken(providerID, modelID)
+    const after = textarea.value.substring(state.atEnd)
+    const suffix = /^\s/.test(after) ? "" : " "
+    // Add to knownModels BEFORE execCommand so syncMentionedPaths (triggered by
+    // the input event) can discover the new reference. Model tokens stay out of
+    // knownPaths so they are never turned into file attachments.
+    knownModels.add(token)
+    remember(state.atStart, token)
+    // Restore focus before execCommand: the picker's search field owns focus,
+    // which makes execCommand silently no-op.
+    textarea.focus()
+    suppress = true
+    try {
+      textarea.setSelectionRange(state.atStart, state.atEnd)
+      document.execCommand("insertText", false, `@${token}${suffix}`)
+    } finally {
+      suppress = false
+    }
+    setMentionedModels((prev) => new Set([...prev, token]))
+    onSelect?.()
+  }
+
   // When true, onInput skips dropdown logic (used during execCommand changes)
   let suppress = false
 
@@ -629,6 +689,7 @@ export function useFileMention(
     if (suppress) return
     closeSessionPicker()
     setWorktreePicker(false)
+    setModelPicker(false)
     const before = val.substring(0, cursor)
     const match = before.match(AT_PATTERN)
     if (!match) {
@@ -723,8 +784,9 @@ export function useFileMention(
   }
 
   // Mention tokens that count as atomic units for cursor movement, deletion
-  // and selection snapping: file paths plus past-chat title tokens.
-  const mentionTokens = () => new Set([...mentionedPaths(), ...mentionedSessions().keys()])
+  // and selection snapping: file paths, past-chat title tokens and model
+  // references.
+  const mentionTokens = () => new Set([...mentionedPaths(), ...mentionedSessions().keys(), ...mentionedModels()])
 
   const parseFileAttachments = (text: string): FileAttachment[] => {
     const worktrees = references()
@@ -858,7 +920,11 @@ export function useFileMention(
     const re = /@((?:[A-Za-z]:)?(?:[\w./-]+\.[\w]+|[\w.-]+\/[\w./-]+))/g
     let m: RegExpExecArray | null
     while ((m = re.exec(text))) {
-      knownPaths.add(m[1])
+      const token = m[1]!
+      // A known model reference is inline text, not a path, so it must not be
+      // seeded into knownPaths where it would become a file attachment.
+      if (modelKeys?.().has(token)) knownModels.add(token)
+      else knownPaths.add(token)
     }
     syncMentionedPaths(text)
   }
@@ -926,8 +992,10 @@ export function useFileMention(
   return {
     mentionedPaths,
     mentionedSessions,
+    mentionedModels,
     sessionPicker,
     sessionCandidates,
+    modelPicker,
     worktreePicker,
     worktreeCandidates,
     selectWorktree,
@@ -950,5 +1018,6 @@ export function useFileMention(
     seedFromParts,
     seedSessions,
     selectSession,
+    selectModelReference,
   }
 }

--- a/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
+++ b/packages/kilo-vscode/webview-ui/src/hooks/useFileMention.ts
@@ -487,9 +487,24 @@ export function useFileMention(
 
   const syncMentionedPaths = (text: string) => {
     references()
+    reclassifyModels()
     setMentionedPaths(() => _syncMentionedPaths(knownPaths, text))
     setMentionedSessions(() => _syncMentionedSessions(knownSessions, text))
     setMentionedModels(() => _syncMentionedPaths(knownModels, text))
+  }
+
+  // A restored draft can be seeded before the model catalog has loaded, so the
+  // seed-time split between files and models is not final. Re-run it against the
+  // live catalog so a model reference that was momentarily treated as a file
+  // moves to the model set instead of becoming a bogus attachment.
+  const reclassifyModels = () => {
+    const keys = modelKeys?.()
+    if (!keys?.size) return
+    for (const key of keys) {
+      if (!knownPaths.has(key)) continue
+      knownPaths.delete(key)
+      knownModels.add(key)
+    }
   }
 
   // Past chats are searched client-side (fuzzysort, same as the Agent Manager
@@ -790,7 +805,11 @@ export function useFileMention(
 
   const parseFileAttachments = (text: string): FileAttachment[] => {
     const worktrees = references()
-    const paths = new Set([..._syncMentionedPaths(knownPaths, text)].filter((path) => !knownWorktrees.has(path)))
+    reclassifyModels()
+    const keys = modelKeys?.()
+    const paths = new Set(
+      [..._syncMentionedPaths(knownPaths, text)].filter((path) => !knownWorktrees.has(path) && !keys?.has(path)),
+    )
     return [
       ...buildFileAttachments(text, paths, workspaceDir),
       ...buildSessionAttachments(text, mentionedSessions()),

--- a/packages/kilo-vscode/webview-ui/src/styles/prompt-dropdowns.css
+++ b/packages/kilo-vscode/webview-ui/src/styles/prompt-dropdowns.css
@@ -72,6 +72,20 @@
   opacity: 0.5;
 }
 
+/* Inline model reference reuses the shared ModelSelectorBase. The component
+   renders its own trigger button, so the wrapper collapses it to a zero-size,
+   non-focusable anchor that only positions the popover above the prompt. */
+.mention-model-anchor {
+  width: 0;
+  height: 0;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.mention-model-anchor button {
+  visibility: hidden;
+}
+
 /* ============================================
    Session Mention Picker (past chats)
    ============================================ */


### PR DESCRIPTION
## What Problem This Solves

An orchestrator cannot tell an Agent Manager session or the subagent tool which model to use from the prompt. It has to describe the model in prose, and the receiving agent has to guess the exact `provider/model` key. There is no way to pick a model inline while composing a prompt.

## Why This Change Was Made

The `@` mention menu already powers files, terminal output, git changes, past chats, and worktrees. This adds a **Model** entry to that menu. Selecting it opens the existing shared model selector and inserts an `@providerID/modelID` token into the prompt text.

The token is inline text, not a file attachment. It is tracked separately from file paths, so it is never sent as a file or rendered as a clickable path link. This keeps the exact model key visible to the model reading the prompt, for example to pass as the `model` parameter of the subagent or Agent Manager tool.

The reuse is deliberately non-invasive:

- `ModelSelectorBase` gains an optional `collapsed` prop. The inline `@` picker forces the compact list, because there is no current model to preview and picking is a one-click insert. Normal chat and settings selectors keep the persisted expand/collapse preference.
- The hidden instance is opened through the selector's existing `openModelPicker` event, keyed to a `mention-model` trigger, so the chat selector and `/models` are unaffected.
- No existing caller changes behavior when `collapsed` is not passed.

## User Impact

Typing `@`, then choosing **Model**, opens the model picker. Picking a model inserts `@provider/model` into the prompt. It does not change the active session model. The token behaves as one atomic unit for cursor movement and deletion.

## Evidence

The `@` menu now lists **Model** first:

<img width="560" alt="The @ mention menu with the Model entry" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260910-inline-model-mention-menu.png" />

Picking it opens the shared model picker in its compact form:

<img width="560" alt="The inline model picker" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260910-inline-model-mention-picker.png" />

The inserted reference is inline text; the session model stays unchanged:

<img width="560" alt="The prompt with an inserted model reference" src="https://raw.githubusercontent.com/marius-kilocode/pr-assets/assets/20260910-inline-model-mention-inserted.png" />

Verified in an isolated VS Code instance (sidebar and Agent Manager): the menu entry appears and filters, the picker opens and searches, keyboard navigation and Enter insert, Escape closes and refocuses the prompt, the session model is unchanged, and no console errors appear. `bun run test:unit` passes (5505 pass, 2 skip), along with extension lint, typecheck, knip, and `check-kilocode-change`.
