### PR TITLE
chore(ci): remove benchmark smoke gate from publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -373,21 +373,6 @@ jobs:
           name: kilo-vscode
           path: packages/kilo-vscode/out
 
-  # kilocode_change start
-  # Run smoke tests against CLI assets uploaded to the draft GitHub release
-  # before publishing the release and package artifacts.
-  smoke-test:
-    name: Smoke Test (pre-publish gate)
-    needs:
-      - version
-      - build-cli
-    if: github.repository == 'Kilo-Org/kilocode'
-    uses: ./.github/workflows/smoke-test.yml
-    with:
-      cli_version: ${{ needs.version.outputs.version }}
-    secrets: inherit
-  # kilocode_change end
-
   publish:
     needs:
       - version
@@ -395,7 +380,6 @@ jobs:
       - build-vscode
       - validate-cli-unix # kilocode_change
       - validate-cli-windows # kilocode_change
-      - smoke-test
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6 # kilocode_change

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -7,7 +7,7 @@
 #
 # Triggers:
 #   - workflow_dispatch: manually from Actions tab (optionally pass a CLI version)
-#   - workflow_call: from publish.yml after draft release assets are uploaded
+#   - workflow_call: reusable by other workflows with an optional CLI version
 #
 # Required secrets:
 #   KILO_API_KEY         — Kilo Gateway key
@@ -35,7 +35,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write # needed to read draft release assets when called from publish.yml
+  contents: write # needed to read draft release assets when testing an unpublished version
 
 jobs:
   smoke-test:


### PR DESCRIPTION
## Summary
Remove the Harbor/kilo-bench pre-publish gate so releases no longer depend on the external benchmark harness and its setup/network dependencies. Keep the native Unix/Windows CLI validation gates and the standalone smoke workflow available for manual or reusable runs.

## Investigation
The suspected container/package EOL cause was not confirmed. The tested images use Ubuntu 24.04 and Python 3.13 on Debian Bookworm; the historical installer uses Node 22.

- [September 4 benchmark failure](https://github.com/Kilo-Org/kilocode/actions/runs/33866603432/job/101003786641): harness preparation failed before a usable Harbor job was created. The workflow supplied a GitHub API asset URL, but the checked-out harness only accepted release-download URLs, a concrete integration mismatch consistent with the generic preparation error.
- [Later September 4 failure](https://github.com/Kilo-Org/kilocode/actions/runs/33873085148/job/101027074228): both benchmark tasks passed; publishing failed on a Marketplace upload timeout.
- The three latest publish runs inspected passed both benchmarks on their first attempt.

This change intentionally removes the benchmark dependency, not the native binary smoke checks. It does not fix unrelated Marketplace or registry outages.