### PR TITLE
fix(shell): decode Chinese Windows GBK command output

### DIFF
--- a/.changeset/windows-python-shell-gbk.md
+++ b/.changeset/windows-python-shell-gbk.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Decode Chinese Windows GBK/cp936 Python shell output instead of showing U+FFFD diamonds.

--- a/packages/opencode/src/kilocode/shell-output-encoding.ts
+++ b/packages/opencode/src/kilocode/shell-output-encoding.ts
@@ -1,0 +1,128 @@
+/**
+ * Agent shell captures stdout through a pipe and historically decoded it as
+ * UTF-8. On Chinese Windows, Python writes GBK/cp936 unless PYTHONIOENCODING
+ * is set, so CJK becomes U+FFFD diamonds. This helper injects that env
+ * (without overriding a user value) and decodes leftover locale bytes as
+ * GB18030 when they are not valid UTF-8.
+ *
+ * Bytes stay tentative UTF-8 until a definite invalid sequence appears, then
+ * GB18030 is locked so a later window cut cannot flip the whole stream.
+ * Do not set PYTHONUTF8 — that also changes open() defaults.
+ */
+
+import * as Encoding from "./encoding"
+
+const PYTHON_IO_ENCODING = "PYTHONIOENCODING"
+
+export function hasEnv(env: NodeJS.ProcessEnv, key: string): boolean {
+  if (env[key] !== undefined) return true
+  if (process.platform !== "win32") return false
+  const found = Object.keys(env).find((item) => item.toLowerCase() === key.toLowerCase())
+  return found !== undefined && env[found] !== undefined
+}
+
+/** Add PYTHONIOENCODING=utf-8 when neither the overlay nor process.env already set it. */
+export function withUtf8StdioEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  if (hasEnv(env, PYTHON_IO_ENCODING) || hasEnv(process.env, PYTHON_IO_ENCODING)) return env
+  return { ...env, [PYTHON_IO_ENCODING]: "utf-8" }
+}
+
+function isValidUtf8(bytes: Buffer): boolean {
+  try {
+    new TextDecoder("utf-8", { fatal: true }).decode(bytes)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function isUtf8SequenceStart(bytes: Buffer): boolean {
+  if (bytes.length === 0) return true
+  const b = bytes[0]
+  if (b < 0x80) return true
+  if (b >= 0xc2 && b <= 0xdf) return bytes.length < 2
+  if (b >= 0xe0 && b <= 0xef) return bytes.length < 3
+  if (b >= 0xf0 && b <= 0xf4) return bytes.length < 4
+  return false
+}
+
+/** Longest valid UTF-8 prefix. -1 means a definite invalid sequence. */
+function utf8CompletePrefix(bytes: Buffer): number {
+  if (isValidUtf8(bytes)) return bytes.length
+  for (let n = 1; n <= 3 && n <= bytes.length; n++) {
+    const head = bytes.subarray(0, bytes.length - n)
+    const tail = bytes.subarray(bytes.length - n)
+    if (isValidUtf8(head) && isUtf8SequenceStart(tail)) return head.length
+  }
+  return -1
+}
+
+function takeCompleteGbk(bytes: Buffer): { complete: Buffer; leftover: Buffer } {
+  let i = 0
+  while (i < bytes.length) {
+    const lead = bytes[i]
+    if (lead < 0x80) {
+      i += 1
+      continue
+    }
+    if (lead < 0x81 || lead > 0xfe) {
+      i += 1
+      continue
+    }
+    if (i + 1 >= bytes.length) break
+    const trail = bytes[i + 1]
+    if (trail >= 0x30 && trail <= 0x39) {
+      if (i + 3 >= bytes.length) break
+      i += 4
+      continue
+    }
+    i += 2
+  }
+  return { complete: bytes.subarray(0, i), leftover: bytes.subarray(i) }
+}
+
+export class ShellOutputDecoder {
+  private leftover = Buffer.alloc(0)
+  private encoding: "gb18030" | undefined
+  private readonly utf8 = new TextDecoder("utf-8")
+
+  push(chunk: Uint8Array): string {
+    const buf = Buffer.concat([this.leftover, Buffer.from(chunk)])
+    this.leftover = Buffer.alloc(0)
+    if (buf.length === 0) return ""
+    if (this.encoding === "gb18030") return this.decodeGbk(buf)
+
+    const prefix = utf8CompletePrefix(buf)
+    if (prefix === buf.length) return this.utf8.decode(buf, { stream: true })
+    if (prefix >= 0) {
+      this.leftover = buf.subarray(prefix)
+      return prefix === 0 ? "" : this.utf8.decode(buf.subarray(0, prefix), { stream: true })
+    }
+    this.encoding = "gb18030"
+    return this.decodeGbk(buf)
+  }
+
+  flush(): string {
+    if (this.leftover.length === 0) {
+      return this.encoding === "gb18030" ? "" : this.utf8.decode()
+    }
+    const pending = this.leftover
+    this.leftover = Buffer.alloc(0)
+    if (this.encoding === "gb18030" || !isValidUtf8(pending)) {
+      return Encoding.decode(pending, "gb18030")
+    }
+    return this.utf8.decode(pending)
+  }
+
+  private decodeGbk(buf: Buffer): string {
+    const { complete, leftover } = takeCompleteGbk(buf)
+    this.leftover = leftover
+    return complete.length === 0 ? "" : Encoding.decode(complete, "gb18030")
+  }
+}
+
+/** One-shot decode of a complete captured buffer. */
+export function decodeShellOutput(bytes: Uint8Array): string {
+  const decoder = new ShellOutputDecoder()
+  return decoder.push(bytes) + decoder.flush()
+}

--- a/packages/opencode/src/kilocode/shell-output-encoding.ts
+++ b/packages/opencode/src/kilocode/shell-output-encoding.ts
@@ -2,17 +2,23 @@
  * Agent shell captures stdout through a pipe and historically decoded it as
  * UTF-8. On Chinese Windows, Python writes GBK/cp936 unless PYTHONIOENCODING
  * is set, so CJK becomes U+FFFD diamonds. This helper injects that env
- * (without overriding a user value) and decodes leftover locale bytes as
- * GB18030 when they are not valid UTF-8.
+ * (without overriding a user value) and, on Windows, decodes leftover locale
+ * bytes as GB18030 when they are not valid UTF-8.
  *
  * Bytes stay tentative UTF-8 until a definite invalid sequence appears, then
  * GB18030 is locked so a later window cut cannot flip the whole stream.
+ * Incomplete UTF-8 leftovers flush as UTF-8 replacement, not GB18030.
  * Do not set PYTHONUTF8 — that also changes open() defaults.
  */
 
 import * as Encoding from "./encoding"
 
 const PYTHON_IO_ENCODING = "PYTHONIOENCODING"
+
+export type ShellOutputDecoderOptions = {
+  /** Override the Windows-only GB18030 fallback. Tests pass true to exercise GBK. */
+  allowGb18030?: boolean
+}
 
 export function hasEnv(env: NodeJS.ProcessEnv, key: string): boolean {
   if (env[key] !== undefined) return true
@@ -25,6 +31,11 @@ export function hasEnv(env: NodeJS.ProcessEnv, key: string): boolean {
 export function withUtf8StdioEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   if (hasEnv(env, PYTHON_IO_ENCODING) || hasEnv(process.env, PYTHON_IO_ENCODING)) return env
   return { ...env, [PYTHON_IO_ENCODING]: "utf-8" }
+}
+
+/** GB18030 lock is Windows-only so Linux/macOS invalid UTF-8 stays replacement. */
+export function shouldAllowGb18030Fallback(platform = process.platform): boolean {
+  return platform === "win32"
 }
 
 function isValidUtf8(bytes: Buffer): boolean {
@@ -85,6 +96,11 @@ export class ShellOutputDecoder {
   private leftover = Buffer.alloc(0)
   private encoding: "gb18030" | undefined
   private readonly utf8 = new TextDecoder("utf-8")
+  private readonly allowGb18030: boolean
+
+  constructor(options: ShellOutputDecoderOptions = {}) {
+    this.allowGb18030 = options.allowGb18030 ?? shouldAllowGb18030Fallback()
+  }
 
   push(chunk: Uint8Array): string {
     const buf = Buffer.concat([this.leftover, Buffer.from(chunk)])
@@ -98,6 +114,7 @@ export class ShellOutputDecoder {
       this.leftover = buf.subarray(prefix)
       return prefix === 0 ? "" : this.utf8.decode(buf.subarray(0, prefix), { stream: true })
     }
+    if (!this.allowGb18030) return this.utf8.decode(buf)
     this.encoding = "gb18030"
     return this.decodeGbk(buf)
   }
@@ -108,9 +125,7 @@ export class ShellOutputDecoder {
     }
     const pending = this.leftover
     this.leftover = Buffer.alloc(0)
-    if (this.encoding === "gb18030" || !isValidUtf8(pending)) {
-      return Encoding.decode(pending, "gb18030")
-    }
+    if (this.encoding === "gb18030") return Encoding.decode(pending, "gb18030")
     return this.utf8.decode(pending)
   }
 
@@ -122,7 +137,7 @@ export class ShellOutputDecoder {
 }
 
 /** One-shot decode of a complete captured buffer. */
-export function decodeShellOutput(bytes: Uint8Array): string {
-  const decoder = new ShellOutputDecoder()
+export function decodeShellOutput(bytes: Uint8Array, options?: ShellOutputDecoderOptions): string {
+  const decoder = new ShellOutputDecoder(options)
   return decoder.push(bytes) + decoder.flush()
 }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -21,6 +21,7 @@ import { KiloReadObject } from "@/kilocode/tool/read-object" // kilocode_change
 import { isInterrupted } from "@/kilocode/effect/cause" // kilocode_change
 import * as SandboxPolicy from "@/kilocode/sandbox/policy" // kilocode_change
 import { CommandTimeout } from "@/kilocode/command-timeout" // kilocode_change
+import { ShellOutputDecoder, withUtf8StdioEnv } from "@/kilocode/shell-output-encoding" // kilocode_change
 import { Suggestion } from "@/kilocode/suggestion" // kilocode_change
 import { Question } from "@/question" // kilocode_change
 import { BUILTIN_COMMANDS } from "@/kilocode/session/builtin-commands" // kilocode_change
@@ -763,17 +764,18 @@ export const layer = Layer.effect(
               const cmd = ChildProcess.make(sh, args, {
                 cwd,
                 extendEnv: true,
-                env: { ...shellEnv.env, TERM: "dumb" },
+                env: withUtf8StdioEnv({ ...shellEnv.env, TERM: "dumb" }), // kilocode_change
                 stdin: "ignore",
                 forceKillAfter: "3 seconds",
               })
               const handle = yield* spawner.spawn(cmd)
+              const decoder = new ShellOutputDecoder() // kilocode_change
               // kilocode_change start
               timeout = yield* CommandTimeout.drain(
                 handle,
-                Stream.runForEach(Stream.decodeText(handle.all), (chunk) =>
+                Stream.runForEach(handle.all, (chunk) =>
                   Effect.gen(function* () {
-                    output += chunk
+                    output += decoder.push(chunk)
                     if (part.state.status === "running") {
                       part.state.metadata = { output }
                       yield* sessions.updatePart(part)
@@ -782,6 +784,7 @@ export const layer = Layer.effect(
                 ),
                 "shell command terminated",
               )
+              output += decoder.flush()
               // kilocode_change end
             }).pipe(Effect.scoped, Effect.orDie),
           ).pipe(Effect.exit)

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -13,6 +13,7 @@ import { fileURLToPath } from "url"
 import { Config } from "@/config/config"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { model as modelEnv } from "@/kilocode/process/env" // kilocode_change
+import { ShellOutputDecoder, withUtf8StdioEnv } from "@/kilocode/shell-output-encoding" // kilocode_change
 import { Shell } from "@opencode-ai/core/shell"
 import { ShellID } from "./shell/id"
 
@@ -539,7 +540,7 @@ export const ShellTool = Tool.define(
         { cwd, sessionID: ctx.sessionID, callID: ctx.callID },
         { env: {} },
       )
-      return modelEnv(extra.env) // kilocode_change - model shells must not inherit backend credentials
+      return withUtf8StdioEnv(modelEnv(extra.env)) // kilocode_change - strip backend credentials; set PYTHONIOENCODING unless already set
     })
 
     const run = Effect.fn("ShellTool.run")(function* (
@@ -558,6 +559,7 @@ export const ShellTool = Tool.define(
       let full = ""
       let last = ""
       const list: Chunk[] = []
+      const decoder = new ShellOutputDecoder() // kilocode_change - lock UTF-8 vs GB18030 from stream start
       let used = 0
       let file = ""
       let sink: ReturnType<typeof createWriteStream> | undefined
@@ -603,9 +605,19 @@ export const ShellTool = Tool.define(
 
           const reader = yield* Effect.forkScoped(
             // kilocode_change - keep the fiber so trailing output can be drained
-            Stream.runForEach(Stream.decodeText(handle.all), (chunk) => {
-              const size = Buffer.byteLength(chunk, "utf-8")
-              list.push({ text: chunk, size })
+            Stream.runForEach(handle.all, (chunk) => {
+              // kilocode_change start - decode raw bytes as UTF-8 or GB18030
+              const text = decoder.push(chunk)
+              if (!text) {
+                return ctx.metadata({
+                  metadata: {
+                    output: last,
+                  },
+                })
+              }
+              // kilocode_change end
+              const size = Buffer.byteLength(text, "utf-8")
+              list.push({ text, size })
               used += size
               while (used > keep && list.length > 1) {
                 const item = list.shift()
@@ -614,12 +626,12 @@ export const ShellTool = Tool.define(
                 cut = true
               }
 
-              last = preview(last + chunk)
+              last = preview(last + text)
 
               if (file) {
-                sink?.write(chunk)
+                sink?.write(text)
               } else {
-                full += chunk
+                full += text
                 if (Buffer.byteLength(full, "utf-8") > limits.maxBytes) {
                   return trunc.write(full).pipe(
                     Effect.andThen((next) =>
@@ -677,6 +689,13 @@ export const ShellTool = Tool.define(
           // buffered output that arrived just before the process exited. Wait for the stream to
           // finish (it ends once stdio closes) so fast commands do not lose their final chunks.
           yield* Fiber.await(reader).pipe(Effect.timeout("3 seconds"), Effect.ignore)
+          const rest = decoder.flush()
+          if (rest) {
+            list.push({ text: rest, size: Buffer.byteLength(rest, "utf-8") })
+            last = preview(last + rest)
+            if (file) sink?.write(rest)
+            else full += rest
+          }
           // kilocode_change end
 
           return exit.kind === "exit" ? exit.code : null

--- a/packages/opencode/test/kilocode/shell-output-encoding.test.ts
+++ b/packages/opencode/test/kilocode/shell-output-encoding.test.ts
@@ -4,8 +4,11 @@ import {
   decodeShellOutput,
   hasEnv,
   ShellOutputDecoder,
+  shouldAllowGb18030Fallback,
   withUtf8StdioEnv,
 } from "../../src/kilocode/shell-output-encoding"
+
+const gbkOptions = { allowGb18030: true } as const
 
 const chinese = "你好，世界！步骤5a自动检查通过"
 
@@ -70,18 +73,25 @@ describe("decodeShellOutput", () => {
     const gbk = iconv.encode(chinese, "gbk")
     expect(gbk.equals(Buffer.from(chinese, "utf-8"))).toBe(false)
     expect(() => new TextDecoder("utf-8", { fatal: true }).decode(gbk)).toThrow()
-    expect(decodeShellOutput(gbk)).toBe(chinese)
-    expect(decodeShellOutput(gbk)).not.toContain("\uFFFD")
+    expect(decodeShellOutput(gbk, gbkOptions)).toBe(chinese)
+    expect(decodeShellOutput(gbk, gbkOptions)).not.toContain("\uFFFD")
   })
 
   test("decodes a short GBK 你好 that chardet labels as Shift_JIS", () => {
     const hello = Buffer.from([0xc4, 0xe3, 0xba, 0xc3])
-    expect(decodeShellOutput(hello)).toBe("你好")
+    expect(decodeShellOutput(hello, gbkOptions)).toBe("你好")
   })
 
   test("decodes GB18030 Chinese", () => {
     const bytes = iconv.encode(chinese, "gb18030")
-    expect(decodeShellOutput(bytes)).toBe(chinese)
+    expect(decodeShellOutput(bytes, gbkOptions)).toBe(chinese)
+  })
+
+  test("does not lock GB18030 for invalid UTF-8 when fallback is off", () => {
+    const hello = Buffer.from([0xc4, 0xe3, 0xba, 0xc3])
+    const text = decodeShellOutput(hello, { allowGb18030: false })
+    expect(text).not.toBe("你好")
+    expect(text).toContain("\uFFFD")
   })
 
   test("keeps ASCII unchanged", () => {
@@ -106,24 +116,42 @@ describe("ShellOutputDecoder", () => {
   test("one-shot truncated UTF-8 keeps the valid prefix instead of GB18030", () => {
     const bytes = Buffer.from("步骤5a自动检查通过", "utf-8")
     const truncated = bytes.subarray(0, bytes.length - 1)
-    const text = decodeShellOutput(truncated)
+    const text = decodeShellOutput(truncated, gbkOptions)
     expect(text).toContain("步骤5a")
     expect(text).not.toBe(iconv.decode(truncated, "gb18030"))
   })
 
+  test("flushes an incomplete UTF-8 leftover as replacement, not GB18030", () => {
+    const bytes = Buffer.from("你好", "utf-8")
+    const decoder = new ShellOutputDecoder(gbkOptions)
+    const first = decoder.push(bytes.subarray(0, 2))
+    const flushed = decoder.flush()
+    expect(first).toBe("")
+    expect(flushed).not.toBe(iconv.decode(bytes.subarray(0, 2), "gb18030"))
+    expect(flushed).toContain("\uFFFD")
+  })
+
   test("streams GBK 你好 across a split lead byte", () => {
     const gbk = Buffer.from([0xc4, 0xe3, 0xba, 0xc3])
-    const decoder = new ShellOutputDecoder()
+    const decoder = new ShellOutputDecoder(gbkOptions)
     const first = decoder.push(gbk.subarray(0, 1))
     const rest = decoder.push(gbk.subarray(1)) + decoder.flush()
     expect(first + rest).toBe("你好")
   })
 
   test("keeps ASCII already emitted when later bytes lock GB18030", () => {
-    const decoder = new ShellOutputDecoder()
+    const decoder = new ShellOutputDecoder(gbkOptions)
     const ascii = decoder.push(Buffer.from("PASS A1\n"))
     const next = decoder.push(iconv.encode("你好", "gbk")) + decoder.flush()
     expect(ascii).toBe("PASS A1\n")
     expect(next).toBe("你好")
+  })
+})
+
+describe("shouldAllowGb18030Fallback", () => {
+  test("allows the fallback only on Windows", () => {
+    expect(shouldAllowGb18030Fallback("win32")).toBe(true)
+    expect(shouldAllowGb18030Fallback("darwin")).toBe(false)
+    expect(shouldAllowGb18030Fallback("linux")).toBe(false)
   })
 })

--- a/packages/opencode/test/kilocode/shell-output-encoding.test.ts
+++ b/packages/opencode/test/kilocode/shell-output-encoding.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test"
+import iconv from "iconv-lite"
+import {
+  decodeShellOutput,
+  hasEnv,
+  ShellOutputDecoder,
+  withUtf8StdioEnv,
+} from "../../src/kilocode/shell-output-encoding"
+
+const chinese = "你好，世界！步骤5a自动检查通过"
+
+describe("withUtf8StdioEnv", () => {
+  test("adds PYTHONIOENCODING=utf-8 when unset", () => {
+    const previous = process.env.PYTHONIOENCODING
+    delete process.env.PYTHONIOENCODING
+    try {
+      const next = withUtf8StdioEnv({ PATH: "/usr/bin" })
+      expect(next.PYTHONIOENCODING).toBe("utf-8")
+      expect(next.PATH).toBe("/usr/bin")
+    } finally {
+      if (previous === undefined) delete process.env.PYTHONIOENCODING
+      else process.env.PYTHONIOENCODING = previous
+    }
+  })
+
+  test("does not override an existing PYTHONIOENCODING on the overlay", () => {
+    const next = withUtf8StdioEnv({ PYTHONIOENCODING: "gbk" })
+    expect(next.PYTHONIOENCODING).toBe("gbk")
+  })
+
+  test("does not override PYTHONIOENCODING inherited from process.env", () => {
+    const previous = process.env.PYTHONIOENCODING
+    process.env.PYTHONIOENCODING = "gbk"
+    try {
+      const next = withUtf8StdioEnv({ PATH: "/usr/bin" })
+      expect(next.PYTHONIOENCODING).toBeUndefined()
+      expect(next.PATH).toBe("/usr/bin")
+    } finally {
+      if (previous === undefined) delete process.env.PYTHONIOENCODING
+      else process.env.PYTHONIOENCODING = previous
+    }
+  })
+
+  test("does not set PYTHONUTF8", () => {
+    const previous = process.env.PYTHONIOENCODING
+    delete process.env.PYTHONIOENCODING
+    try {
+      const next = withUtf8StdioEnv({})
+      expect(next.PYTHONUTF8).toBeUndefined()
+    } finally {
+      if (previous === undefined) delete process.env.PYTHONIOENCODING
+      else process.env.PYTHONIOENCODING = previous
+    }
+  })
+})
+
+describe("hasEnv", () => {
+  test("finds an exact key", () => {
+    expect(hasEnv({ PYTHONIOENCODING: "utf-8" }, "PYTHONIOENCODING")).toBe(true)
+    expect(hasEnv({ PATH: "/bin" }, "PYTHONIOENCODING")).toBe(false)
+  })
+})
+
+describe("decodeShellOutput", () => {
+  test("keeps valid UTF-8 Chinese", () => {
+    expect(decodeShellOutput(Buffer.from(chinese, "utf-8"))).toBe(chinese)
+  })
+
+  test("decodes GBK Chinese that UTF-8 would replace with U+FFFD", () => {
+    const gbk = iconv.encode(chinese, "gbk")
+    expect(gbk.equals(Buffer.from(chinese, "utf-8"))).toBe(false)
+    expect(() => new TextDecoder("utf-8", { fatal: true }).decode(gbk)).toThrow()
+    expect(decodeShellOutput(gbk)).toBe(chinese)
+    expect(decodeShellOutput(gbk)).not.toContain("\uFFFD")
+  })
+
+  test("decodes a short GBK 你好 that chardet labels as Shift_JIS", () => {
+    const hello = Buffer.from([0xc4, 0xe3, 0xba, 0xc3])
+    expect(decodeShellOutput(hello)).toBe("你好")
+  })
+
+  test("decodes GB18030 Chinese", () => {
+    const bytes = iconv.encode(chinese, "gb18030")
+    expect(decodeShellOutput(bytes)).toBe(chinese)
+  })
+
+  test("keeps ASCII unchanged", () => {
+    expect(decodeShellOutput(Buffer.from("PASS A1\nPASS A2\n"))).toBe("PASS A1\nPASS A2\n")
+  })
+
+  test("returns empty string for empty bytes", () => {
+    expect(decodeShellOutput(Buffer.alloc(0))).toBe("")
+  })
+})
+
+describe("ShellOutputDecoder", () => {
+  test("keeps UTF-8 Chinese when a character is split across pushes", () => {
+    const bytes = Buffer.from("你好", "utf-8")
+    const decoder = new ShellOutputDecoder()
+    const first = decoder.push(bytes.subarray(0, 2))
+    const rest = decoder.push(bytes.subarray(2)) + decoder.flush()
+    expect(first + rest).toBe("你好")
+    expect(first + rest).not.toContain("\uFFFD")
+  })
+
+  test("one-shot truncated UTF-8 keeps the valid prefix instead of GB18030", () => {
+    const bytes = Buffer.from("步骤5a自动检查通过", "utf-8")
+    const truncated = bytes.subarray(0, bytes.length - 1)
+    const text = decodeShellOutput(truncated)
+    expect(text).toContain("步骤5a")
+    expect(text).not.toBe(iconv.decode(truncated, "gb18030"))
+  })
+
+  test("streams GBK 你好 across a split lead byte", () => {
+    const gbk = Buffer.from([0xc4, 0xe3, 0xba, 0xc3])
+    const decoder = new ShellOutputDecoder()
+    const first = decoder.push(gbk.subarray(0, 1))
+    const rest = decoder.push(gbk.subarray(1)) + decoder.flush()
+    expect(first + rest).toBe("你好")
+  })
+
+  test("keeps ASCII already emitted when later bytes lock GB18030", () => {
+    const decoder = new ShellOutputDecoder()
+    const ascii = decoder.push(Buffer.from("PASS A1\n"))
+    const next = decoder.push(iconv.encode("你好", "gbk")) + decoder.flush()
+    expect(ascii).toBe("PASS A1\n")
+    expect(next).toBe("你好")
+  })
+})

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -194,6 +194,24 @@ describe("tool.shell", () => {
     ),
   )
 
+  // kilocode_change start - Windows Python often writes GBK; decode must not turn CJK into U+FFFD
+  it.live("decodes GBK Chinese stdout that is not valid UTF-8", () =>
+    runIn(
+      projectRoot,
+      Effect.gen(function* () {
+        const text = `${bin} -e ${evalarg("process.stdout.write(Buffer.from([0xc4,0xe3,0xba,0xc3]))")}`
+        const result = yield* run({
+          command: PS.has(sh()) ? `& ${text}` : text,
+          description: "Write GBK hello",
+        })
+        expect(result.metadata.exit).toBe(0)
+        expect(result.output).toContain("你好")
+        expect(result.output).not.toContain("\uFFFD")
+      }),
+    ),
+  )
+  // kilocode_change end
+
   it.live("falls back from terminal-only configured shell", () =>
     Effect.gen(function* () {
       const tmp = yield* tmpdirScoped({ config: { shell: "fish" } })


### PR DESCRIPTION
## Issue

Fixes #14008

## Context

Agent/CLI shell tools capture command stdout through a pipe and decode it with `Stream.decodeText` (UTF-8). On Chinese Windows, CPython writes GBK/cp936 unless `PYTHONIOENCODING` is set, so the same script that prints readable Chinese in a real terminal becomes U+FFFD diamonds in Kilo's captured output. Other Chinese in the UI is fine; this is a pipe-decode bug, not a font issue.

## Implementation

- Inject `PYTHONIOENCODING=utf-8` on the child env when the caller has not already set it. Do not set `PYTHONUTF8`, which also changes `open()` defaults.
- Stream-decode leftover bytes: stay tentative UTF-8 until a definite invalid sequence, then lock GB18030 (superset of GBK). Frame GBK by complete 1/2/4-byte sequences.
- Avoid chardet on this path. Short GBK `你好` (`C4 E3 BA C3`) is often labeled Shift_JIS.
- Same source/sink is wired into the shell tool and the session shell path.

## Screenshots / Video

N/A — no visual/UI change. The captured tool output string changes from U+FFFD diamonds to readable CJK.

## How to Test

### Manual/local verification

- Agent-executed unit assertions for `withUtf8StdioEnv` / `ShellOutputDecoder` / `decodeShellOutput` passed via `bun --eval` (UTF-8 keep, GBK `你好`, GB18030, split multi-byte, truncated UTF-8 prefix, ASCII-then-GBK lock).
- Official `bun test ./test/kilocode/shell-output-encoding.test.ts` was not run in this clone because it has no `node_modules` / `@opentui/solid` preload. CI should run that file plus the new live case in `packages/opencode/test/tool/shell.test.ts`.

### Reviewer test steps

1. On Chinese Windows (`chcp 936`), run `print("你好，世界")` through the Kilo shell/bash tool without setting `PYTHONIOENCODING`.
2. Confirm the tool result contains `你好，世界` and no U+FFFD diamonds.
3. Confirm a pre-set `PYTHONIOENCODING=gbk` is not overridden, and that UTF-8 Python output still decodes correctly.

### Blocked checks and substitute verification

- `bun test` from `packages/opencode/` could not complete locally: this checkout is a shallow clone without `bun install`. Substitute verification was the decoder assertion script above.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.