### PR TITLE
fix(cli): inject agent-switch reminder when switching from Code back to Ask

### DIFF
--- a/.changeset/code-ask-switch-reminder.md
+++ b/.changeset/code-ask-switch-reminder.md
@@ -1,0 +1,5 @@
+---
+"@kilocode/cli": patch
+---
+
+Inject agent-switch reminder when switching from Code back to Ask so the assistant transitions cleanly to read-only behavior.

--- a/packages/opencode/src/kilocode/session/code-ask-switch.txt
+++ b/packages/opencode/src/kilocode/session/code-ask-switch.txt
@@ -1,0 +1,6 @@
+<system-reminder>
+The active agent has changed from Code to Ask.
+You are now in read-only mode. Do not modify files, run shell commands, or use tools that change the project.
+Follow the current Ask agent instructions and the permissions configured for this agent.
+Ignore earlier conversation text that says you are in Code mode or may make changes.
+</system-reminder>

--- a/packages/opencode/src/kilocode/session/prompt.ts
+++ b/packages/opencode/src/kilocode/session/prompt.ts
@@ -29,6 +29,7 @@ import { MemoryMarker } from "@/kilocode/memory/marker"
 import { KilocodeSystemPrompt } from "@/kilocode/system-prompt"
 import { KiloToolRegistry } from "@/kilocode/tool/registry"
 import ASK_CODE_SWITCH from "./ask-code-switch.txt"
+import CODE_ASK_SWITCH from "./code-ask-switch.txt"
 import { consumeAutoTitle, markAutoTitle } from "@/kilo-sessions/rename-adoptions"
 
 export namespace KiloSessionPrompt {
@@ -568,16 +569,24 @@ export namespace KiloSessionPrompt {
     userMessage: MessageV2.WithParts
     messages: MessageV2.WithParts[]
   }) {
-    if (mode(input.agent.name) !== "code") return
+    const current = mode(input.agent.name)
     const prior = input.messages.findLast((msg) => msg.info.id !== input.userMessage.info.id)
-    if (!prior || mode(prior.info.agent) !== "ask") return
-    if (input.userMessage.parts.some((part) => part.type === "text" && part.text === ASK_CODE_SWITCH)) return
+    if (!prior) return
+    const prev = mode(prior.info.agent)
+    const text =
+      current === "code" && prev === "ask"
+        ? ASK_CODE_SWITCH
+        : current === "ask" && prev === "code"
+          ? CODE_ASK_SWITCH
+          : undefined
+    if (!text) return
+    if (input.userMessage.parts.some((part) => part.type === "text" && part.text === text)) return
     return {
       id: PartID.ascending(),
       messageID: input.userMessage.info.id,
       sessionID: input.userMessage.info.sessionID,
       type: "text" as const,
-      text: ASK_CODE_SWITCH,
+      text,
       synthetic: true,
     }
   }

--- a/packages/opencode/test/kilocode/ask-switch-reminder.test.ts
+++ b/packages/opencode/test/kilocode/ask-switch-reminder.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import ASK_CODE_SWITCH from "../../src/kilocode/session/ask-code-switch.txt"
+import CODE_ASK_SWITCH from "../../src/kilocode/session/code-ask-switch.txt"
 import { SessionID, MessageID, PartID } from "../../src/session/schema"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
@@ -64,11 +65,11 @@ function assistant(input: { sessionID: SessionID; parentID: MessageID; agent: st
   } satisfies MessageV2.WithParts
 }
 
