### PR TITLE
fix(core): stop duplicating the cut entry into both head and recent during compaction

### DIFF
--- a/.changeset/compaction-split-duplication.md
+++ b/.changeset/compaction-split-duplication.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Fix auto-compaction duplicating the cut conversation entry into both the summary input and the kept recent context, which could inflate the summary prompt and cause compaction to be skipped when the context window overflows.

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -125,7 +125,7 @@ const settings = (documents: readonly Config.Entry[]) => {
   )
 }
 
-const select = (
+export const select = (
   entries: readonly Entry[],
   tokens: number,
 ): { readonly head: string; readonly recent: string } | undefined => {
@@ -136,6 +136,7 @@ const select = (
   if (conversation.length === 0) return
   let total = 0
   let split = conversation.length
+  let cut = conversation.length
   let splitPrefix = ""
   let splitSuffix = ""
   for (let index = conversation.length - 1; index >= 0; index--) {
@@ -146,14 +147,16 @@ const select = (
         splitPrefix = conversation[index].slice(0, -remaining)
         splitSuffix = conversation[index].slice(-remaining)
         split = index + 1
+        cut = index
       }
       break
     }
     total = next
     split = index
+    cut = index
   }
   return {
-    head: [...conversation.slice(0, split), splitPrefix].filter(Boolean).join("\n\n"),
+    head: [...conversation.slice(0, cut), splitPrefix].filter(Boolean).join("\n\n"),
     recent: [splitSuffix, ...conversation.slice(split)].filter(Boolean).join("\n\n"),
   }
 }

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "bun:test"
+import { DateTime } from "effect"
 import { SessionCompaction } from "@opencode-ai/core/session/compaction"
+import { SessionMessage } from "@opencode-ai/core/session/message"
 
 test("compaction prompt preserves detailed work state and relevant files", () => {
   const prompt = SessionCompaction.buildPrompt({ context: ["conversation history"] })
@@ -24,4 +26,30 @@ test("compaction describes tool media without embedding base64", () => {
 
   expect(serialized).toBe("Image read successfully\n[Attached image/png: pixel.png]")
   expect(serialized).not.toContain(base64)
+})
+
+test("compaction split does not duplicate the cut entry in head and recent", () => {
+  const entry = (index: number) => ({
+    seq: index,
+    message: SessionMessage.System.make({
+      id: SessionMessage.ID.make(`msg_sys${index}`),
+      type: "system",
+      text: `START${index}${"x".repeat(390)}END${index}`,
+      time: { created: DateTime.makeUnsafe(index) },
+    }),
+  })
+  // Each entry serializes to 417 chars (~104 tokens); a 250-token budget fits
+  // the two newest entries, then splits the third across head and recent.
+  const selected = SessionCompaction.select([0, 1, 2, 3].map(entry), 250)
+
+  expect(selected).toBeDefined()
+  expect(selected!.head).toContain("START0")
+  expect(selected!.head).toContain("END0")
+  expect(selected!.head).toContain("START1")
+  expect(selected!.head).not.toContain("END1")
+  expect(selected!.head).not.toContain("START2")
+  expect(selected!.recent).not.toContain("START1")
+  expect(selected!.recent).toContain("END1")
+  expect(selected!.recent).toContain("START2")
+  expect(selected!.recent).toContain("END3")
 })


### PR DESCRIPTION
## What

Fixes an off-by-one in `SessionCompaction.select()` (`packages/core/src/session/compaction.ts`) that duplicated the partially-split conversation entry into both the `head` (summarized away) and `recent` (kept) outputs of auto-compaction.

## Why

When the keep budget overflows mid-entry, the entry at `index` is split into a prefix (intended for `head`) and a suffix (intended for `recent`). But `head` was built with `conversation.slice(0, split)` where `split = index + 1`, so the **full** entry was included in `head` in addition to its prefix — and its suffix therefore appeared in both outputs. The summary prompt sent to the model contained duplicated content with an inflated token count, which also makes the `Token.estimate(summaryPrompt) > context - summaryOutput` guard more likely to abort auto-compaction entirely, leaving the session stuck on context-overflow errors.

The fix keeps separate cut points: `head` takes the entries before the split index plus the prefix; `recent` takes the suffix plus the entries after it.

## Testing

Added a regression test in `packages/core/test/session-compaction.test.ts` that constructs four fixed-size entries with a budget that splits the third one. It fails on the previous logic (`head` contains the cut entry's tail) and passes with the fix. `bun test` (packages/core, 1325 pass) and `bun run typecheck` are green; the single failure in the full suite (`ProjectCopy > requires force to remove a dirty git worktree`) reproduces on unmodified `main` on this machine and is unrelated.
