### PR TITLE
docs(kilo-docs): label custom agents in navigation and related links

### DIFF
--- a/packages/kilo-docs/lib/nav/customize.ts
+++ b/packages/kilo-docs/lib/nav/customize.ts
@@ -8,7 +8,7 @@ export const CustomizeNav: NavSection[] = [
       { href: "/customize/marketplace", children: "Marketplace", platform: "new" },
       {
         href: "/customize/custom-modes",
-        children: "Custom Modes",
+        children: "Custom Agents",
       },
       {
         href: "/customize/custom-rules",

--- a/packages/kilo-docs/pages/code-with-ai/agents/using-agents.md
+++ b/packages/kilo-docs/pages/code-with-ai/agents/using-agents.md
@@ -157,6 +157,6 @@ The VSCode extension and CLI do not include a built-in Review agent. Code review
 
 ## Custom Agents
 
-Create your own specialized assistants by defining tool access, file permissions, and behavior instructions. Custom agents help enforce team standards or create purpose-specific assistants. See [Custom Modes documentation](/docs/customize/custom-modes) for setup instructions.
+Create your own specialized assistants by defining tool access, file permissions, and behavior instructions. Custom agents help enforce team standards or create purpose-specific assistants. See [Custom Agents documentation](/docs/customize/custom-modes) for setup instructions.
 
 To keep an agent working toward a single objective across turns, see [Session Goals](/docs/code-with-ai/agents/goals).

--- a/packages/kilo-docs/pages/contributing/index.md
+++ b/packages/kilo-docs/pages/contributing/index.md
@@ -167,7 +167,7 @@ The [Kilo Marketplace](https://github.com/Kilo-Org/kilo-marketplace) is a commun
 
 To contribute:
 
-1. Follow the documentation for [Custom Modes](/docs/customize/custom-modes), [Skills](/docs/customize/skills), or [MCP Servers](/docs/automate/mcp/overview) to create your resource
+1. Follow the documentation for [Custom Agents](/docs/customize/custom-modes), [Skills](/docs/customize/skills), or [MCP Servers](/docs/automate/mcp/overview) to create your resource
 
 2. Test your contribution thoroughly
 

--- a/packages/kilo-docs/pages/customize/agent-permissions.md
+++ b/packages/kilo-docs/pages/customize/agent-permissions.md
@@ -182,7 +182,7 @@ This allows delegation only to `code-reviewer` and `docs-writer`.
 
 ## Related
 
-- [Custom Modes](/docs/customize/custom-modes)
+- [Custom Agents](/docs/customize/custom-modes)
 - [Custom Subagents](/docs/customize/custom-subagents)
 - [Auto-Approving Actions](/docs/getting-started/settings/auto-approving-actions)
 - [.kilocodeignore](/docs/customize/context/kilocodeignore)

--- a/packages/kilo-docs/pages/customize/agents-md.md
+++ b/packages/kilo-docs/pages/customize/agents-md.md
@@ -201,7 +201,7 @@ AGENTS.md itself cannot be individually disabled — it is always loaded if pres
 ## Related Features
 
 - **[Custom Rules](/docs/customize/custom-rules)** - Kilo Code-specific rules with more control
-- **[Custom Modes](/docs/customize/custom-modes)** - Specialized workflows with specific permissions
+- **[Custom Agents](/docs/customize/custom-modes)** - Specialized workflows with specific permissions
 - **[Custom Instructions](/docs/customize/custom-instructions)** - Personal preferences across all projects
 - **[Migrating from Cursor or Windsurf](/docs/getting-started/migrating)** - Migration guide for other tools
 

--- a/packages/kilo-docs/pages/customize/custom-instructions.md
+++ b/packages/kilo-docs/pages/customize/custom-instructions.md
@@ -157,7 +157,7 @@ If your project contains `.kilocoderules` files from the VSCode extension, these
 
 ## Related Features
 
-- [Custom Modes](/docs/customize/custom-modes)
+- [Custom Agents](/docs/customize/custom-modes)
 - [Custom Rules](/docs/customize/custom-rules)
 - [Settings Management](/docs/getting-started/settings)
 - [Auto-Approval Settings](/docs/getting-started/settings/auto-approving-actions)

--- a/packages/kilo-docs/pages/customize/custom-modes.md
+++ b/packages/kilo-docs/pages/customize/custom-modes.md
@@ -1,9 +1,9 @@
 ---
-title: "Custom Modes"
+title: "Custom Agents"
 description: "Create and configure custom modes in Kilo Code"
 ---
 
-# Custom Modes
+# Custom Agents {% #custom-modes %}
 
 Kilo Code allows you to create **custom modes** (also called **agents**) to tailor Kilo's behavior to specific tasks or workflows. Custom modes can be **global** (available across all projects), **project-specific** (defined within a single project), or **organization-managed** (provided by your Kilo organization).
 

--- a/packages/kilo-docs/pages/customize/custom-rules.md
+++ b/packages/kilo-docs/pages/customize/custom-rules.md
@@ -316,7 +316,7 @@ If your rules aren't being followed:
 
 ## Related Features
 
-- [Custom Modes](/docs/customize/custom-modes)
+- [Custom Agents](/docs/customize/custom-modes)
 - [Custom Instructions](/docs/customize/custom-instructions)
 - [Settings Management](/docs/getting-started/settings)
 - [Auto-Approval Settings](/docs/getting-started/settings/auto-approving-actions)

--- a/packages/kilo-docs/pages/customize/custom-subagents.md
+++ b/packages/kilo-docs/pages/customize/custom-subagents.md
@@ -396,7 +396,7 @@ To disable a built-in agent entirely:
 
 ## Related
 
-- [Custom Modes](/docs/customize/custom-modes) — Create specialized primary agents with tool restrictions
+- [Custom Agents](/docs/customize/custom-modes) — Create specialized primary agents with tool restrictions
 - [Custom Rules](/docs/customize/custom-rules) — Define rules that apply to specific file types or situations
 - [Orchestrator Mode](/docs/code-with-ai/agents/orchestrator-mode) — Legacy mode for task delegation (now built into full-tool agents)
 - [Task tool](/docs/automate/tools#task-tool) — The tool used to invoke subagents

--- a/packages/kilo-docs/pages/getting-started/migrating.md
+++ b/packages/kilo-docs/pages/getting-started/migrating.md
@@ -437,7 +437,7 @@ mkdir -p .kilo/rules-docs
 ## Next Steps
 
 - [Learn about Custom Rules](/docs/customize/custom-rules)
-- [Explore Custom Modes](/docs/customize/custom-modes)
+- [Explore Custom Agents](/docs/customize/custom-modes)
 - [Set up Custom Instructions](/docs/customize/custom-instructions)
 - [Join our Discord](https://kilo.ai/discord) for migration support
 

--- a/packages/kilo-docs/pages/index.tsx
+++ b/packages/kilo-docs/pages/index.tsx
@@ -97,7 +97,7 @@ const categories = [
     ),
     links: [
       { title: "The Chat Interface", href: "/code-with-ai" },
-      { title: "Using Modes", href: "/code-with-ai" },
+      { title: "Using Agents", href: "/code-with-ai" },
       { title: "Custom Rules", href: "/code-with-ai" },
     ],
   },
@@ -198,7 +198,7 @@ export default function HomePage() {
   return (
     <div className="homepage">
       <Head>
-        <title>Kilo Code Docs: Setup, Models, MCP, Custom Modes & CLI</title>
+        <title>Kilo Code Docs: Setup, Models, MCP, Custom Agents & CLI</title>
       </Head>
       {/* Dotted background pattern */}
       <div className="dot-pattern" />


### PR DESCRIPTION
Use Custom Agents for the page title, sidebar entry, and selected related links; update the homepage labels to match current agent terminology.

Keep all route targets unchanged and preserve the custom-modes heading anchor. Organization dashboard labels and legacy migration instructions remain untouched. Avoid editing lines already covered by the earlier terminology PRs; remaining mixed descriptions can be handled separately.