-function reminder(message: MessageV2.WithParts) {
+function reminder(message: MessageV2.WithParts, text = ASK_CODE_SWITCH) {
   return message.parts
     .filter((part): part is MessageV2.TextPart => part.type === "text")
     .map((part) => part.text)
-    .find((text) => text === ASK_CODE_SWITCH)
+    .find((val) => val === text)
 }
 
 describe("insertAgentSwitchReminder", () => {
@@ -244,4 +245,109 @@ describe("insertAgentSwitchReminder", () => {
     expect(added).toBeUndefined()
     expect(reminder(next)).toBeUndefined()
   })
+
+  test("injects Code to Ask reminder when the previous turn was Code", () => {
+    const code = user({ agent: "code", text: "Please implement the change." })
+    const reply = assistant({
+      sessionID: code.info.sessionID,
+      parentID: code.info.id,
+      agent: "code",
+      text: "I have implemented the change.",
+    })
+    const next = user({ agent: "ask", text: "Can you explain how it works?" })
+    next.info.sessionID = code.info.sessionID
+    for (const part of next.parts) part.sessionID = code.info.sessionID
+
+    const added = KiloSessionPrompt.insertAgentSwitchReminder({
+      agent: { name: "ask" },
+      userMessage: next,
+      messages: [code, reply, next],
+    })
+
+    expect(added?.text).toBe(CODE_ASK_SWITCH)
+    expect(reminder(next, CODE_ASK_SWITCH)).toBeUndefined()
+    next.parts.push(added!)
+    expect(reminder(next, CODE_ASK_SWITCH)).toBe(CODE_ASK_SWITCH)
+    expect(CODE_ASK_SWITCH).toContain("from Code to Ask")
+    expect(CODE_ASK_SWITCH).toContain("read-only mode")
+    expect(CODE_ASK_SWITCH).toContain("permissions configured for this agent")
+    expect(CODE_ASK_SWITCH).not.toContain("from Ask to Code")
+  })
+
+  test("does not inject on later Ask turns after switching from Code", () => {
+    const code = user({ agent: "code", text: "Implement it." })
+    const reply = assistant({
+      sessionID: code.info.sessionID,
+      parentID: code.info.id,
+      agent: "code",
+      text: "Done.",
+    })
+    const first = user({ agent: "ask", text: "Explain it." })
+    first.info.sessionID = code.info.sessionID
+    const asked = assistant({
+      sessionID: code.info.sessionID,
+      parentID: first.info.id,
+      agent: "ask",
+      text: "Here is the explanation.",
+    })
+    const later = user({ agent: "ask", text: "One more question." })
+    later.info.sessionID = code.info.sessionID
+
+    KiloSessionPrompt.insertAgentSwitchReminder({
+      agent: { name: "ask" },
+      userMessage: later,
+      messages: [code, reply, first, asked, later],
+    })
+
+    expect(reminder(later, CODE_ASK_SWITCH)).toBeUndefined()
+  })
+
+  test("does not inject twice on the same user message for Code to Ask", () => {
+    const code = user({ agent: "code", text: "Implement it." })
+    const reply = assistant({
+      sessionID: code.info.sessionID,
+      parentID: code.info.id,
+      agent: "code",
+      text: "Done.",
+    })
+    const next = user({ agent: "ask", text: "Explain the implementation." })
+    next.info.sessionID = code.info.sessionID
+
+    const first = KiloSessionPrompt.insertAgentSwitchReminder({
+      agent: { name: "ask" },
+      userMessage: next,
+      messages: [code, reply, next],
+    })
+    next.parts.push(first!)
+    const second = KiloSessionPrompt.insertAgentSwitchReminder({
+      agent: { name: "ask" },
+      userMessage: next,
+      messages: [code, reply, next],
+    })
+
+    expect(second).toBeUndefined()
+    expect(next.parts.filter((part) => part.type === "text" && part.text === CODE_ASK_SWITCH)).toHaveLength(1)
+  })
+
+  test("does not inject on Plan to Ask", () => {
+    const plan = user({ agent: "plan", text: "Make a plan." })
+    const reply = assistant({
+      sessionID: plan.info.sessionID,
+      parentID: plan.info.id,
+      agent: "plan",
+      text: "Here is the plan.",
+    })
+    const next = user({ agent: "ask", text: "Explain the architecture." })
+    next.info.sessionID = plan.info.sessionID
+
+    const added = KiloSessionPrompt.insertAgentSwitchReminder({
+      agent: { name: "ask" },
+      userMessage: next,
+      messages: [plan, reply, next],
+    })
+
+    expect(added).toBeUndefined()
+    expect(reminder(next, CODE_ASK_SWITCH)).toBeUndefined()
+  })
 })
+


### PR DESCRIPTION
Fixes #14060

### Summary of Changes
When switching from Ask to Code, Kilo injects a `<system-reminder>` notifying the model that it has switched to Code mode. However, when switching back from Code to Ask, `insertAgentSwitchReminder` previously exited early with `if (mode(input.agent.name) !== "code") return`, leaving the model unaware of the transition and often attempting file edits or commands prohibited in Ask mode.

This PR:
- Adds `code-ask-switch.txt` reminder instructing the agent that it is now in read-only Ask mode.
- Updates `insertAgentSwitchReminder` in `packages/opencode/src/kilocode/session/prompt.ts` to inject the appropriate reminder for both Ask → Code and Code → Ask transitions.
- Adds comprehensive unit tests in `packages/opencode/test/kilocode/ask-switch-reminder.test.ts` verifying injection, message text, and deduplication.
- Includes a patch changeset for `@kilocode/cli`.

### Test Plan
- Run unit tests: `bun test ./test/kilocode/ask-switch-reminder.test.ts` (all 11 tests pass).
- Verify annotations: `bun run script/check-opencode-annotations.ts --worktree` (clean pass).
