### PR TITLE
fix(permission): show human-only asks in auto mode instead of answering them

### DIFF
--- a/.changeset/permission-human-only-asks.md
+++ b/.changeset/permission-human-only-asks.md
@@ -1,0 +1,6 @@
+---
+"@kilocode/cli": patch
+"kilo-code": patch
+---
+
+Show permission asks only a human may answer instead of auto-answering them, so a skill-shell batch or sandbox escalation no longer leaves the turn hanging with no prompt. An approval made by auto mode is now attributed to the mode rather than reported back as approved by you.

--- a/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliDataParser.kt
+++ b/packages/kilo-jetbrains/backend/src/main/kotlin/ai/kilocode/backend/cli/KiloCliDataParser.kt
@@ -120,7 +120,7 @@ object KiloCliDataParser {
     private val READ_TOOL_LINE = Regex("^\\s*Called\\s+the\\s+Read\\s+tool\\s+with\\s+the\\s+following\\s+input:", RegexOption.IGNORE_CASE)
     private val READ_TOOL_PATH = Regex("\"(?:filePath|path)\"\\s*:")
     private val FIELD_RE = ConcurrentHashMap<String, Regex>()
-    private val APPROVAL_SOURCES = setOf("agent", "global", "project", "yolo", "session", "manual", "default")
+    private val APPROVAL_SOURCES = setOf("agent", "global", "project", "yolo", "session", "manual", "auto", "default")
 
     // ================================================================
     // SSE event parsing

--- a/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/views/tool/ToolApprovalText.kt
+++ b/packages/kilo-jetbrains/frontend/src/main/kotlin/ai/kilocode/client/session/views/tool/ToolApprovalText.kt
@@ -34,6 +34,7 @@ private fun source(approval: ToolApproval): String? = when (approval.source) {
     "project" -> KiloBundle.message("session.part.tool.approval.source.project")
     "yolo" -> KiloBundle.message("session.part.tool.approval.source.yolo")
     "session" -> KiloBundle.message("session.part.tool.approval.source.session")
+    "auto" -> KiloBundle.message("session.part.tool.approval.source.auto")
     "default" -> KiloBundle.message("session.part.tool.approval.source.default")
     else -> null
 }

--- a/packages/kilo-jetbrains/frontend/src/main/resources/messages/KiloBundle.properties
+++ b/packages/kilo-jetbrains/frontend/src/main/resources/messages/KiloBundle.properties
@@ -212,6 +212,7 @@ session.part.tool.approval.source.global=by your global config
 session.part.tool.approval.source.project=by the project config
 session.part.tool.approval.source.yolo=by auto-approve (YOLO) mode
 session.part.tool.approval.source.session=by a session auto-approve rule
+session.part.tool.approval.source.auto=by auto mode
 session.part.tool.approval.source.default=by default
 session.part.tool.approval.rule=matched `{0}` rule `{1}`
 session.part.tool.approval.outsideWorkspace=(outside your workspace: {0})

--- a/packages/kilo-ui/src/components/tool-approval.tsx
+++ b/packages/kilo-ui/src/components/tool-approval.tsx
@@ -10,7 +10,7 @@ import { Icon } from "./icon"
  * free of any i18n key coupling.
  */
 export type ToolApproval = {
-  source: "agent" | "global" | "project" | "yolo" | "session" | "manual" | "default"
+  source: "agent" | "global" | "project" | "yolo" | "session" | "manual" | "auto" | "default"
   agent?: string
   rule?: { permission: string; pattern: string; action: string }
   /** True when the tool call's target path was outside the workspace/worktree. */
@@ -28,7 +28,7 @@ export type ToolApprovalDisplay = {
   outsideWorkspace?: string
 }
 
-const SOURCE_KEYS = ["agent", "global", "project", "yolo", "session", "manual", "default"] as const
+const SOURCE_KEYS = ["agent", "global", "project", "yolo", "session", "manual", "auto", "default"] as const
 
 const Context = createContext<Accessor<ToolApprovalDisplay | undefined>>(() => undefined)
 

--- a/packages/kilo-vscode/src/commands/toggle-auto-approve.ts
+++ b/packages/kilo-vscode/src/commands/toggle-auto-approve.ts
@@ -73,7 +73,9 @@ export function registerToggleAutoApprove(
         const { data: pending } = await client.permission.list({ directory: dir }, { throwOnError: true })
         for (const req of pending) {
           if (generation !== snapshot) break
-          if (req.metadata?.["sandboxEscalation"] === true) continue
+          // The server refuses a non-interactive approval for these and leaves the ask pending, so
+          // replying only costs a round trip and suppresses the attention nudge for a live prompt.
+          if (req.metadata?.["sandboxEscalation"] === true || req.metadata?.["skillShell"] === true) continue
           await client.permission
             .reply({ requestID: req.id, directory: dir, reply: "once" }, { throwOnError: true })
             .catch((err) => {
@@ -93,6 +95,7 @@ export function registerToggleAutoApprove(
     const client = tryGetClient(connectionService)
     if (!client) return false
     if (event.properties.metadata?.["sandboxEscalation"] === true) return false
+    if (event.properties.metadata?.["skillShell"] === true) return false
     const dir =
       directory ?? connectionService.getPermissionDirectory(event.properties.id) ?? resolve(event.properties.sessionID)
     return client.permission

--- a/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ar.ts
@@ -297,6 +297,7 @@ export const dict = {
   "ui.approval.source.yolo": "بواسطة وضع الموافقة التلقائية (YOLO)",
   "ui.approval.source.session": "بواسطة قاعدة موافقة تلقائية للجلسة",
   "ui.approval.source.default": "افتراضيًا",
+  "ui.approval.source.auto": "بواسطة الوضع التلقائي",
   "ui.approval.outsideWorkspace": "(خارج مساحة العمل: {{file}})",
 
   "session.tab.review": "مراجعة",

--- a/packages/kilo-vscode/webview-ui/src/i18n/br.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/br.ts
@@ -307,6 +307,7 @@ export const dict = {
   "ui.approval.source.yolo": "pelo modo de aprovação automática (YOLO)",
   "ui.approval.source.session": "por uma regra de aprovação automática da sessão",
   "ui.approval.source.default": "por padrão",
+  "ui.approval.source.auto": "pelo modo automático",
   "ui.approval.outsideWorkspace": "(fora do seu espaço de trabalho: {{file}})",
 
   "session.tab.review": "Revisão",

--- a/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/bs.ts
@@ -305,6 +305,7 @@ export const dict = {
   "ui.approval.source.yolo": "režimom automatskog odobravanja (YOLO)",
   "ui.approval.source.session": "pravilom automatskog odobravanja sesije",
   "ui.approval.source.default": "podrazumevano",
+  "ui.approval.source.auto": "automatskim načinom",
   "ui.approval.outsideWorkspace": "(izvan vašeg radnog prostora: {{file}})",
 
   "session.tab.review": "Pregled",

--- a/packages/kilo-vscode/webview-ui/src/i18n/da.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/da.ts
@@ -304,6 +304,7 @@ export const dict = {
   "ui.approval.source.yolo": "af automatisk godkendelse (YOLO)",
   "ui.approval.source.session": "af en session-autogodkendelsesregel",
   "ui.approval.source.default": "som standard",
+  "ui.approval.source.auto": "af auto-tilstand",
   "ui.approval.outsideWorkspace": "(uden for dit arbejdsområde: {{file}})",
 
   "session.tab.review": "Gennemgang",

--- a/packages/kilo-vscode/webview-ui/src/i18n/de.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/de.ts
@@ -312,6 +312,7 @@ export const dict = {
   "ui.approval.source.yolo": "durch den Auto-Genehmigungsmodus (YOLO)",
   "ui.approval.source.session": "durch eine Sitzungs-Auto-Genehmigungsregel",
   "ui.approval.source.default": "standardmäßig",
+  "ui.approval.source.auto": "durch den Auto-Modus",
   "ui.approval.outsideWorkspace": "(außerhalb deines Arbeitsbereichs: {{file}})",
 
   "session.tab.review": "Überprüfung",

--- a/packages/kilo-vscode/webview-ui/src/i18n/en.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/en.ts
@@ -299,6 +299,7 @@ export const dict = {
   "ui.approval.source.yolo": "by auto-approve (YOLO) mode",
   "ui.approval.source.session": "by a session auto-approve rule",
   "ui.approval.source.default": "by default",
+  "ui.approval.source.auto": "by auto mode",
   "ui.approval.outsideWorkspace": "(outside your workspace: {{file}})",
 
   "session.tab.review": "Review",

--- a/packages/kilo-vscode/webview-ui/src/i18n/es.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/es.ts
@@ -307,6 +307,7 @@ export const dict = {
   "ui.approval.source.yolo": "por el modo de aprobación automática (YOLO)",
   "ui.approval.source.session": "por una regla de aprobación automática de sesión",
   "ui.approval.source.default": "de forma predeterminada",
+  "ui.approval.source.auto": "por el modo automático",
   "ui.approval.outsideWorkspace": "(fuera de tu espacio de trabajo: {{file}})",
 
   "session.tab.review": "Revisión",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fa.ts
@@ -302,6 +302,7 @@ export const dict = {
   "ui.approval.source.yolo": "توسط حالت تأیید خودکار (YOLO)",
   "ui.approval.source.session": "توسط قانون تأیید خودکار جلسه",
   "ui.approval.source.default": "به‌طور پیش‌فرض",
+  "ui.approval.source.auto": "توسط حالت خودکار",
   "ui.approval.outsideWorkspace": "(خارج از فضای کاری شما: {{file}})",
 
   "session.tab.review": "بررسی",

--- a/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/fr.ts
@@ -307,6 +307,7 @@ export const dict = {
   "ui.approval.source.yolo": "par le mode d'approbation automatique (YOLO)",
   "ui.approval.source.session": "par une règle d'approbation automatique de session",
   "ui.approval.source.default": "par défaut",
+  "ui.approval.source.auto": "par le mode auto",
   "ui.approval.outsideWorkspace": "(hors de votre espace de travail : {{file}})",
 
   "session.tab.review": "Revue",

--- a/packages/kilo-vscode/webview-ui/src/i18n/it.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/it.ts
@@ -242,6 +242,7 @@ export const dict = {
   "ui.approval.source.yolo": "dalla modalità di approvazione automatica (YOLO)",
   "ui.approval.source.session": "da una regola di approvazione automatica della sessione",
   "ui.approval.source.default": "per impostazione predefinita",
+  "ui.approval.source.auto": "dalla modalità auto",
   "ui.approval.outsideWorkspace": "(fuori dall'area di lavoro: {{file}})",
   "session.tab.review": "Revisione",
   "session.review.filesChanged": "{{count}} file modificati",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ja.ts
@@ -304,6 +304,7 @@ export const dict = {
   "ui.approval.source.yolo": "自動承認（YOLO）モードによって",
   "ui.approval.source.session": "セッションの自動承認ルールによって",
   "ui.approval.source.default": "デフォルトで",
+  "ui.approval.source.auto": "自動モードにより",
   "ui.approval.outsideWorkspace": "（ワークスペース外：{{file}}）",
 
   "session.tab.review": "レビュー",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ko.ts
@@ -305,6 +305,7 @@ export const dict = {
   "ui.approval.source.yolo": "자동 승인(YOLO) 모드에 의해",
   "ui.approval.source.session": "세션 자동 승인 규칙에 의해",
   "ui.approval.source.default": "기본값으로",
+  "ui.approval.source.auto": "자동 모드에 의해",
   "ui.approval.outsideWorkspace": "(작업 영역 외부: {{file}})",
 
   "session.tab.review": "검토",

--- a/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/nl.ts
@@ -307,6 +307,7 @@ export const dict = {
   "ui.approval.source.yolo": "door de automatische goedkeuringsmodus (YOLO)",
   "ui.approval.source.session": "door een sessie-automatische-goedkeuringsregel",
   "ui.approval.source.default": "standaard",
+  "ui.approval.source.auto": "door de automatische modus",
   "ui.approval.outsideWorkspace": "(buiten je werkruimte: {{file}})",
 
   "session.tab.review": "Beoordelen",

--- a/packages/kilo-vscode/webview-ui/src/i18n/no.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/no.ts
@@ -311,6 +311,7 @@ export const dict = {
   "ui.approval.source.yolo": "av automatisk godkjenning (YOLO)",
   "ui.approval.source.session": "av en økt-autogodkjenningsregel",
   "ui.approval.source.default": "som standard",
+  "ui.approval.source.auto": "av auto-modus",
   "ui.approval.outsideWorkspace": "(utenfor arbeidsområdet ditt: {{file}})",
 
   "session.tab.review": "Gjennomgang",

--- a/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/pl.ts
@@ -305,6 +305,7 @@ export const dict = {
   "ui.approval.source.yolo": "przez tryb automatycznego zatwierdzania (YOLO)",
   "ui.approval.source.session": "przez regułę automatycznego zatwierdzania sesji",
   "ui.approval.source.default": "domyślnie",
+  "ui.approval.source.auto": "przez tryb auto",
   "ui.approval.outsideWorkspace": "(poza obszarem roboczym: {{file}})",
 
   "session.tab.review": "Przegląd",

--- a/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/ru.ts
@@ -303,6 +303,7 @@ export const dict = {
   "ui.approval.source.yolo": "режимом автоодобрения (YOLO)",
   "ui.approval.source.session": "правилом автоодобрения сессии",
   "ui.approval.source.default": "по умолчанию",
+  "ui.approval.source.auto": "режимом auto",
   "ui.approval.outsideWorkspace": "(за пределами вашей рабочей области: {{file}})",
 
   "session.tab.review": "Обзор",

--- a/packages/kilo-vscode/webview-ui/src/i18n/th.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/th.ts
@@ -302,6 +302,7 @@ export const dict = {
   "ui.approval.source.yolo": "โดยโหมดอนุมัติอัตโนมัติ (YOLO)",
   "ui.approval.source.session": "โดยกฎอนุมัติอัตโนมัติของเซสชัน",
   "ui.approval.source.default": "ตามค่าเริ่มต้น",
+  "ui.approval.source.auto": "โดยโหมดอัตโนมัติ",
   "ui.approval.outsideWorkspace": "(นอกพื้นที่ทำงานของคุณ: {{file}})",
 
   "session.tab.review": "ตรวจสอบ",

--- a/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/tr.ts
@@ -304,6 +304,7 @@ export const dict = {
   "ui.approval.source.yolo": "otomatik onay (YOLO) modu tarafından",
   "ui.approval.source.session": "bir oturum otomatik onay kuralı tarafından",
   "ui.approval.source.default": "varsayılan olarak",
+  "ui.approval.source.auto": "otomatik mod tarafından",
   "ui.approval.outsideWorkspace": "(çalışma alanınızın dışında: {{file}})",
 
   "session.tab.review": "İnceleme",

--- a/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/uk.ts
@@ -307,6 +307,7 @@ export const dict = {
   "ui.approval.source.yolo": "режимом автосхвалення (YOLO)",
   "ui.approval.source.session": "правилом автосхвалення сесії",
   "ui.approval.source.default": "за замовчуванням",
+  "ui.approval.source.auto": "режимом auto",
   "ui.approval.outsideWorkspace": "(за межами вашого робочого простору: {{file}})",
 
   "session.tab.review": "Огляд",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zh.ts
@@ -291,6 +291,7 @@ export const dict = {
   "ui.approval.source.yolo": "由自动批准（YOLO）模式",
   "ui.approval.source.session": "由会话自动批准规则",
   "ui.approval.source.default": "默认",
+  "ui.approval.source.auto": "由自动模式",
   "ui.approval.outsideWorkspace": "（工作区之外：{{file}}）",
 
   "session.tab.review": "审查",

--- a/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
+++ b/packages/kilo-vscode/webview-ui/src/i18n/zht.ts
@@ -289,6 +289,7 @@ export const dict = {
   "ui.approval.source.yolo": "由自動核准（YOLO）模式",
   "ui.approval.source.session": "由工作階段自動核准規則",
   "ui.approval.source.default": "預設",
+  "ui.approval.source.auto": "由自動模式",
   "ui.approval.outsideWorkspace": "（工作區之外：{{file}}）",
 
   "session.tab.review": "審查",

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -287,6 +287,7 @@ export const RunCommand = effectCmd({
     const { KiloRunAuto } = yield* Effect.promise(() => import("@/kilocode/cli/run-auto"))
     const { KiloRunDrain } = yield* Effect.promise(() => import("@/kilocode/cli/run-drain"))
     const { KiloHeadless } = yield* Effect.promise(() => import("@/kilocode/permission/headless"))
+    const { PermissionHumanOnly } = yield* Effect.promise(() => import("@/kilocode/permission/human-only"))
     const { KiloRun, KiloRunDaemon } = yield* Effect.promise(() => import("@/kilocode/cli/cmd/run"))
     // kilocode_change end
     const agentSvc = yield* Agent.Service
@@ -941,9 +942,10 @@ export const RunCommand = effectCmd({
             if (event.type === "permission.asked") {
               const permission = event.properties
               if (!KiloRunAuto.allowed(tracked, permission.sessionID)) continue // kilocode_change
-              // kilocode_change start - skill shell batches need an interactive human decision. The server ignores
+              // kilocode_change start - some asks need an interactive human decision. The server ignores
               // non-interactive approvals, so headless runs must reject explicitly rather than leave them pending.
-              if (permission.metadata?.["skillShell"] === true || permission.metadata?.["sandboxEscalation"] === true) {
+              // The predicate is shared with the server guard and the TUI so the three cannot drift apart.
+              if (PermissionHumanOnly.requires(permission.metadata)) {
                 await client.permission.reply({ requestID: permission.id, reply: "reject" })
                 continue
               }

--- a/packages/opencode/src/kilocode/permission/drain.ts
+++ b/packages/opencode/src/kilocode/permission/drain.ts
@@ -1,6 +1,7 @@
 import { Deferred, Effect } from "effect"
 import { Permission } from "@/permission"
 import { ConfigProtection } from "@/kilocode/permission/config-paths"
+import { SecurityAsk } from "@/kilocode/security-decision/ask"
 
 interface PendingEntry {
   info: Permission.Request
@@ -36,6 +37,9 @@ export function drainCovered(
       // Never auto-resolve a skill shell batch; it must get an explicit reply.
       if (entry.info.metadata?.["skillShell"] === true) continue
       if (entry.info.metadata?.["sandboxEscalation"] === true) continue
+      // Never auto-resolve an ask the security layer raised: the rule that would cover it is the
+      // very rule the layer overrode, so draining it would auto-approve a security decision.
+      if (SecurityAsk.is(entry.info.metadata)) continue
       const actions = entry.info.patterns.map((pattern: string) => {
         const rule = skill
           ? Permission.evaluate(entry.info.permission, skill, approved)

--- a/packages/opencode/src/kilocode/permission/drain.ts
+++ b/packages/opencode/src/kilocode/permission/drain.ts
@@ -7,6 +7,8 @@ interface PendingEntry {
   info: Permission.Request
   ruleset: Permission.Ruleset
   hardRuleset?: Permission.Ruleset
+  /** Written back so `ask` can report who approved a drained sibling; see `interactive` below. */
+  approval?: { interactive: boolean }
   deferred: Deferred.Deferred<void, Permission.RejectedError | Permission.CorrectedError>
 }
 
@@ -21,12 +23,17 @@ type PublishReply = (data: {
  * Auto-resolve pending permissions now fully covered by approved or denied rules.
  * When the user approves/denies a rule on subagent A, sibling subagent B's
  * pending permission for the same pattern resolves or rejects automatically.
+ *
+ * `interactive` says whether a human made the decision that covers them: a drained sibling is
+ * approved by whoever set the covering rule, so it must be attributed the same way rather than
+ * reported as a decision the mode made on its own.
  */
 export function drainCovered(
   pending: Map<string, PendingEntry>,
   approved: Permission.Ruleset,
   publishReply: PublishReply,
   exclude?: string,
+  interactive = false,
 ): Effect.Effect<void> {
   return Effect.gen(function* () {
     for (const [id, entry] of pending) {
@@ -60,6 +67,7 @@ export function drainCovered(
         yield* Deferred.fail(entry.deferred, new Permission.RejectedError())
       } else {
         yield* publishReply({ sessionID: entry.info.sessionID, requestID: entry.info.id, reply: "always" })
+        entry.approval = { interactive }
         yield* Deferred.succeed(entry.deferred, undefined)
       }
     }

--- a/packages/opencode/src/kilocode/permission/human-only.ts
+++ b/packages/opencode/src/kilocode/permission/human-only.ts
@@ -1,0 +1,19 @@
+// kilocode_change - new file
+import { SecurityAsk } from "@/kilocode/security-decision/ask"
+
+/**
+ * Asks that only a human may answer.
+ *
+ * The server refuses a machine reply to these and leaves the prompt pending; a client in auto mode
+ * must therefore show them rather than answer them. The two sides used to spell the set out
+ * separately and drifted: the client auto-answered a sandbox escalation, the server refused that
+ * answer, and because the client had already taken its auto-reply branch it never displayed the
+ * prompt — so the request waited for a human nobody had told, and the turn hung with no error.
+ *
+ * Kept dependency-free (no Effect, no node) so the TUI imports the same predicate the server uses.
+ */
+export namespace PermissionHumanOnly {
+  export function requires(metadata: Record<string, unknown> | undefined): boolean {
+    return metadata?.["skillShell"] === true || metadata?.["sandboxEscalation"] === true || SecurityAsk.is(metadata)
+  }
+}

--- a/packages/opencode/src/kilocode/permission/provenance.ts
+++ b/packages/opencode/src/kilocode/permission/provenance.ts
@@ -10,7 +10,18 @@ import type { Permission } from "@/permission"
  */
 export namespace PermissionProvenance {
   /** Where the deciding rule came from. */
-  export type Source = "agent" | "global" | "project" | "yolo" | "session" | "manual" | "default"
+  export type Source = "agent" | "global" | "project" | "yolo" | "session" | "manual" | "auto" | "default"
+
+  /**
+   * Who answered a prompt that was actually raised.
+   *
+   * Auto mode replies from the client and omits `interactive`, so an approval nobody looked at is
+   * attributed to the mode rather than to the user — "approved by you" about a decision the user
+   * never made is worse than saying nothing.
+   */
+  export function fromManual(outcome: { interactive?: boolean }): Approval {
+    return { source: outcome.interactive === true ? "manual" : "auto" }
+  }
 
   /** A rule optionally carrying its origin. `source` is runtime-only, never persisted. */
   export type SourcedRule = Permission.Rule & { source?: Source }
@@ -92,10 +103,7 @@ export namespace PermissionProvenance {
    * metadata, so the second ask's `outsideWorkspace` marker would otherwise clobber the first's
    * even though `"approval" in next` is true. Merge that marker forward so it survives.
    */
-  export function carryApproval(
-    prev: Record<string, unknown> | undefined,
-    next: Record<string, unknown> | undefined,
-  ) {
+  export function carryApproval(prev: Record<string, unknown> | undefined, next: Record<string, unknown> | undefined) {
     if (!next) return next
     const prior = prev?.approval as Approval | undefined
     if (!("approval" in next)) return prior ? { ...next, approval: prior } : next
@@ -122,7 +130,8 @@ export namespace PermissionProvenance {
     const rule = input.rule
     if (!rule) return { source: "default" }
     const source =
-      (rule as SourcedRule).source ?? (isYolo(rule) ? "yolo" : configSource(rule.permission, rule.pattern, input.origins))
+      (rule as SourcedRule).source ??
+      (isYolo(rule) ? "yolo" : configSource(rule.permission, rule.pattern, input.origins))
     return {
       source,
       ...(source === "agent" ? { agent: input.agent } : {}),

--- a/packages/opencode/src/kilocode/security-decision/ask.ts
+++ b/packages/opencode/src/kilocode/security-decision/ask.ts
@@ -1,0 +1,49 @@
+// kilocode_change - new file
+/**
+ * Typed provenance for a permission ask the deterministic security layer raised itself.
+ *
+ * Clients must be able to tell a security-generated ask from an ordinary Kilo ask *structurally* —
+ * never from the prompt text and never by guessing at a rule id — because the two carry opposite
+ * auto-approval rules: an ordinary ask may be auto-approved by `kilo run --auto`, a security ask
+ * never may. The marker rides on the published request metadata and carries nothing but the stable
+ * rule id, so it echoes no command, path or content.
+ *
+ * Kept dependency-free (no Effect, no node) so the TUI can import it too.
+ */
+export namespace SecurityAsk {
+  /** Metadata key holding the marker on a published permission request. */
+  export const KEY = "securityAsk" as const
+
+  export type Marker = Readonly<{ rule_id: string }>
+
+  /** What a client must do with a published ask. */
+  export type Decision = "prompt" | "block" | "once"
+
+  export function mark<M extends Record<string, unknown>>(metadata: M, marker: Marker) {
+    return { ...metadata, [KEY]: { rule_id: marker.rule_id } }
+  }
+
+  export function of(metadata: Record<string, unknown> | undefined): Marker | undefined {
+    const value = metadata?.[KEY]
+    if (!value || typeof value !== "object") return undefined
+    const rule_id = (value as { rule_id?: unknown }).rule_id
+    if (typeof rule_id !== "string" || rule_id.length === 0) return undefined
+    return { rule_id }
+  }
+
+  export function is(metadata: Record<string, unknown> | undefined): boolean {
+    return of(metadata) !== undefined
+  }
+
+  /**
+   * How an automated run answers a published ask.
+   *
+   * Interactive runs never answer machine-side — a human decides, `--auto` included. Headless runs
+   * keep auto-approving ordinary asks, and reject a security-generated one: that blocks the single
+   * call while leaving the turn free to take another path.
+   */
+  export function autoDecision(input: { interactive: boolean; metadata?: Record<string, unknown> }): Decision {
+    if (input.interactive) return "prompt"
+    return is(input.metadata) ? "block" : "once"
+  }
+}

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -371,7 +371,8 @@ export namespace KiloSessionPrompt {
     })
     const outcome = yield* input.permission.ask({ ...input.request, ruleset, hardRuleset })
 
-    if (outcome.manual) return { source: "manual" } satisfies PermissionProvenance.Approval
+    // kilocode_change - distinguish a human's answer from auto mode's own
+    if (outcome.manual) return PermissionProvenance.fromManual(outcome)
     return PermissionProvenance.classify({ rule: outcome.rule, agent: agent.name, origins: input.origins })
   })
 

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -20,6 +20,7 @@ import { ReadPermission } from "@/kilocode/permission/read"
 import { AgentManagerPermission } from "@/kilocode/permission/agent-manager" // kilocode_change
 import { ExternalDirectoryPermission } from "@/kilocode/permission/external-directory"
 import { PermissionHumanOnly } from "@/kilocode/permission/human-only" // kilocode_change
+import { SecurityAsk } from "@/kilocode/security-decision/ask" // kilocode_change
 // kilocode_change end
 
 export const Event = PermissionV1.Event
@@ -161,6 +162,8 @@ function covered(entry: PendingEntry, approved: Ruleset, local: Ruleset) {
   if (ConfigProtection.isRequest(entry.info)) return false
   if (entry.info.metadata?.["skillShell"] === true) return false // kilocode_change - skill batch needs an explicit reply
   if (entry.info.metadata?.["sandboxEscalation"] === true) return false // kilocode_change - host access needs an explicit reply
+  // kilocode_change - the rule that would cover a security ask is the very rule the layer overrode
+  if (SecurityAsk.is(entry.info.metadata)) return false
   return entry.info.patterns.every((pattern) => {
     if (veto(entry.info.permission, pattern, entry.hardRuleset)) return false
     return resolve(entry.info.permission, pattern, entry.ruleset, approved, local).action === "allow"
@@ -369,8 +372,12 @@ const layer = Layer.effect(
         }
       }
 
-      yield* drainCovered(pending as unknown as Map<string, PendingEntry>, approved, (data) =>
-        Effect.asVoid(events.publish(Event.Replied, data)),
+      yield* drainCovered(
+        pending as unknown as Map<string, PendingEntry>,
+        approved,
+        (data) => Effect.asVoid(events.publish(Event.Replied, data)),
+        undefined,
+        input.interactive === true, // kilocode_change - a drained sibling inherits the answerer of the rule that covered it
       ) // kilocode_change - drain publishes replies through the same EventV2Bridge channel
 
       if (!existing.saved) {
@@ -427,6 +434,7 @@ const layer = Layer.effect(
         s.approved,
         (data) => Effect.asVoid(events.publish(Event.Replied, data)),
         input.requestID as unknown as string,
+        true, // kilocode_change - always-rules are chosen in the permission dialog, by a human
       )
     })
 

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -19,6 +19,7 @@ import { drainCovered } from "@/kilocode/permission/drain"
 import { ReadPermission } from "@/kilocode/permission/read"
 import { AgentManagerPermission } from "@/kilocode/permission/agent-manager" // kilocode_change
 import { ExternalDirectoryPermission } from "@/kilocode/permission/external-directory"
+import { PermissionHumanOnly } from "@/kilocode/permission/human-only" // kilocode_change
 // kilocode_change end
 
 export const Event = PermissionV1.Event
@@ -69,6 +70,8 @@ export interface AskOutcome {
   manual: boolean
   /** The winning rule (carries an optional `source` marker set at ruleset-build time). */
   rule?: Rule
+  /** For a manual outcome: whether a human actually answered, or a client replied on their behalf. */
+  readonly interactive?: boolean // kilocode_change
 }
 // kilocode_change end
 
@@ -89,6 +92,17 @@ interface PendingEntry {
   ruleset: Ruleset
   hardRuleset?: Ruleset
   saved?: boolean
+  /**
+   * Set by `reply` when a human or a client actually rejected this request, so `ask` can tell an
+   * answered rejection from a session teardown that fails every pending deferred at once.
+   */
+  rejection?: { interactive: boolean }
+  /**
+   * Set by `reply` when this request was approved, recording whether a human actually answered.
+   * Auto mode replies from the client without `interactive`, and an approval nobody looked at must
+   * not be reported back as one the user gave.
+   */
+  approval?: { interactive: boolean }
   // kilocode_change end
   deferred: Deferred.Deferred<void, RejectedError | CorrectedError>
 }
@@ -270,7 +284,8 @@ const layer = Layer.effect(
       yield* Effect.logInfo("asking", { id, permission: info.permission, patterns: info.patterns })
 
       const deferred = yield* Deferred.make<void, RejectedError | CorrectedError>()
-      pending.set(id, { info, ruleset, hardRuleset, deferred }) // kilocode_change
+      const entry: PendingEntry = { info, ruleset, hardRuleset, deferred } // kilocode_change
+      pending.set(id, entry) // kilocode_change
       yield* events.publish(Event.Asked, info) // kilocode_change - was bus.publish
       // kilocode_change start - was `return yield* Effect.ensuring(...)`; report the manual decision to callers
       yield* Effect.ensuring(
@@ -279,7 +294,8 @@ const layer = Layer.effect(
           pending.delete(id)
         }),
       )
-      return { manual: true } // the user was prompted and replied
+      // kilocode_change - auto mode replies without `interactive`, so name the answerer honestly
+      return { manual: true, interactive: entry.approval?.interactive === true } // the user was prompted and replied
       // kilocode_change end
     })
 
@@ -293,7 +309,7 @@ const layer = Layer.effect(
       // Log rather than fail silently: a genuine human client sets `interactive`, so a refused reply here
       // means an auto-approver tried to answer — the request intentionally stays pending for a human.
       if (
-        (existing.info.metadata?.["skillShell"] === true || existing.info.metadata?.["sandboxEscalation"] === true) &&
+        PermissionHumanOnly.requires(existing.info.metadata) && // kilocode_change - one predicate, shared with the clients
         input.reply !== "reject" &&
         input.interactive !== true
       ) {
@@ -312,6 +328,7 @@ const layer = Layer.effect(
       })
 
       if (input.reply === "reject") {
+        existing.rejection = { interactive: input.interactive === true } // kilocode_change - answered, not torn down
         yield* Deferred.fail(
           existing.deferred,
           input.message
@@ -321,6 +338,7 @@ const layer = Layer.effect(
 
         for (const [id, item] of pending.entries()) {
           if (item.info.sessionID !== existing.info.sessionID) continue
+          item.rejection = { interactive: false } // kilocode_change - cascaded, so no human saw this one
           pending.delete(id)
           yield* events.publish(Event.Replied, {
             sessionID: item.info.sessionID,
@@ -332,6 +350,7 @@ const layer = Layer.effect(
         return
       }
 
+      existing.approval = { interactive: input.interactive === true } // kilocode_change
       yield* Deferred.succeed(existing.deferred, undefined)
       if (input.reply === "once") return
 

--- a/packages/opencode/test/kilocode/permission/auto-reply-provenance.test.ts
+++ b/packages/opencode/test/kilocode/permission/auto-reply-provenance.test.ts
@@ -1,0 +1,89 @@
+// kilocode_change - new file
+import { expect } from "bun:test"
+import { Effect, Fiber, Layer } from "effect"
+import * as CrossSpawnSpawner from "@opencode-ai/core/cross-spawn-spawner"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Permission } from "@/permission"
+import * as Config from "@/config/config"
+import { SessionID } from "@/session/schema"
+import { PermissionProvenance } from "@/kilocode/permission/provenance"
+import { testEffect } from "../../lib/effect"
+
+/**
+ * Who actually answered the prompt.
+ *
+ * Auto mode answers on the user's behalf from the client, and that reply deliberately omits
+ * `interactive` — the same signal the reject path already uses to tell an answered refusal from a
+ * cascaded one. Without carrying it through the approval too, a call nobody looked at is reported
+ * as "approved by you", which is a claim about the user that is simply untrue.
+ */
+const env = Layer.mergeAll(
+  AppNodeBuilder.build(Permission.node),
+  AppNodeBuilder.build(Config.node),
+  AppNodeBuilder.build(CrossSpawnSpawner.node),
+)
+const it = testEffect(env)
+
+const sessionID = SessionID.make("ses_auto_reply")
+
+const request = {
+  sessionID,
+  permission: "bash",
+  patterns: ["git status"],
+  always: [] as string[],
+  metadata: {},
+  ruleset: [{ permission: "bash", pattern: "*", action: "ask" as const }],
+}
+
+const answer = (interactive: boolean | undefined) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    const fiber = yield* Effect.gen(function* () {
+      return yield* permission.ask(request)
+    }).pipe(Effect.forkScoped)
+
+    const pending = yield* Effect.gen(function* () {
+      while (true) {
+        const list = yield* permission.list()
+        if (list.length === 1) return list
+        yield* Effect.sleep("10 millis")
+      }
+    }).pipe(Effect.timeoutOrElse({ duration: "2 seconds", orElse: () => Effect.fail(new Error("timed out")) }))
+
+    yield* permission.reply({
+      requestID: pending[0]!.id,
+      reply: "once",
+      ...(interactive === undefined ? {} : { interactive }),
+    })
+    return yield* Fiber.join(fiber)
+  })
+
+it.instance("reports a reply a human actually gave as interactive", () =>
+  Effect.gen(function* () {
+    const outcome = yield* answer(true)
+    expect(outcome.manual).toBe(true)
+    expect(outcome.interactive).toBe(true)
+  }),
+)
+
+it.instance("reports a client's auto-reply as not interactive", () =>
+  Effect.gen(function* () {
+    const outcome = yield* answer(undefined)
+    expect(outcome.manual).toBe(true)
+    expect(outcome.interactive).toBe(false)
+  }),
+)
+
+it.instance("a human's approval is attributed to the user", () =>
+  Effect.gen(function* () {
+    const outcome = yield* answer(true)
+    expect(PermissionProvenance.fromManual(outcome).source).toBe("manual")
+  }),
+)
+
+it.instance("an auto-reply is attributed to auto mode, not to the user", () =>
+  Effect.gen(function* () {
+    const outcome = yield* answer(undefined)
+    expect(PermissionProvenance.fromManual(outcome).source).toBe("auto")
+  }),
+)

--- a/packages/opencode/test/kilocode/permission/auto-reply-provenance.test.ts
+++ b/packages/opencode/test/kilocode/permission/auto-reply-provenance.test.ts
@@ -87,3 +87,51 @@ it.instance("an auto-reply is attributed to auto mode, not to the user", () =>
     expect(PermissionProvenance.fromManual(outcome).source).toBe("auto")
   }),
 )
+
+/**
+ * A sibling ask resolved by the rule the user just approved was never shown to anyone, but it is
+ * still that human's decision — the covering rule is theirs. It must be attributed the same way the
+ * covering reply was, rather than reported as something the mode decided on its own.
+ */
+const drained = (interactive: boolean | undefined) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    const covering = { ...request, always: ["git status"] }
+    const sibling = { ...covering, sessionID: SessionID.make("ses_auto_reply_sibling") }
+
+    const first = yield* Effect.forkScoped(permission.ask(covering))
+    const second = yield* Effect.forkScoped(permission.ask(sibling))
+
+    const pending = yield* Effect.gen(function* () {
+      while (true) {
+        const list = yield* permission.list()
+        if (list.length === 2) return list
+        yield* Effect.sleep("10 millis")
+      }
+    }).pipe(Effect.timeoutOrElse({ duration: "2 seconds", orElse: () => Effect.fail(new Error("timed out")) }))
+
+    const covered = pending.find((entry) => entry.sessionID === sessionID)!
+    yield* permission.reply({
+      requestID: covered.id,
+      reply: "always",
+      ...(interactive === undefined ? {} : { interactive }),
+    })
+
+    yield* Fiber.join(first)
+    // The sibling was drained by the rule the reply saved, never answered on its own.
+    return yield* Fiber.join(second)
+  })
+
+it.instance("a sibling drained by a human's always-rule is still attributed to the user", () =>
+  Effect.gen(function* () {
+    const outcome = yield* drained(true)
+    expect(PermissionProvenance.fromManual(outcome).source).toBe("manual")
+  }),
+)
+
+it.instance("a sibling drained by an auto-reply's always-rule is attributed to auto mode", () =>
+  Effect.gen(function* () {
+    const outcome = yield* drained(undefined)
+    expect(PermissionProvenance.fromManual(outcome).source).toBe("auto")
+  }),
+)

--- a/packages/opencode/test/kilocode/permission/human-only.test.ts
+++ b/packages/opencode/test/kilocode/permission/human-only.test.ts
@@ -1,0 +1,27 @@
+// kilocode_change - new file
+import { describe, expect, test } from "bun:test"
+import { PermissionHumanOnly } from "@/kilocode/permission/human-only"
+import { SecurityAsk } from "@/kilocode/security-decision/ask"
+
+/**
+ * One predicate, used by the server guard and by every client that answers on the user's behalf.
+ * Two copies of it is what produced a prompt the server would not accept an answer for and the
+ * client would not display.
+ */
+describe("PermissionHumanOnly.requires", () => {
+  test.each([
+    ["a skill shell batch", { skillShell: true }],
+    ["a sandbox escalation", { sandboxEscalation: true }],
+    ["a security-raised ask", SecurityAsk.mark({}, { rule_id: "SEC.V1.CONTAINED_EXEC" })],
+  ])("%s may only be answered by a human", (_name, metadata) => {
+    expect(PermissionHumanOnly.requires(metadata)).toBe(true)
+  })
+
+  test.each([
+    ["an ordinary ask", {}],
+    ["no metadata at all", undefined],
+    ["a false flag", { sandboxEscalation: false, skillShell: false }],
+  ])("%s may be answered automatically", (_name, metadata) => {
+    expect(PermissionHumanOnly.requires(metadata)).toBe(false)
+  })
+})

--- a/packages/opencode/test/kilocode/permission/provenance.test.ts
+++ b/packages/opencode/test/kilocode/permission/provenance.test.ts
@@ -186,9 +186,7 @@ describe("PermissionProvenance.tagOutsideWorkspace", () => {
 
 describe("PermissionProvenance.filepathOf", () => {
   test("reads the filepath an external_directory ask's metadata carries", () => {
-    expect(PermissionProvenance.filepathOf({ filepath: "/tmp/secret.txt", parentDir: "/tmp" })).toBe(
-      "/tmp/secret.txt",
-    )
+    expect(PermissionProvenance.filepathOf({ filepath: "/tmp/secret.txt", parentDir: "/tmp" })).toBe("/tmp/secret.txt")
   })
 
   test("returns undefined when there is no filepath, e.g. a bash directory scan", () => {
@@ -229,8 +227,14 @@ describe("askPermission returns provenance", () => {
       Effect.runPromise,
     )
 
-  test("manual reply reports the manual source", async () => {
-    expect(await run({ manual: true })).toEqual({ source: "manual" })
+  test("a reply a human gave reports the manual source", async () => {
+    expect(await run({ manual: true, interactive: true })).toEqual({ source: "manual" })
+  })
+
+  // Auto mode replies from the client without `interactive`; attributing that to the user would
+  // claim a decision they never made.
+  test("an auto-reply reports the auto source", async () => {
+    expect(await run({ manual: true })).toEqual({ source: "auto" })
   })
 
   test("agent-default rule classifies as agent with its name", async () => {
@@ -253,9 +257,15 @@ describe("askPermission returns provenance", () => {
   test("global and project patterns under the same key are attributed independently", async () => {
     // global: bash "git status" allow; project: bash "npm test" allow -> both live under bash.
     const origins = { bash: { "git status": "global" as const, "npm test": "local" as const } }
-    const fromGlobal = await run({ manual: false, rule: { permission: "bash", pattern: "git status", action: "allow" } }, origins)
+    const fromGlobal = await run(
+      { manual: false, rule: { permission: "bash", pattern: "git status", action: "allow" } },
+      origins,
+    )
     expect(fromGlobal.source).toBe("global")
-    const fromProject = await run({ manual: false, rule: { permission: "bash", pattern: "npm test", action: "allow" } }, origins)
+    const fromProject = await run(
+      { manual: false, rule: { permission: "bash", pattern: "npm test", action: "allow" } },
+      origins,
+    )
     expect(fromProject.source).toBe("project")
   })
 
@@ -269,7 +279,10 @@ describe("askPermission returns provenance", () => {
       permission: Permission.fromConfig({ bash: "allow" }),
       options: {},
     }
-    const planSession = { id: sessionID, permission: [{ permission: "edit", pattern: "*", action: "deny" }] } as unknown as Session.Info
+    const planSession = {
+      id: sessionID,
+      permission: [{ permission: "edit", pattern: "*", action: "deny" }],
+    } as unknown as Session.Info
     await Effect.gen(function* () {
       yield* KiloSessionPrompt.askPermission({
         permission: yield* Permission.Service,

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -40,6 +40,7 @@ import { at, recent, slot } from "../kilocode/message-order" // kilocode_change
 import { useToast } from "../ui/toast" // kilocode_change
 import { usePermission } from "./permission"
 import { GoalSync } from "@/kilocode/cli/cmd/tui/goal-sync" // kilocode_change
+import { PermissionHumanOnly } from "@/kilocode/permission/human-only" // kilocode_change
 
 const emptyConsoleState: ConsoleState = {
   consoleManagedProviders: [],
@@ -248,7 +249,10 @@ export const {
 
         case "permission.asked": {
           const request = event.properties
-          if (permission.mode === "auto") {
+          // kilocode_change start - the server refuses a machine reply to these, so answering here
+          // would leave the prompt pending with nobody shown it; fall through and display it instead
+          if (permission.mode === "auto" && !PermissionHumanOnly.requires(request.metadata)) {
+            // kilocode_change end
             void sdk.client.permission.reply({
               requestID: request.id,
               reply: "once",
@@ -782,11 +786,7 @@ export const {
               setStore("provider_default", reconcile(providers.default))
               setStore("provider_next", reconcile(providerList))
               // kilocode_change start - fail closed when the backend omits the capability
-              setStore(
-                "capabilities",
-                "experimentalBackgroundSubagents",
-                capabilities?.backgroundSubagents === true,
-              )
+              setStore("capabilities", "experimentalBackgroundSubagents", capabilities?.backgroundSubagents === true)
               // kilocode_change end
               setStore("console_state", reconcile(consoleState))
               setStore("agent", reconcile(agents))

--- a/packages/tui/src/kilocode/tool-approval.tsx
+++ b/packages/tui/src/kilocode/tool-approval.tsx
@@ -8,7 +8,7 @@ export function stateMetadata(state: ToolState | undefined) {
   return state && "metadata" in state ? state.metadata : undefined
 }
 
-const SOURCES = ["agent", "global", "project", "yolo", "session", "manual", "default"] as const
+const SOURCES = ["agent", "global", "project", "yolo", "session", "manual", "auto", "default"] as const
 
 /** Read the approval/denial provenance off a tool part's metadata, if present. */
 export function toolApprovalFrom(metadata: Record<string, unknown> | undefined) {
@@ -30,6 +30,8 @@ function sourceLabel(approval: PermissionProvenance.Approval): string | undefine
       return "by auto-approve (YOLO) mode"
     case "session":
       return "by a session auto-approve rule"
+    case "auto":
+      return "by auto mode"
     case "default":
       return "by default"
     default:

--- a/packages/tui/src/routes/session/permission.tsx
+++ b/packages/tui/src/routes/session/permission.tsx
@@ -207,6 +207,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               directory: props.directory,
               message: message || undefined,
               workspace: project.workspace.current(),
+              interactive: true, // kilocode_change - human answered this prompt, as the approve replies already report
             })
           }}
           onCancel={() => {
@@ -515,6 +516,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
                     requestID: props.request.id,
                     directory: props.directory,
                     workspace: project.workspace.current(),
+                    interactive: true, // kilocode_change - a human pressed reject here too
                   })
                   return
                 }


### PR DESCRIPTION
## Issue

No existing issue. Related to #14033 — auto mode answering on the user's behalf is that issue's subject — but this is not part of the decision layer and needs none of it: it is a standalone fix for a client and a server that disagreed about which asks a machine may answer.

## Context

Auto mode answered every published permission request from the client. But the server refuses a machine reply to some of them — a skill-shell batch, a sandbox escalation — and leaves the request pending. The client had already taken its auto-reply branch and never displayed the prompt, so the request sat waiting for a human nobody had told, and the turn hung with no error.

The second half is a correctness problem in what the user is told afterwards: a call auto mode approved was reported back as "approved by you", a claim about a decision the user never made.

## Implementation

Both sides now share one predicate for the asks only a human may answer (`kilocode/permission/human-only.ts`), so the client can no longer take an auto-reply branch on a request the server will refuse to auto-answer. The client displays those asks instead.

Approvals additionally record whether a human actually answered, and provenance carries that through, so an automatic approval is attributed to the mode rather than to the user.

`security-decision/ask.ts` is a dependency-free marker type (no Effect, no node) so the TUI can import it too; it lets a client tell a security-raised ask from an ordinary one structurally rather than by prompt text or a guessed rule id.

Extracted from #13893 as a standalone fix — it stands on its own and needs none of the decision layer in that branch.

## Screenshots / Video

N/A — no visual change beyond a prompt now being shown where previously nothing appeared. Locale strings are added for the new prompt in all 21 shipped languages.

## How to Test

### Manual/local verification

- `bun run test kilocode/permission` in `packages/opencode` — 13 files, all pass. Includes the new `human-only.test.ts` (the shared predicate) and `auto-reply-provenance.test.ts` (an auto-approved call is attributed to the mode, not to the user).
- `bun test test/kilocode` in `packages/tui` — 48 pass.
- `bun run typecheck` in `packages/opencode` and in `packages/tui` — both clean.
- `bun run check:architecture` — ok, 0 boundary violations.

All of the above executed by the agent on this branch.

### Reviewer test steps

1. `bun run test kilocode/permission` in `packages/opencode` — passes.
2. With `kilo run --auto`, trigger an ask the server will not let a machine answer (a skill-shell batch, or a sandbox escalation): the prompt is now shown and the turn proceeds once answered. Before this change the turn hangs silently.
3. Approve a call in auto mode and check the attribution on the tool row — it names the mode, not you.

### Blocked checks and substitute verification

- Repository CI workflows do not run on this PR without maintainer approval (fork PR, `check-org-member`). Substitute verification is the local runs listed above.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch

<!-- -->

