### PR TITLE
docs(kilo-docs): retire stale banners and show-and-tell links

### DIFF
--- a/packages/kilo-docs/components/PageFooter.tsx
+++ b/packages/kilo-docs/components/PageFooter.tsx
@@ -100,6 +100,16 @@ export function PageFooter() {
             <span>Edit page</span>
           </button>
         </div>
+        <p className="footer-note">
+          Kilo has been acquired by Anaconda.{" "}
+          <a
+            href="https://www.anaconda.com/blog/anaconda-acquires-kilo-code"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Read the announcement
+          </a>
+        </p>
       </footer>
       <style jsx>{`
         .page-footer {
@@ -153,6 +163,22 @@ export function PageFooter() {
 
         .footer-action.errored {
           color: var(--error-color, #ef4444);
+        }
+
+        .footer-note {
+          margin: 0.75rem 0 0;
+          font-size: 0.8125rem;
+          color: var(--text-secondary);
+        }
+
+        .footer-note a {
+          color: var(--accent-color);
+          text-decoration: none;
+          font-weight: 500;
+        }
+
+        .footer-note a:hover {
+          color: var(--accent-hover);
         }
       `}</style>
     </>

--- a/packages/kilo-docs/components/TopNav.tsx
+++ b/packages/kilo-docs/components/TopNav.tsx
@@ -348,15 +348,6 @@ export function TopNav({ onMobileMenuToggle, isMobileMenuOpen = false, showMobil
         </div>
       </div>
 
-      {/* Announcement banner */}
-      <div className="announcement-banner">
-        <p>
-          The all-new Kilo Code extension is here, rebuilt on the{" "}
-          <Link href="/code-with-ai/platforms/vscode/whats-new">Kilo CLI</Link> for speed, flexibility, and continued
-          access to 500+ models via the Kilo Gateway →
-        </p>
-      </div>
-
       <style jsx>{`
         .top-header {
           position: fixed;
@@ -541,35 +532,6 @@ export function TopNav({ onMobileMenuToggle, isMobileMenuOpen = false, showMobil
 
           .right-actions {
             gap: 0.5rem;
-          }
-        }
-
-        .announcement-banner {
-          background: var(--bg-secondary);
-          color: var(--text-color);
-          padding: 0.5rem 1rem;
-          text-align: center;
-          font-size: 0.875rem;
-          border-bottom: 1px solid var(--border-color);
-        }
-
-        .announcement-banner p {
-          margin: 0;
-        }
-
-        .announcement-banner :global(a) {
-          color: var(--accent-color);
-          text-decoration: underline;
-          text-underline-offset: 2px;
-        }
-
-        .announcement-banner :global(a:hover) {
-          color: var(--accent-hover);
-        }
-
-        @media (max-width: 768px) {
-          .announcement-banner {
-            font-size: 0.8rem;
           }
         }
       `}</style>

--- a/packages/kilo-docs/pages/community/index.md
+++ b/packages/kilo-docs/pages/community/index.md
@@ -15,8 +15,6 @@ These resources are maintained by the community unless explicitly noted otherwis
 
 - **[Kilo Marketplace](https://github.com/Kilo-Org/kilo-marketplace)**  
   Share and install community-created Modes, Skills, and MCP servers.
-- **[Kilo Code Show and Tell Discussions](https://github.com/Kilo-Org/kilocode/discussions/categories/show-and-tell)**  
-  Real examples from users building workflows with Kilo Code.
 - **[MCP Official Resources](https://github.com/modelcontextprotocol)**  
   Reference implementations and docs for MCP servers used with Kilo.
 
@@ -32,4 +30,4 @@ Before adopting a community project, check:
 ## Share Your Project
 
 Built something useful with Kilo Code?  
-Share it in [Show and Tell](https://github.com/Kilo-Org/kilocode/discussions/categories/show-and-tell) or contribute it to the [Kilo Marketplace](https://github.com/Kilo-Org/kilo-marketplace).
+Contribute it to the [Kilo Marketplace](https://github.com/Kilo-Org/kilo-marketplace).

--- a/packages/kilo-docs/pages/contributing/index.md
+++ b/packages/kilo-docs/pages/contributing/index.md
@@ -5,10 +5,6 @@ description: "Contribute to Kilo Code"
 
 # Contributing Overview
 
-{% callout type="info" %}
-**New versions of the VS Code extension and CLI are being developed in [Kilo-Org/kilocode](https://github.com/Kilo-Org/kilocode)** (extension at `packages/kilo-vscode`, CLI at `packages/opencode`). If you're looking to contribute to the extension or CLI, please head over to that repository.
-{% /callout %}
-
 Kilo Code is an open-source project that welcomes contributions from developers of all skill levels. This guide will help you get started with contributing to Kilo Code, whether you're fixing bugs, adding features, improving documentation, or sharing custom modes.
 
 ## Ways to Contribute

--- a/packages/kilo-docs/pages/customize/custom-modes.md
+++ b/packages/kilo-docs/pages/customize/custom-modes.md
@@ -740,7 +740,3 @@ Focus on:
 
 {% /tab %}
 {% /tabs %}
-
-## Community Gallery
-
-Ready to explore more? Check out the [Show and Tell](https://github.com/Kilo-Org/kilocode/discussions/categories/show-and-tell) to discover and share custom modes and agents created by the community!

--- a/packages/kilo-docs/pages/index.tsx
+++ b/packages/kilo-docs/pages/index.tsx
@@ -372,6 +372,20 @@ export default function HomePage() {
               </Link>
             </div>
           </div>
+          <div className="footer-item">
+            <span className="footer-icon">🐍</span>
+            <div>
+              <strong>Kilo has been acquired by Anaconda</strong>
+              <Link
+                href="https://www.anaconda.com/blog/anaconda-acquires-kilo-code"
+                className="footer-link"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Read the announcement
+              </Link>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -790,7 +804,7 @@ export default function HomePage() {
 
         .footer-grid {
           display: grid;
-          grid-template-columns: repeat(3, 1fr);
+          grid-template-columns: repeat(4, 1fr);
           gap: 2rem;
         }
 

--- a/packages/kilo-docs/public/globals.css
+++ b/packages/kilo-docs/public/globals.css
@@ -4,7 +4,7 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 :root {
-  --top-nav-height: 141px; /* 105px nav + 36px banner */
+  --top-nav-height: 105px;
   --border-color: #dce6e9;
   --bg-color: theme(colors.zinc.50);
   --bg-secondary: theme(colors.zinc.100);
@@ -385,7 +385,7 @@ pre[class*="language-"] {
 
 @media (max-width: 768px) {
   :root {
-    --top-nav-height: 116px; /* 60px nav + 56px banner */
+    --top-nav-height: 60px;
   }
 
   /* Hide desktop sidenav, show via mobile toggle */


### PR DESCRIPTION
## What

Update the docs site chrome and a few contributor/community pages:

- Remove the top announcement banner about the rebuilt VS Code extension
- Drop the outdated contributing overview callout pointing people to a different repo
- Add the Anaconda acquisition announcement to the docs homepage footer and article page footer
- Remove Show and Tell discussion links from Community Projects and Custom Modes

## Why

Those banners and callouts are stale. Acquisition context belongs in the footer, matching kilo.ai, and community sharing should point at the marketplace instead of Show and Tell.