### PR TITLE
fix(cli): avoid false frontmatter errors when saving command files

### DIFF
--- a/.changeset/command-frontmatter-instance.md
+++ b/.changeset/command-frontmatter-instance.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Stop reporting a false frontmatter parse error when saving command markdown files

--- a/packages/opencode/src/kilocode/config-validation.ts
+++ b/packages/opencode/src/kilocode/config-validation.ts
@@ -9,7 +9,7 @@ import { Config } from "@/config/config"
 import { ConfigAgentV1 } from "@opencode-ai/core/v1/config/agent"
 import { ConfigCommandV1 } from "@opencode-ai/core/v1/config/command"
 import { ConfigErrorV1, FrontmatterError } from "@opencode-ai/core/v1/config/error"
-import { Instance } from "@/kilocode/instance"
+import { Instance, capture } from "@/kilocode/instance"
 import { Filesystem } from "@/util/filesystem"
 
 export namespace ConfigValidation {
@@ -64,7 +64,7 @@ export namespace ConfigValidation {
     return `\n\n<config_validation>\nConfig file validated successfully.\n</config_validation>`
   }
 
-  async function markdown(filepath: string): Promise<string> {
+  async function markdown(filepath: string, ctx = capture()) {
     const dir = path.basename(path.dirname(filepath))
 
     // Determine schema from parent directory
@@ -74,11 +74,11 @@ export namespace ConfigValidation {
     let md: Awaited<ReturnType<typeof ConfigMarkdown.parse>>
     try {
       const trusted = path.isAbsolute(filepath) && ConfigProtection.isAbsolute(filepath)
-      const ctx = Instance.current
-      const root = ctx.worktree === "/" ? ctx.directory : ctx.worktree
+      const root = ctx == null ? undefined : ctx.worktree === "/" ? ctx.directory : ctx.worktree
+      if (!trusted && root == null) return ""
       md = await ConfigMarkdown.parse(filepath, {
         trusted,
-        fileScope: trusted ? undefined : { root, source: filepath },
+        fileScope: trusted || root == null ? undefined : { root, source: filepath },
       })
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
@@ -154,6 +154,7 @@ export namespace ConfigValidation {
    */
   export async function check(filepath: string): Promise<string> {
     if (!isConfig(filepath)) return ""
+    const ctx = capture()
 
     const ext = path.extname(filepath).toLowerCase()
 
@@ -166,7 +167,7 @@ export namespace ConfigValidation {
     }
 
     const prefix = await existing()
-    const validation = JSONC_EXT.has(ext) ? await jsonc(filepath) : ext === ".md" ? await markdown(filepath) : ""
+    const validation = JSONC_EXT.has(ext) ? await jsonc(filepath) : ext === ".md" ? await markdown(filepath, ctx) : ""
 
     if (!validation) return ""
 

--- a/packages/opencode/test/kilocode/config-validation.test.ts
+++ b/packages/opencode/test/kilocode/config-validation.test.ts
@@ -1,12 +1,15 @@
 // kilocode_change - new file
 import { afterEach, describe, expect, test } from "bun:test"
 import path from "path"
+import { Effect, Layer } from "effect"
 import { ConfigValidation } from "../../src/kilocode/config-validation"
-import { provideTestInstance } from "../fixture/fixture"
 import { Config } from "../../src/config/config"
 import { AppRuntime } from "../../src/effect/app-runtime"
 import { Filesystem } from "../../src/util/filesystem"
-import { disposeAllInstances, tmpdir } from "../fixture/fixture"
+import { disposeAllInstances, provideTestInstance, TestInstance, tmpdir } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(Layer.empty)
 
 afterEach(async () => {
   await disposeAllInstances()
@@ -184,4 +187,50 @@ Broken agent`,
     expect(result).toContain("broken.md")
     expect(result).toContain("Post-edit validation")
   })
+
+  // write/edit/apply_patch call check() via Effect.promise, which drops the
+  // Effect fiber after the first await inside check. Reproduce that path.
+  async function probe(dir: string, name: string, body: string) {
+    const filepath = path.join(dir, ".kilo", "command", name)
+    await Filesystem.write(filepath, body)
+    return filepath
+  }
+
+  it.instance(
+    "accepts a command file with no frontmatter via Effect.promise",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = yield* Effect.promise(() => probe(test.directory, "probe.md", "just a body, no frontmatter\n"))
+        const result = yield* Effect.promise(() => check(filepath))
+        expect(result).not.toContain("Failed to parse frontmatter")
+        expect(result).not.toContain("No context found for instance")
+        expect(result).toContain("validated successfully")
+      }),
+    { git: true },
+  )
+
+  it.instance(
+    "accepts a command file with valid frontmatter via Effect.promise",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = yield* Effect.promise(() =>
+          probe(
+            test.directory,
+            "probe.md",
+            `---
+description: probe
+---
+probe
+`,
+          ),
+        )
+        const result = yield* Effect.promise(() => check(filepath))
+        expect(result).not.toContain("Failed to parse frontmatter")
+        expect(result).not.toContain("No context found for instance")
+        expect(result).toContain("validated successfully")
+      }),
+    { git: true },
+  )
 })


### PR DESCRIPTION
## Issue

Fixes #14040

## Context

Saving or editing a Markdown file under `.kilo/command/` no longer reports:

```
Failed to parse frontmatter: No context found for instance
```

The error appeared with valid frontmatter, with only `description`, and with no `---` block. The same body saved outside `command/` (e.g. `.kilo/probe.md`) did not. Frontmatter is optional for command files (`description`, `agent`, and the other command fields are all optional).

The message is not a YAML failure. Write, edit, and apply_patch append config validation inside `Effect.promise`. After the first await, project instance context is gone, so `Instance.current` throws and the validator catch labels it as a frontmatter parse error. That catch is the only place this string is built.

## Implementation

`ConfigValidation.check` captures the project instance at the start, while the Effect fiber is still visible, and passes it into markdown validation instead of calling `Instance.current` after `existing()` awaits.

Decision: capture the instance in the Kilo-owned validator before the await.
Alternative: switch write/edit/apply_patch from `Effect.promise` to `EffectBridge.fromPromise`.
Reason: the throw is `Instance.current` after that await. Capturing in the validator is the smallest change and avoids touching three shared tool files.

## Screenshots / Video

N/A (tool-output string, not a visual change)

## How to Test

### Manual/local verification

- Tests call `ConfigValidation.check` through `Effect.promise`, matching write/edit/apply_patch.
- Without the fix those tests fail with `Failed to parse frontmatter: No context found for instance` for both no-frontmatter and valid-frontmatter command files.
- With the fix they report `validated successfully`.
- From `packages/opencode/`: `bun test ./test/kilocode/config-validation.test.ts` (12 pass, 0 fail) and `bun run typecheck` (`tsgo --noEmit`, exit 0).

### Reviewer test steps

1. In a project, create `.kilo/command/probe.md` with only a body (no `---` block).
2. Have the agent write or edit that file (write, edit, or apply_patch).
3. Confirm tool output contains `Config file validated successfully` and does not contain `Failed to parse frontmatter` or `No context found for instance`.
4. Repeat with:

```
---
description: probe
---
probe
```

5. Confirm a non-command file such as `.kilo/probe.md` still produces no config-validation block.

### Blocked checks and substitute verification

- Windows VS Code GUI was not run. The failure is the Effect `Instance` context being dropped after `await`, which reproduced on macOS with the same error string the reporter saw. No Windows-only branch is involved. Substitute: the `Effect.promise` unit tests above.

## Checklist

- [x] Issue linked above, or exception explained
- [x] Tests/verification described
- [x] Screenshots/video included for visual changes, or marked N/A
- [x] Changeset considered for user-facing changes
- [x] I personally reviewed the diff and can explain the changes, including any AI-assisted work.

## Get in Touch
