### PR TITLE
docs(kilo-docs): use agent terminology in customization overview

### DIFF
--- a/packages/kilo-docs/pages/customize/index.md
+++ b/packages/kilo-docs/pages/customize/index.md
@@ -1,19 +1,19 @@
 ﻿---
 title: "Customize"
-description: "Make Kilo Code work your way with custom modes, rules, instructions, and more"
+description: "Make Kilo Code work your way with custom agents, rules, instructions, and more"
 ---
 
 # {% $markdoc.frontmatter.title %}
 
 {% callout type="generic" %}
-Kilo Code is highly customizable. Tailor its behavior to match your workflow, team standards, and project requirements with custom modes, rules, instructions, and more.
+Kilo Code is highly customizable. Tailor its behavior to match your workflow, team standards, and project requirements with custom agents, rules, instructions, and more.
 {% /callout %}
 
 ## Customization
 
 Configure how Kilo Code behaves and responds:
 
-- [**Custom Modes**](/docs/customize/custom-modes) - Create specialized modes for different tasks (code review, documentation, testing, etc.)
+- [**Custom Modes**](/docs/customize/custom-modes) - Create specialized agents for different tasks (code review, documentation, testing, etc.)
 - [**Custom Rules**](/docs/customize/custom-rules) - Define rules that apply to specific file types or situations
 - [**Custom Instructions**](/docs/customize/custom-instructions) - Add project-specific guidelines and context
 - [**Custom Subagents**](/docs/customize/custom-subagents) - Create specialized subagents with custom prompts, models, and permissions
@@ -36,14 +36,14 @@ Help Kilo understand your codebase better:
 New to customization? Here's where to start:
 
 1. **Start with Custom Instructions** — Set up instructions in the [Custom Instructions](/docs/customize/custom-instructions) section to guide Kilo Code's behavior
-2. **Explore Custom Modes** — Try the built-in modes first, then create your own
+2. **Explore Custom Agents** — Try the built-in agents first, then create your own
 3. **Enable Codebase Indexing** — Help Kilo understand your project structure
 
 ## Best Practices
 
 - Keep custom instructions concise and actionable
-- Use custom modes for repetitive tasks
-- Combine rules with modes for powerful workflows
+- Use custom agents for repetitive tasks
+- Combine rules with agents for powerful workflows
 
 ## Next Steps
 


### PR DESCRIPTION
Update six lines in the Customize overview to describe current behavioral profiles as agents, including the page description, introduction, and workflow advice.

Keep the existing Custom Modes link label and URL because they match the destination page and navigation title. Configuration fields, migration guidance, and the detailed custom-modes page remain unchanged for a separate focused pass.

This is an independent follow-up to #14067 and does not include that PR's edits.