### PR TITLE
docs(kilo-docs): clarify organization-managed agent terminology

### DIFF
--- a/packages/kilo-docs/pages/customize/custom-modes.md
+++ b/packages/kilo-docs/pages/customize/custom-modes.md
@@ -1,14 +1,14 @@
 ---
 title: "Custom Modes"
-description: "Create and configure custom modes in Kilo Code"
+description: "Create and configure custom agents in Kilo Code"
 ---
 
 # Custom Modes
 
-Kilo Code allows you to create **custom modes** (also called **agents**) to tailor Kilo's behavior to specific tasks or workflows. Custom modes can be **global** (available across all projects), **project-specific** (defined within a single project), or **organization-managed** (provided by your Kilo organization).
+Kilo Code allows you to create **custom agents** (also called **custom modes**) to tailor Kilo's behavior to specific tasks or workflows. Custom agents can be **global** (available across all projects), **project-specific** (defined within a single project), or **organization-managed** (provided by your Kilo organization).
 
 {% callout type="info" %}
-The current VS Code extension (built on the Kilo CLI) uses **agent Markdown files** to define custom modes. The legacy extension used `custom_modes.yaml` / `.kilocodemodes`. See the tabs below for the relevant approach.
+The current VS Code extension (built on the Kilo CLI) uses **agent Markdown files** to define custom agents. The legacy extension used `custom_modes.yaml` / `.kilocodemodes`. See the tabs below for the relevant approach.
 {% /callout %}
 
 ## Why Use Custom Modes?
@@ -19,17 +19,17 @@ The current VS Code extension (built on the Kilo CLI) uses **agent Markdown file
 - **Team Collaboration:** Share custom modes with your team to standardize workflows
 - **Organization Consistency:** Use organization-managed agents/custom modes so members share the same behavior for common workflows
 
-## Organization-Managed Custom Modes
+## Organization-managed agents {% #organization-managed-custom-modes %}
 
-If your Kilo organization provides custom modes, Kilo adds them to your local experience as organization-sourced agents/custom modes. They appear alongside built-in and personal agents so members can select them directly where Kilo shows user-selectable agents or modes.
+If your Kilo organization provides custom modes, the VS Code extension and CLI load them as organization-sourced agents. They appear alongside built-in and personal agents in the agent picker.
 
-Organization-managed modes are controlled at the organization level:
+Organization-managed agents are controlled at the organization level:
 
-- An organization-managed mode can use the same name as a built-in agent. When it does, the organization-provided definition takes precedence for members of that organization.
-- Individual members cannot remove organization-managed modes from their local agent list. Changes need to be made in the organization-managed definition.
-- Organization-managed modes are useful for shared prompts, instructions, and tool access expectations that should stay consistent across a team.
+- An organization-managed agent can use the same name as a built-in agent. When it does, the organization-provided definition takes precedence for members of that organization.
+- Individual members cannot remove organization-managed agents from their local agent list. Changes need to be made in the organization-managed definition.
+- Organization-managed agents are useful for shared prompts, instructions, and tool access expectations that should stay consistent across a team.
 
-For organization members, contact the person or team that manages Kilo for your organization if an organization mode appears unexpectedly, needs different instructions, or needs different tool access. For admins and support teams, keep the purpose and owner of each organization custom mode clear so members know when to use it and where to request changes.
+For organization members, contact the person or team that manages Kilo for your organization if an organization agent appears unexpectedly, needs different instructions, or needs different tool access. For admins and support teams, keep the purpose and owner of each organization-managed agent clear so members know when to use it and where to request changes.
 
 {% tabs %}
 {% tab label="VSCode" %}


### PR DESCRIPTION
Update ten lines in the custom-agent introduction and organization-managed section to use agents for the profiles people select in the CLI and VS Code extension.

Clarify that organization-provided custom modes load as agents, retaining the distinction from dashboard terminology. Preserve the existing organization-managed-custom-modes heading anchor, page title, legacy filenames, configuration fields, and migration instructions.

This is independent of the previous terminology PRs. In particular, it leaves the benefits section from #14070 untouched.