### PR TITLE
docs(kilo-docs): use agent terminology in introductory guidance

### DIFF
--- a/packages/kilo-docs/pages/ai-providers/openai-chatgpt-plus-pro.md
+++ b/packages/kilo-docs/pages/ai-providers/openai-chatgpt-plus-pro.md
@@ -13,7 +13,7 @@ If you already pay for ChatGPT Plus or Pro, you can use that subscription to run
 - **Flat-rate access to OpenAI models:** Your subscription covers usage without pay-as-you-go API costs.
 - **OAuth login — no API keys:** Click "Sign in to OpenAI Codex," authenticate in your browser, and you're done.
 - **Full agentic workflows:** Generate, refactor, debug, edit files, and run terminal commands inside Kilo Code.
-- **Multiple AI modes:** Switch between Code, Plan, Debug, and Ask modes for different tasks.
+- **Specialized agents:** Switch between the Code, Plan, Debug, and Ask agents for different tasks.
 
 {% callout type="note" %}
 Your ChatGPT subscription works with Kilo Code's core functionality (VS Code extension and CLI), but does **not** include cloud features such as Cloud Agents or Kilo Deploy. To use GPT models in those features, use the [Kilo Gateway](/docs/gateway).

--- a/packages/kilo-docs/pages/automate/extending/shell-integration.md
+++ b/packages/kilo-docs/pages/automate/extending/shell-integration.md
@@ -59,7 +59,7 @@ When using the Kilo Code VS Code extension with the Agent Manager, each agent se
 | Shortcut | Action |
 |---|---|
 | <kbd>Cmd</kbd>+<kbd>/</kbd> | Focus the session's terminal |
-| <kbd>Cmd</kbd>+<kbd>.</kbd> | Cycle agent mode |
+| <kbd>Cmd</kbd>+<kbd>.</kbd> | Cycle agents |
 
 ### Terminal Context Menu Actions
 

--- a/packages/kilo-docs/pages/collaborate/teams/getting-started.md
+++ b/packages/kilo-docs/pages/collaborate/teams/getting-started.md
@@ -66,7 +66,7 @@ Team members receive invitation emails with these steps:
 ## First Steps for Your Team
 
 1. **Try basic tasks** - code generation, debugging, documentation
-2. **Explore different modes** - Code, Architect, Ask, Debug
+2. **Explore different agents** - Code, Plan, Ask, Debug
 3. **Set personal preferences** - model selection, auto-approval settings
 4. **Review usage patterns** in the dashboard after first week
 

--- a/packages/kilo-docs/pages/contributing/architecture/cli-runtime.md
+++ b/packages/kilo-docs/pages/contributing/architecture/cli-runtime.md
@@ -25,7 +25,7 @@ These terms describe local execution. They are separate from hosted Cloud Agent 
 | Local routing workspace | Optional routing context that can resolve to a local directory or remote target |
 | Worktree directory | Alternate git worktree path used as directory context for isolated concurrent work |
 | Process-shared state | Runtime service state shared by every directory context in one Kilo CLI process |
-| Modes | Configurable agent presets for tools, prompts, restrictions, and behavior |
+| Agents | Configurable presets for tools, prompts, restrictions, and behavior |
 | MCP | Protocol for extending agent tools |
 
 One `kilo serve` process can host several local runtime instances. Directory-keyed state stays isolated. Process-shared service state does not.

--- a/packages/kilo-docs/pages/contributing/architecture/vscode-extension.md
+++ b/packages/kilo-docs/pages/contributing/architecture/vscode-extension.md
@@ -119,7 +119,7 @@ Agent Manager PTY WebSocket URL uses `auth_token=<base64 kilo:password>` query m
 | Config owner | Examples |
 |---|---|
 | VS Code settings | `kilo-code.new.*` extension UI, proxy, autocomplete, and integration settings |
-| CLI config | Global and project `kilo.jsonc`, `kilo.json`, compatible OpenCode files, provider auth, tools, permissions, modes |
+| CLI config | Global and project `kilo.jsonc`, `kilo.json`, compatible OpenCode files, provider auth, tools, permissions, agents |
 
 Extension-specific behavior belongs in VS Code settings. Agent runtime behavior belongs in CLI config so TUI, Console, VS Code, and JetBrains can share it.
 

--- a/packages/kilo-docs/pages/getting-started/index.md
+++ b/packages/kilo-docs/pages/getting-started/index.md
@@ -20,7 +20,7 @@ Your sessions sync across all of these, so you can start a task on your phone an
 
 ## What Kilo Can Do
 
-- [**Code with AI**](/docs/code-with-ai) — Generate, refactor, and debug code through natural conversation. Use specialized modes (Code, Architect, Debug, Ask) or create your own. Get inline suggestions with Autocomplete.
+- [**Code with AI**](/docs/code-with-ai) — Generate, refactor, and debug code through natural conversation. Use specialized agents (Code, Plan, Debug, Ask) or create your own. Get inline suggestions with Autocomplete.
 - [**Collaborate**](/docs/collaborate) — Share sessions, manage team settings, and track AI adoption across your organization.
 - [**Automate**](/docs/automate) — Set up AI-powered code reviews, triage agents, and auto-fixers that open new PRs based on issues.
 - [**Deploy & Secure**](/docs/deploy-secure) — Build and deploy apps directly from Kilo. Run security scans and manage issues with AI assistance.


### PR DESCRIPTION
Replace six unambiguous references to modes with agents in introductory guidance, the agent-cycling shortcut description, and architecture terminology. Use Plan instead of Architect in two current-agent lists to match the built-in agents.

This is an intentionally small first pass, not a global replacement. Preserve configuration keys, literal UI labels, historical and migration terminology, URLs, and unrelated uses of mode. Customization, navigation, and behavior-sensitive guidance remain for separate focused changes.