### PR TITLE
fix(vscode): prevent transcript handoff flicker

### DIFF
--- a/.changeset/transcript-step-handoff-flicker.md
+++ b/.changeset/transcript-step-handoff-flicker.md
@@ -1,0 +1,5 @@
+---
+"kilo-code": patch
+---
+
+Stop the transcript from twitching down and back up for one frame when the agent starts its next step after running tools

--- a/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
+++ b/packages/kilo-vscode/webview-ui/src/components/chat/MessageList.tsx
@@ -958,6 +958,29 @@ export const MessageList: Component<MessageListProps> = (props) => {
   const indexes = createMemo(() => new Map(keys().map((key, index) => [key, index])))
   const fingerprint = createMemo(() => rowFingerprint(keys()))
 
+  // A row handed from the direct tail to Virtua (each new step of the same
+  // turn moves the previous assistant message) mounts at the 260px estimate
+  // until Virtua's ResizeObserver measures it. The auto-scroll pins to that
+  // shorter layout, the correction lands in the same ResizeObserver pass, and
+  // the follow-up pin is deferred to the next frame, so one frame paints with
+  // the transcript sitting below the bottom. Measure the handed rows in the
+  // same task and re-pin before anything is painted.
+  createEffect(
+    on(
+      () => ({ sid: session.currentSessionID(), keys: keys() }),
+      (now, prev) => {
+        if (!prev || prev.sid !== now.sid) return
+        if (now.keys.length <= prev.keys.length || now.keys.at(-1) === prev.keys.at(-1)) return
+        queueMicrotask(() => {
+          const handle = virtualizer()
+          if (!handle) return
+          handle.measure()
+          autoScroll.scrollToBottom()
+        })
+      },
+    ),
+  )
+
   const [pending, setPending] = createSignal<{ sid: string; key: string }>()
 
   // Scrolls the transcript to a row by key. Virtualized rows jump through

--- a/patches/virtua@0.49.1.patch
+++ b/patches/virtua@0.49.1.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/solid/Virtualizer.d.ts b/lib/solid/Virtualizer.d.ts
-index 144dd7f..819aab9 100644
+index 144dd7fba894d440069a8dc0415f4b778a98793d..819aab92c5727d3bca4ef51da08ab05ec1af452f 100644
 --- a/lib/solid/Virtualizer.d.ts
 +++ b/lib/solid/Virtualizer.d.ts
 @@ -38,6 +38,10 @@ export interface VirtualizerHandle {
@@ -13,8 +13,47 @@ index 144dd7f..819aab9 100644
      /**
       * Scroll to the item specified by index.
       * @param index index of item
+diff --git a/lib/solid/index.js b/lib/solid/index.js
+index dbf44b0231abaf594c026488dd0261a3fa3fafc7..2fb3544c283a2f241a65be574ad01d0f21db4e3a 100644
+--- a/lib/solid/index.js
++++ b/lib/solid/index.js
+@@ -306,7 +306,7 @@ const b = null, {min: z, max: w, abs: x, floor: y} = Math, _ = (e, t, r) => z(r,
+     }, r);
+     const c = q(r.data.length, o, void 0, i, !o), l = ((e, t) => {
+         let r;
+-        const n = t ? "width" : "height", o = new WeakMap, s = D(t => {
++        const n = t ? "width" : "height", o = new WeakMap, m = new Map, s = D(t => {
+             const s = [];
+             for (const {target: i, contentRect: c} of t) if (i.offsetParent) if (i === r) e.H(4, c[n]); else {
+                 const e = o.get(i);
+@@ -318,9 +318,15 @@ const b = null, {min: z, max: w, abs: x, floor: y} = Math, _ = (e, t, r) => z(r,
+             G(e) {
+                 s.q(r = e);
+             },
+-            K: (e, t) => (o.set(e, t), s.q(e), () => {
+-                o.delete(e), s.N(e);
++            K: (e, t) => (o.set(e, t), m.set(t, e), s.q(e), () => {
++                o.delete(e), m.get(t) === e && m.delete(t), s.N(e);
+             }),
++            ae() {
++                const t = [];
++                m.forEach((e, r) => {
++                    e.offsetParent && t.push([ r, e.getBoundingClientRect()[n] ]);
++                }), t.length && e.H(3, t);
++            },
+             p: s.W
+         };
+     })(c, s), $ = ((e, t) => {
+@@ -397,6 +403,7 @@ const b = null, {min: z, max: w, abs: x, floor: y} = Math, _ = (e, t, r) => z(r,
+             findItemIndex: c.$,
+             getItemOffset: c.I,
+             getItemSize: c.k,
++            measure: l.ae,
+             scrollToIndex: $.ne,
+             scrollTo: $.te,
+             scrollBy: $.re
 diff --git a/lib/solid/index.jsx b/lib/solid/index.jsx
-index 029201a..3949cd4 100644
+index 029201a2c88fe71645242b3f6f11493a7f91fa86..3949cd43438aae3edc5f8c9cdd6c75fb7c091e83 100644
 --- a/lib/solid/index.jsx
 +++ b/lib/solid/index.jsx
 @@ -1085,6 +1085,7 @@ const createResizer = (store, isHorizontal) => {


### PR DESCRIPTION
## What Problem This Solves

The VS Code transcript can flicker briefly when a reasoning block is followed by parallel bash tools and the agent starts its next step. The visible symptom is a short jump down and back up around the second shell card.

## Why This Change Was Made

The transcript intentionally keeps the growing assistant suffix outside Virtua. When a new assistant message starts, the previous assistant row moves from the direct tail into Virtua. Virtua initially assigns a new row its `itemSize` estimate of 260px, while the real row in this scenario is about 546px tall.

The sequence was:

1. The mutation observer auto-scrolled against the 260px estimate.
2. The browser clamped `scrollTop` to the shorter layout.
3. Virtua's `ResizeObserver` measured the real row and expanded the layout.
4. The content resize observer re-pinned on the next frame, leaving one painted frame at the wrong scroll position.

The fix measures newly handed-off virtual rows in a microtask and re-pins before the next paint. It only runs when the virtual row list grows at the end within the same session, so session changes, prepending older messages, and user-paused scrolling are not treated as handoffs.

The repository already patches Virtua 0.49.1 with a synchronous `VirtualizerHandle.measure()` API, but that patch previously changed only `lib/solid/index.jsx`. The VS Code webview esbuild configuration resolves the package's default Solid entry, `lib/solid/index.js`, rather than the `solid` conditional JSX entry. Therefore the method existed in the TypeScript declaration and JSX source but was missing from the runtime entry used by the webview. This PR mirrors the existing patch in the compiled entry so the runtime API used by the fix exists where it is bundled.

Updating Virtua did not remove the need for this change. The current latest release still exposes no `measure()` method in the compiled Solid handle, and the existing 0.49.1 patch remains the fork's source of the synchronous measurement behavior.

## User Impact

The transcript remains pinned to the bottom without a one-frame vertical twitch when the next reasoning step begins after tool calls. User-paused scrolling remains unchanged.

## Evidence

- Baseline self-test reproduced the scroll reversal in 3/3 synthetic streams matching the real event order: reasoning, two parallel bash calls, step finish, completed assistant message, then a new reasoning message.
- Baseline post-paint samples showed `scrollTop` changing from `139` to `127` while `scrollHeight` was already `725`, then recovering to `216.5` on the next frame.
- The fixed build had no position reversals or scroll reversals in 3/3 runs. Samples moved directly from the previous bottom to the corrected bottom.
- `bun run typecheck` passed in `packages/kilo-vscode`.
- `bun run lint` passed in `packages/kilo-vscode`.
- `bun run test:unit` passed, 5,528 tests across 418 files.
- The focused self-test used an isolated VS Code instance and was cleaned up after verification.
