### PR TITLE
fix(gateway): tolerate transient poll errors during device authorization

### DIFF
--- a/.changeset/gateway-poll-transient-errors.md
+++ b/.changeset/gateway-poll-transient-errors.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/kilo-gateway": patch
+---
+
+Keep device authorization login polling alive through transient errors (a single 5xx or network blip no longer aborts the sign-in flow); the last poll error is thrown only once all attempts are exhausted.

--- a/packages/kilo-gateway/src/auth/polling.ts
+++ b/packages/kilo-gateway/src/auth/polling.ts
@@ -8,6 +8,7 @@ import type { PollOptions, PollResult } from "../types.js"
  */
 export async function poll<T>(options: PollOptions<T>): Promise<T> {
   const { interval, maxAttempts, pollFn } = options
+  let error: unknown
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     // Wait before polling (except first attempt)
@@ -15,7 +16,15 @@ export async function poll<T>(options: PollOptions<T>): Promise<T> {
       await new Promise((resolve) => setTimeout(resolve, interval))
     }
 
-    const result: PollResult<T> = await pollFn()
+    // A thrown poll error (e.g. a transient 5xx or network failure) is not
+    // terminal: remember it and keep polling until attempts run out.
+    const result: PollResult<T> | undefined = await Promise.resolve()
+      .then(pollFn)
+      .catch((err: unknown) => {
+        error = err
+        return undefined
+      })
+    if (!result) continue
 
     // If polling should stop
     if (!result.continue) {
@@ -29,6 +38,7 @@ export async function poll<T>(options: PollOptions<T>): Promise<T> {
     }
   }
 
+  if (error) throw error
   throw new Error("Polling timeout: Maximum attempts reached")
 }
 

--- a/packages/kilo-gateway/test/auth/polling.test.ts
+++ b/packages/kilo-gateway/test/auth/polling.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { poll } from "../../src/auth/polling.js"
+import type { PollResult } from "../../src/types.js"
+
+const options = { interval: 1, maxAttempts: 5 }
+
+test("poll keeps polling after transient thrown errors and returns data", async () => {
+  let calls = 0
+  const pollFn = (): Promise<PollResult<string>> => {
+    calls++
+    if (calls < 3) throw new Error(`transient failure ${calls}`)
+    return Promise.resolve({ continue: false, data: "token" })
+  }
+
+  await expect(poll<string>({ ...options, pollFn })).resolves.toBe("token")
+  expect(calls).toBe(3)
+})
+
+test("poll throws the last poll error when attempts run out", async () => {
+  let calls = 0
+  const pollFn = (): Promise<PollResult<string>> => {
+    calls++
+    return Promise.reject(new Error("gateway down"))
+  }
+
+  await expect(poll<string>({ interval: 1, maxAttempts: 3, pollFn })).rejects.toThrow("gateway down")
+  expect(calls).toBe(3)
+})
+
+test("poll still stops immediately on a terminal result error", async () => {
+  let calls = 0
+  const pollFn = (): Promise<PollResult<string>> => {
+    calls++
+    return Promise.resolve({ continue: false, error: new Error("authorization denied") })
+  }
+
+  await expect(poll<string>({ ...options, pollFn })).rejects.toThrow("authorization denied")
+  expect(calls).toBe(1)
+})
+
+test("poll reports a timeout when attempts run out without any thrown error", async () => {
+  const pollFn = (): Promise<PollResult<string>> => Promise.resolve({ continue: true })
+
+  await expect(poll<string>({ interval: 1, maxAttempts: 2, pollFn })).rejects.toThrow(
+    "Polling timeout: Maximum attempts reached",
+  )
+})


### PR DESCRIPTION
## What

Makes `poll()` in `@kilocode/kilo-gateway` (`packages/kilo-gateway/src/auth/polling.ts`) tolerate transient errors from the poll function instead of aborting on the first one.

## Why

During device authorization sign-in, the poll function (`pollDeviceAuth`) throws on any non-202/403/410 non-OK status (500/502/429) and on network failures. `poll()` previously let that throw propagate, so a single transient error — a gateway deploy, a proxy hiccup, a brief network drop — killed the entire login flow while the user was mid-authorization in the browser, forcing them to start over. The `PollResult.error` contract already distinguishes terminal failures (denied/expired, returned as `{ continue: false, error }`) from everything else; a thrown request error is not a terminal state and shouldn't end the flow.

Now a thrown poll error is treated as a failed attempt: polling continues, and the last error is thrown only once `maxAttempts` is exhausted (instead of the generic timeout message). Terminal result errors still stop polling immediately, and the no-data and timeout paths are unchanged.

## Testing

Added `packages/kilo-gateway/test/auth/polling.test.ts` covering: recovery after transient thrown errors (fails on the previous implementation), last-error propagation with full attempt consumption on exhaustion, immediate stop on terminal result errors, and the unchanged no-error timeout path. `bun test` (packages/kilo-gateway, 115 pass) and `bun run typecheck` are green.
